### PR TITLE
fix(cutover): the chart outgrew the 1 MiB Helm release Secret and could not install anywhere (Refs #6004)

### DIFF
--- a/.github/workflows/blueprint-release.yaml
+++ b/.github/workflows/blueprint-release.yaml
@@ -455,6 +455,34 @@ jobs:
           done
           echo "All chart-test scripts passed."
 
+      # ──────────────────────────────────────────────────────────────
+      # GATE — the Helm release Secret must fit in a Kubernetes Secret
+      # ──────────────────────────────────────────────────────────────
+      # #6004: helm stores a release as base64(gzip(json(release))) in
+      # Secret sh.helm.release.v1.<name>.v<n>, and Kubernetes caps a
+      # Secret's data at 1048576 bytes. bp-self-sovereign-cutover grew
+      # past that ceiling over ~7 releases and 0.1.177 could not be
+      # installed on ANY Sovereign — Phase 1 failed 10 times on hw293
+      # with `data: Too long: must have at most 1048576 bytes`, and
+      # Pillar 5 became unprovable. Every earlier gate in this job was
+      # green: the chart rendered, packaged, and round-tripped fine. The
+      # ceiling is only reached at INSTALL time, which is why it has to
+      # be measured here, before the artifact exists on GHCR.
+      #
+      # This runs after `helm dependency build`, so it measures the real
+      # payload including upstream subcharts — the number the sweep in
+      # check-helm-release-payload-size.yaml cannot compute for a chart
+      # that declares dependencies.
+      - name: "Release-Secret payload under the 1 MiB ceiling (#6004)"
+        if: steps.chart.outputs.skip != 'true'
+        run: |
+          set -euo pipefail
+          pip install --quiet pyyaml
+          python3 scripts/check-helm-release-payload-size.py --self-test
+          python3 scripts/check-helm-release-payload-size.py "${{ matrix.path }}/chart" \
+            --release-name "${{ steps.chart.outputs.name }}" \
+            --namespace catalyst
+
       - name: Helm push to GHCR
         if: steps.chart.outputs.skip != 'true'
         id: push

--- a/.github/workflows/check-helm-release-payload-size.yaml
+++ b/.github/workflows/check-helm-release-payload-size.yaml
@@ -1,0 +1,61 @@
+# check-helm-release-payload-size.yaml — no chart may outgrow the 1 MiB Helm
+# release Secret.
+#
+# #6004: bp-self-sovereign-cutover@0.1.177 could not be installed on ANY
+# Sovereign. Helm stores a release as base64(gzip(json(release))) in a Secret,
+# Kubernetes caps Secret data at 1048576 bytes, and the chart had grown past it
+# — so Phase 1 failed 10 times on hw293 and Pillar 5 became unprovable. Nothing
+# in CI measured that number; the first place it was observable was a fresh
+# Sovereign's install.
+#
+# The sweep can only PACKAGE charts that vendor no upstream subcharts, so charts
+# declaring `dependencies:` are deferred, by name and by count, to the identical
+# check inside blueprint-release.yaml — which runs after `helm dependency build`
+# and BEFORE `helm push`, so nothing reaches GHCR unmeasured. A dependency-free
+# chart that fails to package is reported as an ERROR, never as a pass.
+#
+# --self-test runs first and always: it builds one over-budget and one
+# under-budget chart and asserts the gate returns 1 and 0 respectively. A size
+# check nobody has seen fail is not a check.
+name: check-helm-release-payload-size
+
+on:
+  pull_request:
+    paths:
+      - "platform/*/chart/**"
+      - "products/*/chart/**"
+      - "products/*/charts/*/**"
+      - "scripts/check-helm-release-payload-size.py"
+      - ".github/workflows/check-helm-release-payload-size.yaml"
+  push:
+    branches: [main]
+    paths:
+      - "platform/*/chart/**"
+      - "products/*/chart/**"
+      - "products/*/charts/*/**"
+      - "scripts/check-helm-release-payload-size.py"
+      - ".github/workflows/check-helm-release-payload-size.yaml"
+
+permissions:
+  contents: read
+
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: azure/setup-helm@v4
+        with:
+          # Same version blueprint-release.yaml publishes with, so the sweep
+          # measures the bytes that workflow would actually push.
+          version: v3.18.4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install PyYAML
+        run: pip install --quiet pyyaml
+      - name: Self-test — the gate must go red over budget and green under it
+        run: python3 scripts/check-helm-release-payload-size.py --self-test
+      - name: Every standalone-packageable chart stays under the 1 MiB ceiling
+        run: python3 scripts/check-helm-release-payload-size.py --all .

--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -1069,9 +1069,9 @@ spec:
       # 0.1.179 (#6004): the chart could not be INSTALLED at all. Its Helm
       # release Secret had grown to 1,233,060 bytes against Kubernetes' 1048576
       # cap, so slot 06a failed 10 times on hw293 Phase 1 with `data: Too long`
-      # and Pillar 5 was unprovable. 5,507 `#` template comments became
-      # {{/* */}} (stored once instead of twice, no prose lost) and chart/tests/
-      # left the package via .helmignore: 743,780 bytes, 70.9% of the ceiling.
+      # and Pillar 5 was unprovable. 5,170 `#` template comments became Helm
+      # block comments (stored once instead of twice, no prose lost) and
+      # chart/tests/ left the package via .helmignore: 757,264 bytes, 72.2%.
       # The rendered manifest is byte-identical modulo comments — no step,
       # value or RBAC change, still 11 steps.
       version: 0.1.179

--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -1066,7 +1066,15 @@ spec:
       # Sovereign (the git overwrite cannot preserve step-06's durable
       # HelmRepository-pivot commit); the reconciler also gains a CONTINUOUS
       # source-host drift lint (daytwoReconciler.sourceHostLint).
-      version: 0.1.177
+      # 0.1.179 (#6004): the chart could not be INSTALLED at all. Its Helm
+      # release Secret had grown to 1,233,060 bytes against Kubernetes' 1048576
+      # cap, so slot 06a failed 10 times on hw293 Phase 1 with `data: Too long`
+      # and Pillar 5 was unprovable. 5,507 `#` template comments became
+      # {{/* */}} (stored once instead of twice, no prose lost) and chart/tests/
+      # left the package via .helmignore: 743,780 bytes, 70.9% of the ceiling.
+      # The rendered manifest is byte-identical modulo comments — no step,
+      # value or RBAC change, still 11 steps.
+      version: 0.1.179
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1356,7 +1356,7 @@ spec:
       #   umbrella, so the new pin only reaches a Sovereign once the umbrella
       #   republishes and this pin advances (#5734). Lockstep w/
       #   products/catalyst/chart/Chart.yaml + slot-06a (0.1.177).
-      version: 1.4.1332
+      version: 1.4.1334
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.177
+  version: 0.1.179
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/.helmignore
+++ b/platform/self-sovereign-cutover/chart/.helmignore
@@ -1,0 +1,17 @@
+# Files that must NOT ship inside the packaged chart (#6004).
+#
+# Everything a chart packages is stored, base64-encoded, inside every Helm
+# release Secret — and Kubernetes caps a Secret's data at 1048576 bytes. At
+# 0.1.177 this chart's tests/ directory alone was 527,883 of those bytes and
+# the install failed on hw293 with
+#
+#   Secret "sh.helm.release.v1.self-sovereign-cutover.v1" is invalid:
+#   data: Too long: must have at most 1048576 bytes
+#
+# tests/*.sh are CI-side chart tests. blueprint-release.yaml runs them with
+# `bash "$s" "$chart_dir"` against the WORKING TREE, never against the
+# package, so ignoring them here costs the gate nothing and removes ~300 KB
+# from the compressed payload of every release of this chart.
+#
+# scripts/check-helm-release-payload-size.py is the gate that measures this.
+tests/

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1,5 +1,48 @@
 apiVersion: v2
 name: bp-self-sovereign-cutover
+# 0.1.179 (#6004) — THIS CHART COULD NO LONGER BE INSTALLED ON ANY SOVEREIGN.
+# Helm stores a release as base64(gzip(json(release))) in Secret
+# sh.helm.release.v1.<release>.v<n>, and Kubernetes caps a Secret's data at
+# 1048576 bytes. Measured with helm's own storage encoder, 0.1.177 produced
+# 1,233,060 bytes — 117.6% of the ceiling. hw293's Phase 1 finished 66/67 with
+# this one failure, repeated 10 times between 13:04:38Z and 13:17:56Z:
+#
+#   create: failed to create: Secret "sh.helm.release.v1.self-sovereign-
+#   cutover.v1" is invalid: data: Too long: must have at most 1048576 bytes
+#
+# Deterministic, not a race. Pillar 5 was unprovable on every future prov until
+# this landed, and no gate in the repo measured that number — the chart
+# rendered, packaged and round-tripped green all the way to a Sovereign.
+#
+# WHERE THE BYTES WERE. Helm stores the chart's TEMPLATES (base64) and the
+# RENDERED manifest, so a `#` comment in a template is paid for TWICE, while a
+# {{/* … */}} comment is stripped at render and paid for once. 43% of the
+# rendered manifest — 384,279 bytes — was `#` prose. Separately, chart/tests/
+# *.sh (527,883 bytes of CI-side test scripts, which blueprint-release.yaml runs
+# from the WORKING TREE, never from the package) shipped inside every release.
+# Chart.yaml and values.yaml are stored PARSED, so their own commentary — the
+# largest files in the tree — never cost a byte and were never the problem.
+#
+# WHAT CHANGED, AND WHAT DID NOT. 5,507 whole-line `#` comments across 22
+# templates became {{/* … */}} block comments: every word still sits at the
+# exact line a source reader is looking at, and none of it reaches the release
+# Secret. Nothing was deleted. Sixteen comment lines stayed `#` on purpose —
+# they are region anchors the chart's own tests navigate the RENDER by
+# (settled-roll-preflight BEGIN/END, Phase A4/Phase B, Phase 2c, Phase 0: ADD
+# harbor, Phase 3 strip, the Day-2 loop truncation point, the #5359 candidate
+# chain, and the #5215 CSI exclusion the tests require to be auditable in the
+# manifest); each now says so inline. tests/ moved to a new .helmignore.
+#
+# PROOF THE BEHAVIOUR IS UNCHANGED: the rendered manifest, with `#` comment
+# lines and blank lines removed, is BYTE-IDENTICAL to 0.1.177's — 507,299 bytes
+# on both sides, zero differing lines. All 16 chart/tests/*.sh pass, as they do
+# on 0.1.177.
+#
+# RESULT: 1,233,060 -> 743,780 bytes, 70.93% of the ceiling, 304,796 bytes of
+# headroom. scripts/check-helm-release-payload-size.py is the gate that now
+# measures this before publish, and it fails on 0.1.177's content (119.45%).
+# No step, value, RBAC rule or step-count change; still 11 steps.
+#
 # 0.1.173 (#5467) — STEP-09 STOPS PRINTING THE TAIL OF THE MINTED GITEA TOKEN.
 # #5467 was filed and fixed against step-03, which printed `pat=${ghcr_pat:0:8}`
 # — the first 8 characters of the GHCR PAT. The fix landed in 0.1.169. What the
@@ -3652,7 +3695,7 @@ name: bp-self-sovereign-cutover
 # pin + blueprint.yaml + catalog-seed source.version + spec.version + the API
 # blueprints.json + the generated UI catalog move to 0.1.176 in lockstep
 # (Inviolable Principle #13).
-version: 0.1.177
+version: 0.1.179
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -23,22 +23,32 @@ name: bp-self-sovereign-cutover
 # Chart.yaml and values.yaml are stored PARSED, so their own commentary — the
 # largest files in the tree — never cost a byte and were never the problem.
 #
-# WHAT CHANGED, AND WHAT DID NOT. 5,507 whole-line `#` comments across 22
-# templates became {{/* … */}} block comments: every word still sits at the
-# exact line a source reader is looking at, and none of it reaches the release
-# Secret. Nothing was deleted. Sixteen comment lines stayed `#` on purpose —
-# they are region anchors the chart's own tests navigate the RENDER by
-# (settled-roll-preflight BEGIN/END, Phase A4/Phase B, Phase 2c, Phase 0: ADD
-# harbor, Phase 3 strip, the Day-2 loop truncation point, the #5359 candidate
-# chain, and the #5215 CSI exclusion the tests require to be auditable in the
-# manifest); each now says so inline. tests/ moved to a new .helmignore.
+# WHAT CHANGED, AND WHAT DID NOT. 5,170 whole-line `#` comments across 21
+# templates became 718 Helm block comments: every word still sits at the exact
+# line a source reader is looking at, and none of it reaches the release Secret.
+# Nothing was deleted.
+#
+# Two sets of `#` comments stayed `#` ON PURPOSE, and now say so inline.
+# (a) Sixteen region anchors the chart's own tests navigate the RENDER by —
+#     settled-roll-preflight BEGIN/END, Phase A4 / Phase B, Phase 2c,
+#     "Phase 0: ADD harbor", the Phase 3 strip header whose LINE NUMBER
+#     cutover-contract Case 17b compares against the executable del(.auths[...])
+#     to prove strip-after-pivot, the Day-2 loop truncation point, the #5359
+#     candidate chain, and the #5215 CSI exclusion Case 64 requires to be
+#     auditable in the manifest rather than merely absent.
+# (b) ALL of 04-registry-pivot-daemonset.yaml. cutover_registry_pivot_mirror_
+#     test.go slices shell functions out of that template VERBATIM and runs
+#     them under /bin/sh with no Helm rendering, so a Helm comment inside a
+#     function body is a dash syntax error, not a comment. See that file's
+#     header.
+# chart/tests/*.sh left the package via a new .helmignore.
 #
 # PROOF THE BEHAVIOUR IS UNCHANGED: the rendered manifest, with `#` comment
-# lines and blank lines removed, is BYTE-IDENTICAL to 0.1.177's — 507,299 bytes
-# on both sides, zero differing lines. All 16 chart/tests/*.sh pass, as they do
-# on 0.1.177.
+# lines and blank lines removed and the helm.sh/chart version label normalised,
+# is BYTE-IDENTICAL to 0.1.177's — 507,299 bytes on both sides, zero differing
+# lines. All 16 chart/tests/*.sh pass, as they do on 0.1.177.
 #
-# RESULT: 1,233,060 -> 743,780 bytes, 70.93% of the ceiling, 304,796 bytes of
+# RESULT: 1,233,060 -> 757,264 bytes, 72.22% of the ceiling, 291,312 bytes of
 # headroom. scripts/check-helm-release-payload-size.py is the gate that now
 # measures this before publish, and it fails on 0.1.177's content (119.45%).
 # No step, value, RBAC rule or step-count change; still 11 steps.

--- a/platform/self-sovereign-cutover/chart/templates/00-gitea-admin-secret-bridge-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/00-gitea-admin-secret-bridge-job.yaml
@@ -84,8 +84,10 @@ metadata:
     {{- include "bp-self-sovereign-cutover.labels" . | nindent 4 }}
     catalyst.openova.io/component: gitea-admin-secret-bridge
 ---
-# Same-namespace Role: create (NO resourceNames per RBAC authz) + get/patch
-# (name-scoped) on Secrets, so the Job can write the destination Secret.
+{{- /*
+ Same-namespace Role: create (NO resourceNames per RBAC authz) + get/patch
+ (name-scoped) on Secrets, so the Job can write the destination Secret.
+*/}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -120,8 +122,10 @@ subjects:
     name: {{ $saName }}
     namespace: {{ $destNs }}
 ---
-# Source-namespace Role: get on Secrets scoped via resourceNames to ONLY
-# `gitea-admin-secret` — the Job cannot read any other Secret in `gitea`.
+{{- /*
+ Source-namespace Role: get on Secrets scoped via resourceNames to ONLY
+ `gitea-admin-secret` — the Job cannot read any other Secret in `gitea`.
+*/}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -181,16 +185,20 @@ spec:
           type: RuntimeDefault
       containers:
         - name: gitea-secret-bridge
-          # alpine/k8s is the canonical kubectl image already used by every
-          # other cutover step Job (images.kubectl). cutoverPhase: pre — this
-          # Job runs at install time, long before the step-04 registry pivot,
-          # so it must pull from the bootstrap-configured proxy host, not the
-          # post-pivot local-Harbor global.imageRegistry.
+          {{- /*
+           alpine/k8s is the canonical kubectl image already used by every
+           other cutover step Job (images.kubectl). cutoverPhase: pre — this
+           Job runs at install time, long before the step-04 registry pivot,
+           so it must pull from the bootstrap-configured proxy host, not the
+           post-pivot local-Harbor global.imageRegistry.
+          */}}
           image: {{ include "bp-self-sovereign-cutover.image" (dict "repository" .Values.images.kubectl.repository "tag" .Values.images.kubectl.tag "cutoverPhase" "pre" "Values" .Values) }}
           imagePullPolicy: IfNotPresent
           env:
-            # kubectl writes its discovery/http cache under $HOME/.kube — point
-            # HOME at the writable emptyDir since readOnlyRootFilesystem:true.
+            {{- /*
+             kubectl writes its discovery/http cache under $HOME/.kube — point
+             HOME at the writable emptyDir since readOnlyRootFilesystem:true.
+            */}}
             - name: HOME
               value: /tmp
             - name: SRC_NAMESPACE
@@ -214,24 +222,28 @@ spec:
               echo "[gitea-secret-bridge] dest   = ${DEST_NAMESPACE}/${DEST_SECRET_NAME}"
               echo "[gitea-secret-bridge] poll   = ${POLL_INTERVAL_SECONDS}s x ${POLL_MAX_ATTEMPTS} attempts"
 
-              # ── 1. Fast path — destination already carries a usable secret ──
-              # If the render-time lookup bridge (00-gitea-admin-secret-bridge
-              # .yaml) already emitted the secret (gitea was up at render
-              # time), this Job is a no-op. We still RE-COPY below if the source
-              # is present, so a Gitea admin-password rotation propagates — but
-              # if the source is not yet up AND the dest already exists we exit
-              # 0 immediately rather than burning the poll budget.
+              {{- /*
+               ── 1. Fast path — destination already carries a usable secret ──
+               If the render-time lookup bridge (00-gitea-admin-secret-bridge
+               .yaml) already emitted the secret (gitea was up at render
+               time), this Job is a no-op. We still RE-COPY below if the source
+               is present, so a Gitea admin-password rotation propagates — but
+               if the source is not yet up AND the dest already exists we exit
+               0 immediately rather than burning the poll budget.
+              */}}
               dest_present="false"
               if kubectl -n "${DEST_NAMESPACE}" get secret "${DEST_SECRET_NAME}" >/dev/null 2>&1; then
                 dest_present="true"
                 echo "[gitea-secret-bridge] destination secret already present (render-time bridge or prior run)"
               fi
 
-              # ── 2. Wait at RUNTIME for the source secret to materialise ─────
-              # This is the whole point: bp-gitea (slot ~14) converges AFTER
-              # this chart (slot 06a), so on a fresh prov the source is absent
-              # at install. Poll until it appears (event-driven), bounded by the
-              # values-overridable budget.
+              {{- /*
+               ── 2. Wait at RUNTIME for the source secret to materialise ─────
+               This is the whole point: bp-gitea (slot ~14) converges AFTER
+               this chart (slot 06a), so on a fresh prov the source is absent
+               at install. Poll until it appears (event-driven), bounded by the
+               values-overridable budget.
+              */}}
               attempt=0
               src_ready="false"
               while [ "${attempt}" -lt "${POLL_MAX_ATTEMPTS}" ]; do
@@ -254,15 +266,17 @@ spec:
                 exit 1
               fi
 
-              # ── 3. Copy source → destination (stream in-pod, never echo) ────
-              # kubectl get -o json of the source, jq-rewrite metadata (strip
-              # the source-bound resourceVersion / uid / managedFields /
-              # creationTimestamp / ownerReferences, re-target the namespace +
-              # name, stamp provenance annotations + labels), then apply into
-              # the destination. The .data (base64 password bytes) flows
-              # kubectl→jq→kubectl and is NEVER printed. `kubectl apply`
-              # create-or-updates, so a password rotation on the source
-              # propagates on a re-run.
+              {{- /*
+               ── 3. Copy source → destination (stream in-pod, never echo) ────
+               kubectl get -o json of the source, jq-rewrite metadata (strip
+               the source-bound resourceVersion / uid / managedFields /
+               creationTimestamp / ownerReferences, re-target the namespace +
+               name, stamp provenance annotations + labels), then apply into
+               the destination. The .data (base64 password bytes) flows
+               kubectl→jq→kubectl and is NEVER printed. `kubectl apply`
+               create-or-updates, so a password rotation on the source
+               propagates on a re-run.
+              */}}
               echo "[gitea-secret-bridge] copying ${SRC_NAMESPACE}/${SRC_SECRET_NAME} -> ${DEST_NAMESPACE}/${DEST_SECRET_NAME}"
               kubectl -n "${SRC_NAMESPACE}" get secret "${SRC_SECRET_NAME}" -o json \
                 | jq \
@@ -288,7 +302,7 @@ spec:
                       data: (.data // {})}' \
                 | kubectl -n "${DEST_NAMESPACE}" apply -f - >/dev/null
 
-              # ── 4. Verify the destination now exists with the password key ──
+              {{- /* ── 4. Verify the destination now exists with the password key ── */}}
               if ! kubectl -n "${DEST_NAMESPACE}" get secret "${DEST_SECRET_NAME}" \
                    -o jsonpath='{.data.password}' 2>/dev/null | grep -q .; then
                 echo "[gitea-secret-bridge] FATAL: destination secret missing the password key after copy" >&2

--- a/platform/self-sovereign-cutover/chart/templates/00-gitea-admin-secret-bridge.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/00-gitea-admin-secret-bridge.yaml
@@ -85,23 +85,31 @@ metadata:
     catalyst.openova.io/blueprint: bp-self-sovereign-cutover
     catalyst.openova.io/component: gitea-admin-secret-bridge
     app.kubernetes.io/part-of: catalyst
-    # Required by the kyverno `flux-managed` Enforce policy if the release ns
-    # is not namespace-excluded — the bridged Secret is helm/Flux-owned.
+    {{- /*
+     Required by the kyverno `flux-managed` Enforce policy if the release ns
+     is not namespace-excluded — the bridged Secret is helm/Flux-owned.
+    */}}
     app.kubernetes.io/managed-by: flux
   annotations:
-    # Provenance for ops: makes it obvious this is the #4557 cutover-ns bridge
-    # of the host gitea-admin-secret, not a stray hand-rolled credential.
+    {{- /*
+     Provenance for ops: makes it obvious this is the #4557 cutover-ns bridge
+     of the host gitea-admin-secret, not a stray hand-rolled credential.
+    */}}
     catalyst.openova.io/mirrored-from: {{ printf "%s/%s" $srcNs $srcName | quote }}
     catalyst.openova.io/bridge: "gitea-admin-secret-cutover-ns-bridge-4557"
-    # Survive helm uninstall so the bridged Secret outlives the release; it is
-    # re-emitted verbatim from the live source on every reconcile (source-wins),
-    # so a vCluster/gitea admin-password rotation propagates on the next tick.
+    {{- /*
+     Survive helm uninstall so the bridged Secret outlives the release; it is
+     re-emitted verbatim from the live source on every reconcile (source-wins),
+     so a vCluster/gitea admin-password rotation propagates on the next tick.
+    */}}
     helm.sh/resource-policy: keep
 type: Opaque
 data:
-  # Verbatim copy of the host admin credential. username is `gitea_admin`;
-  # password is the gitea chart's randAlphaNum-32 (never echoed). Both keys
-  # match the cutover step Jobs' secretKeyRef usernameKey/passwordKey.
+  {{- /*
+   Verbatim copy of the host admin credential. username is `gitea_admin`;
+   password is the gitea chart's randAlphaNum-32 (never echoed). Both keys
+   match the cutover step Jobs' secretKeyRef usernameKey/passwordKey.
+  */}}
   {{ $userKey }}: {{ index $src.data $userKey | quote }}
   {{ $passKey }}: {{ index $src.data $passKey | quote }}
 {{- end }}

--- a/platform/self-sovereign-cutover/chart/templates/00-mgmt-isolation-carveout.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/00-mgmt-isolation-carveout.yaml
@@ -70,18 +70,22 @@ metadata:
   labels:
     {{- include "bp-self-sovereign-cutover.labels" $ | nindent 4 }}
 spec:
-  # podSelector {} = all pods in the plane namespace (the same scope the
-  # plane's own default-deny policy selects). This policy ONLY adds an
-  # ingress allow; it declares no Egress policyType, so it never constrains
-  # plane egress.
+  {{- /*
+   podSelector {} = all pods in the plane namespace (the same scope the
+   plane's own default-deny policy selects). This policy ONLY adds an
+   ingress allow; it declares no Egress policyType, so it never constrains
+   plane egress.
+  */}}
   podSelector: {}
   policyTypes:
     - Ingress
   ingress:
-    # Allow ingress from the cutover Job namespace (this chart's release
-    # namespace — the `catalyst` ns where catalyst-api stamps the step
-    # Jobs). Matches the kubernetes.io/metadata.name label the control
-    # plane auto-stamps on every namespace (since K8s 1.21).
+    {{- /*
+     Allow ingress from the cutover Job namespace (this chart's release
+     namespace — the `catalyst` ns where catalyst-api stamps the step
+     Jobs). Matches the kubernetes.io/metadata.name label the control
+     plane auto-stamps on every namespace (since K8s 1.21).
+    */}}
     - from:
         - namespaceSelector:
             matchLabels:

--- a/platform/self-sovereign-cutover/chart/templates/01-gitea-mirror-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/01-gitea-mirror-job.yaml
@@ -36,12 +36,14 @@ data:
     activeDeadlineSeconds: {{ .Values.stepTimeouts.giteaMirrorSeconds }}
     containers:
       - name: gitea-mirror
-        # #3584 — image is now the alpine/k8s (images.kubectl) image, NOT
-        # alpine/git. We need `kubectl` to read the cross-namespace
-        # `catalyst-gitea-token` PAT from catalyst-system (same as step-05
-        # #3536) + `curl` for token-auth API calls; alpine/k8s bundles
-        # kubectl + curl + git (steps 05/06/07/09/10 already git clone/push
-        # from this image). The git clone/push below is unchanged.
+        {{- /*
+         #3584 — image is now the alpine/k8s (images.kubectl) image, NOT
+         alpine/git. We need `kubectl` to read the cross-namespace
+         `catalyst-gitea-token` PAT from catalyst-system (same as step-05
+         #3536) + `curl` for token-auth API calls; alpine/k8s bundles
+         kubectl + curl + git (steps 05/06/07/09/10 already git clone/push
+         from this image). The git clone/push below is unchanged.
+        */}}
         image: {{ include "bp-self-sovereign-cutover.image" (dict "repository" .Values.images.kubectl.repository "tag" .Values.images.kubectl.tag "cutoverPhase" "pre" "Values" .Values) }}
         imagePullPolicy: IfNotPresent
         env:
@@ -57,22 +59,26 @@ data:
             value: {{ .Values.gitea.repo | quote }}
           - name: MIRROR_INTERVAL
             value: {{ .Values.upstream.mirrorInterval | quote }}
-          # #3584 — Gitea git-push username. A Gitea PAT is accepted as the
-          # HTTP git password under ANY existing username; we use the admin
-          # login (`gitea_admin`) for auditability. The git push embeds
-          # ${GITEA_USERNAME}:${GITEA_PAT}@ in the URL.
+          {{- /*
+           #3584 — Gitea git-push username. A Gitea PAT is accepted as the
+           HTTP git password under ANY existing username; we use the admin
+           login (`gitea_admin`) for auditability. The git push embeds
+           ${GITEA_USERNAME}:${GITEA_PAT}@ in the URL.
+          */}}
           - name: GITEA_USERNAME
             value: {{ .Values.gitRepositorySecretRef.username | quote }}
-          # #3584 — PAT source coordinates (reuses the step-05 #3536 values
-          # block). The `catalyst-gitea-token` PAT is minted at BOOTSTRAP by
-          # bp-catalyst-platform's pre-install hook in catalyst-system. We
-          # read it cross-namespace here. WHY token auth (not the admin
-          # password): bp-gitea configures an `openova-sso` OAuth2 login
-          # source; Gitea's apiAuth consults that EXTERNAL source when
-          # validating a BasicAuth PASSWORD, so during the cutover window
-          # (Keycloak still converging) every BasicAuth API call hangs
-          # ~130s then 401s (v1/api.go:748). A PAT is a direct local sha1
-          # lookup that never touches the external source → fast + immune.
+          {{- /*
+           #3584 — PAT source coordinates (reuses the step-05 #3536 values
+           block). The `catalyst-gitea-token` PAT is minted at BOOTSTRAP by
+           bp-catalyst-platform's pre-install hook in catalyst-system. We
+           read it cross-namespace here. WHY token auth (not the admin
+           password): bp-gitea configures an `openova-sso` OAuth2 login
+           source; Gitea's apiAuth consults that EXTERNAL source when
+           validating a BasicAuth PASSWORD, so during the cutover window
+           (Keycloak still converging) every BasicAuth API call hangs
+           ~130s then 401s (v1/api.go:748). A PAT is a direct local sha1
+           lookup that never touches the external source → fast + immune.
+          */}}
           - name: PAT_SOURCE_NAMESPACE
             value: {{ .Values.gitRepositorySecretRef.patSourceNamespace | quote }}
           - name: PAT_SOURCE_SECRET_NAME
@@ -83,33 +89,37 @@ data:
         args:
           - |
             set -eu
-            # Credential hygiene: never echo $GITEA_PAT. We feed it to git
-            # via URL embedding only inside the redirected http call below;
-            # stdout shows just the redacted form. The HTTP API calls use
-            # an `Authorization: token <PAT>` header (#3584 — was BasicAuth,
-            # which hangs ~130s then 401s because Gitea's apiAuth consults
-            # the external openova-sso OAuth2 source for password creds).
+            {{- /*
+             Credential hygiene: never echo $GITEA_PAT. We feed it to git
+             via URL embedding only inside the redirected http call below;
+             stdout shows just the redacted form. The HTTP API calls use
+             an `Authorization: token <PAT>` header (#3584 — was BasicAuth,
+             which hangs ~130s then 401s because Gitea's apiAuth consults
+             the external openova-sso OAuth2 source for password creds).
+            */}}
             redacted_url="${GITEA_INTERNAL_URL}/${GITEA_ORG}/${GITEA_REPO}.git"
             echo "[gitea-mirror] upstream=${UPSTREAM_REPO_URL} branch=${UPSTREAM_BRANCH}"
             echo "[gitea-mirror] target=${redacted_url}"
             echo "[gitea-mirror] mirror_interval=${MIRROR_INTERVAL}"
 
-            # #968 — DNS-readiness probe for gitea-http.
-            #
-            # The cutover auto-trigger fires within seconds of bp-self-
-            # sovereign-cutover Helm-install completing. On a fresh
-            # Sovereign the gitea Pod can still be moving from Running
-            # to Ready, in which case the headless service `gitea-http`
-            # has no DNS record published yet. Without this probe the
-            # very first wget call returns `bad address` and the Job
-            # exits non-zero. catalyst-api's cutover engine treats that
-            # as a hard failure (per cutover.go #968 backoffLimit was
-            # raised to 3, but local resolve here is cheaper and faster
-            # than burning Pod-restart budget). On otech115 2026-05-05
-            # this race fired Step-01 at +8s after gitea reached Ready
-            # and DNS hadn't propagated; one nslookup wait of ~10s would
-            # have been sufficient. Loop budget = 30 × 5s = 150s, well
-            # under the step's activeDeadlineSeconds.
+            {{- /*
+             #968 — DNS-readiness probe for gitea-http.
+
+             The cutover auto-trigger fires within seconds of bp-self-
+             sovereign-cutover Helm-install completing. On a fresh
+             Sovereign the gitea Pod can still be moving from Running
+             to Ready, in which case the headless service `gitea-http`
+             has no DNS record published yet. Without this probe the
+             very first wget call returns `bad address` and the Job
+             exits non-zero. catalyst-api's cutover engine treats that
+             as a hard failure (per cutover.go #968 backoffLimit was
+             raised to 3, but local resolve here is cheaper and faster
+             than burning Pod-restart budget). On otech115 2026-05-05
+             this race fired Step-01 at +8s after gitea reached Ready
+             and DNS hadn't propagated; one nslookup wait of ~10s would
+             have been sufficient. Loop budget = 30 × 5s = 150s, well
+             under the step's activeDeadlineSeconds.
+            */}}
             gitea_host="$(printf '%s' "${GITEA_INTERNAL_URL}" | sed -E 's|^https?://||' | cut -d: -f1 | cut -d/ -f1)"
             if [ -n "${gitea_host}" ]; then
               echo "[gitea-mirror] waiting for DNS resolution of ${gitea_host}"
@@ -128,16 +138,18 @@ data:
               fi
             fi
 
-            # #3584 — read the `catalyst-gitea-token` PAT (minted at BOOTSTRAP
-            # by bp-catalyst-platform in ${PAT_SOURCE_NAMESPACE}). All Gitea
-            # API calls below send `Authorization: token ${GITEA_PAT}`; the
-            # git push embeds ${GITEA_USERNAME}:${GITEA_PAT}@ in the URL. This
-            # replaces the admin-password BasicAuth that hung ~130s then 401s
-            # during the cutover window (Keycloak still converging — apiAuth
-            # consults the external openova-sso OAuth2 source for password
-            # creds; token auth is a direct local sha1 lookup, immune).
-            # Bounded wait: the PAT Secret exists from bootstrap but its
-            # `token` byte may be momentarily empty if the minter is mid-flight.
+            {{- /*
+             #3584 — read the `catalyst-gitea-token` PAT (minted at BOOTSTRAP
+             by bp-catalyst-platform in ${PAT_SOURCE_NAMESPACE}). All Gitea
+             API calls below send `Authorization: token ${GITEA_PAT}`; the
+             git push embeds ${GITEA_USERNAME}:${GITEA_PAT}@ in the URL. This
+             replaces the admin-password BasicAuth that hung ~130s then 401s
+             during the cutover window (Keycloak still converging — apiAuth
+             consults the external openova-sso OAuth2 source for password
+             creds; token auth is a direct local sha1 lookup, immune).
+             Bounded wait: the PAT Secret exists from bootstrap but its
+             `token` byte may be momentarily empty if the minter is mid-flight.
+            */}}
             echo "[gitea-mirror] reading PAT ${PAT_SOURCE_NAMESPACE}/${PAT_SOURCE_SECRET_NAME}.${PAT_SOURCE_KEY}"
             GITEA_PAT=""
             for i in $(seq 1 30); do
@@ -155,12 +167,14 @@ data:
               exit 1
             fi
 
-            # 1. Ensure the org exists in Gitea (idempotent — POST /orgs
-            #    returns 422 if a same-named user exists, 422 if org
-            #    exists, 201 on create). We swallow non-201 because the
-            #    "already exists" surface is the steady-state path. curl -f
-            #    makes the existence GET return non-zero on any 4xx so the
-            #    "missing" branch fires only when the org truly absent.
+            {{- /*
+             1. Ensure the org exists in Gitea (idempotent — POST /orgs
+                returns 422 if a same-named user exists, 422 if org
+                exists, 201 on create). We swallow non-201 because the
+                "already exists" surface is the steady-state path. curl -f
+                makes the existence GET return non-zero on any 4xx so the
+                "missing" branch fires only when the org truly absent.
+            */}}
             api_url="${GITEA_INTERNAL_URL}/api/v1"
             if curl -fsS -o /dev/null \
               -H "Authorization: token ${GITEA_PAT}" \
@@ -177,22 +191,24 @@ data:
                 "${api_url}/orgs" 2>/dev/null || true
             fi
 
-            # 2. Ensure the repo exists in Gitea as a REGULAR (non-mirror)
-            #    repository, then bare-clone upstream and push so the
-            #    local Gitea has the same content. This replaces the
-            #    earlier `/repos/migrate {mirror:true}` approach (PR
-            #    #970) — Gitea pull-mirrors are read-only and block the
-            #    cutover step-06 push that pivots HelmRepository URLs
-            #    to local Harbor (see PR #1029, otech125 incident).
-            #    Gitea 1.22 does not support converting a pull-mirror
-            #    to standalone via API (only `mirror_interval: "0s"`
-            #    silently no-ops, leaving `mirror: true` set, which
-            #    keeps the repo read-only). The architecturally correct
-            #    behaviour at cutover IS to stop tracking upstream — the
-            #    Sovereign is going self-hosted from this point on. If
-            #    operator wants a chart rollout post-cutover they
-            #    re-run this Job (idempotent: rebases local main on
-            #    upstream main and force-pushes any new commits).
+            {{- /*
+             2. Ensure the repo exists in Gitea as a REGULAR (non-mirror)
+                repository, then bare-clone upstream and push so the
+                local Gitea has the same content. This replaces the
+                earlier `/repos/migrate {mirror:true}` approach (PR
+                #970) — Gitea pull-mirrors are read-only and block the
+                cutover step-06 push that pivots HelmRepository URLs
+                to local Harbor (see PR #1029, otech125 incident).
+                Gitea 1.22 does not support converting a pull-mirror
+                to standalone via API (only `mirror_interval: "0s"`
+                silently no-ops, leaving `mirror: true` set, which
+                keeps the repo read-only). The architecturally correct
+                behaviour at cutover IS to stop tracking upstream — the
+                Sovereign is going self-hosted from this point on. If
+                operator wants a chart rollout post-cutover they
+                re-run this Job (idempotent: rebases local main on
+                upstream main and force-pushes any new commits).
+            */}}
             if curl -fsS -o /dev/null \
               -H "Authorization: token ${GITEA_PAT}" \
               -H "Accept: application/json" \
@@ -218,19 +234,21 @@ data:
               echo "[gitea-mirror] empty repo created"
             fi
 
-            # 3. Bare-clone upstream and push to local Gitea via EXPLICIT
-            #    refspecs — refs/heads/* + refs/tags/* — NEVER mirror mode
-            #    (#5011). Mirror mode makes the remote EXACTLY match the
-            #    clone, DELETING refs absent upstream; on hw242 (2026-07-12,
-            #    dep f05b0718dac62fe9) it pruned the sovereign-LOCAL branches
-            #    `catalog-sovereign` (catalyst-api catalog seed) and
-            #    `org-tenants` (org-controller per-Org GitOps tree) — both
-            #    exist ONLY in the local Gitea, never on GitHub — breaking
-            #    the flux GitRepositories openova-catalog-sovereign +
-            #    openova-org-tenants mid-cutover. The explicit refspecs
-            #    force-update/create every GitHub-derived branch + tag
-            #    (--force keeps re-runs idempotent even after an upstream
-            #    history rewrite) but never touch remote-only refs.
+            {{- /*
+             3. Bare-clone upstream and push to local Gitea via EXPLICIT
+                refspecs — refs/heads/* + refs/tags/* — NEVER mirror mode
+                (#5011). Mirror mode makes the remote EXACTLY match the
+                clone, DELETING refs absent upstream; on hw242 (2026-07-12,
+                dep f05b0718dac62fe9) it pruned the sovereign-LOCAL branches
+                `catalog-sovereign` (catalyst-api catalog seed) and
+                `org-tenants` (org-controller per-Org GitOps tree) — both
+                exist ONLY in the local Gitea, never on GitHub — breaking
+                the flux GitRepositories openova-catalog-sovereign +
+                openova-org-tenants mid-cutover. The explicit refspecs
+                force-update/create every GitHub-derived branch + tag
+                (--force keeps re-runs idempotent even after an upstream
+                history rewrite) but never touch remote-only refs.
+            */}}
             export HOME=/tmp
             git config --global user.name "self-sovereign-cutover"
             git config --global user.email "cutover@${gitea_host}"
@@ -245,16 +263,20 @@ data:
             echo "[gitea-mirror] pushing upstream branches + tags (explicit refspecs, never prunes sovereign-local refs) to ${redacted_url}"
             push_err=$(git push --force "${local_url}" 'refs/heads/*:refs/heads/*' 'refs/tags/*:refs/tags/*' 2>&1) || {
               echo "[gitea-mirror] FATAL: git push to local Gitea failed" >&2
-              # Surface git stderr WITHOUT the embedded credential — git
-              # redacts URLs in error messages by default but be defensive.
+              {{- /*
+               Surface git stderr WITHOUT the embedded credential — git
+               redacts URLs in error messages by default but be defensive.
+              */}}
               printf '%s\n' "${push_err}" | sed -E "s,${GITEA_PAT}+,REDACTED,g" >&2
               exit 1
             }
             echo "[gitea-mirror] pushed all upstream branches + tags successfully (sovereign-local refs untouched)"
 
-            # 4. Verify by reading back the default branch SHA and
-            #    confirming non-empty (auto_init=false means a missing
-            #    push leaves the repo "empty: true").
+            {{- /*
+             4. Verify by reading back the default branch SHA and
+                confirming non-empty (auto_init=false means a missing
+                push leaves the repo "empty: true").
+            */}}
             repo_meta=$(curl -fsS \
               -H "Authorization: token ${GITEA_PAT}" \
               -H "Accept: application/json" \
@@ -268,36 +290,38 @@ data:
               echo "[gitea-mirror] verified: mirror=false on ${GITEA_ORG}/${GITEA_REPO} (writable for cutover step-06)"
             fi
 
-            # G75 #2622 (2026-05-31): SEVER UPSTREAM GIT TETHER (ADR-0002
-            # Pillar 5 contract). gitea-mirror-resync CronJob runs every
-            # 5min doing a mirror-mode force-push from upstream → local
-            # Gitea, which CLOBBERS cutover Step 06+07 pushes. G62
-            # "Gitea persist" pattern has been a no-op architecturally
-            # because of this tether — Step 06+07 pushes survive ~5min
-            # then get force-overwritten. Verified live hw86
-            # afc8800bc03751c6 2026-05-31: Step 06 pushed HelmRepository
-            # URL pivot 11:34, mirror-resync fired 11:45 wiped it, Step
-            # 08 fired 12:00 saw HRs still at ghcr.io → FAILED.
-            #
-            # B' shape (per lead): IaC removal (HR values flag) + live
-            # DELETE + post-verify wait window. Suspend would be a
-            # workaround per Principle 14 — severance must be irreversible.
-            #
-            # Order: HR patch FIRST (so Flux re-reconcile doesn't recreate
-            # after live delete), THEN live delete, THEN post-verify
-            # waits ≥1 mirror-resync interval to confirm the tether stays
-            # severed.
-            # G75 #3606 fast-path: with mirrorResync.enabled defaulting to
-            # false (values.yaml), template 11-mirror-resync-cronjob.yaml
-            # renders NOTHING — the gitea-mirror-resync CronJob never exists
-            # on a default Sovereign, so the tether is already severed at the
-            # IaC (git) layer. The old imperative `kubectl patch hr ...
-            # mirrorResync.enabled=false` was the #3606 bug: Flux owns this
-            # HR from git and REVERTED the patch every reconcile, re-rendering
-            # the CronJob → this 6-min post-verify FATAL'd → step-01 looped.
-            # We no longer patch the HR. We only DELETE + post-verify a
-            # rendered remnant when one actually exists (an operator overlay
-            # may have opted IN to mirrorResync pre-cutover).
+            {{- /*
+             G75 #2622 (2026-05-31): SEVER UPSTREAM GIT TETHER (ADR-0002
+             Pillar 5 contract). gitea-mirror-resync CronJob runs every
+             5min doing a mirror-mode force-push from upstream → local
+             Gitea, which CLOBBERS cutover Step 06+07 pushes. G62
+             "Gitea persist" pattern has been a no-op architecturally
+             because of this tether — Step 06+07 pushes survive ~5min
+             then get force-overwritten. Verified live hw86
+             afc8800bc03751c6 2026-05-31: Step 06 pushed HelmRepository
+             URL pivot 11:34, mirror-resync fired 11:45 wiped it, Step
+             08 fired 12:00 saw HRs still at ghcr.io → FAILED.
+
+             B' shape (per lead): IaC removal (HR values flag) + live
+             DELETE + post-verify wait window. Suspend would be a
+             workaround per Principle 14 — severance must be irreversible.
+
+             Order: HR patch FIRST (so Flux re-reconcile doesn't recreate
+             after live delete), THEN live delete, THEN post-verify
+             waits ≥1 mirror-resync interval to confirm the tether stays
+             severed.
+             G75 #3606 fast-path: with mirrorResync.enabled defaulting to
+             false (values.yaml), template 11-mirror-resync-cronjob.yaml
+             renders NOTHING — the gitea-mirror-resync CronJob never exists
+             on a default Sovereign, so the tether is already severed at the
+             IaC (git) layer. The old imperative `kubectl patch hr ...
+             mirrorResync.enabled=false` was the #3606 bug: Flux owns this
+             HR from git and REVERTED the patch every reconcile, re-rendering
+             the CronJob → this 6-min post-verify FATAL'd → step-01 looped.
+             We no longer patch the HR. We only DELETE + post-verify a
+             rendered remnant when one actually exists (an operator overlay
+             may have opted IN to mirrorResync pre-cutover).
+            */}}
             if ! kubectl get cronjob -n {{ .Release.Namespace }} gitea-mirror-resync >/dev/null 2>&1; then
               echo "[gitea-mirror] G75 OK: mirror-resync already severed at IaC layer (mirrorResync.enabled=false default) — skipping live-delete + post-verify hold"
             else
@@ -310,8 +334,10 @@ data:
               kubectl delete cronjob -n {{ .Release.Namespace }} gitea-mirror-resync --ignore-not-found=true 2>&1 || \
                 echo "[gitea-mirror] G75 WARN: cronjob delete failed (RBAC?)"
 
-              # Post-verify: wait 6min (>1 mirror-resync interval) + confirm
-              # CronJob still absent + confirm local Gitea HEAD unchanged.
+              {{- /*
+               Post-verify: wait 6min (>1 mirror-resync interval) + confirm
+               CronJob still absent + confirm local Gitea HEAD unchanged.
+              */}}
               CRONJOB_NS={{ .Release.Namespace }}
               for i in $(seq 1 6); do
                 sleep 60

--- a/platform/self-sovereign-cutover/chart/templates/02-harbor-projects-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/02-harbor-projects-job.yaml
@@ -31,30 +31,32 @@ data:
         image: {{ include "bp-self-sovereign-cutover.image" (dict "repository" .Values.images.curl.repository "tag" .Values.images.curl.tag "cutoverPhase" "pre" "Values" .Values) }}
         imagePullPolicy: IfNotPresent
         env:
-          # #5036 (Refs #5007; reverts #4688) — the Harbor CONTROL-PLANE API
-          # (registry + project creation) is dialed via the IN-CLUSTER Service
-          # harbor-core.harbor.svc.cluster.local (HARBOR_INTERNAL_URL), NOT the
-          # external host registry.<fqdn>. step-02 runs PRE-pivot, BEFORE step-04
-          # pins registry.<fqdn> in the node /etc/hosts. The external host resolves
-          # in-cluster ONLY if the Sovereign's split-horizon PowerDNS authoritatively
-          # serves a registry.<fqdn> record — NOT guaranteed pre-pivot: on hw246
-          # (dep c38c437f, omani.works) the powerdns-zone-bootstrap flaked
-          # ("Failed to connect to powerdns port 8081"), leaving the zone with only
-          # NS+SOA and no registry.<fqdn> → the harbor-projects Job NXDOMAIN'd with
-          # curl exit 6 on the FIRST /registries POST (4 retry Pods identical). The
-          # in-cluster Service ALWAYS resolves via the CoreDNS kubernetes plugin,
-          # independent of PowerDNS zone state AND the step-04 pin, and
-          # 00-mgmt-isolation-carveout already opens the catalyst -> harbor-core.harbor.svc
-          # path (step-01 gitea dials gitea-http.gitea.svc the same way). #4688's
-          # "DMZ/RTZ multi-cluster segregation" premise does not hold post-#4325
-          # de-vcluster: harbor + catalyst are co-located host namespaces in ONE
-          # cluster (verified live hw246: a Pod in the catalyst ns curls
-          # http://harbor-core.harbor.svc.cluster.local/api/v2.0/ping → HTTP 200).
-          # The external registry.<fqdn> host stays the target of step-04 (containerd)
-          # + step-06 (Flux) — those resolve via node /etc/hosts + public DNS.
+          {{- /*
+           #5036 (Refs #5007; reverts #4688) — the Harbor CONTROL-PLANE API
+           (registry + project creation) is dialed via the IN-CLUSTER Service
+           harbor-core.harbor.svc.cluster.local (HARBOR_INTERNAL_URL), NOT the
+           external host registry.<fqdn>. step-02 runs PRE-pivot, BEFORE step-04
+           pins registry.<fqdn> in the node /etc/hosts. The external host resolves
+           in-cluster ONLY if the Sovereign's split-horizon PowerDNS authoritatively
+           serves a registry.<fqdn> record — NOT guaranteed pre-pivot: on hw246
+           (dep c38c437f, omani.works) the powerdns-zone-bootstrap flaked
+           ("Failed to connect to powerdns port 8081"), leaving the zone with only
+           NS+SOA and no registry.<fqdn> → the harbor-projects Job NXDOMAIN'd with
+           curl exit 6 on the FIRST /registries POST (4 retry Pods identical). The
+           in-cluster Service ALWAYS resolves via the CoreDNS kubernetes plugin,
+           independent of PowerDNS zone state AND the step-04 pin, and
+           00-mgmt-isolation-carveout already opens the catalyst -> harbor-core.harbor.svc
+           path (step-01 gitea dials gitea-http.gitea.svc the same way). #4688's
+           "DMZ/RTZ multi-cluster segregation" premise does not hold post-#4325
+           de-vcluster: harbor + catalyst are co-located host namespaces in ONE
+           cluster (verified live hw246: a Pod in the catalyst ns curls
+           http://harbor-core.harbor.svc.cluster.local/api/v2.0/ping → HTTP 200).
+           The external registry.<fqdn> host stays the target of step-04 (containerd)
+           + step-06 (Flux) — those resolve via node /etc/hosts + public DNS.
+          */}}
           - name: HARBOR_INTERNAL_URL
             value: {{ .Values.sovereign.harborInternalURL | quote }}
-          # Retained for reference; step-02 now dials HARBOR_INTERNAL_URL above.
+          {{- /* Retained for reference; step-02 now dials HARBOR_INTERNAL_URL above. */}}
           - name: HARBOR_PUBLIC_URL
             value: {{ .Values.sovereign.harborPublicURL | quote }}
           - name: HARBOR_USERNAME
@@ -84,7 +86,7 @@ data:
             : "${HARBOR_USERNAME:=admin}"
             base="${HARBOR_INTERNAL_URL}/api/v2.0"  # #5036 in-cluster Harbor Service — always CoreDNS-resolvable pre-pivot (external registry.<fqdn> NXDOMAIN'd on hw246 before the step-04 pin)
 
-            # 1. Decode GHCR creds (used by proxy-ghcr registry, authMode=credential).
+            {{- /* 1. Decode GHCR creds (used by proxy-ghcr registry, authMode=credential). */}}
             if [ -n "${GHCR_DOCKERCONFIG:-}" ]; then
               dc_decoded=$(printf '%s' "${GHCR_DOCKERCONFIG}" | base64 -d 2>/dev/null || printf '%s' "${GHCR_DOCKERCONFIG}")
               auth_b64=$(printf '%s' "${dc_decoded}" | tr -d ' \n\r\t' | awk -F'"auth":"' '{print $2}' | awk -F'"' '{print $1}')
@@ -95,7 +97,7 @@ data:
               ghcr_pass=""
             fi
 
-            # 2. Iterate the proxy-projects spec from the mounted ConfigMap.
+            {{- /* 2. Iterate the proxy-projects spec from the mounted ConfigMap. */}}
             proj_file=/work/proxyProjects.json
             entries=$(awk 'BEGIN{RS="{"; FS="\""} /name/{name=""; up=""; rt=""; am="";
               for(i=1;i<=NF;i++){
@@ -142,15 +144,17 @@ data:
 
             echo "[harbor-projects] all proxy-cache projects ensured"
 
-            # G66 #2615 (2026-05-31): create push-mode projects (no
-            # registry_id) for native-pushed images. Step 03 Phase A
-            # skopeo-pushes openova-io application images into the
-            # `openova-io` project at registry.<sov>/openova-io/...
-            # — Harbor requires the project to exist before push.
-            # Push-mode projects are SEPARATE from proxy-cache projects:
-            # no registry_id field; public=false (private by default;
-            # operators with harbor admin auth push, anonymous pull
-            # gated by Sovereign HTTPRoute auth + Kyverno glob).
+            {{- /*
+             G66 #2615 (2026-05-31): create push-mode projects (no
+             registry_id) for native-pushed images. Step 03 Phase A
+             skopeo-pushes openova-io application images into the
+             `openova-io` project at registry.<sov>/openova-io/...
+             — Harbor requires the project to exist before push.
+             Push-mode projects are SEPARATE from proxy-cache projects:
+             no registry_id field; public=false (private by default;
+             operators with harbor admin auth push, anonymous pull
+             gated by Sovereign HTTPRoute auth + Kyverno glob).
+            */}}
             for push_proj in {{ join " " .Values.harbor.pushProjects }}; do
               echo "[harbor-projects] ensuring push-mode project ${push_proj}"
               proj_payload="{\"project_name\":\"${push_proj}\",\"public\":false,\"metadata\":{\"public\":\"false\"}}"
@@ -164,17 +168,19 @@ data:
             done
             echo "[harbor-projects] all push-mode projects ensured"
 
-            # #4975 (Refs #3379 #3695): PUBLIC push-mode OFFLINE-MIRROR projects.
-            # These hold the complete skopeo-pushed copy of every non-openova
-            # upstream image (step-03 Phase A3) so the node's containerd
-            # (step-04 rewrite) serves them under the step-08 deny-egress hold —
-            # a proxy-cache project cannot (its back-to-source is black-holed).
-            # PUBLIC so an upstream-image pod with NO imagePullSecret pulls
-            # anonymously post-rewrite (the proxy-cache projects these replace
-            # were public:true). Push still requires the harbor admin auth used
-            # here; only anonymous PULL is opened. Names MATCH the mothership
-            # Harbor project names so harbor.openova.io/proxy-<x>/PATH host-swaps
-            # to registry.<fqdn>/proxy-<x>/PATH with the path preserved.
+            {{- /*
+             #4975 (Refs #3379 #3695): PUBLIC push-mode OFFLINE-MIRROR projects.
+             These hold the complete skopeo-pushed copy of every non-openova
+             upstream image (step-03 Phase A3) so the node's containerd
+             (step-04 rewrite) serves them under the step-08 deny-egress hold —
+             a proxy-cache project cannot (its back-to-source is black-holed).
+             PUBLIC so an upstream-image pod with NO imagePullSecret pulls
+             anonymously post-rewrite (the proxy-cache projects these replace
+             were public:true). Push still requires the harbor admin auth used
+             here; only anonymous PULL is opened. Names MATCH the mothership
+             Harbor project names so harbor.openova.io/proxy-<x>/PATH host-swaps
+             to registry.<fqdn>/proxy-<x>/PATH with the path preserved.
+            */}}
             for mirror_proj in {{ join " " .Values.harbor.mirrorProjects }}; do
               echo "[harbor-projects] ensuring public offline-mirror project ${mirror_proj}"
               proj_payload="{\"project_name\":\"${mirror_proj}\",\"public\":true,\"metadata\":{\"public\":\"true\"}}"

--- a/platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml
@@ -46,52 +46,62 @@ data:
     {{- range .Values.prewarm.images }}
     {{ . }}
     {{- end }}
-  # Phase A2 (Refs #3627): the openova-io HelmRepository pivot set — the
-  # SAME list step-06 repoints to local Harbor. Phase A2 mirrors the helm
-  # CHART OCI artifact (not just the container images) for every HelmRelease
-  # whose sourceRef.name is one of these, so the charts are present + pullable
-  # in local Harbor BEFORE step-06 strips the ghcr.io fallback.
+  {{- /*
+   Phase A2 (Refs #3627): the openova-io HelmRepository pivot set — the
+   SAME list step-06 repoints to local Harbor. Phase A2 mirrors the helm
+   CHART OCI artifact (not just the container images) for every HelmRelease
+   whose sourceRef.name is one of these, so the charts are present + pullable
+   in local Harbor BEFORE step-06 strips the ghcr.io fallback.
+  */}}
   chart-mirror-names.txt: |
     {{- range .Values.helmRepositories.names }}
     {{ . }}
     {{- end }}
-  # #5593 — the step script, mounted and exec'd FROM FILE. It must NEVER be
-  # inlined into the container args: the rendered script exceeds the kernel
-  # per-argument cap (MAX_ARG_STRLEN = 128 KiB), so the container dies at
-  # exec with "argument list too long" before a single line runs (live
-  # hw292 dep 1c56518035a83e03 — the cutover chain retry-looped at step 03
-  # forever). scripts/ CI guard asserts every step's inline args stay small.
+  {{- /*
+   #5593 — the step script, mounted and exec'd FROM FILE. It must NEVER be
+   inlined into the container args: the rendered script exceeds the kernel
+   per-argument cap (MAX_ARG_STRLEN = 128 KiB), so the container dies at
+   exec with "argument list too long" before a single line runs (live
+   hw292 dep 1c56518035a83e03 — the cutover chain retry-looped at step 03
+   forever). scripts/ CI guard asserts every step's inline args stay small.
+  */}}
   run.sh: |
     set -eu
     : "${HARBOR_USERNAME:=admin}"
 
-    # #4975 — the offline-mirror image→local-path resolver (shared with
-    # step-08). Defines offlinemirror_normalize_ref + offlinemirror_local_paths
-    # over the HOST_PROJECT_MAP / EXCLUDED_* / LOCAL_REGISTRY_HOST env.
+    {{- /*
+     #4975 — the offline-mirror image→local-path resolver (shared with
+     step-08). Defines offlinemirror_normalize_ref + offlinemirror_local_paths
+     over the HOST_PROJECT_MAP / EXCLUDED_* / LOCAL_REGISTRY_HOST env.
+    */}}
     . /resolver/resolver.sh
-    # #5443 — the catalog chart-set extractor (03c). Defines
-    # catalog_chart_set + catalog_guard_missing + chart_declared_images.
-    # Pure functions; sourced here so Phase A2-catalog, the Phase
-    # A2-guard and Phase A3-catalog-images all read ONE definition of
-    # "what the marketplace offers".
+    {{- /*
+     #5443 — the catalog chart-set extractor (03c). Defines
+     catalog_chart_set + catalog_guard_missing + chart_declared_images.
+     Pure functions; sourced here so Phase A2-catalog, the Phase
+     A2-guard and Phase A3-catalog-images all read ONE definition of
+     "what the marketplace offers".
+    */}}
     . /catalog-set/catalog-set.sh
     echo "[harbor-prewarm] offline-mirror map: ${HOST_PROJECT_MAP}"
     echo "[harbor-prewarm] local registry host: ${LOCAL_REGISTRY_HOST}; excluded hosts: ${EXCLUDED_HOSTS:-<none>}"
 
-    # ─── Phase A: skopeo native push of openova-io images ──────
+    {{- /* ─── Phase A: skopeo native push of openova-io images ────── */}}
     echo "[harbor-prewarm] Phase A: install skopeo + jq + enumerate openova-io images"
-    # G69 #2618 (2026-05-31): alpine/k8s:1.31.4 base image's apk
-    # repos DO NOT carry community/skopeo → `apk add skopeo`
-    # silently no-ops → `command -v skopeo` returns FATAL →
-    # cutover chain breaks at Step 03 → Steps 04-08 NEVER RUN →
-    # Pillar 5 sovereignty NEVER ACHIEVED. Verified live hw78
-    # (de7f6aa8d5ef12b5) post-mandate audit 2026-05-31 04:40Z.
-    #
-    # Fix: download skopeo static binary from GitHub releases
-    # via curl. Falls back to apk if available (image may be
-    # rebased onto a distro with skopeo in repos later). jq is
-    # typically present in alpine/k8s but we verify + install
-    # via apk if not.
+    {{- /*
+     G69 #2618 (2026-05-31): alpine/k8s:1.31.4 base image's apk
+     repos DO NOT carry community/skopeo → `apk add skopeo`
+     silently no-ops → `command -v skopeo` returns FATAL →
+     cutover chain breaks at Step 03 → Steps 04-08 NEVER RUN →
+     Pillar 5 sovereignty NEVER ACHIEVED. Verified live hw78
+     (de7f6aa8d5ef12b5) post-mandate audit 2026-05-31 04:40Z.
+
+     Fix: download skopeo static binary from GitHub releases
+     via curl. Falls back to apk if available (image may be
+     rebased onto a distro with skopeo in repos later). jq is
+     typically present in alpine/k8s but we verify + install
+     via apk if not.
+    */}}
     apk add --no-cache jq >/dev/null 2>&1 || true
     if ! command -v jq >/dev/null 2>&1; then
       echo "[harbor-prewarm] FATAL: jq missing + apk install failed"
@@ -102,67 +112,71 @@ data:
       exit 1
     fi
 
-    # ─── Phase A0: settled-roll pre-flight (#4982 #5391, Refs #3379) ───
-    # harbor-prewarm mirrors the RUNNING / declared-template image tags
-    # (Phase A below). If any HelmRelease or Deployment/StatefulSet on the
-    # HOST cluster is MID-ROLL — a bootstrap-kit pin bumped but not yet
-    # reconciled, or an in-flight helm upgrade — then running != desired:
-    # the cutover would later roll those workloads (registry-pivot step-04
-    # / catalyst-api env-patch step-07) to the DESIRED chart-pinned tags
-    # that were NEVER mirrored here, and step-06's readiness sample +
-    # step-08's pre-hold completeness HEAD 404 on the un-mirrored desired
-    # tag (live hw239, dep f5fa3f08d8c3234f: umbrella HR bp-catalyst-platform
-    # running 1.4.1086 but pin 1.4.1088; catalyst-api/ui running :3412183
-    # but desired :00b6cfe — harbor-prewarm mirrored the running side of
-    # the drift). Once step-05 pivots Flux to the local Gitea the
-    # GitRepository freezes at the cutover-start sha, so the workloads can
-    # NEVER roll to the desired tag during the cutover — a running !=
-    # mirrored deadlock the deny-egress hold then trips on. REFUSE to build
-    # the mirror on an unsettled env (still PRE-PIVOT: steps 01/02 only
-    # mirrored git + created Harbor projects, both idempotent — nothing
-    # destructive has run), naming every offender so the operator waits for
-    # the roll to settle and re-triggers. The "settled-roll pre-flight"
-    # STONE principle. The complementary durable fix — mirror the DESIRED
-    # chart-pinned tags, not just running — is the #4982 follow-up (needs
-    # rendering the desired chart version off each HelmRelease spec); this
-    # gate prevents the whole class today with no render dependency. Runs
-    # BEFORE the ~5-min skopeo static-binary download so it fails fast.
-    #
-    # #5391 NAMED OPERATOR OVERRIDE — the recovery seam. Once Flux marks an
-    # HR Stalled=True (RetriesExceeded) it has stopped retrying PERMANENTLY:
-    # the hw290/hw291 quota-wedged customer releases (#5393) could never
-    # reach Ready, so this gate held the ENTIRE Sovereign's cutover closed
-    # forever with no operator remedy. A sovereign-admin may now exclude a
-    # SPECIFIC genuinely-stuck release:
-    #
-    #   kubectl annotate helmrelease <name> -n <ns> \
-    #     catalyst.openova.io/cutover-settled-roll-override="<reason>"
-    #
-    # The DEFAULT is unchanged — every non-suspended HR must be Ready. An
-    # override is explicit, per-release, and validated FAIL-CLOSED before
-    # any exclusion happens:
-    #   - empty/whitespace reason                  → gate FATALs (unnamed why)
-    #   - annotated release is HEALTHY             → gate FATALs (stale/over-broad)
-    #   - annotated release mid-roll (neither Stalled=True nor
-    #     Ready.reason=DependencyNotReady)         → gate FATALs (it will settle
-    #                                                on its own; overriding would
-    #                                                paper over a live roll)
-    # Honored overrides are recorded DURABLY in the cutover status
-    # ConfigMap (settledRollOverrides / settledRollOverridesAt) — surfaced
-    # as a first-class field on GET /sovereign/cutover/status and in the
-    # admin console — and an override that cannot be recorded is REFUSED
-    # (no unaudited carve-outs). The exclusion narrows only the settle
-    # CHECK: the excluded release's running images + charts are still
-    # mirrored by the Phase A / A2 enumerations, which are gate-independent.
+    {{- /*
+     ─── Phase A0: settled-roll pre-flight (#4982 #5391, Refs #3379) ───
+     harbor-prewarm mirrors the RUNNING / declared-template image tags
+     (Phase A below). If any HelmRelease or Deployment/StatefulSet on the
+     HOST cluster is MID-ROLL — a bootstrap-kit pin bumped but not yet
+     reconciled, or an in-flight helm upgrade — then running != desired:
+     the cutover would later roll those workloads (registry-pivot step-04
+     / catalyst-api env-patch step-07) to the DESIRED chart-pinned tags
+     that were NEVER mirrored here, and step-06's readiness sample +
+     step-08's pre-hold completeness HEAD 404 on the un-mirrored desired
+     tag (live hw239, dep f5fa3f08d8c3234f: umbrella HR bp-catalyst-platform
+     running 1.4.1086 but pin 1.4.1088; catalyst-api/ui running :3412183
+     but desired :00b6cfe — harbor-prewarm mirrored the running side of
+     the drift). Once step-05 pivots Flux to the local Gitea the
+     GitRepository freezes at the cutover-start sha, so the workloads can
+     NEVER roll to the desired tag during the cutover — a running !=
+     mirrored deadlock the deny-egress hold then trips on. REFUSE to build
+     the mirror on an unsettled env (still PRE-PIVOT: steps 01/02 only
+     mirrored git + created Harbor projects, both idempotent — nothing
+     destructive has run), naming every offender so the operator waits for
+     the roll to settle and re-triggers. The "settled-roll pre-flight"
+     STONE principle. The complementary durable fix — mirror the DESIRED
+     chart-pinned tags, not just running — is the #4982 follow-up (needs
+     rendering the desired chart version off each HelmRelease spec); this
+     gate prevents the whole class today with no render dependency. Runs
+     BEFORE the ~5-min skopeo static-binary download so it fails fast.
+
+     #5391 NAMED OPERATOR OVERRIDE — the recovery seam. Once Flux marks an
+     HR Stalled=True (RetriesExceeded) it has stopped retrying PERMANENTLY:
+     the hw290/hw291 quota-wedged customer releases (#5393) could never
+     reach Ready, so this gate held the ENTIRE Sovereign's cutover closed
+     forever with no operator remedy. A sovereign-admin may now exclude a
+     SPECIFIC genuinely-stuck release:
+
+       kubectl annotate helmrelease <name> -n <ns> \
+         catalyst.openova.io/cutover-settled-roll-override="<reason>"
+
+     The DEFAULT is unchanged — every non-suspended HR must be Ready. An
+     override is explicit, per-release, and validated FAIL-CLOSED before
+     any exclusion happens:
+       - empty/whitespace reason                  → gate FATALs (unnamed why)
+       - annotated release is HEALTHY             → gate FATALs (stale/over-broad)
+       - annotated release mid-roll (neither Stalled=True nor
+         Ready.reason=DependencyNotReady)         → gate FATALs (it will settle
+                                                    on its own; overriding would
+                                                    paper over a live roll)
+     Honored overrides are recorded DURABLY in the cutover status
+     ConfigMap (settledRollOverrides / settledRollOverridesAt) — surfaced
+     as a first-class field on GET /sovereign/cutover/status and in the
+     admin console — and an override that cannot be recorded is REFUSED
+     (no unaudited carve-outs). The exclusion narrows only the settle
+     CHECK: the excluded release's running images + charts are still
+     mirrored by the Phase A / A2 enumerations, which are gate-independent.
+    */}}
     # ── settled-roll-preflight BEGIN (Case 77 extraction anchor — tests/cutover-contract.sh executes this block verbatim with a stubbed kubectl) ──
     SETTLED_ROLL_OVERRIDE_ANNOTATION="catalyst.openova.io/cutover-settled-roll-override"
     srp_kubectl_json() {
-      # kubectl get "$@" -o json with a bounded retry; JSON on stdout,
-      # diagnostics on stderr. The gate must SEE the roll state to certify
-      # anything — a read failure returns 1 and the caller FATALs
-      # (fail-closed) instead of silently passing on an empty offender
-      # list (the assert-on-the-VALUE-not-the-KEY trap: the pre-#5391 gate
-      # PASSED whenever the kubectl read itself failed).
+      {{- /*
+       kubectl get "$@" -o json with a bounded retry; JSON on stdout,
+       diagnostics on stderr. The gate must SEE the roll state to certify
+       anything — a read failure returns 1 and the caller FATALs
+       (fail-closed) instead of silently passing on an empty offender
+       list (the assert-on-the-VALUE-not-the-KEY trap: the pre-#5391 gate
+       PASSED whenever the kubectl read itself failed).
+      */}}
       _srp_i=1
       while [ "${_srp_i}" -le 5 ]; do
         if _srp_out=$(kubectl get "$@" -o json 2>/dev/null) && [ -n "${_srp_out}" ]; then
@@ -176,9 +190,11 @@ data:
       return 1
     }
     srp_record_overrides() {
-      # $1 = newline-joined honored "<ns>/<name>=<reason>" list; "" CLEARS
-      # the record on a clean pass so a previous run's override cannot
-      # linger in the status CM as a phantom audit entry.
+      {{- /*
+       $1 = newline-joined honored "<ns>/<name>=<reason>" list; "" CLEARS
+       the record on a clean pass so a previous run's override cannot
+       linger in the status CM as a phantom audit entry.
+      */}}
       if [ -z "${STATUS_CONFIGMAP_NAME:-}" ] || [ -z "${STATUS_CONFIGMAP_NAMESPACE:-}" ]; then
         [ -z "$1" ] && return 0
         echo "[harbor-prewarm] FATAL: settled-roll override(s) in effect but STATUS_CONFIGMAP_NAME/NAMESPACE is unset — cannot write the audit record; an override MUST be recorded to be used (#5391)"
@@ -207,10 +223,12 @@ data:
         echo "[harbor-prewarm] FATAL: Phase A0 could not list Deployments/StatefulSets after 5 attempts — the gate cannot certify a roll state it cannot read; refusing to fail open (#5391)"
         return 1
       fi
-      # #5391 override validation FIRST, before ANY exclusion — the gate
-      # fail-closes on a malformed or over-broad override rather than
-      # honoring it. A SUSPENDED HR is outside the gate's domain entirely
-      # (skipped below), so its annotations are not judged here.
+      {{- /*
+       #5391 override validation FIRST, before ANY exclusion — the gate
+       fail-closes on a malformed or over-broad override rather than
+       honoring it. A SUSPENDED HR is outside the gate's domain entirely
+       (skipped below), so its annotations are not judged here.
+      */}}
       or_bad=$(printf '%s' "${_srp_hr_json}" | jq -r --arg okey "${SETTLED_ROLL_OVERRIDE_ANNOTATION}" '
         .items[]
         | select((.spec.suspend // false) | not)
@@ -238,9 +256,11 @@ data:
         done
         return 1
       fi
-      # Every remaining annotated HR is a VALIDATED override (named, stuck,
-      # reasoned). Newlines/tabs in the reason are flattened so the record
-      # stays one line per release.
+      {{- /*
+       Every remaining annotated HR is a VALIDATED override (named, stuck,
+       reasoned). Newlines/tabs in the reason are flattened so the record
+       stays one line per release.
+      */}}
       or_used=$(printf '%s' "${_srp_hr_json}" | jq -r --arg okey "${SETTLED_ROLL_OVERRIDE_ANNOTATION}" '
         .items[]
         | select((.spec.suspend // false) | not)
@@ -249,21 +269,23 @@ data:
         echo "[harbor-prewarm] FATAL: Phase A0 override-enumeration jq failed — refusing to fail open (#5391)"
         return 1
       }
-      # HelmReleases: a SUSPENDED HR is intentionally frozen (it will NOT
-      # roll during the cutover, so its running IS its desired) → skip it.
-      # A validly-overridden HR (annotation, validated above) → skip it.
-      # Otherwise flag when the spec out-ran the controller
-      # (observedGeneration < generation — the pin-bump case) OR Ready !=
-      # True (mid-reconcile / failed upgrade).
-      # #5391/#5392: distinguish TERMINAL from mid-roll. Once Flux marks an
-      # HR Stalled=True (reason RetriesExceeded) it has stopped retrying
-      # PERMANENTLY — that release will never reach Ready on its own, so
-      # "wait for the roll to settle and re-trigger" is false advice: the
-      # operator would wait forever. Live hw290 (dep 31106b6aa4a7e8e7):
-      # 7 offenders, ALL per-Org customer apps, ALL Stalled/RetriesExceeded
-      # (delta-corp/bp-keycloak `context deadline exceeded` alone cascaded
-      # DependencyNotReady onto 4 siblings). Tag those rows so the operator
-      # can tell "wait 5 minutes" from "this blocks you until you act".
+      {{- /*
+       HelmReleases: a SUSPENDED HR is intentionally frozen (it will NOT
+       roll during the cutover, so its running IS its desired) → skip it.
+       A validly-overridden HR (annotation, validated above) → skip it.
+       Otherwise flag when the spec out-ran the controller
+       (observedGeneration < generation — the pin-bump case) OR Ready !=
+       True (mid-reconcile / failed upgrade).
+       #5391/#5392: distinguish TERMINAL from mid-roll. Once Flux marks an
+       HR Stalled=True (reason RetriesExceeded) it has stopped retrying
+       PERMANENTLY — that release will never reach Ready on its own, so
+       "wait for the roll to settle and re-trigger" is false advice: the
+       operator would wait forever. Live hw290 (dep 31106b6aa4a7e8e7):
+       7 offenders, ALL per-Org customer apps, ALL Stalled/RetriesExceeded
+       (delta-corp/bp-keycloak `context deadline exceeded` alone cascaded
+       DependencyNotReady onto 4 siblings). Tag those rows so the operator
+       can tell "wait 5 minutes" from "this blocks you until you act".
+      */}}
       hr_pending=$(printf '%s' "${_srp_hr_json}" | jq -r --arg okey "${SETTLED_ROLL_OVERRIDE_ANNOTATION}" '
         .items[]
         | select((.spec.suspend // false) | not)
@@ -280,11 +302,13 @@ data:
         echo "[harbor-prewarm] FATAL: Phase A0 HelmRelease-offender jq failed — refusing to fail open (#5391)"
         return 1
       }
-      # Deployments + StatefulSets: a pending rollout — observedGeneration
-      # behind the spec, or updated/ready replicas short of desired. Skip
-      # intentionally scaled-to-zero (spec.replicas == 0). DaemonSets are
-      # deliberately NOT gated: cordoned / control-plane-tainted nodes skew
-      # desired-vs-ready legitimately and would false-positive the gate.
+      {{- /*
+       Deployments + StatefulSets: a pending rollout — observedGeneration
+       behind the spec, or updated/ready replicas short of desired. Skip
+       intentionally scaled-to-zero (spec.replicas == 0). DaemonSets are
+       deliberately NOT gated: cordoned / control-plane-tainted nodes skew
+       desired-vs-ready legitimately and would false-positive the gate.
+      */}}
       wl_pending=$(printf '%s' "${_srp_wl_json}" | jq -r '
         .items[]
         | select((.spec.replicas // 1) > 0)
@@ -303,7 +327,7 @@ data:
         echo "[harbor-prewarm] FATAL: env NOT settled — ${unsettled} release(s)/workload(s) are mid-roll; harbor-prewarm would mirror running tags the cutover then rolls away from (running != desired):"
         printf '%s\n%s\n' "${hr_pending}" "${wl_pending}" | grep . | sed 's/^/  mid-roll: /'
         if [ "${terminal}" -gt 0 ]; then
-          # #5391 — do NOT tell the operator to wait when waiting cannot work.
+          {{- /* #5391 — do NOT tell the operator to wait when waiting cannot work. */}}
           echo "[harbor-prewarm] ${terminal} of these are TERMINAL (Flux Stalled/RetriesExceeded). Waiting will NOT clear them — Flux has already given up retrying. Each one needs an explicit re-drive before the cutover can proceed:"
           echo "[harbor-prewarm]   flux reconcile helmrelease <name> -n <namespace> --reset     # clears Stalled and retries"
           echo "[harbor-prewarm]   (or remove the Organization if the release belongs to a customer app you no longer need)"
@@ -342,18 +366,20 @@ data:
 
     if ! command -v skopeo >/dev/null 2>&1; then
       echo "[harbor-prewarm] skopeo not on PATH; downloading static binary"
-      # skopeo static binaries published by lework on GitHub releases
-      # (containers/skopeo upstream doesn't ship static; lework's
-      # build is reproducible from upstream sources + signed).
-      # Pinned tag v1.15.2 for determinism. Fallback to apk-installed
-      # path if download fails AND apk works on a future image.
-      # G69-followup #2618 (2026-05-31): bump --max-time 60→600
-      # AND add resume support. Live evidence hw79: HCS bandwidth
-      # to github.com is ~120-360KB/s; 38MB skopeo binary needs
-      # ~3-5min on slow links. Original 60s timeout broke at
-      # 7-22MB partial downloads on all 3 retries. Curl --retry +
-      # -C - resumes partial downloads across retries so we
-      # accumulate progress instead of restarting at 0 each time.
+      {{- /*
+       skopeo static binaries published by lework on GitHub releases
+       (containers/skopeo upstream doesn't ship static; lework's
+       build is reproducible from upstream sources + signed).
+       Pinned tag v1.15.2 for determinism. Fallback to apk-installed
+       path if download fails AND apk works on a future image.
+       G69-followup #2618 (2026-05-31): bump --max-time 60→600
+       AND add resume support. Live evidence hw79: HCS bandwidth
+       to github.com is ~120-360KB/s; 38MB skopeo binary needs
+       ~3-5min on slow links. Original 60s timeout broke at
+       7-22MB partial downloads on all 3 retries. Curl --retry +
+       -C - resumes partial downloads across retries so we
+       accumulate progress instead of restarting at 0 each time.
+      */}}
       SKOPEO_URL="https://github.com/lework/skopeo-binary/releases/download/v1.15.2/skopeo-linux-amd64"
       for i in 1 2 3; do
         if curl -fsSL --max-time 600 --retry 3 --retry-delay 5 -C - "${SKOPEO_URL}" -o /tmp/skopeo 2>&1 \
@@ -364,17 +390,21 @@ data:
           break
         fi
         echo "[harbor-prewarm] skopeo download attempt ${i}/3 failed; retrying in 5s"
-        # Keep partial download (do NOT rm) so -C - resumes from
-        # last byte on next attempt; only clear if all 3 fail.
+        {{- /*
+         Keep partial download (do NOT rm) so -C - resumes from
+         last byte on next attempt; only clear if all 3 fail.
+        */}}
         sleep 5
       done
-      # If all 3 retries failed with partial files, clear to avoid
-      # corrupt binary detection.
+      {{- /*
+       If all 3 retries failed with partial files, clear to avoid
+       corrupt binary detection.
+      */}}
       if [ ! -x /tmp/skopeo ] || ! /tmp/skopeo --version >/dev/null 2>&1; then
         rm -f /tmp/skopeo
       fi
       if ! command -v skopeo >/dev/null 2>&1; then
-        # Last resort: try apk again (in case future image has it)
+        {{- /* Last resort: try apk again (in case future image has it) */}}
         apk add --no-cache skopeo >/dev/null 2>&1 || true
         if ! command -v skopeo >/dev/null 2>&1; then
           echo "[harbor-prewarm] FATAL: skopeo unavailable via static download AND apk after 3 retries"
@@ -385,48 +415,54 @@ data:
       echo "[harbor-prewarm] skopeo already on PATH: $(skopeo --version)"
     fi
 
-    # Extract GHCR PAT from dockerconfigjson.
-    # G72 #2618-followup (2026-05-31): Kubernetes env from
-    # secretKeyRef ALWAYS passes the DECODED secret value (raw
-    # bytes/string as stored under .data after base64 decode).
-    # Prior naive `base64 -d 2>/dev/null || raw` fallback fired
-    # base64 -d on already-decoded JSON, which produced garbage
-    # output (busybox base64 doesn't strictly fail on non-base64
-    # input) → jq parse error "Invalid numeric literal at line 1,
-    # column 21". Live evidence hw84 bf7de50d4b5ca99e Step 03.
-    #
-    # Fix: detect if input starts with `{` (JSON object) — if so,
-    # use as-is (no base64 decode attempt). Otherwise try base64
-    # decode then fall back to raw.
+    {{- /*
+     Extract GHCR PAT from dockerconfigjson.
+     G72 #2618-followup (2026-05-31): Kubernetes env from
+     secretKeyRef ALWAYS passes the DECODED secret value (raw
+     bytes/string as stored under .data after base64 decode).
+     Prior naive `base64 -d 2>/dev/null || raw` fallback fired
+     base64 -d on already-decoded JSON, which produced garbage
+     output (busybox base64 doesn't strictly fail on non-base64
+     input) → jq parse error "Invalid numeric literal at line 1,
+     column 21". Live evidence hw84 bf7de50d4b5ca99e Step 03.
+
+     Fix: detect if input starts with `{` (JSON object) — if so,
+     use as-is (no base64 decode attempt). Otherwise try base64
+     decode then fall back to raw.
+    */}}
     if [ "${GHCR_DOCKERCONFIG:0:1}" = "{" ]; then
       dc_decoded="${GHCR_DOCKERCONFIG}"
     else
       dc_decoded=$(printf '%s' "${GHCR_DOCKERCONFIG}" | base64 -d 2>/dev/null || printf '%s' "${GHCR_DOCKERCONFIG}")
     fi
-    # Locate the ghcr.io entry's auth (base64 of "<user>:<PAT>").
+    {{- /* Locate the ghcr.io entry's auth (base64 of "<user>:<PAT>"). */}}
     ghcr_auth_b64=$(printf '%s' "${dc_decoded}" | jq -r '.auths["ghcr.io"].auth // empty')
     if [ -z "${ghcr_auth_b64}" ]; then
       echo "[harbor-prewarm] FATAL: no ghcr.io auth entry in ${GHCR_DOCKERCONFIG_NAMESPACE}/ghcr-pull dockerconfigjson — step 06 phase-0 may have already pivoted (race with cutover order)"
-      # List what auths ARE present for diagnostic
+      {{- /* List what auths ARE present for diagnostic */}}
       printf '%s' "${dc_decoded}" | jq -r '.auths | keys[]' 2>&1 | sed 's/^/  auth-host: /'
       exit 1
     fi
     ghcr_user=$(printf '%s' "${ghcr_auth_b64}" | base64 -d | awk -F: '{print $1}')
     ghcr_pat=$(printf '%s' "${ghcr_auth_b64}" | base64 -d | awk -F: '{print $2}')
-    # #5467 — NEVER print any prefix of the PAT. The `${ghcr_pat:0:8}` disclosed
-    # 4 real secret chars (after the `ghp_` type prefix) + the token type + exact
-    # length + owning account into pod logs, which are read by operators, shipped
-    # by log aggregators, and pasted into issues on a failed cutover. Match the
-    # mothership branch below: user + length only (platform rule — secret values
-    # are never printed; lengths/hashes only).
+    {{- /*
+     #5467 — NEVER print any prefix of the PAT. The `${ghcr_pat:0:8}` disclosed
+     4 real secret chars (after the `ghp_` type prefix) + the token type + exact
+     length + owning account into pod logs, which are read by operators, shipped
+     by log aggregators, and pasted into issues on a failed cutover. Match the
+     mothership branch below: user + length only (platform rule — secret values
+     are never printed; lengths/hashes only).
+    */}}
     echo "[harbor-prewarm] ghcr.io auth extracted: user=${ghcr_user} (len=${#ghcr_pat})"
 
-    # #4975 — OPTIONAL mothership-Harbor source auth. Phase A3 mirrors
-    # `harbor.openova.io/proxy-<x>/...` refs (the dominant bootstrap-kit
-    # image shape) by host-swapping to the local Harbor; the SOURCE pull
-    # from the mothership uses THIS auth when the ghcr-pull dockerconfig
-    # carries it (it usually does — same Secret proxies both). Absent →
-    # anonymous mothership pull (the proxy-<x> projects are public).
+    {{- /*
+     #4975 — OPTIONAL mothership-Harbor source auth. Phase A3 mirrors
+     `harbor.openova.io/proxy-<x>/...` refs (the dominant bootstrap-kit
+     image shape) by host-swapping to the local Harbor; the SOURCE pull
+     from the mothership uses THIS auth when the ghcr-pull dockerconfig
+     carries it (it usually does — same Secret proxies both). Absent →
+     anonymous mothership pull (the proxy-<x> projects are public).
+    */}}
     moth_user=""
     moth_pat=""
     moth_auth_b64=$(printf '%s' "${dc_decoded}" | jq -r --arg h "${MOTHERSHIP_HOST}" '.auths[$h].auth // empty' 2>/dev/null || true)
@@ -436,10 +472,12 @@ data:
       echo "[harbor-prewarm] ${MOTHERSHIP_HOST} auth extracted: user=${moth_user} (len=${#moth_pat})"
     fi
 
-    # #4975 — choose skopeo --src-creds by SOURCE host: ghcr.io → the
-    # ghcr-pull PAT (private openova-io packages); the mothership →
-    # optional mothership auth; every anonymous upstream (docker.io,
-    # quay.io, registry.k8s.io, gcr.io, public.ecr.aws) → NO creds.
+    {{- /*
+     #4975 — choose skopeo --src-creds by SOURCE host: ghcr.io → the
+     ghcr-pull PAT (private openova-io packages); the mothership →
+     optional mothership auth; every anonymous upstream (docker.io,
+     quay.io, registry.k8s.io, gcr.io, public.ecr.aws) → NO creds.
+    */}}
     src_creds_for() {
       case "$1" in
         ghcr.io) printf '%s:%s' "${ghcr_user}" "${ghcr_pat}" ;;
@@ -449,71 +487,75 @@ data:
       esac
     }
 
-    # #5036 (reverts #4688): the skopeo PUSH destination + the Harbor
-    # artifact-API existence check dial the IN-CLUSTER Harbor Service
-    # (harbor-core.harbor.svc, always CoreDNS-resolvable pre-pivot), NOT the
-    # external registry.<fqdn> (which NXDOMAINs pre-pivot on a Sovereign whose
-    # split-horizon PowerDNS lacks the record — hw246 dep c38c437f). The pushed
-    # blobs land in the SAME Harbor project/repo (Harbor stores by project/repo,
-    # host-independent), so post-cutover pulls via registry.<fqdn> — step-04
-    # containerd + step-08 completeness HEAD, which target LOCAL_REGISTRY_HOST,
-    # unchanged — resolve the identical artifacts. HARBOR_HOST is step-03-local
-    # (the resolver returns host-LESS paths; the prefix is stripped in
-    # dest_already_current), so this does not touch step-04/08.
-    #
-    # #5051 (round 2 — supersedes the 0.1.127 :80 attempt): the skopeo
-    # PUSH DEST must be the PUBLIC host. Harbor builds its bearer-token
-    # realm as https://<request-host>/service/token — request host
-    # echoed, scheme HARD-https (probed empirically on hw250 across
-    # harbor-core:80, nginx harbor:80, and the public URL) — and NO
-    # in-cluster harbor Service terminates TLS (all http/80; TLS ends
-    # at the gateway). An in-cluster dest therefore can NEVER complete
-    # the token flow: hw250 went 0/136 twice (bare host → :443
-    # black-hole; :80 host → https-on-plaintext). Only the public host
-    # yields a realm that is actually reachable (gateway + cert). The
-    # #5037 motivation (hw246 pre-pivot NXDOMAIN flake) is handled by
-    # the bounded readiness probe below, NOT by a dest pivot. Harbor
-    # REST API dials (projects, artifact idempotency probe, Phase B
-    # /v2 HEAD — basic auth, no token dance) STAY on
-    # HARBOR_INTERNAL_URL, which step-02 proved works in-cluster.
+    {{- /*
+     #5036 (reverts #4688): the skopeo PUSH destination + the Harbor
+     artifact-API existence check dial the IN-CLUSTER Harbor Service
+     (harbor-core.harbor.svc, always CoreDNS-resolvable pre-pivot), NOT the
+     external registry.<fqdn> (which NXDOMAINs pre-pivot on a Sovereign whose
+     split-horizon PowerDNS lacks the record — hw246 dep c38c437f). The pushed
+     blobs land in the SAME Harbor project/repo (Harbor stores by project/repo,
+     host-independent), so post-cutover pulls via registry.<fqdn> — step-04
+     containerd + step-08 completeness HEAD, which target LOCAL_REGISTRY_HOST,
+     unchanged — resolve the identical artifacts. HARBOR_HOST is step-03-local
+     (the resolver returns host-LESS paths; the prefix is stripped in
+     dest_already_current), so this does not touch step-04/08.
+
+     #5051 (round 2 — supersedes the 0.1.127 :80 attempt): the skopeo
+     PUSH DEST must be the PUBLIC host. Harbor builds its bearer-token
+     realm as https://<request-host>/service/token — request host
+     echoed, scheme HARD-https (probed empirically on hw250 across
+     harbor-core:80, nginx harbor:80, and the public URL) — and NO
+     in-cluster harbor Service terminates TLS (all http/80; TLS ends
+     at the gateway). An in-cluster dest therefore can NEVER complete
+     the token flow: hw250 went 0/136 twice (bare host → :443
+     black-hole; :80 host → https-on-plaintext). Only the public host
+     yields a realm that is actually reachable (gateway + cert). The
+     #5037 motivation (hw246 pre-pivot NXDOMAIN flake) is handled by
+     the bounded readiness probe below, NOT by a dest pivot. Harbor
+     REST API dials (projects, artifact idempotency probe, Phase B
+     /v2 HEAD — basic auth, no token dance) STAY on
+     HARBOR_INTERNAL_URL, which step-02 proved works in-cluster.
+    */}}
     HARBOR_HOST=$(printf '%s' "${HARBOR_PUBLIC_URL}" | sed -e 's,^https\?://,,' -e 's,/$,,')
 
-    # ── #5007 (Refs #5051 #5036 #4652 #4682) — install a kube-system
-    # `coredns-custom` override so registry.<fqdn> resolves IN-CLUSTER to the
-    # cilium-gateway Service ClusterIP, BEFORE the readiness probe + every
-    # skopeo push, making the local-registry datapath INDEPENDENT of public
-    # DNS. #5051 round 2 correctly forced the push DEST back to the PUBLIC host
-    # (only the TLS-terminating gateway serves Harbor's hard-https bearer realm
-    # https://registry.<fqdn>/service/token — no in-cluster :80 Service can
-    # complete the token flow), but that dest was left resolving via PUBLIC
-    # DNS, so it still breaks when the Sovereign zone flakes or a wiped-env
-    # `*.<pool>` wildcard shadows the specific record: hw241's dead
-    # `*.omantel.biz` 49.12.16.160 → readiness probe connection-refused →
-    # 10-min FATAL; hw252's intermittent NXDOMAIN (`lookup registry.hw252.
-    # omani.works on 10.96.0.10:53: no such host`) flapped MID-PUSH →
-    # push_ok=131 push_fail=7 (survived only on a backoffLimit retry).
-    #
-    # WHY CoreDNS, not /etc/hosts: harbor-prewarm runs runAsNonRoot(uid 1000)
-    # + readOnlyRootFilesystem + drop-ALL, so it CANNOT write its own (root-
-    # owned) /etc/hosts, and a pod `hostAliases` can't take a runtime IP. It
-    # instead patches the k3s-native `coredns-custom` ConfigMap — the same
-    # extension point cloud-init uses for the github-ipv4 pin — with a
-    # SEPARATE `.server` block (registry.<fqdn> -> the gateway ClusterIP), so
-    # CoreDNS (which every pod already queries at 10.96.0.10) answers
-    # registry.<fqdn> authoritatively in-cluster. The ClusterIP is ALWAYS
-    # allocated (even TYPE=ClusterIP with no VIP on the §854 ELB-direct model,
-    # #5007 round 2 / 0.1.129); ClusterIP:443 terminates the wildcard TLS and
-    # serves BOTH the /v2 challenge AND the /service/token realm (proven
-    # #4637). Request host / SNI stay registry.<fqdn> so the bearer realm +
-    # gateway HTTPRoute + wildcard cert all still match — ONLY resolution is
-    # pinned. This reverses #4682's public-DNS assumption ONLY for the primary
-    # cluster's CoreDNS + ONLY for the local registry name (a dedicated
-    # `.server` block, never a `.override` — two `hosts` plugins in one block
-    # crash CoreDNS, the #3804 trap); the NODE/containerd path is untouched
-    # (step-04's /etc/hosts pin). FAIL-LOUD: if the pin is enabled but the
-    # gateway ClusterIP can't be resolved, EXIT NON-ZERO rather than silently
-    # push over the flaky public path. The existing readiness probe below is
-    # the sync-confirm — it blocks until CoreDNS actually serves the override.
+    {{- /*
+     ── #5007 (Refs #5051 #5036 #4652 #4682) — install a kube-system
+     `coredns-custom` override so registry.<fqdn> resolves IN-CLUSTER to the
+     cilium-gateway Service ClusterIP, BEFORE the readiness probe + every
+     skopeo push, making the local-registry datapath INDEPENDENT of public
+     DNS. #5051 round 2 correctly forced the push DEST back to the PUBLIC host
+     (only the TLS-terminating gateway serves Harbor's hard-https bearer realm
+     https://registry.<fqdn>/service/token — no in-cluster :80 Service can
+     complete the token flow), but that dest was left resolving via PUBLIC
+     DNS, so it still breaks when the Sovereign zone flakes or a wiped-env
+     `*.<pool>` wildcard shadows the specific record: hw241's dead
+     `*.omantel.biz` 49.12.16.160 → readiness probe connection-refused →
+     10-min FATAL; hw252's intermittent NXDOMAIN (`lookup registry.hw252.
+     omani.works on 10.96.0.10:53: no such host`) flapped MID-PUSH →
+     push_ok=131 push_fail=7 (survived only on a backoffLimit retry).
+
+     WHY CoreDNS, not /etc/hosts: harbor-prewarm runs runAsNonRoot(uid 1000)
+     + readOnlyRootFilesystem + drop-ALL, so it CANNOT write its own (root-
+     owned) /etc/hosts, and a pod `hostAliases` can't take a runtime IP. It
+     instead patches the k3s-native `coredns-custom` ConfigMap — the same
+     extension point cloud-init uses for the github-ipv4 pin — with a
+     SEPARATE `.server` block (registry.<fqdn> -> the gateway ClusterIP), so
+     CoreDNS (which every pod already queries at 10.96.0.10) answers
+     registry.<fqdn> authoritatively in-cluster. The ClusterIP is ALWAYS
+     allocated (even TYPE=ClusterIP with no VIP on the §854 ELB-direct model,
+     #5007 round 2 / 0.1.129); ClusterIP:443 terminates the wildcard TLS and
+     serves BOTH the /v2 challenge AND the /service/token realm (proven
+     #4637). Request host / SNI stay registry.<fqdn> so the bearer realm +
+     gateway HTTPRoute + wildcard cert all still match — ONLY resolution is
+     pinned. This reverses #4682's public-DNS assumption ONLY for the primary
+     cluster's CoreDNS + ONLY for the local registry name (a dedicated
+     `.server` block, never a `.override` — two `hosts` plugins in one block
+     crash CoreDNS, the #3804 trap); the NODE/containerd path is untouched
+     (step-04's /etc/hosts pin). FAIL-LOUD: if the pin is enabled but the
+     gateway ClusterIP can't be resolved, EXIT NON-ZERO rather than silently
+     push over the flaky public path. The existing readiness probe below is
+     the sync-confirm — it blocks until CoreDNS actually serves the override.
+    */}}
     install_coredns_registry_pin() {
       case "${LOCAL_REGISTRY_PIN_ENABLED:-true}" in
         true|True|TRUE|1|yes) : ;;
@@ -524,9 +566,11 @@ data:
       if [ -n "${GATEWAY_LB_SVC_NAME:-}" ]; then
         _pin_attempt=1
         while [ "${_pin_attempt}" -le 5 ]; do
-          # ClusterIP is allocated the moment the gateway Service exists (well
-          # before step-03) in BOTH the LB and the §854 ELB-direct (TYPE=
-          # ClusterIP) gateway models. `services get` RBAC is already granted.
+          {{- /*
+           ClusterIP is allocated the moment the gateway Service exists (well
+           before step-03) in BOTH the LB and the §854 ELB-direct (TYPE=
+           ClusterIP) gateway models. `services get` RBAC is already granted.
+          */}}
           _c=$(kubectl get svc "${GATEWAY_LB_SVC_NAME}" -n "${GATEWAY_LB_SVC_NAMESPACE}" -o jsonpath='{.spec.clusterIP}' 2>/dev/null || true)
           case "${_c}" in
             ""|None) : ;;
@@ -541,13 +585,17 @@ data:
         echo "[harbor-prewarm] FATAL: could not resolve the cilium-gateway Service ClusterIP (${GATEWAY_LB_SVC_NAMESPACE:-}/${GATEWAY_LB_SVC_NAME:-<unset>}). Refusing to push over the flaky public DNS path (#5007). Fix/name the gateway Service (registryPivot.localRegistryHostPin.gatewayServiceName), then re-trigger."
         exit 1
       fi
-      # A SEPARATE `.server` block (NEVER `.override`): a single `hosts` plugin
-      # scoped to the registry zone, mirroring cloud-init's github-ipv4 pin.
+      {{- /*
+       A SEPARATE `.server` block (NEVER `.override`): a single `hosts` plugin
+       scoped to the registry zone, mirroring cloud-init's github-ipv4 pin.
+      */}}
       _cdns_key="cutover-registry-pin.server"
       _cdns_block=$(printf '%s {\n    hosts {\n        %s %s\n        fallthrough\n    }\n    forward . /etc/resolv.conf\n}\n' "${HARBOR_HOST}" "${_cip}" "${HARBOR_HOST}")
-      # Idempotent: if kube-system/coredns-custom already carries our key with
-      # THIS ClusterIP, nothing to do (avoids a needless CoreDNS reload on a
-      # step re-run).
+      {{- /*
+       Idempotent: if kube-system/coredns-custom already carries our key with
+       THIS ClusterIP, nothing to do (avoids a needless CoreDNS reload on a
+       step re-run).
+      */}}
       _cdns_cur=$(kubectl get cm coredns-custom -n kube-system -o json 2>/dev/null | jq -r --arg k "${_cdns_key}" '.data[$k] // ""' 2>/dev/null || true)
       case "${_cdns_cur}" in
         *"${_cip} ${HARBOR_HOST}"*)
@@ -555,9 +603,11 @@ data:
           return 0 ;;
       esac
       _cdns_patch=$(jq -cn --arg k "${_cdns_key}" --arg v "${_cdns_block}" '{data: {($k): $v}}')
-      # MERGE-patch (never replace) so a co-resident github-ipv4.server key is
-      # preserved; create the CM if it does not exist yet (Hetzner renders no
-      # coredns-custom at boot); re-patch on a create race.
+      {{- /*
+       MERGE-patch (never replace) so a co-resident github-ipv4.server key is
+       preserved; create the CM if it does not exist yet (Hetzner renders no
+       coredns-custom at boot); re-patch on a create race.
+      */}}
       if kubectl patch configmap coredns-custom -n kube-system --type merge -p "${_cdns_patch}" >/dev/null 2>&1; then
         :
       elif kubectl create configmap coredns-custom -n kube-system --from-literal="${_cdns_key}=${_cdns_block}" >/dev/null 2>&1; then
@@ -589,47 +639,49 @@ data:
       exit 1
     fi
 
-    # Enumerate openova-io images cluster-wide.
-    #
-    # #3944 root-cause-2 (Refs #3642): a RUNNING-Pod-only enumeration
-    # is INCOMPLETE — it silently omits any openova-io workload that is
-    # not scheduled at enumeration time. Two ways that happens after
-    # #3642 moved the front-door apps (gitea/harbor/keycloak/openbao/
-    # grafana/newapi/guacamole) INTO the vClusters: (a) on a vCluster
-    # NOT running in pod-syncing mode the in-vCluster pods never
-    # materialise in a host namespace, so a host-side `get pods -A`
-    # can't see them at all; (b) even with pod-syncing, an openova-io
-    # workload that is momentarily down / scaled-to-zero / not-yet-
-    # rolled-out (a CronJob between fires, an HR mid-reconcile) has NO
-    # running Pod, so its image is missed. Either way the missed image
-    # never lands in local Harbor → post-cutover ImagePullBackOff the
-    # moment step-06 strips the ghcr.io fallback, or the egress hold
-    # passes over an un-mirrored image. The bytes are unavoidable; the
-    # COMPLETENESS of the source list must NOT depend on which pods
-    # happen to be Running.
-    #
-    # Fix: UNION the running-Pod image set with the DECLARED workload-
-    # template image set (Deployments, StatefulSets, DaemonSets +
-    # CronJob/Job pod templates) across every namespace. Declared
-    # templates are present regardless of replica count or schedule, so
-    # the union is complete on any vCluster sync mode. The union can
-    # only WIDEN the prewarm list (every entry is still skopeo-pushed
-    # idempotently), never narrow it — a strict superset of the prior
-    # behaviour.
-    #
-    # #4975 (Refs #3379 #3695) — GENERALIZED to ALL images, not just
-    # `ghcr.io/openova-io/*`. The `^ghcr.io/openova-io/` grep filter is
-    # DROPPED: the enumeration now unions EVERY container/init/ephemeral
-    # image across running Pods AND declared workload templates, so a
-    # COMPLETE offline mirror of every non-node-cached upstream lands in
-    # local Harbor before the deny-egress hold. copy_one below routes
-    # each image to its local project via the shared resolver
-    # (offlinemirror_local_paths): openova-io → host-drop openova-io/…
-    # (unchanged) + proxy-ghcr/openova-io/…; docker.io/quay.io/registry.
-    # k8s.io/gcr.io/public.ecr.aws → proxy-<host>/…; harbor.openova.io →
-    # host-swap (path preserved); xpkg.upbound.io + rancher/k3s +
-    # loft-sh/vcluster EXCLUDED (offlineMirror.excluded*). This is the
-    # generalization of the former #3944 running-∪-declared union.
+    {{- /*
+     Enumerate openova-io images cluster-wide.
+
+     #3944 root-cause-2 (Refs #3642): a RUNNING-Pod-only enumeration
+     is INCOMPLETE — it silently omits any openova-io workload that is
+     not scheduled at enumeration time. Two ways that happens after
+     #3642 moved the front-door apps (gitea/harbor/keycloak/openbao/
+     grafana/newapi/guacamole) INTO the vClusters: (a) on a vCluster
+     NOT running in pod-syncing mode the in-vCluster pods never
+     materialise in a host namespace, so a host-side `get pods -A`
+     can't see them at all; (b) even with pod-syncing, an openova-io
+     workload that is momentarily down / scaled-to-zero / not-yet-
+     rolled-out (a CronJob between fires, an HR mid-reconcile) has NO
+     running Pod, so its image is missed. Either way the missed image
+     never lands in local Harbor → post-cutover ImagePullBackOff the
+     moment step-06 strips the ghcr.io fallback, or the egress hold
+     passes over an un-mirrored image. The bytes are unavoidable; the
+     COMPLETENESS of the source list must NOT depend on which pods
+     happen to be Running.
+
+     Fix: UNION the running-Pod image set with the DECLARED workload-
+     template image set (Deployments, StatefulSets, DaemonSets +
+     CronJob/Job pod templates) across every namespace. Declared
+     templates are present regardless of replica count or schedule, so
+     the union is complete on any vCluster sync mode. The union can
+     only WIDEN the prewarm list (every entry is still skopeo-pushed
+     idempotently), never narrow it — a strict superset of the prior
+     behaviour.
+
+     #4975 (Refs #3379 #3695) — GENERALIZED to ALL images, not just
+     `ghcr.io/openova-io/*`. The `^ghcr.io/openova-io/` grep filter is
+     DROPPED: the enumeration now unions EVERY container/init/ephemeral
+     image across running Pods AND declared workload templates, so a
+     COMPLETE offline mirror of every non-node-cached upstream lands in
+     local Harbor before the deny-egress hold. copy_one below routes
+     each image to its local project via the shared resolver
+     (offlinemirror_local_paths): openova-io → host-drop openova-io/…
+     (unchanged) + proxy-ghcr/openova-io/…; docker.io/quay.io/registry.
+     k8s.io/gcr.io/public.ecr.aws → proxy-<host>/…; harbor.openova.io →
+     host-swap (path preserved); xpkg.upbound.io + rancher/k3s +
+     loft-sh/vcluster EXCLUDED (offlineMirror.excluded*). This is the
+     generalization of the former #3944 running-∪-declared union.
+    */}}
     echo "[harbor-prewarm] enumerating ALL images across cluster (running pods ∪ declared workload templates)"
     running_images=$(kubectl get pods -A -o json | \
       jq -r '.items[].spec | (.containers // [])[].image, (.initContainers // [])[].image, (.ephemeralContainers // [])[].image' 2>/dev/null || true)
@@ -646,65 +698,69 @@ data:
     count=$(printf '%s\n' "${openova_images}" | grep -c . || true)
     echo "[harbor-prewarm] running-Pod images=${run_count}; union with declared templates=${count} unique image(s) to mirror"
 
-    # Native push each via skopeo copy, run in PARALLEL with a
-    # bounded fan-out.
-    #
-    # #3379 step-03 DeadlineExceeded (hw139, 2026-06-15): these ~29
-    # multi-layer openova-io copies ran STRICTLY SERIAL over kom4dc's
-    # throttled ghcr→Harbor egress and blew the step deadline with
-    # only 6/29 pushed → local Harbor openova-io project incomplete →
-    # post-cutover ImagePullBackOff → Step-08 deny-egress proof never
-    # ran. The bytes themselves are unavoidable (the source images are
-    # PRIVATE on ghcr, so Harbor's anonymous proxy-cache 404s them —
-    # #3534 — this authenticated skopeo push is the only working
-    # route), but the WALL-CLOCK is collapsible: copies are
-    # independent, so we run PREWARM_PARALLELISM of them at once. Each
-    # worker writes its own result sentinel (`.ok`/`.fail`) + captured
-    # log under ${cpdir}; the parent `wait`s for all, then prints each
-    # log prefix-indented and tallies from the sentinels. POSIX sh has
-    # no `wait -n`, so we cap concurrency by counting live background
-    # PIDs and pausing the launch loop until one drains.
-    #
-    # skopeo gains `--retry-times 5` so a single transient ghcr/Harbor
-    # 5xx or reset inside a copy self-heals (resumable layer fetch)
-    # instead of failing the whole image — independent of the binary-
-    # download retry above.
-    #
-    # #3608-followup (hw146 step-03 FATAL, 2026-06-16): even with
-    # `--retry-times`, the two LARGE guacamole images
-    # (guacamole-server:1.5.5 + guacd:1.5.5, ~50MB blobs) still FATAL'd
-    # the whole step on TRANSIENT mid-blob connection resets over a
-    # freshly-bootstrapped network — skopeo logged
-    # `Reading blob ... failed (unexpected EOF), reconnecting ...` then
-    # `writing blob ... use of closed network connection`, and 2/29
-    # copies failed -> push_fail>0 -> `FATAL: 2 openova-io image(s)
-    # failed to push` -> cutover never reached step-04+. `--retry-times`
-    # retries the individual blob fetch INSIDE one `skopeo copy`, but a
-    # Harbor-side reset that closes the dest connection can still abort
-    # the copy as a whole. So copy_one ALSO wraps the `skopeo copy` in an
-    # OUTER per-image retry loop (PREWARM_COPY_ATTEMPTS, default 3): if a
-    # full copy fails after exhausting `--retry-times`, the whole copy is
-    # re-attempted up to N times with a short backoff sleep before the
-    # image is counted as `push_fail`. The FATAL-on-failure contract is
-    # PRESERVED (Pillar 5 requires ALL openova-io images local for the
-    # deny-egress hold) — the step only FATALs once BOTH retry layers are
-    # exhausted for an image. Each outer attempt is logged.
-    #
-    # Two earlier #3379 keystone catches (hw138, 2026-06-14) stay in
-    # force: (1) `--insecure-policy` so skopeo doesn't fatal on the
-    # missing /etc/containers/policy.json that alpine/k8s + the lework
-    # static binary omit; (2) branch on skopeo's REAL exit status
-    # (captured per-worker) rather than a piped `sed` whose status is
-    # always 0 under this `set -eu` (no pipefail) shell — the bug that
-    # made every fatal copy miscount as success.
+    {{- /*
+     Native push each via skopeo copy, run in PARALLEL with a
+     bounded fan-out.
+
+     #3379 step-03 DeadlineExceeded (hw139, 2026-06-15): these ~29
+     multi-layer openova-io copies ran STRICTLY SERIAL over kom4dc's
+     throttled ghcr→Harbor egress and blew the step deadline with
+     only 6/29 pushed → local Harbor openova-io project incomplete →
+     post-cutover ImagePullBackOff → Step-08 deny-egress proof never
+     ran. The bytes themselves are unavoidable (the source images are
+     PRIVATE on ghcr, so Harbor's anonymous proxy-cache 404s them —
+     #3534 — this authenticated skopeo push is the only working
+     route), but the WALL-CLOCK is collapsible: copies are
+     independent, so we run PREWARM_PARALLELISM of them at once. Each
+     worker writes its own result sentinel (`.ok`/`.fail`) + captured
+     log under ${cpdir}; the parent `wait`s for all, then prints each
+     log prefix-indented and tallies from the sentinels. POSIX sh has
+     no `wait -n`, so we cap concurrency by counting live background
+     PIDs and pausing the launch loop until one drains.
+
+     skopeo gains `--retry-times 5` so a single transient ghcr/Harbor
+     5xx or reset inside a copy self-heals (resumable layer fetch)
+     instead of failing the whole image — independent of the binary-
+     download retry above.
+
+     #3608-followup (hw146 step-03 FATAL, 2026-06-16): even with
+     `--retry-times`, the two LARGE guacamole images
+     (guacamole-server:1.5.5 + guacd:1.5.5, ~50MB blobs) still FATAL'd
+     the whole step on TRANSIENT mid-blob connection resets over a
+     freshly-bootstrapped network — skopeo logged
+     `Reading blob ... failed (unexpected EOF), reconnecting ...` then
+     `writing blob ... use of closed network connection`, and 2/29
+     copies failed -> push_fail>0 -> `FATAL: 2 openova-io image(s)
+     failed to push` -> cutover never reached step-04+. `--retry-times`
+     retries the individual blob fetch INSIDE one `skopeo copy`, but a
+     Harbor-side reset that closes the dest connection can still abort
+     the copy as a whole. So copy_one ALSO wraps the `skopeo copy` in an
+     OUTER per-image retry loop (PREWARM_COPY_ATTEMPTS, default 3): if a
+     full copy fails after exhausting `--retry-times`, the whole copy is
+     re-attempted up to N times with a short backoff sleep before the
+     image is counted as `push_fail`. The FATAL-on-failure contract is
+     PRESERVED (Pillar 5 requires ALL openova-io images local for the
+     deny-egress hold) — the step only FATALs once BOTH retry layers are
+     exhausted for an image. Each outer attempt is logged.
+
+     Two earlier #3379 keystone catches (hw138, 2026-06-14) stay in
+     force: (1) `--insecure-policy` so skopeo doesn't fatal on the
+     missing /etc/containers/policy.json that alpine/k8s + the lework
+     static binary omit; (2) branch on skopeo's REAL exit status
+     (captured per-worker) rather than a piped `sed` whose status is
+     always 0 under this `set -eu` (no pipefail) shell — the bug that
+     made every fatal copy miscount as success.
+    */}}
     : "${PREWARM_PARALLELISM:=6}"
     : "${PREWARM_COPY_ATTEMPTS:=3}"
-    # #5095 — separate, wider budget for MOTHERSHIP-PROXY-sourced
-    # copies (exponential backoff spans ≥15 min at the defaults so a
-    # short transit flap toward the mothership can't exhaust it).
+    {{- /*
+     #5095 — separate, wider budget for MOTHERSHIP-PROXY-sourced
+     copies (exponential backoff spans ≥15 min at the defaults so a
+     short transit flap toward the mothership can't exhaust it).
+    */}}
     : "${PREWARM_PROXY_COPY_ATTEMPTS:=6}"
     : "${PREWARM_PROXY_BACKOFF_BASE_SECONDS:=30}"
-    # #5095 round 2 — proxy-DOWN direct-first routing defaults.
+    {{- /* #5095 round 2 — proxy-DOWN direct-first routing defaults. */}}
     : "${PROXY_DIRECT_FIRST_ENABLED:=true}"
     : "${PROXY_PROBE_TIMEOUT_SECONDS:=8}"
     : "${PROXY_PROBE_ATTEMPTS:=3}"
@@ -712,20 +768,22 @@ data:
     rm -rf "${cpdir}"; mkdir -p "${cpdir}"
     echo "[harbor-prewarm] pushing ${count} image(s) with parallelism=${PREWARM_PARALLELISM}"
 
-    # #4955 (Refs #3379): normalize a `name:tag@sha256:...` reference to
-    # digest-only (`name@sha256:...`) before handing it to skopeo.
-    # `skopeo copy docker://name:tag@digest` FATALs with "Docker
-    # references with both a tag and digest are currently not supported",
-    # which fail-closed the WHOLE step on the first openova-io image ever
-    # pinned by BOTH a tag and a digest (`wordpress-tenant-pg` from
-    # bp-wordpress-tenant — live hw235 a3818d29c833ab1e, push_ok=31
-    # push_fail=1 → cutover never reached step-04+). The digest is
-    # authoritative + immutable and is exactly what containerd pulls by
-    # for an `image:tag@digest` pod ref, so dropping the tag preserves the
-    # post-pivot pull (the manifest lands in Harbor addressable by digest).
-    # Tag-only and digest-only refs pass through unchanged. Only the FINAL
-    # path segment's tag is stripped, so a `host:port/...` registry ref is
-    # left intact.
+    {{- /*
+     #4955 (Refs #3379): normalize a `name:tag@sha256:...` reference to
+     digest-only (`name@sha256:...`) before handing it to skopeo.
+     `skopeo copy docker://name:tag@digest` FATALs with "Docker
+     references with both a tag and digest are currently not supported",
+     which fail-closed the WHOLE step on the first openova-io image ever
+     pinned by BOTH a tag and a digest (`wordpress-tenant-pg` from
+     bp-wordpress-tenant — live hw235 a3818d29c833ab1e, push_ok=31
+     push_fail=1 → cutover never reached step-04+). The digest is
+     authoritative + immutable and is exactly what containerd pulls by
+     for an `image:tag@digest` pod ref, so dropping the tag preserves the
+     post-pivot pull (the manifest lands in Harbor addressable by digest).
+     Tag-only and digest-only refs pass through unchanged. Only the FINAL
+     path segment's tag is stripped, so a `host:port/...` registry ref is
+     left intact.
+    */}}
     normalize_ref() {
       _nr="$1"
       case "${_nr}" in
@@ -743,53 +801,55 @@ data:
       esac
     }
 
-    # #5030 (Refs #3379 #4994 #4975) — DURABLE dest-presence idempotency
-    # probe. Returns 0 (SKIP the copy) ONLY when the local Harbor DEST
-    # already serves the SAME manifest DURABLY (pushed into Harbor's own
-    # store), never on a transient pull-through.
-    #
-    # WHY the #4994 shape was WRONG: it proved dest presence with
-    # `skopeo inspect --raw` on the DESTINATION registry endpoint — a
-    # REGISTRY-PROTOCOL read that returns whatever registry.<fqdn> serves
-    # for the ref AT THAT MOMENT. During prewarm (step-03) egress is still
-    # up and the dest ref resolves through a pull-through-reachable path
-    # (a Harbor proxy-cache leg / an upstream still auth'd), so that
-    # inspect PULLS THE MANIFEST THROUGH from upstream and returns
-    # byte-identical bytes for an image that was NEVER durably pushed →
-    # src==dst → false "current" → the real `skopeo copy` is SKIPPED and
-    # the image logs (ok). The pull-through persists only the manifest, no
-    # blobs; after step-08's deny-egress hold the image 404s and step-08's
-    # completeness gate FAILS → cutoverComplete is never reached. Live
-    # hw244: proxy-ghcr/open-telemetry/opentelemetry-operator:0.101.0
-    # (durable Harbor artifact API returned NOT_FOUND while the dest
-    # inspect pull-throughs). Same class killed hw243 (velero/cnpg; #5026
-    # fixed only the host-pivot leg).
-    #
-    # FIX: probe the DEST via the Harbor ARTIFACT API
-    # (GET /api/v2.0/projects/<proj>/repositories/<repo>/artifacts/<ref>) —
-    # served by Harbor CORE against its DATABASE, so it reflects ONLY
-    # durably-stored artifacts and CANNOT pull through at ANY cutover phase.
-    # This is the SAME durable-presence assertion step-08's completeness
-    # gate makes, so a step-03 skip can NEVER diverge from the gate that
-    # then judges it. The SOURCE digest still comes from `skopeo inspect
-    # --raw` on the SOURCE (source pull-through is irrelevant — that IS the
-    # manifest we mirror FROM; its sha256 IS the manifest/-list digest, no
-    # blob pulled, correct for single-arch AND multi-arch). Skip ONLY on a
-    # real durable digest MATCH. Fail-CLOSED on ANY ambiguity: empty source
-    # sha (upstream unreachable), 404/absent/partial dest, curl/API error,
-    # or empty/mismatched dest digest all return non-zero → the caller does
-    # the real copy. So the fail-closed completeness contract is UNTOUCHED;
-    # this only elides a genuinely-redundant re-transfer.
-    # #5443 — the DURABLE-presence half of #5030, extracted so the
-    # Phase A2-guard asserts local-Harbor presence through the EXACT
-    # probe the idempotency skip trusts (and the one step-08's
-    # completeness gate makes). Harbor CORE answers this from its
-    # DATABASE, so it reflects only durably-stored artifacts and can
-    # never pull through — the whole point of #5030. Emits the artifact
-    # digest on stdout (empty when absent); exit status is curl/jq's,
-    # never load-bearing on its own.
-    #   $1 = local dest ref: the resolver PATH project/repo[:tag|@digest]
-    #        or a HARBOR_HOST-prefixed lref.
+    {{- /*
+     #5030 (Refs #3379 #4994 #4975) — DURABLE dest-presence idempotency
+     probe. Returns 0 (SKIP the copy) ONLY when the local Harbor DEST
+     already serves the SAME manifest DURABLY (pushed into Harbor's own
+     store), never on a transient pull-through.
+
+     WHY the #4994 shape was WRONG: it proved dest presence with
+     `skopeo inspect --raw` on the DESTINATION registry endpoint — a
+     REGISTRY-PROTOCOL read that returns whatever registry.<fqdn> serves
+     for the ref AT THAT MOMENT. During prewarm (step-03) egress is still
+     up and the dest ref resolves through a pull-through-reachable path
+     (a Harbor proxy-cache leg / an upstream still auth'd), so that
+     inspect PULLS THE MANIFEST THROUGH from upstream and returns
+     byte-identical bytes for an image that was NEVER durably pushed →
+     src==dst → false "current" → the real `skopeo copy` is SKIPPED and
+     the image logs (ok). The pull-through persists only the manifest, no
+     blobs; after step-08's deny-egress hold the image 404s and step-08's
+     completeness gate FAILS → cutoverComplete is never reached. Live
+     hw244: proxy-ghcr/open-telemetry/opentelemetry-operator:0.101.0
+     (durable Harbor artifact API returned NOT_FOUND while the dest
+     inspect pull-throughs). Same class killed hw243 (velero/cnpg; #5026
+     fixed only the host-pivot leg).
+
+     FIX: probe the DEST via the Harbor ARTIFACT API
+     (GET /api/v2.0/projects/<proj>/repositories/<repo>/artifacts/<ref>) —
+     served by Harbor CORE against its DATABASE, so it reflects ONLY
+     durably-stored artifacts and CANNOT pull through at ANY cutover phase.
+     This is the SAME durable-presence assertion step-08's completeness
+     gate makes, so a step-03 skip can NEVER diverge from the gate that
+     then judges it. The SOURCE digest still comes from `skopeo inspect
+     --raw` on the SOURCE (source pull-through is irrelevant — that IS the
+     manifest we mirror FROM; its sha256 IS the manifest/-list digest, no
+     blob pulled, correct for single-arch AND multi-arch). Skip ONLY on a
+     real durable digest MATCH. Fail-CLOSED on ANY ambiguity: empty source
+     sha (upstream unreachable), 404/absent/partial dest, curl/API error,
+     or empty/mismatched dest digest all return non-zero → the caller does
+     the real copy. So the fail-closed completeness contract is UNTOUCHED;
+     this only elides a genuinely-redundant re-transfer.
+     #5443 — the DURABLE-presence half of #5030, extracted so the
+     Phase A2-guard asserts local-Harbor presence through the EXACT
+     probe the idempotency skip trusts (and the one step-08's
+     completeness gate makes). Harbor CORE answers this from its
+     DATABASE, so it reflects only durably-stored artifacts and can
+     never pull through — the whole point of #5030. Emits the artifact
+     digest on stdout (empty when absent); exit status is curl/jq's,
+     never load-bearing on its own.
+       $1 = local dest ref: the resolver PATH project/repo[:tag|@digest]
+            or a HARBOR_HOST-prefixed lref.
+    */}}
     harbor_durable_digest() {
       _hd_pp="${1#${HARBOR_HOST}/}"
       _hd_ref="latest"
@@ -800,21 +860,23 @@ data:
         *)
           case "${_hd_pp##*/}" in *:*) _hd_ref="${_hd_pp##*:}"; _hd_pp="${_hd_pp%:*}" ;; esac ;;
       esac
-      # project = first path segment; repository = the (possibly nested) rest.
+      {{- /* project = first path segment; repository = the (possibly nested) rest. */}}
       case "${_hd_pp}" in
         */*) _hd_proj="${_hd_pp%%/*}"; _hd_repo="${_hd_pp#*/}" ;;
         *)   _hd_proj="${_hd_pp}";     _hd_repo="" ;;
       esac
-      # No repository segment → cannot address an artifact.
+      {{- /* No repository segment → cannot address an artifact. */}}
       [ -z "${_hd_repo}" ] && return 1
-      # Harbor's artifact API needs the nested repo name's `/` encoded as
-      # %2F. #5036: this check dials the Harbor CORE Service DIRECTLY
-      # (HARBOR_INTERNAL_URL) with NO gateway in the path, so SINGLE-encode
-      # (`/` -> %2F) — harbor-core receives %2F and routes the nested repo.
-      # (Under #4688's gateway path this was DOUBLE-encoded `%252F` to survive
-      # envoy's one-layer decode before Harbor; the direct Service path has no
-      # such decode.) -k is harmless over the plain-HTTP Service; retained so
-      # an https harborInternalURL override still works.
+      {{- /*
+       Harbor's artifact API needs the nested repo name's `/` encoded as
+       %2F. #5036: this check dials the Harbor CORE Service DIRECTLY
+       (HARBOR_INTERNAL_URL) with NO gateway in the path, so SINGLE-encode
+       (`/` -> %2F) — harbor-core receives %2F and routes the nested repo.
+       (Under #4688's gateway path this was DOUBLE-encoded `%252F` to survive
+       envoy's one-layer decode before Harbor; the direct Service path has no
+       such decode.) -k is harmless over the plain-HTTP Service; retained so
+       an https harborInternalURL override still works.
+      */}}
       _hd_repo_enc=$(printf '%s' "${_hd_repo}" | sed 's#/#%2F#g')
       curl -sk --max-time 30 \
         -u "${HARBOR_USERNAME}:${HARBOR_PASSWORD}" \
@@ -823,11 +885,13 @@ data:
     }
 
     dest_already_current() {
-      # $1 upstream ref  $2 local dest ref (either the resolver PATH
-      #    project/repo[:tag|@digest] OR a HARBOR_HOST-prefixed lref)
-      #    $3 src creds (may be empty)
+      {{- /*
+       $1 upstream ref  $2 local dest ref (either the resolver PATH
+          project/repo[:tag|@digest] OR a HARBOR_HOST-prefixed lref)
+          $3 src creds (may be empty)
+      */}}
       _dc_up="$1"; _dc_dref="$2"; _dc_sc="$3"
-      # SOURCE manifest digest (sha256 of the raw manifest/-list bytes).
+      {{- /* SOURCE manifest digest (sha256 of the raw manifest/-list bytes). */}}
       if [ -n "${_dc_sc}" ]; then
         _dc_s=$(skopeo --command-timeout "${PREWARM_SKOPEO_TIMEOUT}" inspect --raw \
           --creds="${_dc_sc}" --tls-verify=true "docker://${_dc_up}" 2>/dev/null \
@@ -839,98 +903,104 @@ data:
       fi
       [ -z "${_dc_s}" ] && return 1
       _dc_s="sha256:${_dc_s}"
-      # Durable DEST digest from Harbor CORE (never pull-through) via the
-      # in-cluster Service (#5036) — #5443 factored the probe into
-      # harbor_durable_digest above so the Phase A2-guard cannot fork it.
-      # Fail-closed: an absent/404/partial dest yields an empty digest and
-      # falls through to a full re-copy — never a false "already current".
+      {{- /*
+       Durable DEST digest from Harbor CORE (never pull-through) via the
+       in-cluster Service (#5036) — #5443 factored the probe into
+       harbor_durable_digest above so the Phase A2-guard cannot fork it.
+       Fail-closed: an absent/404/partial dest yields an empty digest and
+       falls through to a full re-copy — never a false "already current".
+      */}}
       _dc_d=$(harbor_durable_digest "${_dc_dref}")
       [ -n "${_dc_d}" ] && [ "${_dc_s}" = "${_dc_d}" ]
     }
 
-    # #5095 — ONE bounded skopeo image copy SRC → LREF with optional
-    # src creds; output appended to LOGFILE. Factored out of copy_one
-    # so the proxy-source attempt and the #5095 direct-upstream
-    # fallback attempt share ONE invocation. The function's exit
-    # status is skopeo's REAL status (the #3379 hw138 always-0 trap
-    # stays closed: callers branch on it inside an if/else, never a
-    # pipeline). All prior flags are preserved:
-    #   • #3944 --command-timeout (GLOBAL flag before `copy`) bounds a
-    #     stalled-but-alive connection so it FAILS FAST and the outer
-    #     per-image retry loop can self-heal.
-    #   • #4529 --dest-tls-verify=${PREWARM_DEST_TLS_VERIFY} (default
-    #     false — in-cluster/LE-staging Harbor dest); --src-tls-verify
-    #     stays true (external public-CA sources).
-    #   • #4975 --multi-arch all: skopeo's default `--multi-arch
-    #     system` copies ONLY the running platform's sub-image out of
-    #     a manifest LIST while the copy is ADDRESSED by the list's
-    #     digest — Harbor computes the single-arch digest ≠ list
-    #     digest → `digest invalid` (live hw239: all 8 multi-arch
-    #     images FAILED). containerd pulls BY the list digest, so the
-    #     FULL list + all arch sub-manifests + blobs must land.
-    #     Single-arch refs are unaffected.
-    #   • #5468 the ONE documented exception to `--multi-arch all`, per
-    #     image, via prewarm_multiarch_flags below.
+    {{- /*
+     #5095 — ONE bounded skopeo image copy SRC → LREF with optional
+     src creds; output appended to LOGFILE. Factored out of copy_one
+     so the proxy-source attempt and the #5095 direct-upstream
+     fallback attempt share ONE invocation. The function's exit
+     status is skopeo's REAL status (the #3379 hw138 always-0 trap
+     stays closed: callers branch on it inside an if/else, never a
+     pipeline). All prior flags are preserved:
+       • #3944 --command-timeout (GLOBAL flag before `copy`) bounds a
+         stalled-but-alive connection so it FAILS FAST and the outer
+         per-image retry loop can self-heal.
+       • #4529 --dest-tls-verify=${PREWARM_DEST_TLS_VERIFY} (default
+         false — in-cluster/LE-staging Harbor dest); --src-tls-verify
+         stays true (external public-CA sources).
+       • #4975 --multi-arch all: skopeo's default `--multi-arch
+         system` copies ONLY the running platform's sub-image out of
+         a manifest LIST while the copy is ADDRESSED by the list's
+         digest — Harbor computes the single-arch digest ≠ list
+         digest → `digest invalid` (live hw239: all 8 multi-arch
+         images FAILED). containerd pulls BY the list digest, so the
+         FULL list + all arch sub-manifests + blobs must land.
+         Single-arch refs are unaffected.
+       • #5468 the ONE documented exception to `--multi-arch all`, per
+         image, via prewarm_multiarch_flags below.
+    */}}
 
-    # #5468 (Refs #5442 #4975) — emit the skopeo multi-arch flag set for
-    # ONE source ref.
-    #
-    # DEFAULT is `--multi-arch all` for every ref — the #4975 contract is
-    # untouched, and narrowing it GLOBALLY is the wrong fix (it
-    # reproduces hw239's `digest invalid` across every multi-arch image,
-    # because those copies are addressed BY the manifest-list digest).
-    #
-    # THE EXCEPTION. A ref matching PREWARM_SINGLE_PLATFORM_SUBSTRINGS is
-    # copied as a SINGLE platform instead. This exists for upstream
-    # manifest lists that are MALFORMED in a way Harbor cannot ingest, so
-    # that no amount of retrying or egress can ever land them whole.
-    #
-    # The proven instance is ghcr.io/berriai/litellm-database (live hw291
-    # 2026-07-28, step-03 A3 `ok=35 fail=1 durable_miss=1`). Its
-    # `main-v1.57.2` OCI index lists EIGHT entries that are only FOUR
-    # distinct children — every child appears TWICE, byte-identical in
-    # mediaType, digest, size, platform and annotations:
-    #
-    #   c94ccc84 linux/amd64      x2
-    #   10c24c81 linux/arm64      x2
-    #   df4ae6f5 unknown/unknown  x2   (attestation for c94ccc84)
-    #   bc165dad unknown/unknown  x2   (attestation for 10c24c81)
-    #
-    # skopeo copies all eight children fine (they are just the same four
-    # blobs pushed twice) and then FATALs on the manifest-LIST upload
-    # alone: Harbor accepts the PUT and its post-push artifact walk then
-    # inserts one artifact_reference row per index entry — the duplicate
-    # (parent,child) pairs violate the table's uniqueness, the enclosing
-    # transaction rolls back, and the immediately-following read of the
-    # index Harbor was just handed answers
-    #   `unknown: artifact …@sha256:a1ed0885… not found`
-    # for a digest Harbor itself computed. Deterministic and permanent.
-    #
-    # IT IS NOT THE ATTESTATIONS. The same repository's `main-latest` tag
-    # carries the SAME two `unknown/unknown` buildx attestation children
-    # and mirrors cleanly in the same wave — its index simply lists each
-    # child ONCE. Duplication is the whole defect; attestations are a
-    # red herring.
-    #
-    # WHY SINGLE-PLATFORM IS SAFE *HERE* and not globally: the #4975
-    # `digest invalid` trap fires only when the copy is addressed by the
-    # list digest. Both refs this repository declares are addressed BY
-    # TAG (`:main-v1.57.2` from the chart's appVersion, `:main-latest`
-    # hardcoded in the upstream migration Job), so the destination tag
-    # resolving to a single amd64 manifest is exactly what containerd
-    # asks for on a linux/amd64 Sovereign node. The Phase A3-guard
-    # asserts durable PRESENCE via harbor_durable_digest, never
-    # source-digest equality, so a single-platform copy satisfies it.
-    # The #4994 dest_already_current skip WILL miss for these refs (index
-    # digest != child digest), so they re-copy on every step-03 re-run —
-    # fail-OPEN, an extra transfer and never a false present.
-    #
-    # Every env read is `:-`-defaulted because this script runs under
-    # `set -eu` (L387): an unset var would abort the WHOLE step rather
-    # than fall back, and the fallback here — no exception, os/arch
-    # linux/amd64 — is exactly the safe direction. An empty
-    # substrings list iterates zero times, i.e. `--multi-arch all` for
-    # everything, which is the pre-#5468 behaviour.
+    {{- /*
+     #5468 (Refs #5442 #4975) — emit the skopeo multi-arch flag set for
+     ONE source ref.
+
+     DEFAULT is `--multi-arch all` for every ref — the #4975 contract is
+     untouched, and narrowing it GLOBALLY is the wrong fix (it
+     reproduces hw239's `digest invalid` across every multi-arch image,
+     because those copies are addressed BY the manifest-list digest).
+
+     THE EXCEPTION. A ref matching PREWARM_SINGLE_PLATFORM_SUBSTRINGS is
+     copied as a SINGLE platform instead. This exists for upstream
+     manifest lists that are MALFORMED in a way Harbor cannot ingest, so
+     that no amount of retrying or egress can ever land them whole.
+
+     The proven instance is ghcr.io/berriai/litellm-database (live hw291
+     2026-07-28, step-03 A3 `ok=35 fail=1 durable_miss=1`). Its
+     `main-v1.57.2` OCI index lists EIGHT entries that are only FOUR
+     distinct children — every child appears TWICE, byte-identical in
+     mediaType, digest, size, platform and annotations:
+
+       c94ccc84 linux/amd64      x2
+       10c24c81 linux/arm64      x2
+       df4ae6f5 unknown/unknown  x2   (attestation for c94ccc84)
+       bc165dad unknown/unknown  x2   (attestation for 10c24c81)
+
+     skopeo copies all eight children fine (they are just the same four
+     blobs pushed twice) and then FATALs on the manifest-LIST upload
+     alone: Harbor accepts the PUT and its post-push artifact walk then
+     inserts one artifact_reference row per index entry — the duplicate
+     (parent,child) pairs violate the table's uniqueness, the enclosing
+     transaction rolls back, and the immediately-following read of the
+     index Harbor was just handed answers
+       `unknown: artifact …@sha256:a1ed0885… not found`
+     for a digest Harbor itself computed. Deterministic and permanent.
+
+     IT IS NOT THE ATTESTATIONS. The same repository's `main-latest` tag
+     carries the SAME two `unknown/unknown` buildx attestation children
+     and mirrors cleanly in the same wave — its index simply lists each
+     child ONCE. Duplication is the whole defect; attestations are a
+     red herring.
+
+     WHY SINGLE-PLATFORM IS SAFE *HERE* and not globally: the #4975
+     `digest invalid` trap fires only when the copy is addressed by the
+     list digest. Both refs this repository declares are addressed BY
+     TAG (`:main-v1.57.2` from the chart's appVersion, `:main-latest`
+     hardcoded in the upstream migration Job), so the destination tag
+     resolving to a single amd64 manifest is exactly what containerd
+     asks for on a linux/amd64 Sovereign node. The Phase A3-guard
+     asserts durable PRESENCE via harbor_durable_digest, never
+     source-digest equality, so a single-platform copy satisfies it.
+     The #4994 dest_already_current skip WILL miss for these refs (index
+     digest != child digest), so they re-copy on every step-03 re-run —
+     fail-OPEN, an extra transfer and never a false present.
+
+     Every env read is `:-`-defaulted because this script runs under
+     `set -eu` (L387): an unset var would abort the WHOLE step rather
+     than fall back, and the fallback here — no exception, os/arch
+     linux/amd64 — is exactly the safe direction. An empty
+     substrings list iterates zero times, i.e. `--multi-arch all` for
+     everything, which is the pre-#5468 behaviour.
+    */}}
     prewarm_multiarch_flags() {
       _ma_ref="$1"
       for _ma_s in ${PREWARM_SINGLE_PLATFORM_SUBSTRINGS:-}; do
@@ -944,23 +1014,29 @@ data:
       printf -- '--multi-arch all'
     }
 
-    # #5525 leg 2 — slug a registry host into a latch-file-safe token
-    # (same tr class as the per-image log slug above).
+    {{- /*
+     #5525 leg 2 — slug a registry host into a latch-file-safe token
+     (same tr class as the per-image log slug above).
+    */}}
     rl_slug() { printf '%s' "$1" | tr -c 'A-Za-z0-9._-' '_'; }
 
     prewarm_skopeo_copy() {
       _pc_src="$1"; _pc_creds="$2"; _pc_lref="$3"; _pc_log="$4"
-      # #5468 — multi-arch mode FIRST into the function's OWN positional
-      # params (deliberately unquoted: the flag string must word-split).
-      # Matching is on the SOURCE ref, which may be the mothership-proxy
-      # form or the #5095 direct-upstream form — a repository-path
-      # substring matches both, exactly as EXCLUDED_SUBSTRINGS does.
+      {{- /*
+       #5468 — multi-arch mode FIRST into the function's OWN positional
+       params (deliberately unquoted: the flag string must word-split).
+       Matching is on the SOURCE ref, which may be the mothership-proxy
+       form or the #5095 direct-upstream form — a repository-path
+       substring matches both, exactly as EXCLUDED_SUBSTRINGS does.
+      */}}
       set -- $(prewarm_multiarch_flags "${_pc_src}")
-      # Optional --src-creds (empty for anonymous upstreams).
+      {{- /* Optional --src-creds (empty for anonymous upstreams). */}}
       if [ -n "${_pc_creds}" ]; then set -- "$@" --src-creds="${_pc_creds}"; fi
-      # #5525 leg 2 — byte offset of the log BEFORE this leg runs, so
-      # the rate-limit sniff below reads ONLY this leg's own output —
-      # never a prior attempt's, never another source's.
+      {{- /*
+       #5525 leg 2 — byte offset of the log BEFORE this leg runs, so
+       the rate-limit sniff below reads ONLY this leg's own output —
+       never a prior attempt's, never another source's.
+      */}}
       _pc_off=$(wc -c < "${_pc_log}" 2>/dev/null || echo 0)
       if skopeo --command-timeout "${PREWARM_SKOPEO_TIMEOUT}" copy \
         --insecure-policy \
@@ -972,18 +1048,22 @@ data:
         "docker://${_pc_src}" "docker://${_pc_lref}" >>"${_pc_log}" 2>&1; then
         return 0
       else
-        # Capture skopeo's REAL exit status INSIDE the else branch
-        # (the #3379 hw138 always-0 trap).
+        {{- /*
+         Capture skopeo's REAL exit status INSIDE the else branch
+         (the #3379 hw138 always-0 trap).
+        */}}
         _pc_rc=$?
       fi
-      # #5525 leg 2 — `toomanyrequests` is a PER-IP quota window: every
-      # further pull from this host inside the same window (same cluster
-      # egress IP) is guaranteed waste that itself keeps the window
-      # exhausted (hw291 2026-07-30: 3 outer x 5 inner manifest reads
-      # per image per pod attempt SUSTAINED the exhaustion for ~60 min
-      # across 4 pod attempts). Latch the SOURCE host so copy_one skips
-      # it for the remainder of this job attempt wherever a fallback
-      # source exists.
+      {{- /*
+       #5525 leg 2 — `toomanyrequests` is a PER-IP quota window: every
+       further pull from this host inside the same window (same cluster
+       egress IP) is guaranteed waste that itself keeps the window
+       exhausted (hw291 2026-07-30: 3 outer x 5 inner manifest reads
+       per image per pod attempt SUSTAINED the exhaustion for ~60 min
+       across 4 pod attempts). Latch the SOURCE host so copy_one skips
+       it for the remainder of this job attempt wherever a fallback
+       source exists.
+      */}}
       _pc_h="${_pc_src%%/*}"
       if tail -c +"$((_pc_off+1))" "${_pc_log}" 2>/dev/null | grep -qi 'toomanyrequests'; then
         if [ ! -f "${cpdir}/.ratelimited.$(rl_slug "${_pc_h}")" ]; then
@@ -994,45 +1074,49 @@ data:
       return "${_pc_rc}"
     }
 
-    # #4975 — copy ONE upstream image to ALL of its local Harbor
-    # destination path(s) (usually one; TWO for a ghcr.io/openova-io/*
-    # ref — the host-drop openova-io/… convention + proxy-ghcr/openova-io/…).
-    # Destinations come from the shared resolver (offlinemirror_local_paths)
-    # so step-03 push and step-08 completeness HEAD agree byte-for-byte.
-    # The per-image record is .ok only if EVERY dest copy succeeded.
+    {{- /*
+     #4975 — copy ONE upstream image to ALL of its local Harbor
+     destination path(s) (usually one; TWO for a ghcr.io/openova-io/*
+     ref — the host-drop openova-io/… convention + proxy-ghcr/openova-io/…).
+     Destinations come from the shared resolver (offlinemirror_local_paths)
+     so step-03 push and step-08 completeness HEAD agree byte-for-byte.
+     The per-image record is .ok only if EVERY dest copy succeeded.
+    */}}
     copy_one() {
       up=$(offlinemirror_normalize_ref "$1")
       slug=$(printf '%s' "${up}" | tr -c 'A-Za-z0-9._-' '_')
       : >"${cpdir}/${slug}.log"
       dests=$(offlinemirror_local_paths "${up}")
       if [ -z "${dests}" ]; then
-        # Excluded at copy time (belt to the pre-pass filter).
+        {{- /* Excluded at copy time (belt to the pre-pass filter). */}}
         printf '%s (excluded)' "${up}" >"${cpdir}/${slug}.ok"
         return 0
       fi
-      # SOURCE host → src-creds selection (bare official image = docker.io).
+      {{- /* SOURCE host → src-creds selection (bare official image = docker.io). */}}
       srchost="${up%%/*}"
       case "${srchost}" in *.*|*:*|localhost) : ;; *) srchost="docker.io" ;; esac
       sc=$(src_creds_for "${srchost}")
-      # #5095 (Refs #5093) — direct-source fallback derivation for a
-      # MOTHERSHIP-PROXY-sourced ref. A `harbor.openova.io/proxy-<x>/
-      # <path>` source is a hard PRE-cutover tether to mothership
-      # reachability: a routine per-prefix transit flap (hw255
-      # 2026-07-15 05:20–05:55Z, #5093 — mothership healthy worldwide,
-      # only the path black-holed) FAILs every such copy while direct
-      # upstream copies stay fine. Derive the canonical upstream ref
-      # MECHANICALLY from the proxy path via an INVERSE coverage-map
-      # lookup — the FIRST HOST_PROJECT_MAP host whose project equals
-      # the ref's proxy-<x> segment (proxy-dockerhub → docker.io,
-      # proxy-quay → quay.io, proxy-k8s → registry.k8s.io, proxy-gcr →
-      # gcr.io, proxy-ghcr → ghcr.io) — so NO second hand-list exists.
-      # The fallback fires ONLY after the proxy-source copy fails
-      # inside an attempt; the DEST path (host-swap, path preserved)
-      # is untouched, so step-04/07/08 resolve the identical local
-      # artifact. Upstream rate-limit exposure is bounded: ~10-20
-      # images, and only while the proxy path is failing. src-creds
-      # for the fallback host go through the SAME src_creds_for
-      # selector (ghcr.io → PAT; anonymous elsewhere).
+      {{- /*
+       #5095 (Refs #5093) — direct-source fallback derivation for a
+       MOTHERSHIP-PROXY-sourced ref. A `harbor.openova.io/proxy-<x>/
+       <path>` source is a hard PRE-cutover tether to mothership
+       reachability: a routine per-prefix transit flap (hw255
+       2026-07-15 05:20–05:55Z, #5093 — mothership healthy worldwide,
+       only the path black-holed) FAILs every such copy while direct
+       upstream copies stay fine. Derive the canonical upstream ref
+       MECHANICALLY from the proxy path via an INVERSE coverage-map
+       lookup — the FIRST HOST_PROJECT_MAP host whose project equals
+       the ref's proxy-<x> segment (proxy-dockerhub → docker.io,
+       proxy-quay → quay.io, proxy-k8s → registry.k8s.io, proxy-gcr →
+       gcr.io, proxy-ghcr → ghcr.io) — so NO second hand-list exists.
+       The fallback fires ONLY after the proxy-source copy fails
+       inside an attempt; the DEST path (host-swap, path preserved)
+       is untouched, so step-04/07/08 resolve the identical local
+       artifact. Upstream rate-limit exposure is bounded: ~10-20
+       images, and only while the proxy path is failing. src-creds
+       for the fallback host go through the SAME src_creds_for
+       selector (ghcr.io → PAT; anonymous elsewhere).
+      */}}
       proxy_src=0
       fb_up=""
       fb_creds=""
@@ -1057,24 +1141,26 @@ data:
             ;;
         esac
       elif [ -n "${MOTHERSHIP_HOST:-}" ]; then
-        # #5525 leg 1 (Refs #5095 #5442) — Scarf download gateways
-        # (*.docker.scarf.sh) are REDIRECTORS in front of Docker Hub,
-        # not registries: they delegate auth to Docker Hub's own token
-        # service and pass through Hub's verbatim rate-limit body, so
-        # Hub's ANONYMOUS per-IP quota applies THROUGH them. Live hw291
-        # 2026-07-30 (dep 2c2d746b578c636b): 4 litmuschaos refs burned
-        # 4 pod attempts over ~60 min on `toomanyrequests` while the
-        # SAME artifacts were anonymously servable from the mothership
-        # proxy the whole time — the #5095 fallback never engaged
-        # because it fires only for mothership-SOURCED refs. Derive the
-        # INVERSE fallback here — mothership proxy as the SECONDARY
-        # source — via the FORWARD coverage-map lookup (this host's own
-        # project, e.g. litmuschaos.docker.scarf.sh -> proxy-dockerhub),
-        # path preserved: ${MOTHERSHIP_HOST}/<project>/<path>. No
-        # second hand-list; a scarf host absent from the map stays
-        # fallback-less (it would be UNMAPPED in the pre-pass anyway).
-        # Source selection ONLY: the DEST path is untouched, so
-        # step-04/07/08 resolve the identical LOCAL artifact.
+        {{- /*
+         #5525 leg 1 (Refs #5095 #5442) — Scarf download gateways
+         (*.docker.scarf.sh) are REDIRECTORS in front of Docker Hub,
+         not registries: they delegate auth to Docker Hub's own token
+         service and pass through Hub's verbatim rate-limit body, so
+         Hub's ANONYMOUS per-IP quota applies THROUGH them. Live hw291
+         2026-07-30 (dep 2c2d746b578c636b): 4 litmuschaos refs burned
+         4 pod attempts over ~60 min on `toomanyrequests` while the
+         SAME artifacts were anonymously servable from the mothership
+         proxy the whole time — the #5095 fallback never engaged
+         because it fires only for mothership-SOURCED refs. Derive the
+         INVERSE fallback here — mothership proxy as the SECONDARY
+         source — via the FORWARD coverage-map lookup (this host's own
+         project, e.g. litmuschaos.docker.scarf.sh -> proxy-dockerhub),
+         path preserved: ${MOTHERSHIP_HOST}/<project>/<path>. No
+         second hand-list; a scarf host absent from the map stays
+         fallback-less (it would be UNMAPPED in the pre-pass anyway).
+         Source selection ONLY: the DEST path is untouched, so
+         step-04/07/08 resolve the identical LOCAL artifact.
+        */}}
         case "${srchost}" in
           *.docker.scarf.sh)
             _fb_proj=""
@@ -1095,29 +1181,33 @@ data:
       last_rc=0
       for dpath in ${dests}; do
         lref="${HARBOR_HOST}/${dpath}"
-        # #4994 — SKIP the (potentially multi-hundred-MB) copy when the
-        # dest already serves byte-identical content. Streams a real-time
-        # SKIP line to stdout so the operator sees instant forward progress
-        # for pre-warmed / re-run images instead of a silent 68m (hw240).
+        {{- /*
+         #4994 — SKIP the (potentially multi-hundred-MB) copy when the
+         dest already serves byte-identical content. Streams a real-time
+         SKIP line to stdout so the operator sees instant forward progress
+         for pre-warmed / re-run images instead of a silent 68m (hw240).
+        */}}
         if [ "${PREWARM_SKIP_IF_PRESENT:-true}" = "true" ] \
            && dest_already_current "${up}" "${lref}" "${sc}"; then
           echo "[harbor-prewarm] skip ${up} -> ${lref} (dest already current)"
           echo "  SKIP ${up} -> ${lref} (dest already serves identical manifest; copy skipped)" >>"${cpdir}/${slug}.log"
           continue
         fi
-        # OUTER per-dest retry loop: `--retry-times 5` self-heals a
-        # transient blob fetch inside ONE copy; a Harbor-side reset that
-        # closes the dest connection can still abort the whole copy
-        # (hw146 large-image FATAL), so re-attempt the full copy up to
-        # PREWARM_COPY_ATTEMPTS times — or, for a MOTHERSHIP-PROXY-
-        # sourced ref, PREWARM_PROXY_COPY_ATTEMPTS with EXPONENTIAL
-        # backoff (#5095: the fixed 3×5s budget exhausted inside the
-        # hw255 35-min transit flap). The skopeo invocation itself
-        # (with all the #3944/#4529/#4975 flags) lives in
-        # prewarm_skopeo_copy above; the caller branches on its REAL
-        # exit status (the #3379 hw138 always-0 trap stays closed).
-        # FATAL-on-any-failure preserved: the image is .fail unless
-        # every dest copy eventually succeeds from SOME source.
+        {{- /*
+         OUTER per-dest retry loop: `--retry-times 5` self-heals a
+         transient blob fetch inside ONE copy; a Harbor-side reset that
+         closes the dest connection can still abort the whole copy
+         (hw146 large-image FATAL), so re-attempt the full copy up to
+         PREWARM_COPY_ATTEMPTS times — or, for a MOTHERSHIP-PROXY-
+         sourced ref, PREWARM_PROXY_COPY_ATTEMPTS with EXPONENTIAL
+         backoff (#5095: the fixed 3×5s budget exhausted inside the
+         hw255 35-min transit flap). The skopeo invocation itself
+         (with all the #3944/#4529/#4975 flags) lives in
+         prewarm_skopeo_copy above; the caller branches on its REAL
+         exit status (the #3379 hw138 always-0 trap stays closed).
+         FATAL-on-any-failure preserved: the image is .fail unless
+         every dest copy eventually succeeds from SOME source.
+        */}}
         attempt=1
         rc=1
         src_used=""
@@ -1127,26 +1217,28 @@ data:
           max_attempts="${PREWARM_COPY_ATTEMPTS}"
         fi
         while [ "${attempt}" -le "${max_attempts}" ]; do
-          # #5095 round 2 — proxy-DOWN DIRECT-FIRST short-circuit. When the
-          # ref is mothership-proxy-sourced, HAS a mechanically-derived
-          # direct upstream, AND the proxy is latched DOWN for this step
-          # (the upfront probe found it unreachable, or a proxy leg earlier
-          # this wave failed while its direct sibling succeeded), try the
-          # DIRECT upstream FIRST and skip the dead proxy entirely on
-          # success — so no image burns the 1200s --command-timeout probing
-          # the dead proxy before the fast direct path is even tried (round
-          # 1 shipped the fallback but always AFTER the timed-out proxy
-          # leg — the per-image "proxy timeout tax" that dragged the wave to
-          # ~100 min for 140 images). Re-checked every attempt so a latch
-          # flipped by another worker reorders THIS image's remaining
-          # attempts too. The DEST ref is identical (host-swap, path
-          # preserved), so step-04/07/08 resolve the same LOCAL artifact.
-          # On a direct-first MISS we fall straight through to the round-1
-          # proxy-first path below (the proxy might have just recovered).
-          # #5525 — additionally gated on proxy_src: for a scarf-sourced
-          # ref (leg 1 above) fb_up IS the mothership proxy, so a
-          # .proxy_down latch must keep the ordering primary-first, not
-          # route it to the dead proxy first.
+          {{- /*
+           #5095 round 2 — proxy-DOWN DIRECT-FIRST short-circuit. When the
+           ref is mothership-proxy-sourced, HAS a mechanically-derived
+           direct upstream, AND the proxy is latched DOWN for this step
+           (the upfront probe found it unreachable, or a proxy leg earlier
+           this wave failed while its direct sibling succeeded), try the
+           DIRECT upstream FIRST and skip the dead proxy entirely on
+           success — so no image burns the 1200s --command-timeout probing
+           the dead proxy before the fast direct path is even tried (round
+           1 shipped the fallback but always AFTER the timed-out proxy
+           leg — the per-image "proxy timeout tax" that dragged the wave to
+           ~100 min for 140 images). Re-checked every attempt so a latch
+           flipped by another worker reorders THIS image's remaining
+           attempts too. The DEST ref is identical (host-swap, path
+           preserved), so step-04/07/08 resolve the same LOCAL artifact.
+           On a direct-first MISS we fall straight through to the round-1
+           proxy-first path below (the proxy might have just recovered).
+           #5525 — additionally gated on proxy_src: for a scarf-sourced
+           ref (leg 1 above) fb_up IS the mothership proxy, so a
+           .proxy_down latch must keep the ordering primary-first, not
+           route it to the dead proxy first.
+          */}}
           if [ "${proxy_src}" -eq 1 ] && [ -n "${fb_up}" ] && [ "${PROXY_DIRECT_FIRST_ENABLED:-true}" = "true" ] && [ -f "${cpdir}/.proxy_down" ]; then
             echo "[harbor-prewarm] proxy latched DOWN; direct-first ${fb_up} -> ${lref} attempt ${attempt}/${max_attempts} (#5095 round 2)" >>"${cpdir}/${slug}.log"
             if prewarm_skopeo_copy "${fb_up}" "${fb_creds}" "${lref}" "${cpdir}/${slug}.log"; then
@@ -1157,14 +1249,16 @@ data:
               rc=$?
             fi
           fi
-          # #5525 leg 2 — the primary source host answered
-          # `toomanyrequests` earlier in this job attempt and a fallback
-          # source exists: skip the primary leg outright (every pull
-          # from the same egress IP inside the same quota window is
-          # guaranteed waste that re-arms the window) and go straight to
-          # the fallback below. Without a fallback the primary keeps its
-          # attempts — failing instantly with zero copies tried would
-          # trade a slow failure for a certain one.
+          {{- /*
+           #5525 leg 2 — the primary source host answered
+           `toomanyrequests` earlier in this job attempt and a fallback
+           source exists: skip the primary leg outright (every pull
+           from the same egress IP inside the same quota window is
+           guaranteed waste that re-arms the window) and go straight to
+           the fallback below. Without a fallback the primary keeps its
+           attempts — failing instantly with zero copies tried would
+           trade a slow failure for a certain one.
+          */}}
           if [ -n "${fb_up}" ] && [ -f "${cpdir}/.ratelimited.$(rl_slug "${srchost}")" ]; then
             echo "[harbor-prewarm] skip rate-limited primary ${up} (host latched toomanyrequests); straight to fallback ${fb_up} attempt ${attempt}/${max_attempts} (#5525)" >>"${cpdir}/${slug}.log"
             rc=1
@@ -1175,18 +1269,22 @@ data:
               src_used="${up}"
               break
             else
-              # Capture skopeo's REAL exit status INSIDE the else branch
-              # (the #3379 hw138 always-0 trap).
+              {{- /*
+               Capture skopeo's REAL exit status INSIDE the else branch
+               (the #3379 hw138 always-0 trap).
+              */}}
               rc=$?
             fi
           fi
-          # #5095 — direct-source fallback: BEFORE counting this
-          # attempt failed, retry the SAME image from its canonical
-          # upstream (same dest ref, same attempt) when the failed
-          # source was the mothership proxy. A per-prefix transit flap
-          # toward the mothership leaves the direct upstream fully
-          # reachable (proven hw255: ghcr.io copies all ok while every
-          # harbor.openova.io copy FAILed exit=1).
+          {{- /*
+           #5095 — direct-source fallback: BEFORE counting this
+           attempt failed, retry the SAME image from its canonical
+           upstream (same dest ref, same attempt) when the failed
+           source was the mothership proxy. A per-prefix transit flap
+           toward the mothership leaves the direct upstream fully
+           reachable (proven hw255: ghcr.io copies all ok while every
+           harbor.openova.io copy FAILed exit=1).
+          */}}
           if [ -n "${fb_up}" ]; then
             if [ "${proxy_src}" -eq 1 ]; then
               echo "[harbor-prewarm] proxy source failed (exit=${rc}); direct-source fallback ${fb_up} -> ${lref} attempt ${attempt}/${max_attempts} (#5095)" >>"${cpdir}/${slug}.log"
@@ -1196,13 +1294,15 @@ data:
             if prewarm_skopeo_copy "${fb_up}" "${fb_creds}" "${lref}" "${cpdir}/${slug}.log"; then
               rc=0
               src_used="${fb_up}"
-              # #5095 round 2 — the proxy leg failed but its direct sibling
-              # SUCCEEDED: a precise "proxy bad, direct good" signal (the
-              # hw255 signature). Latch the proxy DOWN so the rest of the
-              # wave skips proxy-first via the short-circuit above and pays
-              # no further timeout tax. Fires ONLY when the proxy was tried
-              # (proxy_src=1), never on a broad outage where direct also
-              # fails. Idempotent touch, safe under the parallel fan-out.
+              {{- /*
+               #5095 round 2 — the proxy leg failed but its direct sibling
+               SUCCEEDED: a precise "proxy bad, direct good" signal (the
+               hw255 signature). Latch the proxy DOWN so the rest of the
+               wave skips proxy-first via the short-circuit above and pays
+               no further timeout tax. Fires ONLY when the proxy was tried
+               (proxy_src=1), never on a broad outage where direct also
+               fails. Idempotent touch, safe under the parallel fan-out.
+              */}}
               if [ "${proxy_src}" -eq 1 ] && [ "${PROXY_DIRECT_FIRST_ENABLED:-true}" = "true" ]; then
                 touch "${cpdir}/.proxy_down" 2>/dev/null || true
               fi
@@ -1215,14 +1315,16 @@ data:
           attempt=$((attempt+1))
           if [ "${attempt}" -le "${max_attempts}" ]; then
             if [ "${proxy_src}" -eq 1 ]; then
-              # #5095 flap-tolerant pacing: exponential backoff
-              # base*2^(n-2) before attempt n → 30,60,120,240,480s =
-              # 930s (≥15 min) of spacing across the default 6-attempt
-              # budget, so a short transit flap toward the mothership
-              # cannot exhaust it. Comfortably inside the 9600s step
-              # deadline (#5298); a flap-failure is fast (reset/refused), not a
-              # stall, so the #3944 --command-timeout stays the stall
-              # bound.
+              {{- /*
+               #5095 flap-tolerant pacing: exponential backoff
+               base*2^(n-2) before attempt n → 30,60,120,240,480s =
+               930s (≥15 min) of spacing across the default 6-attempt
+               budget, so a short transit flap toward the mothership
+               cannot exhaust it. Comfortably inside the 9600s step
+               deadline (#5298); a flap-failure is fast (reset/refused), not a
+               stall, so the #3944 --command-timeout stays the stall
+               bound.
+              */}}
               _bo="${PREWARM_PROXY_BACKOFF_BASE_SECONDS}"
               _bi=2
               while [ "${_bi}" -lt "${attempt}" ]; do _bo=$((_bo*2)); _bi=$((_bi+1)); done
@@ -1233,23 +1335,25 @@ data:
             fi
           fi
         done
-        # #5525 leg 3 — a source-side outage must not fail an image the
-        # local registry ALREADY serves. The #4994 skip keys on a SOURCE
-        # manifest read; when that source is rate-limited/unreachable
-        # the skip cannot run, the copy is attempted, fails, and the
-        # image counts failed even though the dest is current (hw291
-        # attempt 1785396281: A3-guard PASS durable_miss=0 alongside
-        # FATAL copy_fail=4 — a self-contradiction). So before counting
-        # the failure: if the SOURCE manifest is unreadable (the host is
-        # rate-limit-latched, or a fresh raw-manifest read yields
-        # nothing — i.e. the skip genuinely could not have run), fall
-        # back to a DEST-presence probe via harbor_durable_digest
-        # (Harbor CORE's DB, never a pull-through). Durably present ⇒
-        # WARN + keep the artifact: freshness against the source is
-        # unverifiable this run, and durable presence is exactly what
-        # the post-pivot pull contract needs. A READABLE source keeps
-        # the strict fail semantics — the failure then is a real
-        # transfer/dest defect, not a source blind spot.
+        {{- /*
+         #5525 leg 3 — a source-side outage must not fail an image the
+         local registry ALREADY serves. The #4994 skip keys on a SOURCE
+         manifest read; when that source is rate-limited/unreachable
+         the skip cannot run, the copy is attempted, fails, and the
+         image counts failed even though the dest is current (hw291
+         attempt 1785396281: A3-guard PASS durable_miss=0 alongside
+         FATAL copy_fail=4 — a self-contradiction). So before counting
+         the failure: if the SOURCE manifest is unreadable (the host is
+         rate-limit-latched, or a fresh raw-manifest read yields
+         nothing — i.e. the skip genuinely could not have run), fall
+         back to a DEST-presence probe via harbor_durable_digest
+         (Harbor CORE's DB, never a pull-through). Durably present ⇒
+         WARN + keep the artifact: freshness against the source is
+         unverifiable this run, and durable presence is exactly what
+         the post-pivot pull contract needs. A READABLE source keeps
+         the strict fail semantics — the failure then is a real
+         transfer/dest defect, not a source blind spot.
+        */}}
         if [ "${rc}" -ne 0 ]; then
           _rs_raw=""
           if [ ! -f "${cpdir}/.ratelimited.$(rl_slug "${srchost}")" ]; then
@@ -1268,8 +1372,10 @@ data:
             src_used=""
           fi
         fi
-        # #5095 — log which source ultimately succeeded (stdout, real
-        # time, next to the done/skip lines + the per-image log).
+        {{- /*
+         #5095 — log which source ultimately succeeded (stdout, real
+         time, next to the done/skip lines + the per-image log).
+        */}}
         if [ "${rc}" -eq 0 ] && [ -n "${src_used}" ] && [ "${src_used}" != "${up}" ]; then
           if [ "${proxy_src}" -eq 1 ]; then
             echo "[harbor-prewarm] ${up} -> ${lref} succeeded via DIRECT upstream ${src_used} (mothership proxy path failing; #5095)"
@@ -1283,9 +1389,11 @@ data:
       done
       if [ "${all_ok}" -eq 1 ]; then
         printf '%s' "${up}" >"${cpdir}/${slug}.ok"
-        # #4994 — real-time per-image completion line to stdout (the worker
-        # runs async; without this the detailed .log is only surfaced after
-        # the whole `wait`, which is what made hw240 look hung for 68m).
+        {{- /*
+         #4994 — real-time per-image completion line to stdout (the worker
+         runs async; without this the detailed .log is only surfaced after
+         the whole `wait`, which is what made hw240 look hung for 68m).
+        */}}
         echo "[harbor-prewarm] done ${up} (ok)"
       else
         printf '%s exit=%s' "${up}" "${last_rc}" >"${cpdir}/${slug}.fail"
@@ -1293,20 +1401,22 @@ data:
       fi
     }
 
-    # #5095 round 2 — ONE-TIME mothership-proxy reachability probe.
-    # A cheap anonymous `GET https://${MOTHERSHIP_HOST}/v2/` (Harbor's
-    # registry API returns 401 for anonymous, 200/403 for public proxy
-    # projects — ANY of those proves the path is alive). A transit hole
-    # toward the mothership /24 yields curl exit!=0 / HTTP 000. On an
-    # unreachable proxy the step latches `${cpdir}/.proxy_down`, which
-    # flips copy_one to DIRECT-FIRST for proxy-sourced refs so no image
-    # burns the 1200s --command-timeout on the dead proxy before the
-    # fast direct upstream is tried (#5095 round 1 shipped that fallback
-    # but always AFTER the timed-out proxy leg). The probe is bounded
-    # (PROXY_PROBE_ATTEMPTS × PROXY_PROBE_TIMEOUT_SECONDS, default
-    # 3 × 8s = 24s worst case — negligible against a multi-image wave)
-    # and NEVER fatal: a down proxy must not fail the step, the direct
-    # path covers it. Re-probes each Job run (cpdir is wiped above).
+    {{- /*
+     #5095 round 2 — ONE-TIME mothership-proxy reachability probe.
+     A cheap anonymous `GET https://${MOTHERSHIP_HOST}/v2/` (Harbor's
+     registry API returns 401 for anonymous, 200/403 for public proxy
+     projects — ANY of those proves the path is alive). A transit hole
+     toward the mothership /24 yields curl exit!=0 / HTTP 000. On an
+     unreachable proxy the step latches `${cpdir}/.proxy_down`, which
+     flips copy_one to DIRECT-FIRST for proxy-sourced refs so no image
+     burns the 1200s --command-timeout on the dead proxy before the
+     fast direct upstream is tried (#5095 round 1 shipped that fallback
+     but always AFTER the timed-out proxy leg). The probe is bounded
+     (PROXY_PROBE_ATTEMPTS × PROXY_PROBE_TIMEOUT_SECONDS, default
+     3 × 8s = 24s worst case — negligible against a multi-image wave)
+     and NEVER fatal: a down proxy must not fail the step, the direct
+     path covers it. Re-probes each Job run (cpdir is wiped above).
+    */}}
     probe_mothership_proxy() {
       [ "${PROXY_DIRECT_FIRST_ENABLED:-true}" = "true" ] || { echo "[harbor-prewarm] proxy-DOWN direct-first routing DISABLED (PROXY_DIRECT_FIRST_ENABLED=${PROXY_DIRECT_FIRST_ENABLED:-}); strict proxy-first ordering (#5095)"; return 0; }
       [ -n "${MOTHERSHIP_HOST:-}" ] || return 0
@@ -1326,14 +1436,16 @@ data:
       echo "[harbor-prewarm] mothership proxy ${MOTHERSHIP_HOST} UNREACHABLE after ${PROXY_PROBE_ATTEMPTS} probes (last HTTP ${_mp_code:-none}) — DIRECT-FIRST for proxy-sourced images this step; no per-image proxy timeout tax (#5095). Images still land in LOCAL Harbor via the direct upstream; sovereignty guarantee intact."
     }
 
-    # #4975 PRE-PASS — resolve every enumerated image through the shared
-    # coverage map BEFORE the parallel fan-out. Excluded images (xpkg /
-    # rancher-k3s / loft-sh-vcluster) are dropped; an image from a
-    # registry host NOT in offlineMirror.hostProjects is UNMAPPED →
-    # FATAL fail-fast (naming the offender). This is the whack-a-mole
-    # trap closing at step-03: a new chart's un-covered registry host
-    # fails the cutover HERE (egress still open, clear message) instead
-    # of surfacing as an opaque ImagePullBackOff mid deny-egress hold.
+    {{- /*
+     #4975 PRE-PASS — resolve every enumerated image through the shared
+     coverage map BEFORE the parallel fan-out. Excluded images (xpkg /
+     rancher-k3s / loft-sh-vcluster) are dropped; an image from a
+     registry host NOT in offlineMirror.hostProjects is UNMAPPED →
+     FATAL fail-fast (naming the offender). This is the whack-a-mole
+     trap closing at step-03: a new chart's un-covered registry host
+     fails the cutover HERE (egress still open, clear message) instead
+     of surfacing as an opaque ImagePullBackOff mid deny-egress hold.
+    */}}
     mirror_work=""
     unmapped=""
     for img in ${openova_images}; do
@@ -1359,20 +1471,24 @@ data:
     count=$(printf '%s\n' ${mirror_work} | grep -c . || true)
     echo "[harbor-prewarm] ${count} mapped image(s) to mirror after resolver filter (parallelism=${PREWARM_PARALLELISM})"
 
-    # #5095 round 2 — probe the mothership proxy ONCE before the fan-out,
-    # but only when this wave actually has mothership-proxy-sourced refs
-    # (all-ghcr provs never dial the proxy, so skip the probe entirely).
+    {{- /*
+     #5095 round 2 — probe the mothership proxy ONCE before the fan-out,
+     but only when this wave actually has mothership-proxy-sourced refs
+     (all-ghcr provs never dial the proxy, so skip the probe entirely).
+    */}}
     if [ -n "${MOTHERSHIP_HOST:-}" ] && printf '%s\n' ${mirror_work} | grep -q "^${MOTHERSHIP_HOST}/"; then
       probe_mothership_proxy
     fi
 
-    # #4994 — real-time progress heartbeat. A bounded, self-stopping
-    # background loop prints "N/M settled" every 30s while the fan-out
-    # drains, so the step is NEVER a silent black box (hw240: "Running 0/1
-    # for 68m, only queue lines"). Combined with copy_one's per-image
-    # `done`/`skip` lines the operator always sees forward progress — and
-    # a genuine hang is now visibly bounded (settled count stops advancing)
-    # rather than indistinguishable from slow-but-working.
+    {{- /*
+     #4994 — real-time progress heartbeat. A bounded, self-stopping
+     background loop prints "N/M settled" every 30s while the fan-out
+     drains, so the step is NEVER a silent black box (hw240: "Running 0/1
+     for 68m, only queue lines"). Combined with copy_one's per-image
+     `done`/`skip` lines the operator always sees forward progress — and
+     a genuine hang is now visibly bounded (settled count stops advancing)
+     rather than indistinguishable from slow-but-working.
+    */}}
     progress_heartbeat() {
       _hb_tot="$1"; _hb_dir="$2"; _hb_label="$3"
       while [ ! -f "${_hb_dir}/.hb_stop" ]; do
@@ -1385,11 +1501,13 @@ data:
     rm -f "${cpdir}/.hb_stop"
     progress_heartbeat "${count}" "${cpdir}" "Phase A" &
     hb_pid=$!
-    # Track live worker PIDs explicitly — POSIX sh's `jobs -p` is
-    # unreliable in a non-interactive shell, so we count by polling
-    # `kill -0 <pid>` against the PIDs we launched. `allpids` accumulates
-    # EVERY worker so the final drain waits on the workers only (a bare
-    # `wait` would also block on the never-returning heartbeat #4994).
+    {{- /*
+     Track live worker PIDs explicitly — POSIX sh's `jobs -p` is
+     unreliable in a non-interactive shell, so we count by polling
+     `kill -0 <pid>` against the PIDs we launched. `allpids` accumulates
+     EVERY worker so the final drain waits on the workers only (a bare
+     `wait` would also block on the never-returning heartbeat #4994).
+    */}}
     pids=""
     allpids=""
     for upstream in ${mirror_work}; do
@@ -1398,8 +1516,10 @@ data:
       _newpid=$!
       pids="${pids} ${_newpid}"
       allpids="${allpids} ${_newpid}"
-      # Throttle: block launching the next copy while
-      # PREWARM_PARALLELISM workers are still alive.
+      {{- /*
+       Throttle: block launching the next copy while
+       PREWARM_PARALLELISM workers are still alive.
+      */}}
       while : ; do
         live=0
         newpids=""
@@ -1414,13 +1534,15 @@ data:
         sleep 2
       done
     done
-    # Drain the workers explicitly (NOT a bare `wait` — that would also
-    # block on the heartbeat, which only stops on the sentinel below).
+    {{- /*
+     Drain the workers explicitly (NOT a bare `wait` — that would also
+     block on the heartbeat, which only stops on the sentinel below).
+    */}}
     for _p in ${allpids}; do wait "${_p}" 2>/dev/null || true; done
     touch "${cpdir}/.hb_stop"
     wait "${hb_pid}" 2>/dev/null || true
 
-    # Tally + surface each copy's captured log.
+    {{- /* Tally + surface each copy's captured log. */}}
     push_ok=0
     push_fail=0
     for f in "${cpdir}"/*.ok; do
@@ -1445,95 +1567,103 @@ data:
       exit 1
     fi
 
-    # ─── Phase A2: skopeo native push of openova-io HELM CHARTS ────────
-    #
-    # #3627 (Refs #3379, root-caused live on hw146): Phase A above
-    # mirrors the openova-io CONTAINER images, but NO cutover step ever
-    # mirrors the helm CHART OCI artifacts. Step-06 Phase-1 repoints
-    # every Flux HelmRepository from oci://ghcr.io/openova-io/<chart>
-    # to oci://registry.<sov-fqdn>/openova-io/<chart>, and step-06
-    # Phase-3 then strips the ghcr.io fallback from ghcr-pull. If the
-    # chart artifacts are NOT in local Harbor at that point, the first
-    # post-strip (re)pull 404s and the HelmRelease wedges. The
-    # HelmReleases survive on hw146 ONLY because they were installed
-    # from ghcr.io at bootstrap and the strip has not yet run; local
-    # Harbor's openova-io project held 29 container repos and ZERO
-    # chart repos. A true sovereignty cutover MUST carry every
-    # openova-io chart in local Harbor BEFORE egress is cut.
-    #
-    # The chart NAME + VERSION are NOT on the HelmRepository (its
-    # spec.url is only the project pointer oci://ghcr.io/openova-io);
-    # they live on each consuming HelmRelease's
+    {{- /*
+     ─── Phase A2: skopeo native push of openova-io HELM CHARTS ────────
+
+     #3627 (Refs #3379, root-caused live on hw146): Phase A above
+     mirrors the openova-io CONTAINER images, but NO cutover step ever
+     mirrors the helm CHART OCI artifacts. Step-06 Phase-1 repoints
+     every Flux HelmRepository from oci://ghcr.io/openova-io/<chart>
+     to oci://registry.<sov-fqdn>/openova-io/<chart>, and step-06
+     Phase-3 then strips the ghcr.io fallback from ghcr-pull. If the
+     chart artifacts are NOT in local Harbor at that point, the first
+     post-strip (re)pull 404s and the HelmRelease wedges. The
+     HelmReleases survive on hw146 ONLY because they were installed
+     from ghcr.io at bootstrap and the strip has not yet run; local
+     Harbor's openova-io project held 29 container repos and ZERO
+     chart repos. A true sovereignty cutover MUST carry every
+     openova-io chart in local Harbor BEFORE egress is cut.
+
+     The chart NAME + VERSION are NOT on the HelmRepository (its
+     spec.url is only the project pointer oci://ghcr.io/openova-io);
+     they live on each consuming HelmRelease's
+    */}}
     # spec.chart.spec.{chart,version,sourceRef.{kind,name}}. We
-    # enumerate those tuples, select the ones whose sourceRef.kind is
-    # HelmRepository and whose sourceRef.name is in the cutover pivot
-    # set (.Values.helmRepositories.names, mounted at /chart-mirror),
-    # dedupe by chart:version, then skopeo-copy each chart OCI artifact
-    # ghcr.io/openova-io/<chart>:<version> → ${HARBOR_HOST}/openova-io/
-    # <chart>:<version>. Helm OCI charts are plain OCI artifacts, so
-    # `skopeo copy` handles them regardless of media type. Same retry
-    # discipline as Phase A (--insecure-policy + --retry-times 3 +
-    # captured real exit status + parallel fan-out via sentinels).
-    #
-    # `openova-catalog` is in the pivot set but is a project POINTER
-    # for per-Application HelmReleases (rendered by bp-catalyst-platform
-    # from .Values.catalog.helmRepository.url), not a single bootstrap
-    # chart artifact — it has no HelmRelease of its own to read a
-    # chart:version off, so the sourceRef-driven enumeration below
-    # naturally excludes it (no bootstrap HR sources from it). Any
-    # per-Application charts an operator later installs are mirrored by
-    # the ongoing gitea-mirror-resync + Harbor's own pull-through, not
-    # by this one-shot cutover prewarm.
+    {{- /*
+     enumerate those tuples, select the ones whose sourceRef.kind is
+     HelmRepository and whose sourceRef.name is in the cutover pivot
+     set (.Values.helmRepositories.names, mounted at /chart-mirror),
+     dedupe by chart:version, then skopeo-copy each chart OCI artifact
+     ghcr.io/openova-io/<chart>:<version> → ${HARBOR_HOST}/openova-io/
+     <chart>:<version>. Helm OCI charts are plain OCI artifacts, so
+     `skopeo copy` handles them regardless of media type. Same retry
+     discipline as Phase A (--insecure-policy + --retry-times 3 +
+     captured real exit status + parallel fan-out via sentinels).
+
+     `openova-catalog` is in the pivot set but is a project POINTER
+     for per-Application HelmReleases (rendered by bp-catalyst-platform
+     from .Values.catalog.helmRepository.url), not a single bootstrap
+     chart artifact — it has no HelmRelease of its own to read a
+     chart:version off, so the sourceRef-driven enumeration below
+     naturally excludes it (no bootstrap HR sources from it). Any
+     per-Application charts an operator later installs are mirrored by
+     the ongoing gitea-mirror-resync + Harbor's own pull-through, not
+     by this one-shot cutover prewarm.
+    */}}
     echo "[harbor-prewarm] Phase A2: mirror openova-io helm charts into local Harbor"
 
-    # Build the pivot-set lookup. #4573 F4 (Refs #3379): the prior
-    # implementation seeded the pivot set ONLY from the static
-    # .Values.helmRepositories.names list (mounted at
-    # /chart-mirror/chart-mirror-names.txt). That list is hand-
-    # maintained and DRIFTED — it omitted ~22 openova-io
-    # HelmRepositories the bootstrap-kit slots actually reference
-    # (bp-cnpg-pair, bp-network-policies, bp-postgres, bp-newapi,
-    # bp-oidc-gate, bp-sso-bridge, bp-sandbox, bp-vllm, bp-plane-
-    # isolation, bp-continuum, bp-guacamole, bp-k8s-ws-proxy,
-    # bp-powerdns-admin, bp-opentelemetry-operator, bp-openova-flow-
-    # {server,emitter}, the hcloud/evs CSI charts, …). Phase A2 then
-    # SKIPPED those charts → they never landed in local Harbor → a
-    # post-strip HR source kick 404s `does not have an artifact`
-    # (live c39f0cd4455b7a46). The COMPLETENESS of the mirror set
-    # must NOT depend on a static list staying in sync with the
-    # slot tree.
-    #
-    # Fix: derive the pivot set DYNAMICALLY from the LIVE cluster —
-    # every Flux HelmRepository whose spec.url is the upstream
-    # openova-io OCI prefix (oci://ghcr.io/openova-io) is in the set,
-    # regardless of whether it is named in the static list. UNION
-    # that live set with the static names file (belt-and-suspenders:
-    # a HR named in the list but momentarily absent from the live
-    # API read is still covered). The union can only WIDEN the set —
-    # every chart is still skopeo-copied idempotently — never narrow
-    # it, a strict superset of the prior behaviour. This is the same
-    # "union live ∪ declared, never depend on a static snapshot"
-    # discipline the container-image enumeration (Phase A) already
-    # uses above.
+    {{- /*
+     Build the pivot-set lookup. #4573 F4 (Refs #3379): the prior
+     implementation seeded the pivot set ONLY from the static
+     .Values.helmRepositories.names list (mounted at
+     /chart-mirror/chart-mirror-names.txt). That list is hand-
+     maintained and DRIFTED — it omitted ~22 openova-io
+     HelmRepositories the bootstrap-kit slots actually reference
+     (bp-cnpg-pair, bp-network-policies, bp-postgres, bp-newapi,
+     bp-oidc-gate, bp-sso-bridge, bp-sandbox, bp-vllm, bp-plane-
+     isolation, bp-continuum, bp-guacamole, bp-k8s-ws-proxy,
+     bp-powerdns-admin, bp-opentelemetry-operator, bp-openova-flow-
+     {server,emitter}, the hcloud/evs CSI charts, …). Phase A2 then
+     SKIPPED those charts → they never landed in local Harbor → a
+     post-strip HR source kick 404s `does not have an artifact`
+     (live c39f0cd4455b7a46). The COMPLETENESS of the mirror set
+     must NOT depend on a static list staying in sync with the
+     slot tree.
+
+     Fix: derive the pivot set DYNAMICALLY from the LIVE cluster —
+     every Flux HelmRepository whose spec.url is the upstream
+     openova-io OCI prefix (oci://ghcr.io/openova-io) is in the set,
+     regardless of whether it is named in the static list. UNION
+     that live set with the static names file (belt-and-suspenders:
+     a HR named in the list but momentarily absent from the live
+     API read is still covered). The union can only WIDEN the set —
+     every chart is still skopeo-copied idempotently — never narrow
+     it, a strict superset of the prior behaviour. This is the same
+     "union live ∪ declared, never depend on a static snapshot"
+     discipline the container-image enumeration (Phase A) already
+     uses above.
+    */}}
     pivot_set_file=/tmp/.chart-pivot-set.txt
     : > "${pivot_set_file}"
-    # (a) static names from the mounted list (legacy contract).
+    {{- /* (a) static names from the mounted list (legacy contract). */}}
     while IFS= read -r pl; do
       pn=$(printf '%s' "${pl}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
       [ -z "${pn}" ] && continue
       printf '%s\n' "${pn}" >> "${pivot_set_file}"
     done < /chart-mirror/chart-mirror-names.txt
-    # (b) live HelmRepositories whose url is the openova-io upstream
-    # OCI prefix — the complete, drift-proof set. UPSTREAM_PREFIX is
-    # `oci://ghcr.io/openova-io`; a HR url may be exactly that prefix
-    # or a `<prefix>/<name>`-suffixed form, so match on the prefix.
+    {{- /*
+     (b) live HelmRepositories whose url is the openova-io upstream
+     OCI prefix — the complete, drift-proof set. UPSTREAM_PREFIX is
+     `oci://ghcr.io/openova-io`; a HR url may be exactly that prefix
+     or a `<prefix>/<name>`-suffixed form, so match on the prefix.
+    */}}
     up_prefix_match=$(printf '%s' "${UPSTREAM_PREFIX}" | sed -e 's,/$,,')
     live_openova_hrs=$(kubectl get helmrepositories.source.toolkit.fluxcd.io -A -o json 2>/dev/null | \
       jq -r --arg p "${up_prefix_match}" \
         '.items[] | select((.spec.url // "") | startswith($p)) | .metadata.name' 2>/dev/null | \
       sort -u || true)
     printf '%s\n' "${live_openova_hrs}" >> "${pivot_set_file}"
-    # Dedupe + drop blanks so the lookup is clean.
+    {{- /* Dedupe + drop blanks so the lookup is clean. */}}
     sort -u "${pivot_set_file}" -o "${pivot_set_file}"
     sed -i '/^[[:space:]]*$/d' "${pivot_set_file}" 2>/dev/null || true
     static_n=$(grep -c . /chart-mirror/chart-mirror-names.txt 2>/dev/null || echo 0)
@@ -1542,38 +1672,40 @@ data:
     echo "[harbor-prewarm] Phase A2 pivot set: static-names=${static_n} ∪ live-openova-io-HelmRepositories=${live_n} → ${union_n} unique sourceRef name(s) (#4573 F4: drift-proof)"
 
     in_pivot_set() {
-      # $1 = HelmRepository name; 0 if present in the pivot set.
+      {{- /* $1 = HelmRepository name; 0 if present in the pivot set. */}}
       grep -Fxq "$1" "${pivot_set_file}"
     }
 
-    # Enumerate (chart, version, sourceRef.kind, sourceRef.name) from
-    # every HelmRelease cluster-wide. Tab-separated; a HR with no
-    # explicit chart.spec is skipped (empty fields).
-    #
-    # #5007 round 3 (Refs #4870 #4982) — mirror the UNION of the DEPLOYED
-    # and the DESIRED chart versions per HR. Two OPPOSITE drifts wedge
-    # step-06 (helmrepository-patches Phase-3a), which reads the SAME
-    # `.status.history[0].chartVersion // .spec.chart.spec.version`
-    # resolution (06-…-job.yaml L1199-1207) — but at a LATER instant:
-    #   • #4870: mirroring ONLY the desired (`.spec.chart.spec.version`)
-    #     breaks when a deploybot catalog bump transiently oscillates the
-    #     desired ahead of the settled deployed → prewarm mirrors 1.4.1039,
-    #     step-06 checks the settled deployed 1.4.1038 → wedge.
-    #   • #5007 round 3 (hw252): mirroring ONLY the deployed
-    #     (`.status.history[0].chartVersion`) breaks when a PR merges +
-    #     re-publishes a chart DURING the cutover — the live HR briefly
-    #     DEPLOYS the just-published 1.4.1121 (so history[0]=1.4.1121),
-    #     while the flux/bootstrap-kit PIN the Sovereign settles back to
-    #     post-step-05 is 1.4.1120 (`.spec.chart.spec.version`). prewarm
-    #     warmed 1.4.1121, step-06 waited FOREVER for the pinned 1.4.1120.
-    # Mirroring the UNION warms BOTH the pinned/desired AND the deployed
-    # tag, so step-06 finds its version locally regardless of which the HR
-    # settles on between the two steps. The union is a strict SUPERSET (an
-    # extra skopeo copy is idempotent + #4994 skip-if-present makes it
-    # cheap), never narrows the set, and the Phase A2 chart_fail>0 FATAL
-    # below is the FAIL-LOUD guard: a PINNED version whose OCI artifact
-    # cannot be pulled fails the cutover HERE (egress still open, named)
-    # instead of silently wedging step-06 under the deny-egress hold.
+    {{- /*
+     Enumerate (chart, version, sourceRef.kind, sourceRef.name) from
+     every HelmRelease cluster-wide. Tab-separated; a HR with no
+     explicit chart.spec is skipped (empty fields).
+
+     #5007 round 3 (Refs #4870 #4982) — mirror the UNION of the DEPLOYED
+     and the DESIRED chart versions per HR. Two OPPOSITE drifts wedge
+     step-06 (helmrepository-patches Phase-3a), which reads the SAME
+     `.status.history[0].chartVersion // .spec.chart.spec.version`
+     resolution (06-…-job.yaml L1199-1207) — but at a LATER instant:
+       • #4870: mirroring ONLY the desired (`.spec.chart.spec.version`)
+         breaks when a deploybot catalog bump transiently oscillates the
+         desired ahead of the settled deployed → prewarm mirrors 1.4.1039,
+         step-06 checks the settled deployed 1.4.1038 → wedge.
+       • #5007 round 3 (hw252): mirroring ONLY the deployed
+         (`.status.history[0].chartVersion`) breaks when a PR merges +
+         re-publishes a chart DURING the cutover — the live HR briefly
+         DEPLOYS the just-published 1.4.1121 (so history[0]=1.4.1121),
+         while the flux/bootstrap-kit PIN the Sovereign settles back to
+         post-step-05 is 1.4.1120 (`.spec.chart.spec.version`). prewarm
+         warmed 1.4.1121, step-06 waited FOREVER for the pinned 1.4.1120.
+     Mirroring the UNION warms BOTH the pinned/desired AND the deployed
+     tag, so step-06 finds its version locally regardless of which the HR
+     settles on between the two steps. The union is a strict SUPERSET (an
+     extra skopeo copy is idempotent + #4994 skip-if-present makes it
+     cheap), never narrows the set, and the Phase A2 chart_fail>0 FATAL
+     below is the FAIL-LOUD guard: a PINNED version whose OCI artifact
+     cannot be pulled fails the cutover HERE (egress still open, named)
+     instead of silently wedging step-06 under the deny-egress hold.
+    */}}
     chart_tuples=$(kubectl get helmreleases -A -o json | \
       jq -r '.items[]
         | .spec.chart.spec as $cs
@@ -1585,11 +1717,13 @@ data:
         | [ $cs.chart, $v, ($cs.sourceRef.kind // ""), ($cs.sourceRef.name // "") ]
         | @tsv' 2>/dev/null | sort -u || true)
 
-    # #5007 round 3 — informational DRIFT report: name every pivot-set HR
-    # whose DEPLOYED (history[0]) and DESIRED (spec) chart versions differ.
-    # Both are warmed by the union above, so this NEVER wedges — it makes a
-    # mid-cutover publish visible in the step-03 log instead of surfacing as
-    # an opaque step-06 "chart not yet pullable" hang.
+    {{- /*
+     #5007 round 3 — informational DRIFT report: name every pivot-set HR
+     whose DEPLOYED (history[0]) and DESIRED (spec) chart versions differ.
+     Both are warmed by the union above, so this NEVER wedges — it makes a
+     mid-cutover publish visible in the step-03 log instead of surfacing as
+     an opaque step-06 "chart not yet pullable" hang.
+    */}}
     chart_drift=$(kubectl get helmreleases -A -o json 2>/dev/null | \
       jq -r '.items[]
         | .spec.chart.spec as $cs
@@ -1602,12 +1736,14 @@ data:
       printf '%s\n' "${chart_drift}" | sed 's/^/  drift: /'
     fi
 
-    # Resolve the UPSTREAM chart-OCI host/project prefix from the same
-    # value step-06 pivots FROM (oci://ghcr.io/openova-io → host
-    # ghcr.io, project path openova-io). Strip the oci:// scheme.
+    {{- /*
+     Resolve the UPSTREAM chart-OCI host/project prefix from the same
+     value step-06 pivots FROM (oci://ghcr.io/openova-io → host
+     ghcr.io, project path openova-io). Strip the oci:// scheme.
+    */}}
     up_chart_prefix=$(printf '%s' "${UPSTREAM_PREFIX}" | sed -e 's,^oci://,,' -e 's,/$,,')
 
-    # Dedupe the work list to chart:version pairs we actually mirror.
+    {{- /* Dedupe the work list to chart:version pairs we actually mirror. */}}
     chart_work=/tmp/.chart-work.txt
     : > "${chart_work}"
     printf '%s\n' "${chart_tuples}" | while IFS="$(printf '\t')" read -r c_chart c_ver c_kind c_name; do
@@ -1618,11 +1754,13 @@ data:
         echo "[harbor-prewarm] Phase A2 WARN: HelmRelease chart ${c_chart} (source ${c_name}) has no pinned version — skipping (cannot mirror a floating tag deterministically)"
         continue
       fi
-      # #5007 round 3 — the union may surface a DESIRED spec.version that is
-      # a semver RANGE (a `<`, `>`, `~`, `^`, `|`, `*` or space) rather than a
-      # concrete OCI tag; a range can't be skopeo-copied deterministically, so
-      # skip it with a clear WARN instead of FATALing on an invalid tag. The
-      # concrete deployed/desired tag(s) for the same chart still mirror.
+      {{- /*
+       #5007 round 3 — the union may surface a DESIRED spec.version that is
+       a semver RANGE (a `<`, `>`, `~`, `^`, `|`, `*` or space) rather than a
+       concrete OCI tag; a range can't be skopeo-copied deterministically, so
+       skip it with a clear WARN instead of FATALing on an invalid tag. The
+       concrete deployed/desired tag(s) for the same chart still mirror.
+      */}}
       case "${c_ver}" in
         *[\<\>~^\|\ ]*|*'*'*)
           echo "[harbor-prewarm] Phase A2 WARN: HelmRelease chart ${c_chart} (source ${c_name}) version '${c_ver}' is a semver range, not a concrete tag — skipping (cannot mirror deterministically)"
@@ -1631,35 +1769,39 @@ data:
       printf '%s\t%s\n' "${c_chart}" "${c_ver}" >> "${chart_work}"
     done
 
-    # ── Phase A2-pins (#5237 round 2, Refs #5007): union the FROZEN
-    # bootstrap-kit pins from the LOCAL GITEA MIRROR into the chart-
-    # mirror set. The live deployed∪desired union above tracks the
-    # CLUSTER — which a mid-cutover catalog merge can roll AWAY from
-    # the pins flux settles back to post-step-05 (the GitRepository
-    # still tracks GitHub until then, so a pin-bump commit landing
-    # between step-01's mirror and step-05's pivot rolls the live HR
-    # to a version the FROZEN mirror never pins; prewarm mirrors the
-    # transient tag, the frozen pin is never warmed, and the first
-    # post-strip (re)pull 404s under the deny-egress hold — the hw274
-    # class, dep d51a69f885872a81). The bootstrap-kit slot files in
-    # the local Gitea mirror ARE the post-cutover pin ground truth,
-    # immune to anything published upstream after step-01 mirrored:
-    # enumerate them (shared extractor 03b — the SAME parser step-06's
-    # Phase 3a-pin gate and the #5265 Day-2 reconciler use) and union
-    # the result in. Strict superset — every entry is still copied
-    # idempotently (#4994 skip-if-present makes an already-mirrored
-    # pin a cheap API GET), and the Phase A2 chart_fail>0 FATAL below
-    # stays the fail-loud guard for a pinned tag that cannot be
-    # pulled. FAIL-LOUD on enumeration failure: an unreadable PAT /
-    # unreachable mirror / zero-pin parse exits 1 HERE (egress open,
-    # recoverable) rather than silently narrowing the mirror.
+    {{- /*
+     ── Phase A2-pins (#5237 round 2, Refs #5007): union the FROZEN
+     bootstrap-kit pins from the LOCAL GITEA MIRROR into the chart-
+     mirror set. The live deployed∪desired union above tracks the
+     CLUSTER — which a mid-cutover catalog merge can roll AWAY from
+     the pins flux settles back to post-step-05 (the GitRepository
+     still tracks GitHub until then, so a pin-bump commit landing
+     between step-01's mirror and step-05's pivot rolls the live HR
+     to a version the FROZEN mirror never pins; prewarm mirrors the
+     transient tag, the frozen pin is never warmed, and the first
+     post-strip (re)pull 404s under the deny-egress hold — the hw274
+     class, dep d51a69f885872a81). The bootstrap-kit slot files in
+     the local Gitea mirror ARE the post-cutover pin ground truth,
+     immune to anything published upstream after step-01 mirrored:
+     enumerate them (shared extractor 03b — the SAME parser step-06's
+     Phase 3a-pin gate and the #5265 Day-2 reconciler use) and union
+     the result in. Strict superset — every entry is still copied
+     idempotently (#4994 skip-if-present makes an already-mirrored
+     pin a cheap API GET), and the Phase A2 chart_fail>0 FATAL below
+     stays the fail-loud guard for a pinned tag that cannot be
+     pulled. FAIL-LOUD on enumeration failure: an unreadable PAT /
+     unreachable mirror / zero-pin parse exits 1 HERE (egress open,
+     recoverable) rather than silently narrowing the mirror.
+    */}}
     : "${PREWARM_BOOTSTRAP_KIT_PINS:=true}"
     if [ "${PREWARM_BOOTSTRAP_KIT_PINS}" = "true" ]; then
       echo "[harbor-prewarm] Phase A2-pins (#5237): enumerating bootstrap-kit chart pins from the local Gitea mirror (the frozen commit flux consumes post-step-05)"
-      # The catalyst-gitea-token PAT — same coordinates + bounded wait
-      # as steps 01/05 (BasicAuth would hang ~130s then 401 while
-      # Keycloak converges; a PAT is a direct local lookup). Never
-      # echoed; sent only via the Authorization header.
+      {{- /*
+       The catalyst-gitea-token PAT — same coordinates + bounded wait
+       as steps 01/05 (BasicAuth would hang ~130s then 401 while
+       Keycloak converges; a PAT is a direct local lookup). Never
+       echoed; sent only via the Authorization header.
+      */}}
       bk_pat=""
       for i in $(seq 1 12); do
         bk_pat=$(kubectl -n "${PAT_SOURCE_NAMESPACE}" get secret "${PAT_SOURCE_SECRET_NAME}" \
@@ -1676,10 +1818,12 @@ data:
       rm -rf "${bk_dir}"; mkdir -p "${bk_dir}"
       bk_api="${GITEA_INTERNAL_URL%/}/api/v1/repos/${GITEA_ORG}/${GITEA_REPO}"
       bk_path="clusters/_template/bootstrap-kit"
-      # Directory listing via the Gitea contents API, then each slot
-      # file raw — ~70 small text fetches against the in-cluster
-      # Gitea Service (step-01 already proved it reachable), far
-      # lighter than a full monorepo clone.
+      {{- /*
+       Directory listing via the Gitea contents API, then each slot
+       file raw — ~70 small text fetches against the in-cluster
+       Gitea Service (step-01 already proved it reachable), far
+       lighter than a full monorepo clone.
+      */}}
       bk_list=$(curl -fsS --retry 3 --retry-delay 5 \
         -H "Authorization: token ${bk_pat}" \
         "${bk_api}/contents/${bk_path}?ref=${UPSTREAM_BRANCH}" 2>/dev/null \
@@ -1702,10 +1846,12 @@ data:
         echo "[harbor-prewarm] FATAL: ${bk_fetch_fail} bootstrap-kit slot file(s) failed to fetch from the local Gitea mirror (named above) — a partial pin set could silently miss the exact version a mid-cutover merge makes load-bearing (#5237). Emergency override: prewarm.bootstrapKitPins.enabled=false."
         exit 1
       fi
-      # Shared extractor (03b): one parser for step-03 + step-06 +
-      # the #5265 Day-2 reconciler. Accepts BOTH the upstream and the
-      # already-pivoted local prefix so a post-step-06 re-run (mirror
-      # already rewritten to local Harbor) still enumerates.
+      {{- /*
+       Shared extractor (03b): one parser for step-03 + step-06 +
+       the #5265 Day-2 reconciler. Accepts BOTH the upstream and the
+       already-pivoted local prefix so a post-step-06 re-run (mirror
+       already rewritten to local Harbor) still enumerates.
+      */}}
       . /pin-extractor/extract-pins.sh
       bk_pins=/tmp/.bootstrap-kit-pins.tsv
       bootstrapkit_pins "${bk_dir}" "${UPSTREAM_PREFIX}" "oci://${HARBOR_HOST}/openova-io" > "${bk_pins}"
@@ -1714,8 +1860,10 @@ data:
         echo "[harbor-prewarm] FATAL: zero pinned openova-io charts parsed from ${bk_path} ($(printf '%s\n' ${bk_list} | grep -c .) slot files fetched) — the bootstrap-kit ALWAYS pins its charts, so an empty parse means the mirror or the slot format drifted; refusing to build a mirror that cannot be proven to cover the frozen flux pin set (#5237). Emergency override: prewarm.bootstrapKitPins.enabled=false."
         exit 1
       fi
-      # Drift visibility: pins NOT already in the live union are
-      # exactly the entries a mid-cutover roll would have lost.
+      {{- /*
+       Drift visibility: pins NOT already in the live union are
+       exactly the entries a mid-cutover roll would have lost.
+      */}}
       sort -u "${chart_work}" -o "${chart_work}"
       bk_pin_only=0
       while IFS="$(printf '\t')" read -r bk_c bk_v; do
@@ -1731,49 +1879,51 @@ data:
       echo "[harbor-prewarm] Phase A2-pins DISABLED (prewarm.bootstrapKitPins.enabled=false) — mirroring the live deployed∪desired union only; the frozen flux pin set is NOT guaranteed locally (#5237)"
     fi
 
-    # ── Phase A2-catalog (#5443, Refs #3627 #5237 #5442): union the
-    # MARKETPLACE's chart set into the mirror.
-    #
-    # Both enumerations above derive from what is INSTALLED — live
-    # HelmReleases (Phase A2) and the frozen bootstrap-kit pins (Phase
-    # A2-pins). The marketplace offers what the CATALOG lists, and those
-    # sets differ by definition: the catalog set is strictly larger.
-    # Step-06 nonetheless pivots `openova-catalog` — the HelmRepository
-    # every per-Org Application HelmRelease resolves through — onto local
-    # Harbor, so after cutover a Sovereign advertises Blueprints whose
-    # charts were never mirrored. Measured on hw290 2026-07-27: 14 of 29
-    # `visibility: listed` entries resolved, 15 returned 404, and the
-    # Harbor `openova-io` project is HOSTED (registry_id: None), so there
-    # is no proxy-cache fallback — the 404 is final and a customer buying
-    # any of those 15 gets an unpullable HelmRelease on a Sovereign that
-    # is by then deliberately cut off from the mothership.
-    #
-    # SOURCE OF TRUTH = the LIVE Blueprint CRs, not the chart-shipped
-    # catalog-seed. The seed only SEEDS them; `/api/v1/catalog` serves the
-    # CRs (catalog_client_cluster_fallback.go listFromCluster), the
-    # console's catalog IaC editor mutates the CRs, and an operator can
-    # curate entries the seed never had. Reading the seed would mirror a
-    # set the marketplace does not necessarily offer, in both directions.
-    #
-    # HARD vs SOFT. `spec.manifests.chart` : `spec.version` is the exact
-    # coordinate the install path requests (blueprintChart() ->
-    # Application.spec.blueprintRef.version -> HR chart.spec.version), so
-    # for a `visibility: listed` entry — the customer-visible contract —
-    # it is HARD: a failed copy is FATAL and the Phase A2-guard below
-    # re-asserts it against Harbor's durable artifact API. Every other row
-    # is SOFT (mirrored best-effort, failure WARNs): `spec.source.version`
-    # is read by NO controller and is a known drift surface (the console
-    # editor can bump spec.version without it, or vice versa — #5444), and
-    # unlisted/private entries are not installable from the marketplace
-    # grid, so a stale pin on one must not hold the whole cutover hostage.
-    # Mirroring them anyway is nearly free — a chart OCI artifact is a
-    # manifest plus one small tgz layer, unlike the image wave that
-    # dominates prewarm's runtime — and it covers the depends[]/companion
-    # closure of the listed set without a graph walk.
+    {{- /*
+     ── Phase A2-catalog (#5443, Refs #3627 #5237 #5442): union the
+     MARKETPLACE's chart set into the mirror.
+
+     Both enumerations above derive from what is INSTALLED — live
+     HelmReleases (Phase A2) and the frozen bootstrap-kit pins (Phase
+     A2-pins). The marketplace offers what the CATALOG lists, and those
+     sets differ by definition: the catalog set is strictly larger.
+     Step-06 nonetheless pivots `openova-catalog` — the HelmRepository
+     every per-Org Application HelmRelease resolves through — onto local
+     Harbor, so after cutover a Sovereign advertises Blueprints whose
+     charts were never mirrored. Measured on hw290 2026-07-27: 14 of 29
+     `visibility: listed` entries resolved, 15 returned 404, and the
+     Harbor `openova-io` project is HOSTED (registry_id: None), so there
+     is no proxy-cache fallback — the 404 is final and a customer buying
+     any of those 15 gets an unpullable HelmRelease on a Sovereign that
+     is by then deliberately cut off from the mothership.
+
+     SOURCE OF TRUTH = the LIVE Blueprint CRs, not the chart-shipped
+     catalog-seed. The seed only SEEDS them; `/api/v1/catalog` serves the
+     CRs (catalog_client_cluster_fallback.go listFromCluster), the
+     console's catalog IaC editor mutates the CRs, and an operator can
+     curate entries the seed never had. Reading the seed would mirror a
+     set the marketplace does not necessarily offer, in both directions.
+
+     HARD vs SOFT. `spec.manifests.chart` : `spec.version` is the exact
+     coordinate the install path requests (blueprintChart() ->
+     Application.spec.blueprintRef.version -> HR chart.spec.version), so
+     for a `visibility: listed` entry — the customer-visible contract —
+     it is HARD: a failed copy is FATAL and the Phase A2-guard below
+     re-asserts it against Harbor's durable artifact API. Every other row
+     is SOFT (mirrored best-effort, failure WARNs): `spec.source.version`
+     is read by NO controller and is a known drift surface (the console
+     editor can bump spec.version without it, or vice versa — #5444), and
+     unlisted/private entries are not installable from the marketplace
+     grid, so a stale pin on one must not hold the whole cutover hostage.
+     Mirroring them anyway is nearly free — a chart OCI artifact is a
+     manifest plus one small tgz layer, unlike the image wave that
+     dominates prewarm's runtime — and it covers the depends[]/companion
+     closure of the listed set without a graph walk.
+    */}}
     : "${PREWARM_CATALOG_CHARTS:=true}"
     : "${PREWARM_CATALOG_HARD_VISIBILITY:=listed}"
     sort -u "${chart_work}" -o "${chart_work}"
-    # Everything enumerated SO FAR keeps the pre-#5443 FATAL semantics.
+    {{- /* Everything enumerated SO FAR keeps the pre-#5443 FATAL semantics. */}}
     chart_hard=/tmp/.chart-hard.tsv
     cp "${chart_work}" "${chart_hard}"
     catalog_set=/tmp/.catalog-set.tsv
@@ -1782,16 +1932,18 @@ data:
     : > "${catalog_hard}"
     if [ "${PREWARM_CATALOG_CHARTS}" = "true" ]; then
       echo "[harbor-prewarm] Phase A2-catalog (#5443): enumerating the live Blueprint CR set — what the marketplace OFFERS, on top of what is installed"
-      # Blueprint is a CLUSTER-scoped CRD (no -A). The v1 storage
-      # version is read first with the still-served v1alpha1 as the
-      # fallback (products/catalyst/chart/crds/blueprint.yaml serves
-      # both). FAIL-LOUD only when NEITHER read succeeds: an
-      # unreadable API / missing CRD / missing RBAC means the mirror
-      # CANNOT be proven to cover the marketplace, which is precisely
-      # the state #5443 shipped. A read that succeeds and returns zero
-      # items is a different thing — a Sovereign with an empty catalog
-      # advertises nothing, so there is nothing to over-advertise; that
-      # WARNs and continues rather than holding the cutover hostage.
+      {{- /*
+       Blueprint is a CLUSTER-scoped CRD (no -A). The v1 storage
+       version is read first with the still-served v1alpha1 as the
+       fallback (products/catalyst/chart/crds/blueprint.yaml serves
+       both). FAIL-LOUD only when NEITHER read succeeds: an
+       unreadable API / missing CRD / missing RBAC means the mirror
+       CANNOT be proven to cover the marketplace, which is precisely
+       the state #5443 shipped. A read that succeeds and returns zero
+       items is a different thing — a Sovereign with an empty catalog
+       advertises nothing, so there is nothing to over-advertise; that
+       WARNs and continues rather than holding the cutover hostage.
+      */}}
       catalog_json=/tmp/.blueprints.json
       : > "${catalog_json}"
       catalog_read=0
@@ -1813,9 +1965,11 @@ data:
       if [ "${catalog_items:-0}" -eq 0 ]; then
         echo "[harbor-prewarm] Phase A2-catalog WARN: the Blueprint CR list is EMPTY — this Sovereign's marketplace offers nothing, so there is nothing for the mirror to cover. Expected a catalog-seed baseline set (products/catalyst/chart templates/catalog-seed); an empty catalog on a real Sovereign is itself worth investigating (#5443)."
       fi
-      # Shared extractor (03c) — the SAME function the guard's hard set
-      # and the image enumeration read, so the mirrored set and the
-      # judged set can never fork.
+      {{- /*
+       Shared extractor (03c) — the SAME function the guard's hard set
+       and the image enumeration read, so the mirrored set and the
+       judged set can never fork.
+      */}}
       catalog_chart_set "${catalog_json}" "${UPSTREAM_PREFIX}" "${PREWARM_CATALOG_HARD_VISIBILITY}" > "${catalog_set}" 2>/tmp/.catalog-set.err || true
       sed 's/^/  /' /tmp/.catalog-set.err 2>/dev/null || true
       cat_rows=$(grep -c . "${catalog_set}" || true)
@@ -1845,7 +1999,7 @@ data:
     chart_count=$(grep -c . "${chart_work}" || true)
     echo "[harbor-prewarm] Phase A2: ${chart_count} unique openova-io chart(s) to mirror"
 
-    # Per-chart copy worker — same sentinel pattern as copy_one.
+    {{- /* Per-chart copy worker — same sentinel pattern as copy_one. */}}
     chart_cpdir=/tmp/chart-mirror-copies
     rm -rf "${chart_cpdir}"; mkdir -p "${chart_cpdir}"
     copy_chart() {
@@ -1853,29 +2007,31 @@ data:
       csrc="docker://${up_chart_prefix}/${cchart}:${cver}"
       cdst="docker://${HARBOR_HOST}/openova-io/${cchart}:${cver}"
       cslug=$(printf '%s_%s' "${cchart}" "${cver}" | tr -c 'A-Za-z0-9._-' '_')
-      # #3944: bound the chart-OCI copy too (skopeo GLOBAL flag before
-      # the `copy` subcommand) so a stalled connection fails fast.
-      # #4529: same dest-TLS treatment as Phase A — the chart OCI dest
-      # is the in-cluster Harbor (PREWARM_DEST_TLS_VERIFY, default
-      # false); src stays verified (external ghcr.io).
-      #
-      # #4581 (Refs #3379): wrap the chart copy in an OUTER attempt loop
-      # with backoff. skopeo's `--retry-times` only re-tries SOURCE-pull
-      # errors; a TRANSIENT in-cluster-Harbor DEST 504 on blob-upload
-      # initiation (Harbor capacity/OBS flap) is NOT retried by it and
-      # FATAL-ed the whole step on ONE chart. Live evidence: prov
-      # 00720a7a, `bp-alloy:1.0.2` → "initiating layer upload ... 504
-      # Gateway Timeout" with chart_ok=61/62, so step-06 aborted the
-      # cutover over a single transient blip. The outer loop (same shape
-      # as the Phase-B PREWARM_COPY_ATTEMPTS image path) turns a
-      # transient dest 504 into a bounded retry instead of a cutover-
-      # killing FATAL.
-      # #4994 idempotency (#5030 durable): skip when local Harbor already
-      # serves this exact chart artifact (re-run / already-mirrored). The
-      # chart OCI is a single manifest; dest_already_current compares the
-      # SOURCE raw-manifest sha against the DEST's Harbor artifact-API digest
-      # (durable, never pull-through) — the HARBOR_HOST prefix is stripped
-      # inside the function, so the openova-io/<chart>:<ver> path resolves.
+      {{- /*
+       #3944: bound the chart-OCI copy too (skopeo GLOBAL flag before
+       the `copy` subcommand) so a stalled connection fails fast.
+       #4529: same dest-TLS treatment as Phase A — the chart OCI dest
+       is the in-cluster Harbor (PREWARM_DEST_TLS_VERIFY, default
+       false); src stays verified (external ghcr.io).
+
+       #4581 (Refs #3379): wrap the chart copy in an OUTER attempt loop
+       with backoff. skopeo's `--retry-times` only re-tries SOURCE-pull
+       errors; a TRANSIENT in-cluster-Harbor DEST 504 on blob-upload
+       initiation (Harbor capacity/OBS flap) is NOT retried by it and
+       FATAL-ed the whole step on ONE chart. Live evidence: prov
+       00720a7a, `bp-alloy:1.0.2` → "initiating layer upload ... 504
+       Gateway Timeout" with chart_ok=61/62, so step-06 aborted the
+       cutover over a single transient blip. The outer loop (same shape
+       as the Phase-B PREWARM_COPY_ATTEMPTS image path) turns a
+       transient dest 504 into a bounded retry instead of a cutover-
+       killing FATAL.
+       #4994 idempotency (#5030 durable): skip when local Harbor already
+       serves this exact chart artifact (re-run / already-mirrored). The
+       chart OCI is a single manifest; dest_already_current compares the
+       SOURCE raw-manifest sha against the DEST's Harbor artifact-API digest
+       (durable, never pull-through) — the HARBOR_HOST prefix is stripped
+       inside the function, so the openova-io/<chart>:<ver> path resolves.
+      */}}
       if [ "${PREWARM_SKIP_IF_PRESENT:-true}" = "true" ] \
          && dest_already_current "${up_chart_prefix}/${cchart}:${cver}" "${HARBOR_HOST}/openova-io/${cchart}:${cver}" "${ghcr_user}:${ghcr_pat}"; then
         echo "[harbor-prewarm] skip chart ${cchart}:${cver} (dest already current)"
@@ -1909,8 +2065,10 @@ data:
       done
     }
 
-    # #4994 — Phase A2 gets the same real-time heartbeat + explicit drain
-    # as Phase A (the chart mirror shares the file-buffered-log silence).
+    {{- /*
+     #4994 — Phase A2 gets the same real-time heartbeat + explicit drain
+     as Phase A (the chart mirror shares the file-buffered-log silence).
+    */}}
     rm -f "${chart_cpdir}/.hb_stop"
     progress_heartbeat "${chart_count}" "${chart_cpdir}" "Phase A2" &
     chart_hb_pid=$!
@@ -1923,7 +2081,7 @@ data:
       _cnp=$!
       chart_pids="${chart_pids} ${_cnp}"
       chart_allpids="${chart_allpids} ${_cnp}"
-      # Throttle to PREWARM_PARALLELISM live workers (POSIX sh, no wait -n).
+      {{- /* Throttle to PREWARM_PARALLELISM live workers (POSIX sh, no wait -n). */}}
       while : ; do
         clive=0
         cnewpids=""
@@ -1938,7 +2096,7 @@ data:
         sleep 2
       done
     done < "${chart_work}"
-    # Drain the chart workers explicitly, then stop + reap the heartbeat.
+    {{- /* Drain the chart workers explicitly, then stop + reap the heartbeat. */}}
     for _p in ${chart_allpids}; do wait "${_p}" 2>/dev/null || true; done
     touch "${chart_cpdir}/.hb_stop"
     wait "${chart_hb_pid}" 2>/dev/null || true
@@ -1953,16 +2111,18 @@ data:
       chart_ok=$((chart_ok+1))
       echo "[harbor-prewarm] OK chart ${cup}"
     done
-    # #5443 — a copy failure is FATAL only for a chart:version in the
-    # HARD set (everything the installed union already required, plus
-    # every contractual `visibility: listed` catalog entry). A row that
-    # exists ONLY because Phase A2-catalog widened the mirror
-    # best-effort — an unlisted/private Blueprint, or a
-    # `spec.source.version` no controller reads — WARNs instead: those
-    # are not installable from the marketplace grid, so a stale pin on
-    # one must not hold the whole cutover hostage. The customer-visible
-    # contract keeps its fail-loud teeth; the widening cannot regress the
-    # cutover's success rate.
+    {{- /*
+     #5443 — a copy failure is FATAL only for a chart:version in the
+     HARD set (everything the installed union already required, plus
+     every contractual `visibility: listed` catalog entry). A row that
+     exists ONLY because Phase A2-catalog widened the mirror
+     best-effort — an unlisted/private Blueprint, or a
+     `spec.source.version` no controller reads — WARNs instead: those
+     are not installable from the marketplace grid, so a stale pin on
+     one must not hold the whole cutover hostage. The customer-visible
+     contract keeps its fail-loud teeth; the widening cannot regress the
+     cutover's success rate.
+    */}}
     chart_soft_fail=0
     for f in "${chart_cpdir}"/*.fail; do
       [ -e "${f}" ] || continue
@@ -1986,20 +2146,22 @@ data:
       exit 1
     fi
 
-    # ── Phase A2-guard (#5443): re-assert the contract against Harbor.
-    #
-    # The copy tally above says "skopeo returned 0"; the guard says "the
-    # pivoted registry actually serves it, durably". Those are not the
-    # same claim — #5030 documents the whole class where a dest read is
-    # satisfied by a pull-through that persists a manifest and no blobs,
-    # and #4994's skip-if-present can elide a copy on that basis. So the
-    # guard probes Harbor CORE's artifact API (its DATABASE, never a
-    # pull-through) through the SAME harbor_durable_digest the skip
-    # trusts and step-08's completeness gate makes, for exactly the
-    # coordinate the install path will request:
-    # `<spec.manifests.chart>:<spec.version>` of every
-    # `visibility: listed` Blueprint. This IS the probe that found #5443
-    # on hw290, and it would have failed that cutover.
+    {{- /*
+     ── Phase A2-guard (#5443): re-assert the contract against Harbor.
+
+     The copy tally above says "skopeo returned 0"; the guard says "the
+     pivoted registry actually serves it, durably". Those are not the
+     same claim — #5030 documents the whole class where a dest read is
+     satisfied by a pull-through that persists a manifest and no blobs,
+     and #4994's skip-if-present can elide a copy on that basis. So the
+     guard probes Harbor CORE's artifact API (its DATABASE, never a
+     pull-through) through the SAME harbor_durable_digest the skip
+     trusts and step-08's completeness gate makes, for exactly the
+     coordinate the install path will request:
+     `<spec.manifests.chart>:<spec.version>` of every
+     `visibility: listed` Blueprint. This IS the probe that found #5443
+     on hw290, and it would have failed that cutover.
+    */}}
     : "${PREWARM_CATALOG_GUARD:=true}"
     if [ "${PREWARM_CATALOG_GUARD}" = "true" ] && [ "${PREWARM_CATALOG_CHARTS}" = "true" ]; then
       guard_n=$(grep -c . "${catalog_hard}" || true)
@@ -2025,51 +2187,53 @@ data:
       echo "[harbor-prewarm] Phase A2-guard DISABLED — the marketplace's advertised set is NOT asserted against the pivoted registry (#5443)"
     fi
 
-    # ── Phase A3-chart-images (#5442, Refs #5443 #5237 #5437): warm the
-    # images the PINNED CHART VERSIONS reference — not only the images
-    # the cluster happens to be running.
-    #
-    # #5442: harbor-prewarm sources its two inputs from two places that
-    # agree ONLY while the cluster has already converged to what the
-    # mirror declares — chart versions from the mirror's pins (Phase A2
-    # / A2-pins), image tags from the LIVE CLUSTER (running Pods ∪
-    # declared templates). A completely FRESH mirror pinning a chart
-    # whose images the cluster has not yet rolled to reproduces the
-    # outage with NO staleness involved, so it survives the #5441
-    # stale-snapshot fix: step-05 pivots Flux onto charts pinning images
-    # the prewarm never warmed, and the local registry correctly answers
-    # NotFound. Live hw290 2026-07-27 — catalyst-api, catalyst-ui and
-    # catalyst-organization-controller all ImagePullBackOff on local
-    # tags that did not exist, and the Sovereign could not self-heal
-    # because catalyst-api is what DRIVES the cutover; recovery meant
-    # hand-pinning all three back to ghcr, i.e. re-tethering.
-    #
-    # #5443's layer-down leg is the same defect seen from the other end:
-    # a mirrored catalog chart whose images are absent fails at pod-pull
-    # instead of chart-pull. Phase A's live-cluster walk by construction
-    # cannot know the images of a chart NOBODY HAS INSTALLED, which is
-    # every catalog entry the marketplace offers but no Org has bought.
-    #
-    # ONE mechanism closes both: the input for the contractual set
-    # becomes the CHART. Every chart in `chart_hard` — the live-HR
-    # deployed∪desired union, the frozen bootstrap-kit pins, and the
-    # contractual catalog entries — is pulled back OUT of the local
-    # Harbor it was just mirrored into (skopeo `dir:` transport: no
-    # `helm registry login` dance, no extra upstream egress, and it
-    # proves the chart mirror in passing), rendered at DEFAULT values,
-    # and every image the render pins is mirrored through the SAME
-    # offline-mirror resolver + copy_one the live wave used, so step-08's
-    # completeness HEAD looks at identical local paths.
-    # blueprint-release.yaml gates every published bp-* chart on a
-    # default-values `helm template` of the packaged tgz (plus a <5-line
-    # empty-render block), so the render is faithful, not heuristic.
-    #
-    # UNION, NOT REPLACEMENT. The live-cluster walk stays exactly as it
-    # was and this set is added to it. Replacing it would be strictly
-    # WORSE: a default-values render cannot see an image behind a
-    # conditional a per-Sovereign overlay turns on, which the runtime
-    # walk does see. A union can only widen coverage, never narrow it —
-    # so this cannot regress any cutover that works today.
+    {{- /*
+     ── Phase A3-chart-images (#5442, Refs #5443 #5237 #5437): warm the
+     images the PINNED CHART VERSIONS reference — not only the images
+     the cluster happens to be running.
+
+     #5442: harbor-prewarm sources its two inputs from two places that
+     agree ONLY while the cluster has already converged to what the
+     mirror declares — chart versions from the mirror's pins (Phase A2
+     / A2-pins), image tags from the LIVE CLUSTER (running Pods ∪
+     declared templates). A completely FRESH mirror pinning a chart
+     whose images the cluster has not yet rolled to reproduces the
+     outage with NO staleness involved, so it survives the #5441
+     stale-snapshot fix: step-05 pivots Flux onto charts pinning images
+     the prewarm never warmed, and the local registry correctly answers
+     NotFound. Live hw290 2026-07-27 — catalyst-api, catalyst-ui and
+     catalyst-organization-controller all ImagePullBackOff on local
+     tags that did not exist, and the Sovereign could not self-heal
+     because catalyst-api is what DRIVES the cutover; recovery meant
+     hand-pinning all three back to ghcr, i.e. re-tethering.
+
+     #5443's layer-down leg is the same defect seen from the other end:
+     a mirrored catalog chart whose images are absent fails at pod-pull
+     instead of chart-pull. Phase A's live-cluster walk by construction
+     cannot know the images of a chart NOBODY HAS INSTALLED, which is
+     every catalog entry the marketplace offers but no Org has bought.
+
+     ONE mechanism closes both: the input for the contractual set
+     becomes the CHART. Every chart in `chart_hard` — the live-HR
+     deployed∪desired union, the frozen bootstrap-kit pins, and the
+     contractual catalog entries — is pulled back OUT of the local
+     Harbor it was just mirrored into (skopeo `dir:` transport: no
+     `helm registry login` dance, no extra upstream egress, and it
+     proves the chart mirror in passing), rendered at DEFAULT values,
+     and every image the render pins is mirrored through the SAME
+     offline-mirror resolver + copy_one the live wave used, so step-08's
+     completeness HEAD looks at identical local paths.
+     blueprint-release.yaml gates every published bp-* chart on a
+     default-values `helm template` of the packaged tgz (plus a <5-line
+     empty-render block), so the render is faithful, not heuristic.
+
+     UNION, NOT REPLACEMENT. The live-cluster walk stays exactly as it
+     was and this set is added to it. Replacing it would be strictly
+     WORSE: a default-values render cannot see an image behind a
+     conditional a per-Sovereign overlay turns on, which the runtime
+     walk does see. A union can only widen coverage, never narrow it —
+     so this cannot regress any cutover that works today.
+    */}}
     : "${PREWARM_CHART_IMAGES:=true}"
     : "${PREWARM_CHART_IMAGES_FATAL:=true}"
     if [ "${PREWARM_CHART_IMAGES}" = "true" ] && [ -s "${chart_hard}" ]; then
@@ -2080,22 +2244,26 @@ data:
       rm -rf "${cat_pull_dir}"; mkdir -p "${cat_pull_dir}"
       CATALOG_SET_TMPDIR=/tmp
       export CATALOG_SET_TMPDIR
-      # helm writes its cache/config/data + $HOME dotfiles on startup;
-      # the container runs readOnlyRootFilesystem:true with only /tmp
-      # writable, so redirect all four the way step-06 Phase-3a and the
-      # #5265 Day-2 reconciler already do — otherwise every render dies
-      # on a read-only HOME and the image enumeration silently degrades
-      # to "this chart has no images".
+      {{- /*
+       helm writes its cache/config/data + $HOME dotfiles on startup;
+       the container runs readOnlyRootFilesystem:true with only /tmp
+       writable, so redirect all four the way step-06 Phase-3a and the
+       #5265 Day-2 reconciler already do — otherwise every render dies
+       on a read-only HOME and the image enumeration silently degrades
+       to "this chart has no images".
+      */}}
       HOME=/tmp/helm-home
       HELM_CACHE_HOME=/tmp/helm-home/cache
       HELM_CONFIG_HOME=/tmp/helm-home/config
       HELM_DATA_HOME=/tmp/helm-home/data
       export HOME HELM_CACHE_HOME HELM_CONFIG_HOME HELM_DATA_HOME
       mkdir -p "${HELM_CACHE_HOME}" "${HELM_CONFIG_HOME}" "${HELM_DATA_HOME}"
-      # Materialise the Phase A wave as a FILE so the "already covered"
-      # test is a plain `grep -Fxq <file>` — never `printf … | grep -q`,
-      # whose early grep exit SIGPIPEs the writer the moment anything
-      # upstream enables pipefail (#5370, #5406).
+      {{- /*
+       Materialise the Phase A wave as a FILE so the "already covered"
+       test is a plain `grep -Fxq <file>` — never `printf … | grep -q`,
+       whose early grep exit SIGPIPEs the writer the moment anything
+       upstream enables pipefail (#5370, #5406).
+      */}}
       cat_wave_file=/tmp/.prewarm-image-wave.txt
       printf '%s\n' ${mirror_work} > "${cat_wave_file}"
       cat_render_fail=0
@@ -2104,8 +2272,10 @@ data:
         ci_slug=$(printf '%s_%s' "${ci_c}" "${ci_v}" | tr -c 'A-Za-z0-9._-' '_')
         ci_dir="${cat_pull_dir}/${ci_slug}"
         rm -rf "${ci_dir}"
-        # skopeo `dir:` transport — no `helm registry login` dance, and
-        # the same creds/TLS treatment the chart push already used.
+        {{- /*
+         skopeo `dir:` transport — no `helm registry login` dance, and
+         the same creds/TLS treatment the chart push already used.
+        */}}
         if ! skopeo --command-timeout "${PREWARM_SKOPEO_TIMEOUT}" copy \
             --insecure-policy \
             --src-creds="${HARBOR_USERNAME}:${HARBOR_PASSWORD}" \
@@ -2117,9 +2287,11 @@ data:
           cat_render_fail=$((cat_render_fail+1))
           continue
         fi
-        # The helm chart content layer is the one blob that is a gzip
-        # tarball — identified by content, not by a skopeo-version-
-        # specific blob filename convention.
+        {{- /*
+         The helm chart content layer is the one blob that is a gzip
+         tarball — identified by content, not by a skopeo-version-
+         specific blob filename convention.
+        */}}
         ci_tgz=""
         for b in "${ci_dir}"/*; do
           [ -f "${b}" ] || continue
@@ -2139,9 +2311,11 @@ data:
         rm -rf "${ci_dir}"
       done < "${chart_hard}"
       sort -u "${cat_img_set}" -o "${cat_img_set}"
-      # Drop everything the image wave already mirrored, and resolve the
-      # remainder through the SHARED coverage map so step-08's
-      # completeness HEAD looks at the identical local paths.
+      {{- /*
+       Drop everything the image wave already mirrored, and resolve the
+       remainder through the SHARED coverage map so step-08's
+       completeness HEAD looks at the identical local paths.
+      */}}
       cat_img_work=""
       cat_img_unmapped=""
       while IFS= read -r ci_ref; do
@@ -2162,25 +2336,31 @@ data:
         echo "[harbor-prewarm] Phase A3-chart-images UNMAPPED — pinned chart(s) reference image(s) from registry host(s) absent from offlineMirror.hostProjects; they CANNOT be mirrored and will ImagePullBackOff post-severance:"
         for u in ${cat_img_unmapped}; do echo "  UNMAPPED ${u}"; done
       fi
-      # Second image wave — copy_one verbatim, over its own sentinel dir
-      # so the Phase A tally is untouched. The #5095 proxy-down latch is
-      # carried across so a dead mothership proxy keeps direct-first
-      # routing instead of re-paying the timeout tax.
+      {{- /*
+       Second image wave — copy_one verbatim, over its own sentinel dir
+       so the Phase A tally is untouched. The #5095 proxy-down latch is
+       carried across so a dead mothership proxy keeps direct-first
+       routing instead of re-paying the timeout tax.
+      */}}
       cat_img_fail=0
       if [ "${cat_img_n}" -gt 0 ]; then
         cat_cpdir=/tmp/prewarm-chart-image-copies
         rm -rf "${cat_cpdir}"; mkdir -p "${cat_cpdir}"
         [ -f "${cpdir}/.proxy_down" ] && touch "${cat_cpdir}/.proxy_down"
-        # #5525 leg 2 — carry the per-host toomanyrequests latches into
-        # the chart-image wave too, so a host that exhausted its quota
-        # during Phase A is not re-hammered by Phase A3.
+        {{- /*
+         #5525 leg 2 — carry the per-host toomanyrequests latches into
+         the chart-image wave too, so a host that exhausted its quota
+         during Phase A is not re-hammered by Phase A3.
+        */}}
         for _rl_f in "${cpdir}"/.ratelimited.*; do
           [ -e "${_rl_f}" ] || continue
           cp "${_rl_f}" "${cat_cpdir}/" 2>/dev/null || true
         done
-        # copy_one writes its sentinels into the GLOBAL cpdir; point it
-        # at this wave's dir and restore afterwards so nothing later in
-        # the step observes a mutated global.
+        {{- /*
+         copy_one writes its sentinels into the GLOBAL cpdir; point it
+         at this wave's dir and restore afterwards so nothing later in
+         the step observes a mutated global.
+        */}}
         cat_cpdir_saved="${cpdir}"
         cpdir="${cat_cpdir}"
         rm -f "${cat_cpdir}/.hb_stop"
@@ -2229,20 +2409,22 @@ data:
       else
         echo "[harbor-prewarm] Phase A3-chart-images copy wave complete: every chart-declared image was already covered by the live-cluster wave (render_fail=${cat_render_fail})"
       fi
-      # ── Phase A3-guard (#5442): every image the pinned charts declare
-      # must resolve DURABLY in local Harbor.
-      #
-      # "skopeo returned 0" and "the pivoted registry serves it" are not
-      # the same claim — #5030 is the whole class where a dest read is
-      # satisfied by a pull-through that persists a manifest and no
-      # blobs, and #4994's skip-if-present can elide a copy on exactly
-      # that basis. So the guard re-asserts through the SAME
-      # harbor_durable_digest (Harbor CORE's artifact API — its
-      # database, never a pull-through) that the skip trusts and that
-      # step-08's completeness gate makes. It covers the WHOLE
-      # chart-declared set, including refs the live wave was credited
-      # with, because a false-present there is precisely how the hw290
-      # control plane ended up unpullable.
+      {{- /*
+       ── Phase A3-guard (#5442): every image the pinned charts declare
+       must resolve DURABLY in local Harbor.
+
+       "skopeo returned 0" and "the pivoted registry serves it" are not
+       the same claim — #5030 is the whole class where a dest read is
+       satisfied by a pull-through that persists a manifest and no
+       blobs, and #4994's skip-if-present can elide a copy on exactly
+       that basis. So the guard re-asserts through the SAME
+       harbor_durable_digest (Harbor CORE's artifact API — its
+       database, never a pull-through) that the skip trusts and that
+       step-08's completeness gate makes. It covers the WHOLE
+       chart-declared set, including refs the live wave was credited
+       with, because a false-present there is precisely how the hw290
+       control plane ended up unpullable.
+      */}}
       img_guard_missing=/tmp/.chart-image-missing.txt
       : > "${img_guard_missing}"
       img_guard_n=0
@@ -2266,29 +2448,33 @@ data:
         echo "[harbor-prewarm] Phase A3-guard (#5442): ${img_missing_n}/${img_guard_n} chart-declared image path(s) NOT durably present in local Harbor:"
         sed 's/^/  MISSING /' "${img_guard_missing}"
       fi
-      # FATAL policy. copy failures, un-mappable registry hosts and
-      # durable-presence misses are all PROVEN post-severance
-      # ImagePullBackOffs — the same two conditions Phase A already
-      # FATALs on for the runtime-derived set, applied to the second
-      # input. Failing HERE, with egress still open and the offender
-      # named, is recoverable; discovering it after the pivot can strand
-      # the control plane that drives the cutover (hw290). A chart that
-      # failed to RENDER is deliberately NOT fatal: it makes no claim
-      # about images either way, so failing on it would fail a cutover
-      # on an enumeration hiccup rather than a missing artifact.
+      {{- /*
+       FATAL policy. copy failures, un-mappable registry hosts and
+       durable-presence misses are all PROVEN post-severance
+       ImagePullBackOffs — the same two conditions Phase A already
+       FATALs on for the runtime-derived set, applied to the second
+       input. Failing HERE, with egress still open and the offender
+       named, is recoverable; discovering it after the pivot can strand
+       the control plane that drives the cutover (hw290). A chart that
+       failed to RENDER is deliberately NOT fatal: it makes no claim
+       about images either way, so failing on it would fail a cutover
+       on an enumeration hiccup rather than a missing artifact.
+      */}}
       if [ "${cat_render_fail}" -gt 0 ]; then
         echo "[harbor-prewarm] Phase A3-chart-images WARN: ${cat_render_fail} chart(s) could not be pulled back or rendered (named above) — their images were NOT enumerated from the chart; those charts rely on the live-cluster wave alone (#5442)"
       fi
-      # #5525 leg 3 — copy_fail ALONE is not a post-severance
-      # ImagePullBackOff: the A3-guard durability sweep directly above
-      # is the AUTHORITATIVE assertion of what the pivoted registry
-      # serves, and copy_fail>0 with durable_miss=0 means every failed
-      # copy was a freshness re-copy against a source we no longer need
-      # (live hw291 attempt 1785396281: `Phase A3-guard (#5442): PASS`
-      # with durable_miss=0 immediately followed by `FATAL ...
-      # copy_fail=4` — the gate contradicted its own sweep). That shape
-      # degrades to a LOUD WARN naming the refs; FATAL keys on
-      # { durable_miss>0 || unmapped } ONLY.
+      {{- /*
+       #5525 leg 3 — copy_fail ALONE is not a post-severance
+       ImagePullBackOff: the A3-guard durability sweep directly above
+       is the AUTHORITATIVE assertion of what the pivoted registry
+       serves, and copy_fail>0 with durable_miss=0 means every failed
+       copy was a freshness re-copy against a source we no longer need
+       (live hw291 attempt 1785396281: `Phase A3-guard (#5442): PASS`
+       with durable_miss=0 immediately followed by `FATAL ...
+       copy_fail=4` — the gate contradicted its own sweep). That shape
+       degrades to a LOUD WARN naming the refs; FATAL keys on
+       { durable_miss>0 || unmapped } ONLY.
+      */}}
       if [ "${cat_img_fail}" -gt 0 ] && [ "${img_missing_n}" -eq 0 ] && [ -z "${cat_img_unmapped}" ]; then
         echo "[harbor-prewarm] Phase A3-chart-images WARN (#5525): ${cat_img_fail} copy attempt(s) failed but EVERY chart-declared image path is durably present in local Harbor (A3-guard PASS, durable_miss=0) — the failures were freshness re-copies against unreachable/rate-limited sources; the pivoted registry serves the full set. Failed ref(s):"
         for f in "${cat_cpdir}"/*.fail; do
@@ -2306,77 +2492,81 @@ data:
     fi
 
     # ─── Phase A4 (#5204): warm Crossplane xpkg provider packages ──────
-    #
-    # #5204 (Refs #5209 #3379). Step-11 (crossplane-provider-pivot)
-    # rewrites every Provider's spec.package to the local Harbor
-    # `proxy-xpkg` project and #5209 wired the package-pull AUTH — but
-    # NOTHING ever placed the xpkg OCI artifact ITSELF in the local
-    # Harbor. `proxy-xpkg` is the ONE local project that stays a Harbor
-    # PROXY-CACHE (0.1.114; Harbor REJECTS pushes into a proxy-cache
-    # project, so the Phase A skopeo-push route cannot serve it), and
-    # xpkg.upbound.io is deliberately in offlineMirror.excludedHosts
-    # (the Crossplane package manager bypasses containerd, so the
-    # generic mirror legs are inert for it). On a COLD cache every
-    # post-severance package re-pull / provider upgrade / inactive-
-    # revision reconcile needs the proxy leg to reach xpkg.upbound.io —
-    # an upstream tether Principle #11 forbids: the fully-severed
-    # Sovereign cannot resolve its own provider package descriptor
-    # from the local registry (live hw270 dep b2f0a9b0585f6781,
-    # provider-opentofu Installed=False).
-    #
-    # FIX: enumerate every providers.pkg.crossplane.io spec.package
-    # (the SAME set step-11 pivots) and perform ONE FULL authenticated
-    # pull THROUGH the local proxy-xpkg endpoint per package
-    # (`skopeo copy docker://${HARBOR_HOST}/proxy-xpkg/<path> dir:…`
-    # with --multi-arch all). The pull-through forces Harbor to fetch
-    # the manifest (list) + EVERY blob from upstream and cache them
-    # DURABLY in the project, so the exact ref step-11 pivots to
-    # serves locally with no upstream leg (Harbor serves cached
-    # proxy-cache content when the upstream is unreachable). A
-    # bounded durable-presence poll via the Harbor ARTIFACT API
-    # (#5030 discipline — Harbor CORE DB, never pull-through;
-    # proxy-cache records artifacts ASYNC, hence the poll) confirms
-    # each package landed; FATAL naming the offender otherwise — the
-    # same fail-loud sovereignty contract as Phase A/A2. Step-11's
-    # verify-before-pivot gate re-asserts this durable presence
-    # immediately before each spec.package rewrite.
-    #
-    # #5232 (Refs #5226) — the durable verify + the step-11 pivot are
-    # DIGEST-addressed end-to-end. Live hw274 (dep d51a69f885872a81):
-    # Harbor proxy-cache NEVER records TAGS for pulled-through xpkg
-    # artifacts (manual tag-create 401s on proxy projects; a fresh
-    # tag manifest GET serves the OCI index but still records no tag
-    # — deterministic, not async lag), so the 0.1.142 tag-based
-    # artifact probe could never pass and a tag-based step-11 pivot
-    # ref would genuinely 404 post-severance. The artifact IS cached
-    # and queryable BY DIGEST — but ONLY via the registry v2 API, not
-    # the artifact-management API (#5232 round 2, live hw274: for a
-    # MULTI-ARCH package the artifact API records only the per-arch
-    # CHILD manifests, never the top-level OCI index by its own digest
-    # → GET artifacts/sha256:<index> 404s there even though every blob
-    # is durable). Phase A4 therefore resolves each package's
-    # tag->digest from a registry v2 HEAD (the Docker-Content-Digest
-    # response header — the exact digest containerd/Crossplane resolve
-    # at pull time), verifies durability with a v2 digest GET (200),
-    # and persists the map in the XPKG_DIGEST_CM ConfigMap for
-    # step-11's digest pivot.
-    #
-    # The two helpers below use the registry v2 manifest API
-    # (${HARBOR_INTERNAL_URL}/v2/<repo>/manifests/<ref>, the SAME
-    # in-cluster Harbor Service Phase B dials) with LITERAL-slash repo
-    # paths (no %2F encode — the /v2 API takes the nested repo name
-    # verbatim). The Accept header covers OCI index + docker manifest
-    # list + single manifest so a single-arch package (whose HEAD
-    # returns a manifest.v2 digest, equally servable) needs no
-    # special-casing.
+    {{- /*
+
+     #5204 (Refs #5209 #3379). Step-11 (crossplane-provider-pivot)
+     rewrites every Provider's spec.package to the local Harbor
+     `proxy-xpkg` project and #5209 wired the package-pull AUTH — but
+     NOTHING ever placed the xpkg OCI artifact ITSELF in the local
+     Harbor. `proxy-xpkg` is the ONE local project that stays a Harbor
+     PROXY-CACHE (0.1.114; Harbor REJECTS pushes into a proxy-cache
+     project, so the Phase A skopeo-push route cannot serve it), and
+     xpkg.upbound.io is deliberately in offlineMirror.excludedHosts
+     (the Crossplane package manager bypasses containerd, so the
+     generic mirror legs are inert for it). On a COLD cache every
+     post-severance package re-pull / provider upgrade / inactive-
+     revision reconcile needs the proxy leg to reach xpkg.upbound.io —
+     an upstream tether Principle #11 forbids: the fully-severed
+     Sovereign cannot resolve its own provider package descriptor
+     from the local registry (live hw270 dep b2f0a9b0585f6781,
+     provider-opentofu Installed=False).
+
+     FIX: enumerate every providers.pkg.crossplane.io spec.package
+     (the SAME set step-11 pivots) and perform ONE FULL authenticated
+     pull THROUGH the local proxy-xpkg endpoint per package
+     (`skopeo copy docker://${HARBOR_HOST}/proxy-xpkg/<path> dir:…`
+     with --multi-arch all). The pull-through forces Harbor to fetch
+     the manifest (list) + EVERY blob from upstream and cache them
+     DURABLY in the project, so the exact ref step-11 pivots to
+     serves locally with no upstream leg (Harbor serves cached
+     proxy-cache content when the upstream is unreachable). A
+     bounded durable-presence poll via the Harbor ARTIFACT API
+     (#5030 discipline — Harbor CORE DB, never pull-through;
+     proxy-cache records artifacts ASYNC, hence the poll) confirms
+     each package landed; FATAL naming the offender otherwise — the
+     same fail-loud sovereignty contract as Phase A/A2. Step-11's
+     verify-before-pivot gate re-asserts this durable presence
+     immediately before each spec.package rewrite.
+
+     #5232 (Refs #5226) — the durable verify + the step-11 pivot are
+     DIGEST-addressed end-to-end. Live hw274 (dep d51a69f885872a81):
+     Harbor proxy-cache NEVER records TAGS for pulled-through xpkg
+     artifacts (manual tag-create 401s on proxy projects; a fresh
+     tag manifest GET serves the OCI index but still records no tag
+     — deterministic, not async lag), so the 0.1.142 tag-based
+     artifact probe could never pass and a tag-based step-11 pivot
+     ref would genuinely 404 post-severance. The artifact IS cached
+     and queryable BY DIGEST — but ONLY via the registry v2 API, not
+     the artifact-management API (#5232 round 2, live hw274: for a
+     MULTI-ARCH package the artifact API records only the per-arch
+     CHILD manifests, never the top-level OCI index by its own digest
+     → GET artifacts/sha256:<index> 404s there even though every blob
+     is durable). Phase A4 therefore resolves each package's
+     tag->digest from a registry v2 HEAD (the Docker-Content-Digest
+     response header — the exact digest containerd/Crossplane resolve
+     at pull time), verifies durability with a v2 digest GET (200),
+     and persists the map in the XPKG_DIGEST_CM ConfigMap for
+     step-11's digest pivot.
+
+     The two helpers below use the registry v2 manifest API
+     (${HARBOR_INTERNAL_URL}/v2/<repo>/manifests/<ref>, the SAME
+     in-cluster Harbor Service Phase B dials) with LITERAL-slash repo
+     paths (no %2F encode — the /v2 API takes the nested repo name
+     verbatim). The Accept header covers OCI index + docker manifest
+     list + single manifest so a single-arch package (whose HEAD
+     returns a manifest.v2 digest, equally servable) needs no
+     special-casing.
+    */}}
     XPKG_V2_ACCEPT='application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.v2+json'
     xpkg_v2_resolve_digest() {
-      # $1 = repo-path (literal slashes, incl. project), $2 = tag.
-      # Echoes the servable manifest/index digest (Docker-Content-Digest
-      # from a v2 HEAD) when the HEAD is 200 + carries the header, else
-      # nothing. This is the durable digest step-11 pivots spec.package
-      # to. Empty tag → nothing (an in-ref digest is authoritative and
-      # never needs resolving).
+      {{- /*
+       $1 = repo-path (literal slashes, incl. project), $2 = tag.
+       Echoes the servable manifest/index digest (Docker-Content-Digest
+       from a v2 HEAD) when the HEAD is 200 + carries the header, else
+       nothing. This is the durable digest step-11 pivots spec.package
+       to. Empty tag → nothing (an in-ref digest is authoritative and
+       never needs resolving).
+      */}}
       _xr_repo="$1"; _xr_tag="$2"
       [ -n "${_xr_tag}" ] || return 0
       curl -sSIk --max-time 30 \
@@ -2386,12 +2576,14 @@ data:
         | tr -d '\r' | grep -i '^docker-content-digest:' | tail -1 | awk '{print $2}'
     }
     xpkg_v2_digest_present() {
-      # $1 = repo-path (literal slashes, incl. project), $2 = sha256
-      # digest. 0 iff the registry v2 API serves that digest (200) —
-      # Harbor CORE serving the durably-cached index/manifest, the
-      # multi-arch-aware durability signal that supersedes the
-      # artifact-management-API probe for xpkg (#5232). Non-zero on ANY
-      # miss → fail-closed (the caller warms / FATALs).
+      {{- /*
+       $1 = repo-path (literal slashes, incl. project), $2 = sha256
+       digest. 0 iff the registry v2 API serves that digest (200) —
+       Harbor CORE serving the durably-cached index/manifest, the
+       multi-arch-aware durability signal that supersedes the
+       artifact-management-API probe for xpkg (#5232). Non-zero on ANY
+       miss → fail-closed (the caller warms / FATALs).
+      */}}
       _xp_repo="$1"; _xp_dig="$2"
       [ -n "${_xp_dig}" ] || return 1
       _xp_code=$(curl -sk -o /dev/null -w '%{http_code}' --max-time 30 \
@@ -2404,10 +2596,12 @@ data:
     if [ "${XPKG_PREWARM_ENABLED:-true}" != "true" ]; then
       echo "[harbor-prewarm] Phase A4 SKIP — prewarm.xpkgPackages.enabled=false (Crossplane package warm disabled; post-severance provider re-pulls stay dependent on proxy-cache upstream reachability)"
     elif ! kubectl get crd providers.pkg.crossplane.io >/dev/null 2>&1; then
-      # Same very-early-handover guard step-11 Phase 1 uses: bp-crossplane
-      # not landed yet → no Provider CRs to warm, and step-11 skips the
-      # live pivot on the SAME probe, so no ref is ever pivoted onto a
-      # cold cache. A step re-run once crossplane lands warms the set.
+      {{- /*
+       Same very-early-handover guard step-11 Phase 1 uses: bp-crossplane
+       not landed yet → no Provider CRs to warm, and step-11 skips the
+       live pivot on the SAME probe, so no ref is ever pivoted onto a
+       cold cache. A step re-run once crossplane lands warms the set.
+      */}}
       echo "[harbor-prewarm] Phase A4 SKIP — providers.pkg.crossplane.io CRD not installed yet (bp-crossplane not landed); packages warm on a later step re-run"
     else
       echo "[harbor-prewarm] Phase A4: warm Crossplane xpkg provider packages through local ${XPKG_REGISTRY_PATH} (#5204; digest-addressed durable verify #5232)"
@@ -2416,25 +2610,31 @@ data:
         -o 'jsonpath={range .items[*]}{.metadata.name}{"\t"}{.spec.package}{"\n"}{end}' 2>/dev/null || true)
       xpkg_warm_dir=/tmp/xpkg-warm
       rm -rf "${xpkg_warm_dir}"; mkdir -p "${xpkg_warm_dir}"
-      # #5232 — the prior-run digest map (also the create-or-replace
-      # target below). A skip-if-present decision may ONLY key on a
-      # digest a PRIOR successful warm minted (full pull-through +
-      # durable verify): resolving a tag via a fresh manifest GET
-      # through the proxy would itself pull the manifest through and
-      # could record the artifact digest with COLD blobs — a
-      # durability hole. No prior digest -> full warm. Fail-closed.
+      {{- /*
+       #5232 — the prior-run digest map (also the create-or-replace
+       target below). A skip-if-present decision may ONLY key on a
+       digest a PRIOR successful warm minted (full pull-through +
+       durable verify): resolving a tag via a fresh manifest GET
+       through the proxy would itself pull the manifest through and
+       could record the artifact digest with COLD blobs — a
+       durability hole. No prior digest -> full warm. Fail-closed.
+      */}}
       xpkg_digest_map_json=$(kubectl get configmap "${XPKG_DIGEST_CM}" -n "${RELEASE_NAMESPACE}" -o json 2>/dev/null) || xpkg_digest_map_json='{}'
       [ -n "${xpkg_digest_map_json}" ] || xpkg_digest_map_json='{}'
       printf '%s\n' "${xpkg_tsv}" | while IFS="$(printf '\t')" read -r _xw_name _xw_pkg; do
         [ -z "${_xw_name}" ] && continue
         [ -z "${_xw_pkg}" ] && continue
-        # tag@digest → digest-only (skopeo rejects a ref carrying both;
-        # the digest is authoritative — the #4955 normalization).
+        {{- /*
+         tag@digest → digest-only (skopeo rejects a ref carrying both;
+         the digest is authoritative — the #4955 normalization).
+        */}}
         _xw_pkg=$(offlinemirror_normalize_ref "${_xw_pkg}")
-        # Route the package to its local proxy-xpkg path. Handles every
-        # shape step-11 handles: the raw upstream host (Hetzner), the
-        # MOTHERSHIP proxy prefix (Huawei fresh-prov, #4488), and the
-        # already-pivoted local aliases (re-run idempotency).
+        {{- /*
+         Route the package to its local proxy-xpkg path. Handles every
+         shape step-11 handles: the raw upstream host (Hetzner), the
+         MOTHERSHIP proxy prefix (Huawei fresh-prov, #4488), and the
+         already-pivoted local aliases (re-run idempotency).
+        */}}
         _xw_lpath=""
         case "${_xw_pkg}" in
           "${XPKG_UPSTREAM_HOST}/"*)
@@ -2446,20 +2646,24 @@ data:
           "${LOCAL_REGISTRY_HOST}/${XPKG_REGISTRY_PATH}/"*)
             _xw_lpath="${_xw_pkg#${LOCAL_REGISTRY_HOST}/}" ;;
           *)
-            # Unmapped package host — the same fail-fast discipline as
-            # the Phase A pre-pass (egress still open, offender named)
-            # instead of a silent post-severance resolution failure.
+            {{- /*
+             Unmapped package host — the same fail-fast discipline as
+             the Phase A pre-pass (egress still open, offender named)
+             instead of a silent post-severance resolution failure.
+            */}}
             echo "[harbor-prewarm] Phase A4 UNMAPPED: Provider ${_xw_name} package '${_xw_pkg}' is from a host not covered by crossplaneProviderPivot (${XPKG_UPSTREAM_HOST} / ${XPKG_MOTHERSHIP_PROXY_PREFIX} / ${xpkg_target_host}/${XPKG_REGISTRY_PATH} / ${LOCAL_REGISTRY_HOST}/${XPKG_REGISTRY_PATH}) — extend the values and re-trigger"
             printf '%s %s (unmapped host)' "${_xw_name}" "${_xw_pkg}" > "${xpkg_warm_dir}/$(printf '%s' "${_xw_name}" | tr -c 'A-Za-z0-9._-' '_').fail"
             continue ;;
         esac
         _xw_slug=$(printf '%s' "${_xw_lpath}" | tr -c 'A-Za-z0-9._-' '_')
         : >"${xpkg_warm_dir}/${_xw_slug}.log"
-        # #5232 — split the local path into repo-path + tag + ref. A
-        # source ref that already carries a digest (#4955 normalized
-        # tag@digest -> digest-only) IS the authoritative digest; the
-        # tag drives the registry v2 HEAD that resolves the servable
-        # digest for a tag-only ref.
+        {{- /*
+         #5232 — split the local path into repo-path + tag + ref. A
+         source ref that already carries a digest (#4955 normalized
+         tag@digest -> digest-only) IS the authoritative digest; the
+         tag drives the registry v2 HEAD that resolves the servable
+         digest for a tag-only ref.
+        */}}
         _xw_repo_path="${_xw_lpath}"
         _xw_digest=""
         _xw_tag=""
@@ -2470,13 +2674,15 @@ data:
           *)
             case "${_xw_lpath##*/}" in *:*) _xw_tag="${_xw_lpath##*:}"; _xw_repo_path="${_xw_lpath%:*}" ;; esac ;;
         esac
-        # Idempotency (#4994/#5232): skip ONLY when a digest is
-        # already authoritative (in-ref, or minted by a PRIOR
-        # successful warm) AND that digest is durably present. A TAG
-        # can never be probed: Harbor proxy-cache NEVER records tags
-        # for pulled-through xpkg artifacts (live hw274 — manual
-        # tag-create 401s on proxy projects; a tag manifest GET does
-        # not record either). Fail-closed — any miss warms.
+        {{- /*
+         Idempotency (#4994/#5232): skip ONLY when a digest is
+         already authoritative (in-ref, or minted by a PRIOR
+         successful warm) AND that digest is durably present. A TAG
+         can never be probed: Harbor proxy-cache NEVER records tags
+         for pulled-through xpkg artifacts (live hw274 — manual
+         tag-create 401s on proxy projects; a tag manifest GET does
+         not record either). Fail-closed — any miss warms.
+        */}}
         if [ "${PREWARM_SKIP_IF_PRESENT:-true}" = "true" ]; then
           _xw_skip_digest="${_xw_digest}"
           if [ -z "${_xw_skip_digest}" ]; then
@@ -2495,14 +2701,16 @@ data:
         while [ "${_xw_attempt}" -le "${PREWARM_COPY_ATTEMPTS}" ]; do
           echo "[harbor-prewarm] Phase A4 warm ${_xw_lpath} attempt ${_xw_attempt}/${PREWARM_COPY_ATTEMPTS}" >>"${xpkg_warm_dir}/${_xw_slug}.log"
           rm -rf "${xpkg_warm_dir}/${_xw_slug}.dir"
-          # SOURCE = the local proxy-xpkg endpoint (the exact ref
-          # step-11 pivots to); admin src-creds satisfy Harbor's
-          # authenticated proxy-cache pull (#5204/#5209). src-tls
-          # follows PREWARM_DEST_TLS_VERIFY — it is the SAME in-cluster
-          # registry.<fqdn> endpoint the Phase A pushes target (#4529
-          # rationale: trust is the cluster network, not a public CA).
-          # --multi-arch all pulls EVERY arch sub-manifest + blobs
-          # through so the cached list is complete (#4975 rationale).
+          {{- /*
+           SOURCE = the local proxy-xpkg endpoint (the exact ref
+           step-11 pivots to); admin src-creds satisfy Harbor's
+           authenticated proxy-cache pull (#5204/#5209). src-tls
+           follows PREWARM_DEST_TLS_VERIFY — it is the SAME in-cluster
+           registry.<fqdn> endpoint the Phase A pushes target (#4529
+           rationale: trust is the cluster network, not a public CA).
+           --multi-arch all pulls EVERY arch sub-manifest + blobs
+           through so the cached list is complete (#4975 rationale).
+          */}}
           if skopeo --command-timeout "${PREWARM_SKOPEO_TIMEOUT}" copy \
               --insecure-policy \
               --multi-arch all \
@@ -2520,22 +2728,26 @@ data:
           _xw_attempt=$((_xw_attempt+1))
           [ "${_xw_attempt}" -le "${PREWARM_COPY_ATTEMPTS}" ] && sleep 5
         done
-        # #5232 (round 2) — resolve the tag->digest from the REGISTRY
-        # V2 API, not the pulled-through scratch: HEAD the tag and read
-        # the `Docker-Content-Digest` response header. That is the
-        # EXACT digest Harbor serves for the tag (and containerd/
-        # Crossplane resolve at pull time) — for a multi-arch package
-        # the top-level OCI INDEX digest, which the artifact-management
-        # API never exposes by its own digest (live hw274: only per-
-        # arch child manifests, so the resolved index 404s there). The
-        # full pull-through above already cached the manifest + every
-        # blob durably, so this HEAD is served from cache. In-ref
-        # digests (#4955) are authoritative and skip the resolve.
+        {{- /*
+         #5232 (round 2) — resolve the tag->digest from the REGISTRY
+         V2 API, not the pulled-through scratch: HEAD the tag and read
+         the `Docker-Content-Digest` response header. That is the
+         EXACT digest Harbor serves for the tag (and containerd/
+         Crossplane resolve at pull time) — for a multi-arch package
+         the top-level OCI INDEX digest, which the artifact-management
+         API never exposes by its own digest (live hw274: only per-
+         arch child manifests, so the resolved index 404s there). The
+         full pull-through above already cached the manifest + every
+         blob durably, so this HEAD is served from cache. In-ref
+         digests (#4955) are authoritative and skip the resolve.
+        */}}
         if [ "${_xw_rc}" -eq 0 ] && [ -z "${_xw_digest}" ]; then
           _xw_digest=$(xpkg_v2_resolve_digest "${_xw_repo_path}" "${_xw_tag}")
         fi
-        # The dir: copy is a scratch side-effect — the durable payload
-        # is what Harbor cached on the way through. Free the emptyDir.
+        {{- /*
+         The dir: copy is a scratch side-effect — the durable payload
+         is what Harbor cached on the way through. Free the emptyDir.
+        */}}
         rm -rf "${xpkg_warm_dir}/${_xw_slug}.dir"
         if [ "${_xw_rc}" -ne 0 ]; then
           printf '%s exit=%s' "${_xw_lpath}" "${_xw_rc}" > "${xpkg_warm_dir}/${_xw_slug}.fail"
@@ -2543,17 +2755,21 @@ data:
           continue
         fi
         if [ -z "${_xw_digest}" ]; then
-          # Without a digest step-11 has NOTHING valid to pivot to (a
-          # tag ref 404s post-severance — Harbor never records tags on
-          # proxy projects, #5232) — fail LOUD while egress is open.
+          {{- /*
+           Without a digest step-11 has NOTHING valid to pivot to (a
+           tag ref 404s post-severance — Harbor never records tags on
+           proxy projects, #5232) — fail LOUD while egress is open.
+          */}}
           printf '%s (pulled through but tag->digest resolution failed)' "${_xw_lpath}" > "${xpkg_warm_dir}/${_xw_slug}.fail"
           echo "[harbor-prewarm] Phase A4 ${_xw_lpath}: pull-through succeeded but the registry v2 HEAD returned no Docker-Content-Digest for tag '${_xw_tag}' (HEAD non-200 or header absent) — no digest to record for the step-11 pivot (#5232)"
           continue
         fi
-        # Durable-presence poll BY DIGEST via the registry v2 API
-        # (#5232 round 2 — the multi-arch-aware durability signal;
-        # Harbor records proxied artifacts ASYNC): GET the digest must
-        # be 200, bounded 12x10s before the fail-closed verdict.
+        {{- /*
+         Durable-presence poll BY DIGEST via the registry v2 API
+         (#5232 round 2 — the multi-arch-aware durability signal;
+         Harbor records proxied artifacts ASYNC): GET the digest must
+         be 200, bounded 12x10s before the fail-closed verdict.
+        */}}
         _xw_present=0
         for _xw_i in $(seq 1 12); do
           if xpkg_v2_digest_present "${_xw_repo_path}" "${_xw_digest}"; then _xw_present=1; break; fi
@@ -2584,10 +2800,12 @@ data:
         echo "[harbor-prewarm] Phase A4 FAIL $(cat "${f}")"
       done
       echo "[harbor-prewarm] Phase A4 complete: xpkg_ok=${xpkg_ok} xpkg_fail=${xpkg_fail}"
-      # #5232 — persist the tag->digest map for step-11 BEFORE the
-      # fail gate so partial progress is durable across a re-run.
-      # Create-or-replace: the enumerated live set fully re-emits
-      # every run (kubectl apply prunes keys absent from the render).
+      {{- /*
+       #5232 — persist the tag->digest map for step-11 BEFORE the
+       fail gate so partial progress is durable across a re-run.
+       Create-or-replace: the enumerated live set fully re-emits
+       every run (kubectl apply prunes keys absent from the render).
+      */}}
       _xd_literals=""
       _xd_count=0
       for f in "${xpkg_warm_dir}"/*.digest; do
@@ -2643,10 +2861,12 @@ data:
     activeDeadlineSeconds: {{ .Values.stepTimeouts.harborPrewarmSeconds }}
     containers:
       - name: harbor-prewarm
-        # G66: switch from curl-only to alpine/k8s (has kubectl) + apt
-        # install skopeo at runtime. alpine/k8s is already the canonical
-        # cutover-step image carrying kubectl; adding skopeo via apk
-        # keeps the image small + composable.
+        {{- /*
+         G66: switch from curl-only to alpine/k8s (has kubectl) + apt
+         install skopeo at runtime. alpine/k8s is already the canonical
+         cutover-step image carrying kubectl; adding skopeo via apk
+         keeps the image small + composable.
+        */}}
         image: {{ include "bp-self-sovereign-cutover.image" (dict "repository" .Values.images.kubectl.repository "tag" .Values.images.kubectl.tag "cutoverPhase" "pre" "Values" .Values) }}
         imagePullPolicy: IfNotPresent
         env:
@@ -2665,11 +2885,13 @@ data:
               secretKeyRef:
                 name: {{ .Values.harbor.adminSecretRef.name }}
                 key: {{ .Values.harbor.adminSecretRef.passwordKey }}
-          # G66: GHCR PAT from flux-system/ghcr-pull (intact at step 03
-          # time, BEFORE step 06 phase-0 strips ghcr.io entry). The
-          # dockerconfigjson auth field carries `<user>:<PAT>` base64-
-          # encoded — Phase A parses it to extract the PAT for skopeo
-          # --src-creds.
+          {{- /*
+           G66: GHCR PAT from flux-system/ghcr-pull (intact at step 03
+           time, BEFORE step 06 phase-0 strips ghcr.io entry). The
+           dockerconfigjson auth field carries `<user>:<PAT>` base64-
+           encoded — Phase A parses it to extract the PAT for skopeo
+           --src-creds.
+          */}}
           - name: GHCR_DOCKERCONFIG
             valueFrom:
               secretKeyRef:
@@ -2677,64 +2899,72 @@ data:
                 key: {{ .Values.harbor.ghcrSecretRef.dockerConfigKey }}
           - name: GHCR_DOCKERCONFIG_NAMESPACE
             value: {{ .Values.harbor.ghcrSecretRef.namespace | quote }}
-          # Phase A2 (Refs #3627 #3379): the cutover pivot set — the
-          # namespace holding the Flux HelmRepositories that step-06 repoints
-          # to local Harbor, and the names of those openova-io HelmRepositories.
-          # Phase A2 reads the chart+version off every HelmRelease whose
-          # sourceRef.kind=HelmRepository and whose sourceRef.name is in this
-          # set, then skopeo-mirrors the chart OCI artifact into local Harbor
-          # so the charts are PULLABLE post-cutover (without this, step-06
-          # only pivots the URL — the chart artifacts themselves never reach
-          # local Harbor, so the first post-strip (re)pull 404s).
+          {{- /*
+           Phase A2 (Refs #3627 #3379): the cutover pivot set — the
+           namespace holding the Flux HelmRepositories that step-06 repoints
+           to local Harbor, and the names of those openova-io HelmRepositories.
+           Phase A2 reads the chart+version off every HelmRelease whose
+           sourceRef.kind=HelmRepository and whose sourceRef.name is in this
+           set, then skopeo-mirrors the chart OCI artifact into local Harbor
+           so the charts are PULLABLE post-cutover (without this, step-06
+           only pivots the URL — the chart artifacts themselves never reach
+           local Harbor, so the first post-strip (re)pull 404s).
+          */}}
           - name: HELMREPO_NAMESPACE
             value: {{ .Values.helmRepositories.namespace | quote }}
           - name: UPSTREAM_PREFIX
             value: {{ .Values.helmRepositories.upstreamPrefix | quote }}
-          # #3944 (Refs #3379 #3642 #3927): per-`skopeo copy` command timeout.
-          # A `skopeo copy` whose TCP connection is ESTABLISHED but then
-          # silently STALLS mid-blob (no bytes, no reset — common on a
-          # freshly-bootstrapped/throttled Sovereign network, or against the
-          # registry.<fqdn> front door that accepts the connect but stops
-          # responding) hangs INDEFINITELY: `--retry-times` only fires on an
-          # ERROR, never on a stuck-but-alive connection. With no command
-          # timeout the copy never returns, the worker never drains, the parent
-          # `wait` blocks forever, and the whole Job sits "active" until the
-          # step's activeDeadlineSeconds (9600s post-#5298) kills it — then
-          # catalyst-api auto-re-runs the DeadlineExceeded step (cutover.go) and
-          # the next full-deadline hang
-          # begins. Back-to-back deadline cycles = the "step-03 active for hours,
-          # never completing" symptom seen live on hw171 (dep 3963e9267c10a90d)
-          # right after #3927 unstuck step-02. `--command-timeout` bounds each
-          # individual copy so a stalled connection FAILS FAST → the per-image
-          # outer retry loop (PREWARM_COPY_ATTEMPTS) re-attempts with backoff,
-          # which is exactly the self-heal path that was unreachable while the
-          # copy hung. 1200s (20m) is generous for the largest multi-layer
-          # PRIVATE openova-io image over throttled egress yet collapses an
-          # infinite hang into a bounded, retryable failure.
+          {{- /*
+           #3944 (Refs #3379 #3642 #3927): per-`skopeo copy` command timeout.
+           A `skopeo copy` whose TCP connection is ESTABLISHED but then
+           silently STALLS mid-blob (no bytes, no reset — common on a
+           freshly-bootstrapped/throttled Sovereign network, or against the
+           registry.<fqdn> front door that accepts the connect but stops
+           responding) hangs INDEFINITELY: `--retry-times` only fires on an
+           ERROR, never on a stuck-but-alive connection. With no command
+           timeout the copy never returns, the worker never drains, the parent
+           `wait` blocks forever, and the whole Job sits "active" until the
+           step's activeDeadlineSeconds (9600s post-#5298) kills it — then
+           catalyst-api auto-re-runs the DeadlineExceeded step (cutover.go) and
+           the next full-deadline hang
+           begins. Back-to-back deadline cycles = the "step-03 active for hours,
+           never completing" symptom seen live on hw171 (dep 3963e9267c10a90d)
+           right after #3927 unstuck step-02. `--command-timeout` bounds each
+           individual copy so a stalled connection FAILS FAST → the per-image
+           outer retry loop (PREWARM_COPY_ATTEMPTS) re-attempts with backoff,
+           which is exactly the self-heal path that was unreachable while the
+           copy hung. 1200s (20m) is generous for the largest multi-layer
+           PRIVATE openova-io image over throttled egress yet collapses an
+           infinite hang into a bounded, retryable failure.
+          */}}
           - name: PREWARM_SKOPEO_TIMEOUT
             value: {{ .Values.prewarm.skopeoCommandTimeout | default "1200s" | quote }}
-          # #4529 (Refs #3379): TLS-verify on the skopeo copy DESTINATION (the
-          # PUBLIC registry.<fqdn> = HARBOR_HOST — restored by #5051 round 2; the
-          # #5036/#5037 in-cluster dest is unusable for pushes because Harbor's
-          # bearer-token realm is hard-https on the echoed host and nothing
-          # in-cluster terminates TLS). DEFAULT false — the target's
-          # wildcard cert was LE-STAGING/untrusted on a fresh prov (and a Job-Pod
-          # skopeo has no node trust store even with production LE), so verifying the
-          # dest against the public CA x509-failed every push (live keystone
-          # 25aadcfc: push_ok=0 push_fail=30 → step-03 FATAL → cutover never reached
-          # the deny-egress hold). Post-#5036 the dest is the plain-HTTP in-cluster
-          # Service on :80; DEST_TLS_VERIFY=false ALSO drives skopeo's https->http
-          # ping fallback (containers/image retries http when InsecureSkipVerify is
-          # set), so the push lands over HTTP with no cert involved. Trust here is the
-          # cluster network, not a public CA. The SRC (ghcr.io) verification is
-          # ALWAYS true (external public host).
+          {{- /*
+           #4529 (Refs #3379): TLS-verify on the skopeo copy DESTINATION (the
+           PUBLIC registry.<fqdn> = HARBOR_HOST — restored by #5051 round 2; the
+           #5036/#5037 in-cluster dest is unusable for pushes because Harbor's
+           bearer-token realm is hard-https on the echoed host and nothing
+           in-cluster terminates TLS). DEFAULT false — the target's
+           wildcard cert was LE-STAGING/untrusted on a fresh prov (and a Job-Pod
+           skopeo has no node trust store even with production LE), so verifying the
+           dest against the public CA x509-failed every push (live keystone
+           25aadcfc: push_ok=0 push_fail=30 → step-03 FATAL → cutover never reached
+           the deny-egress hold). Post-#5036 the dest is the plain-HTTP in-cluster
+           Service on :80; DEST_TLS_VERIFY=false ALSO drives skopeo's https->http
+           ping fallback (containers/image retries http when InsecureSkipVerify is
+           set), so the push lands over HTTP with no cert involved. Trust here is the
+           cluster network, not a public CA. The SRC (ghcr.io) verification is
+           ALWAYS true (external public host).
+          */}}
           - name: PREWARM_DEST_TLS_VERIFY
             value: {{ .Values.prewarm.destTLSVerify | default false | quote }}
-          # #4975 (Refs #3379 #3695) — the offline-mirror coverage map + the
-          # local/mothership hosts, rendered from .Values.offlineMirror by the
-          # shared helpers. Phase A3 resolves every enumerated image to its
-          # local Harbor push path(s) via /resolver/resolver.sh, which reads
-          # THESE — the SAME env step-08's completeness HEAD reads.
+          {{- /*
+           #4975 (Refs #3379 #3695) — the offline-mirror coverage map + the
+           local/mothership hosts, rendered from .Values.offlineMirror by the
+           shared helpers. Phase A3 resolves every enumerated image to its
+           local Harbor push path(s) via /resolver/resolver.sh, which reads
+           THESE — the SAME env step-08's completeness HEAD reads.
+          */}}
           - name: HOST_PROJECT_MAP
             value: {{ include "bp-self-sovereign-cutover.hostProjectMapInline" . | quote }}
           - name: EXCLUDED_HOSTS
@@ -2745,133 +2975,147 @@ data:
             value: {{ include "bp-self-sovereign-cutover.localRegistryHost" . | quote }}
           - name: MOTHERSHIP_HOST
             value: {{ include "bp-self-sovereign-cutover.mothershipHost" . | quote }}
-          # #5007 (Refs #5051 #5036 #4652 #4682) — in-cluster CoreDNS pin of the
-          # local registry host for the PRE-pivot prewarm phase. #5051 round 2
-          # settled that the skopeo push DEST must be the PUBLIC host registry.<fqdn>
-          # (only the TLS-terminating gateway serves Harbor's hard-https bearer
-          # realm), but it was left resolving via PUBLIC DNS → still breaks on a
-          # stale `*.<pool>` wildcard shadow (hw241 dead 49.12.16.160) or a mid-push
-          # NXDOMAIN flap (hw252). harbor-prewarm runs runAsNonRoot(1000) +
-          # readOnlyRootFilesystem + drop-ALL, so it CANNOT write its own /etc/hosts;
-          # instead it installs a kube-system `coredns-custom` `.server` override
-          # (registry.<fqdn> -> the cilium-gateway Service ClusterIP) so CoreDNS —
-          # which every pod already queries — answers registry.<fqdn> in-cluster,
-          # independent of the Sovereign zone / public wildcard. The ClusterIP is
-          # ALWAYS allocated (even TYPE=ClusterIP with no VIP on the §854 ELB-direct
-          # model, #5007 round 2 / 0.1.129) and ClusterIP:443 terminates the wildcard
-          # TLS + serves the /service/token realm (proven #4637). Reuses the SAME
-          # gateway-Service values PR #5008 added for the step-04 node pin + the
-          # configmaps create/get/patch RBAC the runner SA already holds cluster-wide.
+          {{- /*
+           #5007 (Refs #5051 #5036 #4652 #4682) — in-cluster CoreDNS pin of the
+           local registry host for the PRE-pivot prewarm phase. #5051 round 2
+           settled that the skopeo push DEST must be the PUBLIC host registry.<fqdn>
+           (only the TLS-terminating gateway serves Harbor's hard-https bearer
+           realm), but it was left resolving via PUBLIC DNS → still breaks on a
+           stale `*.<pool>` wildcard shadow (hw241 dead 49.12.16.160) or a mid-push
+           NXDOMAIN flap (hw252). harbor-prewarm runs runAsNonRoot(1000) +
+           readOnlyRootFilesystem + drop-ALL, so it CANNOT write its own /etc/hosts;
+           instead it installs a kube-system `coredns-custom` `.server` override
+           (registry.<fqdn> -> the cilium-gateway Service ClusterIP) so CoreDNS —
+           which every pod already queries — answers registry.<fqdn> in-cluster,
+           independent of the Sovereign zone / public wildcard. The ClusterIP is
+           ALWAYS allocated (even TYPE=ClusterIP with no VIP on the §854 ELB-direct
+           model, #5007 round 2 / 0.1.129) and ClusterIP:443 terminates the wildcard
+           TLS + serves the /service/token realm (proven #4637). Reuses the SAME
+           gateway-Service values PR #5008 added for the step-04 node pin + the
+           configmaps create/get/patch RBAC the runner SA already holds cluster-wide.
+          */}}
           - name: LOCAL_REGISTRY_PIN_ENABLED
             value: {{ .Values.registryPivot.localRegistryHostPin.enabled | quote }}
           - name: GATEWAY_LB_SVC_NAME
             value: {{ .Values.registryPivot.localRegistryHostPin.gatewayServiceName | quote }}
           - name: GATEWAY_LB_SVC_NAMESPACE
             value: {{ .Values.registryPivot.localRegistryHostPin.gatewayServiceNamespace | quote }}
-          # #4982 (Refs #3379) — settled-roll pre-flight toggle. When true
-          # (default) Phase A0 REFUSES to build the mirror while any HelmRelease
-          # or Deployment/StatefulSet on the host cluster is mid-roll, so the
-          # mirror can never capture running tags the cutover then rolls away
-          # from (running != desired → step-06/step-08 404 under the deny-egress
-          # hold). Set false only as an emergency override on a manually
-          # confirmed-settled env.
-          # NB: no `| default true` — Sprig `default` treats bool false as empty
-          # (`false | default true` → true), which would silently break the
-          # disable override. The key is always present in values.yaml.
+          {{- /*
+           #4982 (Refs #3379) — settled-roll pre-flight toggle. When true
+           (default) Phase A0 REFUSES to build the mirror while any HelmRelease
+           or Deployment/StatefulSet on the host cluster is mid-roll, so the
+           mirror can never capture running tags the cutover then rolls away
+           from (running != desired → step-06/step-08 404 under the deny-egress
+           hold). Set false only as an emergency override on a manually
+           confirmed-settled env.
+           NB: no `| default true` — Sprig `default` treats bool false as empty
+           (`false | default true` → true), which would silently break the
+           disable override. The key is always present in values.yaml.
+          */}}
           - name: SETTLED_ROLL_PREFLIGHT
             value: {{ .Values.prewarm.settledRollPreflight.enabled | quote }}
-          # #5391 — the named-override audit-record target. Phase A0 writes
-          # every honored settled-roll override (the
-          # catalyst.openova.io/cutover-settled-roll-override annotation,
-          # validated fail-closed) into the cutover status ConfigMap keys
-          # settledRollOverrides / settledRollOverridesAt so
-          # GET /sovereign/cutover/status + the admin console can show a
-          # walk that an override was used; a clean pass clears the record.
-          # An override that cannot be recorded FATALs the step — no
-          # unaudited carve-outs.
+          {{- /*
+           #5391 — the named-override audit-record target. Phase A0 writes
+           every honored settled-roll override (the
+           catalyst.openova.io/cutover-settled-roll-override annotation,
+           validated fail-closed) into the cutover status ConfigMap keys
+           settledRollOverrides / settledRollOverridesAt so
+           GET /sovereign/cutover/status + the admin console can show a
+           walk that an override was used; a clean pass clears the record.
+           An override that cannot be recorded FATALs the step — no
+           unaudited carve-outs.
+          */}}
           - name: STATUS_CONFIGMAP_NAME
             value: {{ .Values.status.configMapName | quote }}
           - name: STATUS_CONFIGMAP_NAMESPACE
             value: {{ .Release.Namespace | quote }}
-          # #4994 (Refs #3379), #5030 — content-digest idempotency. When true
-          # (default) each skopeo copy first compares the SOURCE manifest digest
-          # (`skopeo inspect --raw | sha256sum` on the SOURCE — the sha256 of the
-          # exact manifest bytes IS the digest, single-arch AND multi-arch LISTS,
-          # no blob pulled) against the DEST's DURABLE digest and SKIPS the copy
-          # only on a real match. #5030: the DEST digest now comes from the Harbor
-          # ARTIFACT API (GET /api/v2.0/.../artifacts/<ref>, served by Harbor CORE
-          # against its DB — NEVER pull-through), NOT `skopeo inspect --raw` on the
-          # dest registry endpoint, which pull-throughs on a proxy-cache-reachable
-          # dest and false-"current"-skipped an image the step-08 gate then 404'd
-          # (hw244 otel-operator; hw243 velero/cnpg). A prewarm RE-RUN (catalyst-api
-          # re-fires the step after a DeadlineExceeded) or an already-mirrored image
-          # then costs a cheap API GET instead of re-transferring every
-          # multi-hundred-MB blob from the mothership (the hw240 #4994 "step-03
-          # Running 0/1 for 68m" symptom). Fail-CLOSED: any miss (source
-          # unreachable, dest 404/absent/partial, API error, empty/mismatched dest
-          # digest) FALLS THROUGH to the full copy — a skip happens ONLY on a
-          # positive durable src==dst match. Set false to force re-copy.
+          {{- /*
+           #4994 (Refs #3379), #5030 — content-digest idempotency. When true
+           (default) each skopeo copy first compares the SOURCE manifest digest
+           (`skopeo inspect --raw | sha256sum` on the SOURCE — the sha256 of the
+           exact manifest bytes IS the digest, single-arch AND multi-arch LISTS,
+           no blob pulled) against the DEST's DURABLE digest and SKIPS the copy
+           only on a real match. #5030: the DEST digest now comes from the Harbor
+           ARTIFACT API (GET /api/v2.0/.../artifacts/<ref>, served by Harbor CORE
+           against its DB — NEVER pull-through), NOT `skopeo inspect --raw` on the
+           dest registry endpoint, which pull-throughs on a proxy-cache-reachable
+           dest and false-"current"-skipped an image the step-08 gate then 404'd
+           (hw244 otel-operator; hw243 velero/cnpg). A prewarm RE-RUN (catalyst-api
+           re-fires the step after a DeadlineExceeded) or an already-mirrored image
+           then costs a cheap API GET instead of re-transferring every
+           multi-hundred-MB blob from the mothership (the hw240 #4994 "step-03
+           Running 0/1 for 68m" symptom). Fail-CLOSED: any miss (source
+           unreachable, dest 404/absent/partial, API error, empty/mismatched dest
+           digest) FALLS THROUGH to the full copy — a skip happens ONLY on a
+           positive durable src==dst match. Set false to force re-copy.
+          */}}
           - name: PREWARM_SKIP_IF_PRESENT
             value: {{ .Values.prewarm.skipIfAlreadyPresent | quote }}
-          # #5095 (Refs #5093 #3379) — flap-tolerant pacing for MOTHERSHIP-
-          # PROXY-sourced copies. Docker-Hub-sourced bootstrap images route
-          # through the mothership Harbor proxy-cache (harbor.openova.io/
-          # proxy-dockerhub/...), so step-03 has a hard PRE-cutover tether to
-          # mothership reachability from the Sovereign. During the 2026-07-15
-          # 05:20–05:55Z Omantel→Cogent transit black-hole toward the
-          # mothership /24 (hw255 dep 5762118f, #5093 — the server was healthy
-          # worldwide, only the path was dead) EVERY proxy-sourced copy FAILed
-          # exit=1 while the ghcr.io copies were fine, and the shared
-          # PREWARM_COPY_ATTEMPTS=3 / fixed-5s budget exhausted INSIDE the
-          # 35-min flap → Phase A push_fail=6 → FATAL → a full extra Job
-          # re-run (~30-40 min on the keystone clock). Proxy-sourced refs now
-          # get their OWN attempts budget (default 6) with EXPONENTIAL
-          # backoff (base 30s doubling: 30+60+120+240+480 = 930s ≥ 15 min of
-          # inter-attempt spacing) so a routine per-prefix transit flap is
-          # ridden out instead of FATALing the step; copy_one ALSO retries the
-          # SAME image from its canonical DIRECT upstream (derived
-          # mechanically from the proxy path via the #4975 coverage map)
-          # before an attempt counts as failed. Non-proxy sources keep the
-          # existing 3×5s discipline unchanged. FATAL-on-any-failure (the
-          # sovereignty guarantee) is PRESERVED — this only widens the
-          # transient window the step can survive.
+          {{- /*
+           #5095 (Refs #5093 #3379) — flap-tolerant pacing for MOTHERSHIP-
+           PROXY-sourced copies. Docker-Hub-sourced bootstrap images route
+           through the mothership Harbor proxy-cache (harbor.openova.io/
+           proxy-dockerhub/...), so step-03 has a hard PRE-cutover tether to
+           mothership reachability from the Sovereign. During the 2026-07-15
+           05:20–05:55Z Omantel→Cogent transit black-hole toward the
+           mothership /24 (hw255 dep 5762118f, #5093 — the server was healthy
+           worldwide, only the path was dead) EVERY proxy-sourced copy FAILed
+           exit=1 while the ghcr.io copies were fine, and the shared
+           PREWARM_COPY_ATTEMPTS=3 / fixed-5s budget exhausted INSIDE the
+           35-min flap → Phase A push_fail=6 → FATAL → a full extra Job
+           re-run (~30-40 min on the keystone clock). Proxy-sourced refs now
+           get their OWN attempts budget (default 6) with EXPONENTIAL
+           backoff (base 30s doubling: 30+60+120+240+480 = 930s ≥ 15 min of
+           inter-attempt spacing) so a routine per-prefix transit flap is
+           ridden out instead of FATALing the step; copy_one ALSO retries the
+           SAME image from its canonical DIRECT upstream (derived
+           mechanically from the proxy path via the #4975 coverage map)
+           before an attempt counts as failed. Non-proxy sources keep the
+           existing 3×5s discipline unchanged. FATAL-on-any-failure (the
+           sovereignty guarantee) is PRESERVED — this only widens the
+           transient window the step can survive.
+          */}}
           - name: PREWARM_PROXY_COPY_ATTEMPTS
             value: {{ .Values.prewarm.proxyCopyAttempts | default 6 | quote }}
           - name: PREWARM_PROXY_BACKOFF_BASE_SECONDS
             value: {{ .Values.prewarm.proxyBackoffBaseSeconds | default 30 | quote }}
-          # #5095 round 2 (Refs #5093 #5298) — proxy-DOWN direct-first routing.
-          # The 0.1.136 direct-source fallback fires only AFTER the proxy-source
-          # `skopeo copy` returns non-zero, and that proxy copy is bounded ONLY by
-          # the #3944 --command-timeout (PREWARM_SKOPEO_TIMEOUT, 1200s). When the
-          # mothership Harbor proxy is unreachable for the WHOLE step (a sustained
-          # transit hole toward the mothership /24, not a brief flap — hw281 dep
-          # observed the proxy dead for the full prewarm), EVERY proxy-sourced
-          # image independently burns that timeout on the dead proxy BEFORE the
-          # fast direct upstream is even tried — the per-image "proxy timeout tax"
-          # that dragged the direct-fallback wave to ~100 min for 140 images and
-          # tripped the step deadline (raised separately in #5298/#5299). This
-          # env drives a ONE-TIME cheap HTTP reachability probe of the mothership
-          # proxy at the top of the copy wave; on an unreachable proxy the step
-          # latches proxy-DOWN and copy_one tries the DIRECT upstream FIRST for
-          # proxy-sourced refs (proxy kept as the secondary), so the wave runs at
-          # full parallel speed with no per-image timeout tax. The latch also
-          # trips adaptively the moment any in-flight proxy leg fails, catching a
-          # proxy that dies mid-wave (after the probe passed). Source selection
-          # only — the DEST path (host-swap, path preserved) is untouched, so
-          # step-04/07/08 resolve the identical LOCAL artifact and the
-          # sovereignty guarantee (every image in local Harbor before deny-egress)
-          # is intact. Default true; set false to keep strict proxy-first.
+          {{- /*
+           #5095 round 2 (Refs #5093 #5298) — proxy-DOWN direct-first routing.
+           The 0.1.136 direct-source fallback fires only AFTER the proxy-source
+           `skopeo copy` returns non-zero, and that proxy copy is bounded ONLY by
+           the #3944 --command-timeout (PREWARM_SKOPEO_TIMEOUT, 1200s). When the
+           mothership Harbor proxy is unreachable for the WHOLE step (a sustained
+           transit hole toward the mothership /24, not a brief flap — hw281 dep
+           observed the proxy dead for the full prewarm), EVERY proxy-sourced
+           image independently burns that timeout on the dead proxy BEFORE the
+           fast direct upstream is even tried — the per-image "proxy timeout tax"
+           that dragged the direct-fallback wave to ~100 min for 140 images and
+           tripped the step deadline (raised separately in #5298/#5299). This
+           env drives a ONE-TIME cheap HTTP reachability probe of the mothership
+           proxy at the top of the copy wave; on an unreachable proxy the step
+           latches proxy-DOWN and copy_one tries the DIRECT upstream FIRST for
+           proxy-sourced refs (proxy kept as the secondary), so the wave runs at
+           full parallel speed with no per-image timeout tax. The latch also
+           trips adaptively the moment any in-flight proxy leg fails, catching a
+           proxy that dies mid-wave (after the probe passed). Source selection
+           only — the DEST path (host-swap, path preserved) is untouched, so
+           step-04/07/08 resolve the identical LOCAL artifact and the
+           sovereignty guarantee (every image in local Harbor before deny-egress)
+           is intact. Default true; set false to keep strict proxy-first.
+          */}}
           - name: PROXY_DIRECT_FIRST_ENABLED
             value: {{ .Values.prewarm.proxyDownDirectFirst.enabled | quote }}
           - name: PROXY_PROBE_TIMEOUT_SECONDS
             value: {{ .Values.prewarm.proxyDownDirectFirst.probeTimeoutSeconds | default 8 | quote }}
           - name: PROXY_PROBE_ATTEMPTS
             value: {{ .Values.prewarm.proxyDownDirectFirst.probeAttempts | default 3 | quote }}
-          # #5204 (Refs #5209 #3379) — Phase A4 Crossplane xpkg package warm.
-          # The upstream/mothership/registry-path literals come from the SAME
-          # .Values.crossplaneProviderPivot block step-11 reads, so the warm
-          # set and the pivot target can never drift apart (no second
-          # hand-list — the #4975 single-source discipline).
+          {{- /*
+           #5204 (Refs #5209 #3379) — Phase A4 Crossplane xpkg package warm.
+           The upstream/mothership/registry-path literals come from the SAME
+           .Values.crossplaneProviderPivot block step-11 reads, so the warm
+           set and the pivot target can never drift apart (no second
+           hand-list — the #4975 single-source discipline).
+          */}}
           - name: XPKG_PREWARM_ENABLED
             value: {{ .Values.prewarm.xpkgPackages.enabled | quote }}
           - name: SOVEREIGN_FQDN
@@ -2882,32 +3126,36 @@ data:
             value: {{ .Values.crossplaneProviderPivot.registryPath | quote }}
           - name: XPKG_MOTHERSHIP_PROXY_PREFIX
             value: {{ .Values.crossplaneProviderPivot.mothershipProxyPrefix | quote }}
-          # #5232 (Refs #5226 #5204) — the tag->digest map Phase A4 records
-          # for step-11. Harbor proxy-cache NEVER records TAGS for
-          # pulled-through xpkg artifacts (manual tag-create 401s on proxy
-          # projects; a tag manifest GET serves the index but does not record
-          # the tag either — live hw274 dep d51a69f885872a81), so the step-11
-          # pivot ref must be DIGEST-addressed. Phase A4 resolves each
-          # package's digest at warm time (sha256 of the exact pulled-through
-          # manifest bytes) and persists it here; step-11 reads the SAME
-          # values-driven ConfigMap name (no drift).
+          {{- /*
+           #5232 (Refs #5226 #5204) — the tag->digest map Phase A4 records
+           for step-11. Harbor proxy-cache NEVER records TAGS for
+           pulled-through xpkg artifacts (manual tag-create 401s on proxy
+           projects; a tag manifest GET serves the index but does not record
+           the tag either — live hw274 dep d51a69f885872a81), so the step-11
+           pivot ref must be DIGEST-addressed. Phase A4 resolves each
+           package's digest at warm time (sha256 of the exact pulled-through
+           manifest bytes) and persists it here; step-11 reads the SAME
+           values-driven ConfigMap name (no drift).
+          */}}
           - name: XPKG_DIGEST_CM
             value: {{ .Values.prewarm.xpkgPackages.digestMapConfigMapName | quote }}
           - name: RELEASE_NAMESPACE
             value: {{ .Release.Namespace | quote }}
-          # #5237 round 2 (Refs #5007) — Phase A2-pins: union the chart-mirror
-          # set with the EXACT versions the bootstrap-kit slot pins in the
-          # LOCAL GITEA MIRROR reference — the frozen commit flux consumes
-          # once step-05 pivots the GitRepository, immune to anything a
-          # mid-cutover merge publishes upstream. The slot files are fetched
-          # from the local Gitea (step-01 mirrored them) via the SAME
-          # catalyst-gitea-token PAT steps 01/05 read, and parsed by the
-          # shared cutover-bootstrap-kit-pins extractor (03b — one parser for
-          # step-03, step-06 and the #5265 Day-2 reconciler).
-          # NB: bare `| quote` (NOT `| default true`) — sprig `default`
-          # treats a literal false as empty and would flip an explicit
-          # disable back to true (sprig_default_bool_unsafe); the script's
-          # `: "${VAR:=true}"` restores the on-state for a nil render.
+          {{- /*
+           #5237 round 2 (Refs #5007) — Phase A2-pins: union the chart-mirror
+           set with the EXACT versions the bootstrap-kit slot pins in the
+           LOCAL GITEA MIRROR reference — the frozen commit flux consumes
+           once step-05 pivots the GitRepository, immune to anything a
+           mid-cutover merge publishes upstream. The slot files are fetched
+           from the local Gitea (step-01 mirrored them) via the SAME
+           catalyst-gitea-token PAT steps 01/05 read, and parsed by the
+           shared cutover-bootstrap-kit-pins extractor (03b — one parser for
+           step-03, step-06 and the #5265 Day-2 reconciler).
+           NB: bare `| quote` (NOT `| default true`) — sprig `default`
+           treats a literal false as empty and would flip an explicit
+           disable back to true (sprig_default_bool_unsafe); the script's
+           `: "${VAR:=true}"` restores the on-state for a nil render.
+          */}}
           - name: PREWARM_BOOTSTRAP_KIT_PINS
             value: {{ .Values.prewarm.bootstrapKitPins.enabled | quote }}
           - name: GITEA_INTERNAL_URL
@@ -2924,30 +3172,36 @@ data:
             value: {{ .Values.gitRepositorySecretRef.patSourceSecretName | quote }}
           - name: PAT_SOURCE_KEY
             value: {{ .Values.gitRepositorySecretRef.patSourceKey | quote }}
-          # #5443 — Phase A2-catalog: mirror the MARKETPLACE's chart set (the
-          # live Blueprint CRs) on top of the two installed-derived
-          # enumerations, then GUARD that every contractual entry resolves in
-          # the pivoted registry. Without this the cutover repoints the
-          # marketplace resolver at a registry it never stocked.
-          # NB: bare `| quote` (NOT `| default true`) — sprig `default` treats a
-          # literal false as empty and would flip an explicit disable back to
-          # true (sprig_default_bool_unsafe); the script's `: "${VAR:=…}"`
-          # restores the on-state for a nil render.
+          {{- /*
+           #5443 — Phase A2-catalog: mirror the MARKETPLACE's chart set (the
+           live Blueprint CRs) on top of the two installed-derived
+           enumerations, then GUARD that every contractual entry resolves in
+           the pivoted registry. Without this the cutover repoints the
+           marketplace resolver at a registry it never stocked.
+           NB: bare `| quote` (NOT `| default true`) — sprig `default` treats a
+           literal false as empty and would flip an explicit disable back to
+           true (sprig_default_bool_unsafe); the script's `: "${VAR:=…}"`
+           restores the on-state for a nil render.
+          */}}
           - name: PREWARM_CATALOG_CHARTS
             value: {{ .Values.prewarm.catalogCharts.enabled | quote }}
           - name: PREWARM_CATALOG_GUARD
             value: {{ .Values.prewarm.catalogCharts.guard.enabled | quote }}
           - name: PREWARM_CATALOG_HARD_VISIBILITY
             value: {{ .Values.prewarm.catalogCharts.hardVisibility | quote }}
-          # #5442 — warm images from the PINNED CHART VERSIONS, unioned with
-          # (never replacing) the live-cluster walk.
+          {{- /*
+           #5442 — warm images from the PINNED CHART VERSIONS, unioned with
+           (never replacing) the live-cluster walk.
+          */}}
           - name: PREWARM_CHART_IMAGES
             value: {{ .Values.prewarm.chartImages.enabled | quote }}
           - name: PREWARM_CHART_IMAGES_FATAL
             value: {{ .Values.prewarm.chartImages.fatal | quote }}
-          # #5468 — per-image single-platform copy exception (see
-          # prewarm_multiarch_flags). Space-separated ref substrings; empty
-          # means EVERY copy stays on the #4975 `--multi-arch all` default.
+          {{- /*
+           #5468 — per-image single-platform copy exception (see
+           prewarm_multiarch_flags). Space-separated ref substrings; empty
+           means EVERY copy stays on the #4975 `--multi-arch all` default.
+          */}}
           - name: PREWARM_SINGLE_PLATFORM_SUBSTRINGS
             value: {{ include "bp-self-sovereign-cutover.singlePlatformSubstringsInline" . | quote }}
           - name: PREWARM_SINGLE_PLATFORM_OS
@@ -2980,22 +3234,26 @@ data:
             mountPath: /step-script
         command: ["/bin/sh", "/step-script/run.sh"]
         resources:
-          # G66: bump MEMORY for skopeo image-copy work (downloads layers).
-          # #3608 (Refs #3568): the 500m CPU request was unschedulable on a
-          # tight Sovereign (every node 89–99% CPU-requested → Pending 22+ min,
-          # FailedScheduling Insufficient cpu — live hw145). harbor-prewarm is a
-          # skopeo image-copy Job (I/O-bound, not CPU-bound); right-size the CPU
-          # request to 100m (in line with every other cutover step Job, which
-          # request 25–100m). Memory stays 512Mi — skopeo needs the RAM for
-          # layer buffers.
+          {{- /*
+           G66: bump MEMORY for skopeo image-copy work (downloads layers).
+           #3608 (Refs #3568): the 500m CPU request was unschedulable on a
+           tight Sovereign (every node 89–99% CPU-requested → Pending 22+ min,
+           FailedScheduling Insufficient cpu — live hw145). harbor-prewarm is a
+           skopeo image-copy Job (I/O-bound, not CPU-bound); right-size the CPU
+           request to 100m (in line with every other cutover step Job, which
+           request 25–100m). Memory stays 512Mi — skopeo needs the RAM for
+           layer buffers.
+          */}}
           requests: { cpu: 100m, memory: 512Mi }
           limits:   { memory: 2Gi }
         securityContext:
           runAsNonRoot: true
           runAsUser: 1000
           allowPrivilegeEscalation: false
-          # G66: skopeo needs writable /tmp for layer staging
-          # (emptyDir mount below provides it; root FS stays read-only).
+          {{- /*
+           G66: skopeo needs writable /tmp for layer staging
+           (emptyDir mount below provides it; root FS stays read-only).
+          */}}
           readOnlyRootFilesystem: true
           capabilities:
             drop: ["ALL"]

--- a/platform/self-sovereign-cutover/chart/templates/03a-offline-mirror-resolver.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/03a-offline-mirror-resolver.yaml
@@ -22,12 +22,16 @@ metadata:
     app.kubernetes.io/component: cutover-offline-mirror
 data:
   resolver.sh: |
-    # POSIX sh. Requires env: HOST_PROJECT_MAP EXCLUDED_HOSTS
-    # EXCLUDED_SUBSTRINGS LOCAL_REGISTRY_HOST. No side effects — pure functions.
+    {{- /*
+     POSIX sh. Requires env: HOST_PROJECT_MAP EXCLUDED_HOSTS
+     EXCLUDED_SUBSTRINGS LOCAL_REGISTRY_HOST. No side effects — pure functions.
+    */}}
 
-    # offlinemirror_normalize_ref REF -> REF with a tag-and-digest collapsed to
-    # digest-only (skopeo rejects `name:tag@digest`; the digest is authoritative
-    # and is exactly what containerd pulls by).
+    {{- /*
+     offlinemirror_normalize_ref REF -> REF with a tag-and-digest collapsed to
+     digest-only (skopeo rejects `name:tag@digest`; the digest is authoritative
+     and is exactly what containerd pulls by).
+    */}}
     offlinemirror_normalize_ref() {
       _nr="$1"
       case "${_nr}" in
@@ -43,19 +47,23 @@ data:
       esac
     }
 
-    # offlinemirror_local_paths REF -> the local Harbor path(s) this image must
-    # be reachable at (relative to the local registry host), ONE PER LINE:
-    #   excluded host/substring        -> (nothing) SKIP
-    #   already on the local registry  -> the path verbatim
-    #   host in coverage map, proj P   -> "P/<rest>"  (or "<rest>" when P empty = mothership host-swap)
-    #   ghcr.io/openova-io/*           -> ALSO "<rest>" (the host-drop pivoted-ref path)
-    #   host NOT mapped, not excluded  -> "__UNMAPPED__ <host>"  (caller FATALs, naming the offender)
+    {{- /*
+     offlinemirror_local_paths REF -> the local Harbor path(s) this image must
+     be reachable at (relative to the local registry host), ONE PER LINE:
+       excluded host/substring        -> (nothing) SKIP
+       already on the local registry  -> the path verbatim
+       host in coverage map, proj P   -> "P/<rest>"  (or "<rest>" when P empty = mothership host-swap)
+       ghcr.io/openova-io/*           -> ALSO "<rest>" (the host-drop pivoted-ref path)
+       host NOT mapped, not excluded  -> "__UNMAPPED__ <host>"  (caller FATALs, naming the offender)
+    */}}
     offlinemirror_local_paths() {
       _u=$(offlinemirror_normalize_ref "$1")
-      # Split into host + rest. A registry host exists ONLY when the ref has a
-      # `/` AND the first segment looks like a host (contains `.` or `:port` or
-      # is localhost). A bare `name[:tag]` has NO `/` — the colon is the TAG, NOT
-      # a host:port — so it is a Docker Hub official image (docker.io/library/…).
+      {{- /*
+       Split into host + rest. A registry host exists ONLY when the ref has a
+       `/` AND the first segment looks like a host (contains `.` or `:port` or
+       is localhost). A bare `name[:tag]` has NO `/` — the colon is the TAG, NOT
+       a host:port — so it is a Docker Hub official image (docker.io/library/…).
+      */}}
       case "${_u}" in
         */*)
           _host="${_u%%/*}"
@@ -68,7 +76,7 @@ data:
           _host="docker.io"; _rest="${_u}"           # bare official image
           ;;
       esac
-      # Docker Hub official image: bare "name[:tag]" -> "library/name[:tag]".
+      {{- /* Docker Hub official image: bare "name[:tag]" -> "library/name[:tag]". */}}
       case "${_host}" in
         docker.io|registry-1.docker.io|index.docker.io)
           case "${_rest}" in
@@ -77,20 +85,20 @@ data:
           esac
           ;;
       esac
-      # Excluded host.
+      {{- /* Excluded host. */}}
       for _eh in ${EXCLUDED_HOSTS}; do
         [ "${_host}" = "${_eh}" ] && return 0
       done
-      # Excluded image-path substring.
+      {{- /* Excluded image-path substring. */}}
       for _es in ${EXCLUDED_SUBSTRINGS}; do
         case "${_u}" in *"${_es}"*) return 0 ;; esac
       done
-      # Already on the local registry (openova-io host-drop pivoted refs, etc.).
+      {{- /* Already on the local registry (openova-io host-drop pivoted refs, etc.). */}}
       if [ "${_host}" = "${LOCAL_REGISTRY_HOST}" ]; then
         printf '%s\n' "${_rest}"
         return 0
       fi
-      # Coverage-map lookup.
+      {{- /* Coverage-map lookup. */}}
       _proj="__NOMATCH__"
       for _pair in ${HOST_PROJECT_MAP}; do
         _ph="${_pair%%:*}"
@@ -106,9 +114,11 @@ data:
       else
         printf '%s/%s\n' "${_proj}" "${_rest}"
       fi
-      # openova-io host-drop DUAL dest: an un-pivoted ghcr.io/openova-io/* ref
-      # resolves to proxy-ghcr/openova-io/<path> (above) AND the step-06/07
-      # pivoted registry.<fqdn>/openova-io/<path> convention — both must exist.
+      {{- /*
+       openova-io host-drop DUAL dest: an un-pivoted ghcr.io/openova-io/* ref
+       resolves to proxy-ghcr/openova-io/<path> (above) AND the step-06/07
+       pivoted registry.<fqdn>/openova-io/<path> convention — both must exist.
+      */}}
       if [ "${_host}" = "ghcr.io" ]; then
         case "${_rest}" in
           openova-io/*) printf '%s\n' "${_rest}" ;;
@@ -116,30 +126,32 @@ data:
       fi
     }
 
-    # offlinemirror_upstream_ref REF -> the UPSTREAM ref a local-registry ref
-    # came from, or EMPTY (exit 1) when the map cannot name one.
-    #
-    # WHY THIS EXISTS (#5640). step-07's pod-spec sweep rewrites every workload
-    # image to `registry.<fqdn>/<local-path>` (sweep_one_workload ->
-    # podspec_pivot_ref). Post-cutover, therefore, the refs a Day-2 loop reads
-    # off the LIVE cluster no longer carry an upstream host at all. Handing such
-    # a ref to a copy as the SOURCE asks skopeo to copy the local registry to
-    # itself — for an artifact the local registry has just 404'd, which can never
-    # deliver anything. Recovering the upstream is not guesswork: the forward map
-    # is injective on the classes that exist, so it inverts.
-    #
-    #   registry.<fqdn>/openova-io/openova/catalyst-api:e3342f9
-    #       -> ghcr.io/openova-io/openova/catalyst-api:e3342f9   (host-drop inverse)
-    #   registry.<fqdn>/proxy-dockerhub/library/redis:7
-    #       -> docker.io/library/redis:7                         (project inverse)
-    #
-    # A mothership host-swapped path (project "" in the map) already carries its
-    # `proxy-<x>` segment, so the project inverse below resolves it to the ORIGIN
-    # host rather than back to harbor.openova.io — which is both correct and the
-    # source #5095's DIRECT fallback prefers anyway. No separate branch needed.
-    #
-    # A ref that already carries a real registry host is returned unchanged: it
-    # is an upstream ref, and there is nothing to invert.
+    {{- /*
+     offlinemirror_upstream_ref REF -> the UPSTREAM ref a local-registry ref
+     came from, or EMPTY (exit 1) when the map cannot name one.
+
+     WHY THIS EXISTS (#5640). step-07's pod-spec sweep rewrites every workload
+     image to `registry.<fqdn>/<local-path>` (sweep_one_workload ->
+     podspec_pivot_ref). Post-cutover, therefore, the refs a Day-2 loop reads
+     off the LIVE cluster no longer carry an upstream host at all. Handing such
+     a ref to a copy as the SOURCE asks skopeo to copy the local registry to
+     itself — for an artifact the local registry has just 404'd, which can never
+     deliver anything. Recovering the upstream is not guesswork: the forward map
+     is injective on the classes that exist, so it inverts.
+
+       registry.<fqdn>/openova-io/openova/catalyst-api:e3342f9
+           -> ghcr.io/openova-io/openova/catalyst-api:e3342f9   (host-drop inverse)
+       registry.<fqdn>/proxy-dockerhub/library/redis:7
+           -> docker.io/library/redis:7                         (project inverse)
+
+     A mothership host-swapped path (project "" in the map) already carries its
+     `proxy-<x>` segment, so the project inverse below resolves it to the ORIGIN
+     host rather than back to harbor.openova.io — which is both correct and the
+     source #5095's DIRECT fallback prefers anyway. No separate branch needed.
+
+     A ref that already carries a real registry host is returned unchanged: it
+     is an upstream ref, and there is nothing to invert.
+    */}}
     offlinemirror_upstream_ref() {
       _ur=$(offlinemirror_normalize_ref "$1")
       case "${_ur}" in
@@ -156,7 +168,7 @@ data:
         */*) _ur_proj="${_ur_path%%/*}"; _ur_rest="${_ur_path#*/}" ;;
         *) return 1 ;;
       esac
-      # (1) project -> host: the exact inverse of the coverage-map lookup above.
+      {{- /* (1) project -> host: the exact inverse of the coverage-map lookup above. */}}
       for _ur_pair in ${HOST_PROJECT_MAP}; do
         _ur_ph="${_ur_pair%%:*}"
         case "${_ur_pair}" in *:*) _ur_pp="${_ur_pair#*:}" ;; *) _ur_pp="" ;; esac
@@ -165,12 +177,16 @@ data:
           return 0
         fi
       done
-      # (2) the openova-io host-drop DUAL dest, inverted. Same literal the
-      # forward branch above emits, so the two can never drift apart.
+      {{- /*
+       (2) the openova-io host-drop DUAL dest, inverted. Same literal the
+       forward branch above emits, so the two can never drift apart.
+      */}}
       case "${_ur_path}" in
         openova-io/*) printf 'ghcr.io/%s\n' "${_ur_path}"; return 0 ;;
       esac
-      # Undecidable. Return EMPTY and let the caller fail loudly — a caller that
-      # guessed would produce the self-copy this function exists to prevent.
+      {{- /*
+       Undecidable. Return EMPTY and let the caller fail loudly — a caller that
+       guessed would produce the self-copy this function exists to prevent.
+      */}}
       return 1
     }

--- a/platform/self-sovereign-cutover/chart/templates/03b-bootstrap-kit-pins.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/03b-bootstrap-kit-pins.yaml
@@ -55,31 +55,37 @@ metadata:
     app.kubernetes.io/component: cutover-bootstrap-kit-pins
 data:
   extract-pins.sh: |
-    # POSIX sh + awk. No runtime deps. Pure function — no side effects.
-    #
-    # bootstrapkit_pins DIR UPSTREAM_PREFIX LOCAL_PREFIX
-    #   Emits one "<chart>\t<version>" line (sorted, deduped) per HelmRelease
-    #   in DIR/[0-9]*.yaml whose chart.spec pins a CONCRETE version AND whose
-    #   sourceRef names a HelmRepository (declared anywhere in DIR) whose url
-    #   starts with UPSTREAM_PREFIX (pre-pivot: oci://ghcr.io/openova-io) or
-    #   LOCAL_PREFIX (a post-step-06 re-run reads the already-pivoted mirror:
-    #   oci://registry.<fqdn>/openova-io). Non-openova sources (e.g. the loft
-    #   charts.loft.sh HelmRepository, slot 60) and semver-range pins are
-    #   skipped with a stderr WARN. Exit 0 always — the caller owns the
-    #   fail-loud policy via a count check on stdout.
+    {{- /*
+     POSIX sh + awk. No runtime deps. Pure function — no side effects.
+
+     bootstrapkit_pins DIR UPSTREAM_PREFIX LOCAL_PREFIX
+       Emits one "<chart>\t<version>" line (sorted, deduped) per HelmRelease
+       in DIR/[0-9]*.yaml whose chart.spec pins a CONCRETE version AND whose
+       sourceRef names a HelmRepository (declared anywhere in DIR) whose url
+       starts with UPSTREAM_PREFIX (pre-pivot: oci://ghcr.io/openova-io) or
+       LOCAL_PREFIX (a post-step-06 re-run reads the already-pivoted mirror:
+       oci://registry.<fqdn>/openova-io). Non-openova sources (e.g. the loft
+       charts.loft.sh HelmRepository, slot 60) and semver-range pins are
+       skipped with a stderr WARN. Exit 0 always — the caller owns the
+       fail-loud policy via a count check on stdout.
+    */}}
     bootstrapkit_pins() {
       _bk_dir="$1"; _bk_up="$2"; _bk_lp="${3:-}"
       [ -d "${_bk_dir}" ] || { echo "[bootstrapkit-pins] WARN: ${_bk_dir} is not a directory" >&2; return 0; }
-      # Slot files are the numbered bootstrap-kit entries; kustomization.yaml
-      # + placement.yaml are not slot manifests.
+      {{- /*
+       Slot files are the numbered bootstrap-kit entries; kustomization.yaml
+       + placement.yaml are not slot manifests.
+      */}}
       _bk_files=$(ls "${_bk_dir}"/[0-9]*.yaml 2>/dev/null || true)
       [ -n "${_bk_files}" ] || { echo "[bootstrapkit-pins] WARN: no [0-9]*.yaml slot files in ${_bk_dir}" >&2; return 0; }
 
-      # Pass A — the openova-io pivot set: HelmRepository metadata.name for
-      # every repo whose spec.url starts with the upstream OR the already-
-      # pivoted local prefix. Slot docs order apiVersion/kind/metadata/spec
-      # with metadata.name at 2-space and spec.url at 2-space; secretRef.name
-      # sits at 4-space, so the exact-indent anchors cannot cross-match.
+      {{- /*
+       Pass A — the openova-io pivot set: HelmRepository metadata.name for
+       every repo whose spec.url starts with the upstream OR the already-
+       pivoted local prefix. Slot docs order apiVersion/kind/metadata/spec
+       with metadata.name at 2-space and spec.url at 2-space; secretRef.name
+       sits at 4-space, so the exact-indent anchors cannot cross-match.
+      */}}
       _bk_pivot=$(awk -v up="${_bk_up}" -v lp="${_bk_lp}" '
         FNR==1 { kind=""; rname="" }
         /^---/ { kind=""; rname=""; next }
@@ -94,13 +100,15 @@ data:
         }
       ' ${_bk_files} | sort -u)
 
-      # Pass B — (chart, version, sourceRef.name) off every HelmRelease
-      # chart.spec: the 6-space `chart:` scalar, the FIRST following 6-space
-      # `version:`, and the 8-space `name:` under the 6-space `sourceRef:`.
-      # Comments are stripped first, so the multi-hundred-line version-history
-      # comment blocks between `chart:` and `version:` (slot 13 carries >1000)
-      # never confuse the pairing; the c!=""/v=="" guards keep any 6-space
-      # key inside a spec.values block from being mis-captured.
+      {{- /*
+       Pass B — (chart, version, sourceRef.name) off every HelmRelease
+       chart.spec: the 6-space `chart:` scalar, the FIRST following 6-space
+       `version:`, and the 8-space `name:` under the 6-space `sourceRef:`.
+       Comments are stripped first, so the multi-hundred-line version-history
+       comment blocks between `chart:` and `version:` (slot 13 carries >1000)
+       never confuse the pairing; the c!=""/v=="" guards keep any 6-space
+       key inside a spec.values block from being mis-captured.
+      */}}
       awk '
         FNR==1 { kind=""; c=""; v=""; insrc=0 }
         /^---/ { kind=""; c=""; v=""; insrc=0; next }
@@ -124,8 +132,10 @@ data:
           echo "[bootstrapkit-pins] WARN: ${_bk_c} (source ${_bk_s}) has no pinned version — skipping (cannot mirror a floating tag deterministically)" >&2
           continue
         fi
-        # Same range guard as step-03 Phase A2 (#5007 round 3): a semver
-        # range is not a concrete OCI tag.
+        {{- /*
+         Same range guard as step-03 Phase A2 (#5007 round 3): a semver
+         range is not a concrete OCI tag.
+        */}}
         case "${_bk_v}" in
           *[\<\>~^\|\ ]*|*'*'*)
             echo "[bootstrapkit-pins] WARN: ${_bk_c} version '${_bk_v}' is a semver range — skipping (cannot mirror deterministically)" >&2

--- a/platform/self-sovereign-cutover/chart/templates/03c-catalog-chart-set.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/03c-catalog-chart-set.yaml
@@ -72,37 +72,43 @@ metadata:
     app.kubernetes.io/component: cutover-catalog-chart-set
 data:
   catalog-set.sh: |
-    # POSIX sh. `catalog_chart_set` needs jq (step-03 installs/verifies it);
-    # `chart_declared_images` needs helm (present in alpine/k8s, the canonical
-    # cutover-step image — step-06 already relies on it). Pure functions: no
-    # side effects beyond a scratch render file under ${CATALOG_SET_TMPDIR}.
+    {{- /*
+     POSIX sh. `catalog_chart_set` needs jq (step-03 installs/verifies it);
+     `chart_declared_images` needs helm (present in alpine/k8s, the canonical
+     cutover-step image — step-06 already relies on it). Pure functions: no
+     side effects beyond a scratch render file under ${CATALOG_SET_TMPDIR}.
+    */}}
 
-    # catalog_chart_set JSON_FILE UPSTREAM_PREFIX [HARD_VISIBILITY]
-    #
-    #   JSON_FILE       `kubectl get blueprints.catalyst.openova.io -o json` output.
-    #   UPSTREAM_PREFIX the openova-io chart-OCI prefix the cutover pivots FROM
-    #                   (oci://ghcr.io/openova-io). A Blueprint whose
-    #                   spec.source.url names a DIFFERENT registry is outside
-    #                   this mirror's contract and is skipped with a named WARN.
-    #   HARD_VISIBILITY the spec.visibility whose entries are CONTRACTUAL
-    #                   (default `listed` — the customer-visible marketplace
-    #                   grid). Only `spec.version` of a HARD entry is marked
-    #                   hard; every other row is best-effort.
-    #
-    #   stdout: "<chart>\t<version>\t<hard 1|0>\t<blueprint>\t<visibility>"
-    #           sorted + deduped on (chart, version); when the same pair is
-    #           reached both hard and soft, HARD wins.
-    #   stderr: skip/WARN diagnostics (never mixed into stdout).
-    #   exit  : always 0 — the CALLER owns the fail-loud policy.
+    {{- /*
+     catalog_chart_set JSON_FILE UPSTREAM_PREFIX [HARD_VISIBILITY]
+
+       JSON_FILE       `kubectl get blueprints.catalyst.openova.io -o json` output.
+       UPSTREAM_PREFIX the openova-io chart-OCI prefix the cutover pivots FROM
+                       (oci://ghcr.io/openova-io). A Blueprint whose
+                       spec.source.url names a DIFFERENT registry is outside
+                       this mirror's contract and is skipped with a named WARN.
+       HARD_VISIBILITY the spec.visibility whose entries are CONTRACTUAL
+                       (default `listed` — the customer-visible marketplace
+                       grid). Only `spec.version` of a HARD entry is marked
+                       hard; every other row is best-effort.
+
+       stdout: "<chart>\t<version>\t<hard 1|0>\t<blueprint>\t<visibility>"
+               sorted + deduped on (chart, version); when the same pair is
+               reached both hard and soft, HARD wins.
+       stderr: skip/WARN diagnostics (never mixed into stdout).
+       exit  : always 0 — the CALLER owns the fail-loud policy.
+    */}}
     catalog_chart_set() {
       _cs_json="$1"
       _cs_up=$(printf '%s' "${2:-}" | sed -e 's,/$,,')
       _cs_hardvis="${3:-listed}"
       [ -f "${_cs_json}" ] || { echo "[catalog-set] WARN: ${_cs_json} is not a file — catalog set empty" >&2; return 0; }
       command -v jq >/dev/null 2>&1 || { echo "[catalog-set] WARN: jq missing — cannot enumerate the catalog chart set" >&2; return 0; }
-      # Row expansion. spec.manifests.chart is the coordinate the application
-      # controller installs by; spec.source.chart / metadata.name are the
-      # documented fallbacks for a CR that omits the manifests block.
+      {{- /*
+       Row expansion. spec.manifests.chart is the coordinate the application
+       controller installs by; spec.source.chart / metadata.name are the
+       documented fallbacks for a CR that omits the manifests block.
+      */}}
       _cs_rows=$(jq -r --arg hardvis "${_cs_hardvis}" '
         (.items // [])[]
         | . as $i
@@ -127,10 +133,12 @@ data:
       printf '%s\n' "${_cs_rows}" | while IFS="$(printf '\t')" read -r _cs_c _cs_v _cs_h _cs_n _cs_vis _cs_url; do
         [ -z "${_cs_c}" ] && continue
         [ -z "${_cs_v}" ] && continue
-        # Foreign registry: the local Harbor `openova-io` project mirrors the
-        # openova-io upstream only. Naming the offender is the point — a LISTED
-        # entry sourced elsewhere is a real catalog gap, not something to
-        # silently drop into a passing guard.
+        {{- /*
+         Foreign registry: the local Harbor `openova-io` project mirrors the
+         openova-io upstream only. Naming the offender is the point — a LISTED
+         entry sourced elsewhere is a real catalog gap, not something to
+         silently drop into a passing guard.
+        */}}
         if [ -n "${_cs_url}" ] && [ -n "${_cs_up}" ]; then
           case "${_cs_url}" in
             "${_cs_up}"|"${_cs_up}"/*) : ;;
@@ -139,8 +147,10 @@ data:
               continue ;;
           esac
         fi
-        # A semver RANGE is not a concrete OCI tag — same guard as step-03
-        # Phase A2 (#5007 round 3) and 03b (#5237).
+        {{- /*
+         A semver RANGE is not a concrete OCI tag — same guard as step-03
+         Phase A2 (#5007 round 3) and 03b (#5237).
+        */}}
         case "${_cs_v}" in
           *[\<\>~^\|\ ]*|*'*'*)
             echo "[catalog-set] WARN: ${_cs_n} version '${_cs_v}' is a semver range, not a concrete tag — skipping (cannot mirror deterministically)" >&2
@@ -156,14 +166,16 @@ data:
       return 0
     }
 
-    # catalog_guard_missing HARD_TSV PRESENT_FILE
-    #
-    #   HARD_TSV      "<chart>\t<version>[\t…]" rows that MUST be pullable.
-    #   PRESENT_FILE  "<chart>:<version>" per artifact proven present in the
-    #                 local registry (the caller supplies the probe).
-    #
-    #   stdout: "<chart>:<version>" per HARD row NOT present.
-    #   exit  : always 0 — the caller decides that a non-empty stdout is fatal.
+    {{- /*
+     catalog_guard_missing HARD_TSV PRESENT_FILE
+
+       HARD_TSV      "<chart>\t<version>[\t…]" rows that MUST be pullable.
+       PRESENT_FILE  "<chart>:<version>" per artifact proven present in the
+                     local registry (the caller supplies the probe).
+
+       stdout: "<chart>:<version>" per HARD row NOT present.
+       exit  : always 0 — the caller decides that a non-empty stdout is fatal.
+    */}}
     catalog_guard_missing() {
       _cg_hard="$1"; _cg_present="$2"
       [ -f "${_cg_hard}" ] || return 0
@@ -177,24 +189,26 @@ data:
       return 0
     }
 
-    # chart_declared_images CHART_TGZ
-    #
-    #   Renders the packaged chart at DEFAULT values and emits every image
-    #   reference the render pins, one per line, sorted + deduped. This is the
-    #   ONLY enumeration available for a chart nobody has installed (#5442:
-    #   prewarm's live-cluster Pod walk cannot see it), and it is faithful
-    #   rather than heuristic because blueprint-release.yaml refuses to publish
-    #   a chart that does not render at default values.
-    #
-    #   Refs without a tag or digest are skipped: an implicit `:latest` is not
-    #   a deterministic mirror target. Refs still carrying template/shell
-    #   syntax are skipped as un-renderable placeholders.
-    #
-    #   stdout: one image ref per line (verbatim as authored — the caller maps
-    #           it through the offline-mirror resolver).
-    #   stderr: render failures + per-ref skips.
-    #   exit  : always 0 — a chart that cannot be rendered yields no images and
-    #           says so loudly; the caller owns the policy.
+    {{- /*
+     chart_declared_images CHART_TGZ
+
+       Renders the packaged chart at DEFAULT values and emits every image
+       reference the render pins, one per line, sorted + deduped. This is the
+       ONLY enumeration available for a chart nobody has installed (#5442:
+       prewarm's live-cluster Pod walk cannot see it), and it is faithful
+       rather than heuristic because blueprint-release.yaml refuses to publish
+       a chart that does not render at default values.
+
+       Refs without a tag or digest are skipped: an implicit `:latest` is not
+       a deterministic mirror target. Refs still carrying template/shell
+       syntax are skipped as un-renderable placeholders.
+
+       stdout: one image ref per line (verbatim as authored — the caller maps
+               it through the offline-mirror resolver).
+       stderr: render failures + per-ref skips.
+       exit  : always 0 — a chart that cannot be rendered yields no images and
+               says so loudly; the caller owns the policy.
+    */}}
     chart_declared_images() {
       _ci_tgz="$1"
       [ -f "${_ci_tgz}" ] || { echo "[catalog-set] WARN: chart archive ${_ci_tgz} not found — no images enumerated" >&2; return 0; }
@@ -202,8 +216,10 @@ data:
       _ci_dir="${CATALOG_SET_TMPDIR:-/tmp}"
       _ci_out="${_ci_dir}/.catalog-render.$$.yaml"
       _ci_err="${_ci_dir}/.catalog-render.$$.err"
-      # Explicit status capture (never a pipeline) so a render failure is seen
-      # rather than masked by the exit status of a downstream filter.
+      {{- /*
+       Explicit status capture (never a pipeline) so a render failure is seen
+       rather than masked by the exit status of a downstream filter.
+      */}}
       if helm template catalog-prewarm "${_ci_tgz}" --namespace catalog-prewarm >"${_ci_out}" 2>"${_ci_err}"; then
         :
       else
@@ -212,43 +228,49 @@ data:
         rm -f "${_ci_out}" "${_ci_err}"
         return 0
       fi
-      # Every `image:` scalar in the render — containers, initContainers, and
-      # any CR field named `image` (an operator's workload pin counts too).
-      # `helm template` emits template text VERBATIM, so a chart authored in
-      # FLOW style (`- {name: c, image: <repo>:<tag>}`) never puts `image:` at
-      # the start of a line: the match must admit `{` and `,` as leading
-      # context, not just indentation and `- `. The leading-context class is
-      # also what keeps `someImage:`-style keys from matching.
-      #
-      # #5468 — strip COMMENT lines before the grep. `helm template` emits the
-      # shell/awk comments inside these ConfigMaps' block scalars verbatim into
-      # the render, so without this the enumerator greps its OWN documentation:
-      # the prose above used to say `image: repo:tag`, which survived every
-      # downstream filter (real-looking name, non-empty tag, no `<`/placeholder
-      # marker) and reached the A3 guard as a FATAL durable-miss on hw291
-      # (`MISSING repo:tag -> proxy-dockerhub/library/repo:tag`), blocking a
-      # cutover over a sentence. A line whose first non-space character is `#`
-      # is a YAML or in-block-scalar comment and can never declare a workload
-      # image. This also drops the WARN noise from `bare`, `.new`, `blocks`,
-      # and `child` — same class, harmless only because they parse as untagged.
+      {{- /*
+       Every `image:` scalar in the render — containers, initContainers, and
+       any CR field named `image` (an operator's workload pin counts too).
+       `helm template` emits template text VERBATIM, so a chart authored in
+       FLOW style (`- {name: c, image: <repo>:<tag>}`) never puts `image:` at
+       the start of a line: the match must admit `{` and `,` as leading
+       context, not just indentation and `- `. The leading-context class is
+       also what keeps `someImage:`-style keys from matching.
+
+       #5468 — strip COMMENT lines before the grep. `helm template` emits the
+       shell/awk comments inside these ConfigMaps' block scalars verbatim into
+       the render, so without this the enumerator greps its OWN documentation:
+       the prose above used to say `image: repo:tag`, which survived every
+       downstream filter (real-looking name, non-empty tag, no `<`/placeholder
+       marker) and reached the A3 guard as a FATAL durable-miss on hw291
+       (`MISSING repo:tag -> proxy-dockerhub/library/repo:tag`), blocking a
+       cutover over a sentence. A line whose first non-space character is `#`
+       is a YAML or in-block-scalar comment and can never declare a workload
+       image. This also drops the WARN noise from `bare`, `.new`, `blocks`,
+       and `child` — same class, harmless only because they parse as untagged.
+      */}}
       grep -v '^[[:space:]]*#' "${_ci_out}" \
         | grep -oE '(^|[[:space:],{])image:[[:space:]]*[^[:space:],}]+' \
         | sed -e 's/^.*image:[[:space:]]*//' -e 's/[[:space:]]*#.*$//' -e 's/^"//' -e 's/"$//' -e "s/^'//" -e "s/'\$//" -e 's/[[:space:]]*$//' \
         | while IFS= read -r _ci_ref; do
             [ -z "${_ci_ref}" ] && continue
-            # A YAML block-scalar header (`image: |`) or any ref still carrying
-            # whitespace / shell / un-rendered Go-template syntax is not an
-            # addressable reference.
+            {{- /*
+             A YAML block-scalar header (`image: |`) or any ref still carrying
+             whitespace / shell / un-rendered Go-template syntax is not an
+             addressable reference.
+            */}}
             case "${_ci_ref}" in
               '|'|'>'|'|-'|'>-'|'|+'|'>+') continue ;;
               *' '*|*'	'*|*'$'*|*'{'*) continue ;;
             esac
-            # Tag/digest sanity. An untagged ref means an implicit `:latest`,
-            # which is not a deterministic mirror target. An EMPTY tag
-            # (`repo:`) and a placeholder tag are what a chart renders for a
-            # component whose image is supplied by an overlay — mirroring
-            # either would fail the copy and, under chartImages.fatal, fail the
-            # cutover on a ref nothing will ever pull.
+            {{- /*
+             Tag/digest sanity. An untagged ref means an implicit `:latest`,
+             which is not a deterministic mirror target. An EMPTY tag
+             (`repo:`) and a placeholder tag are what a chart renders for a
+             component whose image is supplied by an overlay — mirroring
+             either would fail the copy and, under chartImages.fatal, fail the
+             cutover on a ref nothing will ever pull.
+            */}}
             _ci_last="${_ci_ref##*/}"
             case "${_ci_last}" in
               *@*) : ;;

--- a/platform/self-sovereign-cutover/chart/templates/04-registry-pivot-daemonset.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/04-registry-pivot-daemonset.yaml
@@ -99,11 +99,13 @@ spec:
           env:
             - name: HARBOR_PUBLIC_URL
               value: {{ .Values.sovereign.harborPublicURL | quote }}
-            # #4975 (Refs #3379 #3695) — the offline-mirror coverage map + the
-            # local registry host. The pivot writes PER-UPSTREAM-HOST containerd
-            # certs.d entries pointing at registry.<fqdn>/<project> (the exact
-            # path step-03 Phase A3 pushed to), replacing the single _default
-            # dfdaemon catch-all. Same map step-03/step-08 read.
+            {{- /*
+             #4975 (Refs #3379 #3695) — the offline-mirror coverage map + the
+             local registry host. The pivot writes PER-UPSTREAM-HOST containerd
+             certs.d entries pointing at registry.<fqdn>/<project> (the exact
+             path step-03 Phase A3 pushed to), replacing the single _default
+             dfdaemon catch-all. Same map step-03/step-08 read.
+            */}}
             - name: HOST_PROJECT_MAP
               value: {{ include "bp-self-sovereign-cutover.hostProjectMapInline" . | quote }}
             - name: LOCAL_REGISTRY_HOST
@@ -112,13 +114,17 @@ spec:
               value: {{ .Values.status.configMapName | quote }}
             - name: STATUS_CONFIGMAP_NAMESPACE
               value: {{ .Release.Namespace | quote }}
-            # ── Dragonfly coordinates (the #4639 rewrite) ──────────────────
-            # The dfdaemon proxy every node's containerd mirrors through.
+            {{- /*
+             ── Dragonfly coordinates (the #4639 rewrite) ──────────────────
+             The dfdaemon proxy every node's containerd mirrors through.
+            */}}
             - name: DF_PROXY_PORT
               value: {{ .Values.registryPivot.dragonfly.proxyPort | quote }}
-            # The bp-dragonfly mesh namespace + the per-node dfdaemon
-            # DaemonSet + seed-peer + their config ConfigMaps the upstream
-            # flip patch targets.
+            {{- /*
+             The bp-dragonfly mesh namespace + the per-node dfdaemon
+             DaemonSet + seed-peer + their config ConfigMaps the upstream
+             flip patch targets.
+            */}}
             - name: DF_NAMESPACE
               value: {{ .Values.registryPivot.dragonfly.namespace | quote }}
             - name: DF_CLIENT_DAEMONSET
@@ -131,17 +137,21 @@ spec:
               value: {{ .Values.registryPivot.dragonfly.seedConfigMap | quote }}
             - name: DF_RESTART_ON_FLIP
               value: {{ .Values.registryPivot.dragonfly.restartOnFlip | quote }}
-            # The Sovereign FQDN — the wildcard-TLS Secret name is
-            # <prefix><fqdn-dashed>. Sourced from the chart's sovereign.fqdn
-            # (cloud-init substitutes ${SOVEREIGN_FQDN} via the 06a overlay).
+            {{- /*
+             The Sovereign FQDN — the wildcard-TLS Secret name is
+             <prefix><fqdn-dashed>. Sourced from the chart's sovereign.fqdn
+             (cloud-init substitutes ${SOVEREIGN_FQDN} via the 06a overlay).
+            */}}
             - name: SOVEREIGN_FQDN
               value: {{ .Values.sovereign.fqdn | quote }}
-            # ── #4652 dfdaemon registryMirror.cert (the x509 fix) ─────────────
-            # Read the in-cluster Harbor wildcard TLS Secret, create a dragonfly-
-            # namespace Opaque Secret carrying tls.crt (bp-dragonfly 0.1.1 mounts
-            # it OPTIONALLY at HARBOR_CA_MOUNT_PATH), and set
-            # proxy.registryMirror.cert = <mount>/<file> in the dfdaemon ConfigMap
-            # patch that flips registryMirror.addr. Same tls.crt-fallback as #3379.
+            {{- /*
+             ── #4652 dfdaemon registryMirror.cert (the x509 fix) ─────────────
+             Read the in-cluster Harbor wildcard TLS Secret, create a dragonfly-
+             namespace Opaque Secret carrying tls.crt (bp-dragonfly 0.1.1 mounts
+             it OPTIONALLY at HARBOR_CA_MOUNT_PATH), and set
+             proxy.registryMirror.cert = <mount>/<file> in the dfdaemon ConfigMap
+             patch that flips registryMirror.addr. Same tls.crt-fallback as #3379.
+            */}}
             - name: HARBOR_CA_ENABLED
               value: {{ .Values.registryPivot.dragonfly.harborCA.enabled | quote }}
             - name: HARBOR_CA_SRC_NAMESPACE
@@ -158,55 +168,65 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-            # #4637 follow-up: the dfdaemon-serving probe must reach the NODE's
-            # dfdaemon, but this pod is NOT hostNetwork — so its 127.0.0.1 is the
-            # pod loopback, never the node's :DF_PROXY_PORT. The dfdaemon binds
-            # 0.0.0.0:DF_PROXY_PORT (hostNetwork), so HOST_IP:DF_PROXY_PORT is
-            # reachable from this pod. (containerd still pulls via 127.0.0.1 in
-            # the NODE netns — that is correct and unchanged.)
+            {{- /*
+             #4637 follow-up: the dfdaemon-serving probe must reach the NODE's
+             dfdaemon, but this pod is NOT hostNetwork — so its 127.0.0.1 is the
+             pod loopback, never the node's :DF_PROXY_PORT. The dfdaemon binds
+             0.0.0.0:DF_PROXY_PORT (hostNetwork), so HOST_IP:DF_PROXY_PORT is
+             reachable from this pod. (containerd still pulls via 127.0.0.1 in
+             the NODE netns — that is correct and unchanged.)
+            */}}
             - name: HOST_IP
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
-            # ── #5007 (Refs #4682 #3379) — NODE /etc/hosts pin for the local
-            # registry. containerd resolves registry.<fqdn> via the NODE resolver,
-            # which on hw241 returned the DEAD `*.omantel.biz` wildcard IP
-            # (49.12.16.160) instead of the live specific record → post-pivot fresh
-            # pulls ImagePullBackOff. The pivot pins registry.<fqdn> DIRECTLY to the
-            # gateway VIP the platform already knows (derived at runtime, no
-            # hardcoded IP), so the local-registry datapath NEVER depends on public
-            # DNS. GATEWAY_LB_SVC_* is the cilium-gateway LoadBalancer Service whose
-            # ingress IP is the VIP (empty → node-own-IP hostNetwork fallback).
+            {{- /*
+             ── #5007 (Refs #4682 #3379) — NODE /etc/hosts pin for the local
+             registry. containerd resolves registry.<fqdn> via the NODE resolver,
+             which on hw241 returned the DEAD `*.omantel.biz` wildcard IP
+             (49.12.16.160) instead of the live specific record → post-pivot fresh
+             pulls ImagePullBackOff. The pivot pins registry.<fqdn> DIRECTLY to the
+             gateway VIP the platform already knows (derived at runtime, no
+             hardcoded IP), so the local-registry datapath NEVER depends on public
+             DNS. GATEWAY_LB_SVC_* is the cilium-gateway LoadBalancer Service whose
+             ingress IP is the VIP (empty → node-own-IP hostNetwork fallback).
+            */}}
             - name: LOCAL_REGISTRY_PIN_ENABLED
               value: {{ .Values.registryPivot.localRegistryHostPin.enabled | quote }}
             - name: GATEWAY_LB_SVC_NAME
               value: {{ .Values.registryPivot.localRegistryHostPin.gatewayServiceName | quote }}
             - name: GATEWAY_LB_SVC_NAMESPACE
               value: {{ .Values.registryPivot.localRegistryHostPin.gatewayServiceNamespace | quote }}
-          # readinessProbe: the script touches /tmp/ready after its first
-          # successful reconcile pass. catalyst-api's daemonset-wait
-          # then sees numberReady=desired and proceeds.
+          {{- /*
+           readinessProbe: the script touches /tmp/ready after its first
+           successful reconcile pass. catalyst-api's daemonset-wait
+           then sees numberReady=desired and proceeds.
+          */}}
           readinessProbe:
             exec:
               command: ["/bin/sh", "-c", "test -f /tmp/ready"]
             initialDelaySeconds: 5
             periodSeconds: 5
           volumeMounts:
-            # #3647/#4639: the containerd certs.d host-mirror dir. The pivot
-            # loop writes the `_default/hosts.toml` catch-all that points
-            # containerd at the node-local dfdaemon proxy; containerd re-reads
-            # it per-pull so the pivot is effective on the RUNNING node.
+            {{- /*
+             #3647/#4639: the containerd certs.d host-mirror dir. The pivot
+             loop writes the `_default/hosts.toml` catch-all that points
+             containerd at the node-local dfdaemon proxy; containerd re-reads
+             it per-pull so the pivot is effective on the RUNNING node.
+            */}}
             - name: containerd-certs-d
               mountPath: /host/var/lib/rancher/k3s/agent/etc/containerd/certs.d
             - name: pivot-script
               mountPath: /usr/local/bin/pivot.sh
               subPath: pivot.sh
               readOnly: true
-            # #5007 — the node's /etc/hosts (single-file bind mount). The pivot
-            # maintains a managed `<gateway-VIP> registry.<fqdn>` line so
-            # containerd resolves the local registry DIRECTLY to the gateway VIP,
-            # never via the public DNS wildcard-vs-specific race (the hw241 dead
-            # `*.omantel.biz` 49.12.16.160 ImagePullBackOff).
+            {{- /*
+             #5007 — the node's /etc/hosts (single-file bind mount). The pivot
+             maintains a managed `<gateway-VIP> registry.<fqdn>` line so
+             containerd resolves the local registry DIRECTLY to the gateway VIP,
+             never via the public DNS wildcard-vs-specific race (the hw241 dead
+             `*.omantel.biz` 49.12.16.160 ImagePullBackOff).
+            */}}
             - name: node-etc-hosts
               mountPath: /host/etc/hosts
           command: ["/bin/sh", "/usr/local/bin/pivot.sh"]
@@ -214,11 +234,13 @@ spec:
             requests: { cpu: 25m, memory: 32Mi }
             limits:   { memory: 128Mi }
       volumes:
-        # #3647/#4639: containerd host-mirror dir (k3s default data-dir; no
-        # --data-dir override in cloudinit-control-plane.tftpl). containerd
-        # re-reads <ns>/hosts.toml here on every pull, so writing the
-        # `_default/hosts.toml` catch-all makes the dfdaemon mirror effective
-        # on a RUNNING node — no k3s restart, no node reboot.
+        {{- /*
+         #3647/#4639: containerd host-mirror dir (k3s default data-dir; no
+         --data-dir override in cloudinit-control-plane.tftpl). containerd
+         re-reads <ns>/hosts.toml here on every pull, so writing the
+         `_default/hosts.toml` catch-all makes the dfdaemon mirror effective
+         on a RUNNING node — no k3s restart, no node reboot.
+        */}}
         - name: containerd-certs-d
           hostPath:
             path: /var/lib/rancher/k3s/agent/etc/containerd/certs.d
@@ -227,19 +249,23 @@ spec:
           configMap:
             name: registry-pivot-script
             defaultMode: 0755
-        # #5007 — node /etc/hosts (type: File bind mount). The pivot rewrites it
-        # IN PLACE (truncate, never mv — a single-file bind mount keeps the inode)
-        # to pin registry.<fqdn> -> the gateway VIP the platform already knows, so
-        # the local-registry pull never depends on public DNS resolution.
+        {{- /*
+         #5007 — node /etc/hosts (type: File bind mount). The pivot rewrites it
+         IN PLACE (truncate, never mv — a single-file bind mount keeps the inode)
+         to pin registry.<fqdn> -> the gateway VIP the platform already knows, so
+         the local-registry pull never depends on public DNS resolution.
+        */}}
         - name: node-etc-hosts
           hostPath:
             path: /etc/hosts
             type: File
 ---
-# Step ConfigMap for catalyst-api consumer (mode=daemonset-wait).
-# The handler resolves the DaemonSet name from the `bp.openova.io/cutover-daemonset`
-# label; we set it explicitly so the lookup is stable even if the cm
-# name convention changes.
+{{- /*
+ Step ConfigMap for catalyst-api consumer (mode=daemonset-wait).
+ The handler resolves the DaemonSet name from the `bp.openova.io/cutover-daemonset`
+ label; we set it explicitly so the lookup is stable even if the cm
+ name convention changes.
+*/}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -253,8 +279,10 @@ metadata:
     bp.openova.io/cutover-daemonset: "registry-pivot"
 data:
   stepName: registry-pivot
-  # podSpec is intentionally absent — mode=daemonset-wait does NOT use it.
-  # Catalyst-api's parser tolerates absent podSpec when mode!=job.
+  {{- /*
+   podSpec is intentionally absent — mode=daemonset-wait does NOT use it.
+   Catalyst-api's parser tolerates absent podSpec when mode!=job.
+  */}}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -267,43 +295,47 @@ metadata:
 data:
   pivot.sh: |
     #!/bin/sh
-    # shellcheck disable=SC2086  # ${CT} (= "--max-time 20") is word-split ON PURPOSE so the two tokens become separate curl args; quoting it would pass a single bad arg.
-    # registry-pivot reconcile loop (Dragonfly rewrite, #4639 Refs #4637).
-    # Reads registriesYamlActive from the cutover-status ConfigMap; when the
-    # value changes:
-    #   v2 → (a) write the containerd `_default/hosts.toml` catch-all that
-    #            mirrors EVERY registry namespace through the node-local
-    #            dfdaemon proxy http://127.0.0.1:${DF_PROXY_PORT};
-    #        (b) ONCE (cluster-wide, guarded): flip the dfdaemon (+ seed)
-    #            registryMirror.addr ghcr → the local Harbor external host
-    #            https://registry.<fqdn> (:443 via the Gateway LoadBalancer), set
-    #            the registryMirror.cert trust anchor, and bounce dfdaemon.
-    #   v1/rollback → remove the catch-all + revert the dfdaemon upstream.
-    #
-    # NB on `set -u` (NOT `set -eu`): this is a long-running best-effort
-    # RECONCILE LOOP — every apiserver call is already individually guarded
-    # (--max-time + `|| true` / `&& … || …` fallbacks) and a transient miss is
-    # MEANT to be retried on the next 15s sweep, never to abort the loop. Under
-    # `errexit` any guarded sub-command that legitimately exits non-zero (a
-    # best-effort ack that 409s, a `[ test ]` that is false at the tail of an
-    # `&&` chain) would kill the whole DaemonSet pod and the per-node pivot
-    # would silently stall. `set -u` keeps unset-variable protection (the real
-    # footgun) without the errexit fragility. The daemonset-wait + per-node ack
-    # contract is unchanged.
+    {{- /*
+     shellcheck disable=SC2086  # ${CT} (= "--max-time 20") is word-split ON PURPOSE so the two tokens become separate curl args; quoting it would pass a single bad arg.
+     registry-pivot reconcile loop (Dragonfly rewrite, #4639 Refs #4637).
+     Reads registriesYamlActive from the cutover-status ConfigMap; when the
+     value changes:
+       v2 → (a) write the containerd `_default/hosts.toml` catch-all that
+                mirrors EVERY registry namespace through the node-local
+                dfdaemon proxy http://127.0.0.1:${DF_PROXY_PORT};
+            (b) ONCE (cluster-wide, guarded): flip the dfdaemon (+ seed)
+                registryMirror.addr ghcr → the local Harbor external host
+                https://registry.<fqdn> (:443 via the Gateway LoadBalancer), set
+                the registryMirror.cert trust anchor, and bounce dfdaemon.
+       v1/rollback → remove the catch-all + revert the dfdaemon upstream.
+
+     NB on `set -u` (NOT `set -eu`): this is a long-running best-effort
+     RECONCILE LOOP — every apiserver call is already individually guarded
+     (--max-time + `|| true` / `&& … || …` fallbacks) and a transient miss is
+     MEANT to be retried on the next 15s sweep, never to abort the loop. Under
+     `errexit` any guarded sub-command that legitimately exits non-zero (a
+     best-effort ack that 409s, a `[ test ]` that is false at the tail of an
+     `&&` chain) would kill the whole DaemonSet pod and the per-node pivot
+     would silently stall. `set -u` keeps unset-variable protection (the real
+     footgun) without the errexit fragility. The daemonset-wait + per-node ack
+     contract is unchanged.
+    */}}
     set -u
 
-    # #5191 — the pivot toolchain (curl + jq) is load-bearing: Harbor CA
-    # extraction, dragonfly-CA/dfdaemon patch, LB-IP discovery, and the per-node
-    # `registriesYaml` acks (write_node_ack / cm_patch_status) all shell out to
-    # them. The former `apk add ... || true` SILENTLY proceeded tool-less on an
-    # egress miss, so every ack failed (`jq: not found`) and the node never
-    # acked v2 — the step-04 daemonset-wait then wedged the WHOLE cutover with
-    # NO failed-step flag (observed live: hw268 2 rebooted nodes lost the apk
-    # toolchain with no egress to reinstall). Retry, then verify, then FAIL
-    # LOUD: a still-missing tool crashes the Pod (a visible CrashLoopBackOff
-    # that self-heals the moment apk succeeds), never a silent tool-less
-    # proceed. Explicit exit — `set -u` here is deliberate (NOT errexit), so the
-    # guard cannot rely on a non-zero apk killing the shell.
+    {{- /*
+     #5191 — the pivot toolchain (curl + jq) is load-bearing: Harbor CA
+     extraction, dragonfly-CA/dfdaemon patch, LB-IP discovery, and the per-node
+     `registriesYaml` acks (write_node_ack / cm_patch_status) all shell out to
+     them. The former `apk add ... || true` SILENTLY proceeded tool-less on an
+     egress miss, so every ack failed (`jq: not found`) and the node never
+     acked v2 — the step-04 daemonset-wait then wedged the WHOLE cutover with
+     NO failed-step flag (observed live: hw268 2 rebooted nodes lost the apk
+     toolchain with no egress to reinstall). Retry, then verify, then FAIL
+     LOUD: a still-missing tool crashes the Pod (a visible CrashLoopBackOff
+     that self-heals the moment apk succeeds), never a silent tool-less
+     proceed. Explicit exit — `set -u` here is deliberate (NOT errexit), so the
+     guard cannot rely on a non-zero apk killing the shell.
+    */}}
     i=0
     while [ "${i}" -lt 6 ]; do
       apk add --no-cache curl jq >/dev/null 2>&1 && break
@@ -320,72 +352,88 @@ data:
     token=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
     cacert=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
     cm_url="${api}/api/v1/namespaces/${STATUS_CONFIGMAP_NAMESPACE}/configmaps/${STATUS_CONFIGMAP_NAME}"
-    # EVERY apiserver call carries --max-time so a kom4dc network blip FAIL-FASTs
-    # instead of wedging the reconcile loop forever (a stuck-but-alive connection
-    # never trips curl's -f). 20s is generous for an in-cluster apiserver call;
-    # the 15s sweep retries any miss. Word-split intentionally ($CT not quoted).
+    {{- /*
+     EVERY apiserver call carries --max-time so a kom4dc network blip FAIL-FASTs
+     instead of wedging the reconcile loop forever (a stuck-but-alive connection
+     never trips curl's -f). 20s is generous for an in-cluster apiserver call;
+     the 15s sweep retries any miss. Word-split intentionally ($CT not quoted).
+    */}}
     CT="--max-time 20"
 
-    # containerd host-mirror dir, mounted from the host. containerd re-reads
-    # certs.d/<ns>/hosts.toml PER PULL, so writing the `_default` catch-all
-    # here makes new pulls hit the local dfdaemon immediately — no k3s restart.
+    {{- /*
+     containerd host-mirror dir, mounted from the host. containerd re-reads
+     certs.d/<ns>/hosts.toml PER PULL, so writing the `_default` catch-all
+     here makes new pulls hit the local dfdaemon immediately — no k3s restart.
+    */}}
     certs_d=/host/var/lib/rancher/k3s/agent/etc/containerd/certs.d
     df_proxy="http://127.0.0.1:${DF_PROXY_PORT}"
     last_state=""
-    # #5007 — the node's /etc/hosts (bind-mounted from the host) + the marker that
-    # tags the pin line this pivot owns, so it is idempotently re-writeable and
-    # cleanly removable on rollback.
+    {{- /*
+     #5007 — the node's /etc/hosts (bind-mounted from the host) + the marker that
+     tags the pin line this pivot owns, so it is idempotently re-writeable and
+     cleanly removable on rollback.
+    */}}
     etc_hosts=/host/etc/hosts
     pin_marker="# managed by bp-self-sovereign-cutover registry-pivot (#5007) — DO NOT EDIT"
 
-    # ── helpers ────────────────────────────────────────────────────────────
+    {{- /* ── helpers ──────────────────────────────────────────────────────────── */}}
 
-    # The dfdaemon upstream the cutover flips TO: the cluster-LOCAL Harbor's
-    # EXTERNAL routable host on the standard HTTPS port :443 (#4682). The Cilium
-    # Gateway serves `registry.<fqdn>` via a `Service type=LoadBalancer` on :443,
-    # so the dfdaemon dials the host directly over public DNS — no ClusterIP
-    # hostAlias, no NodePort, no CoreDNS rewrite. The token-realm follow-up
-    # Harbor reflects carries the same bare host, so it stays on :443 too.
+    {{- /*
+     The dfdaemon upstream the cutover flips TO: the cluster-LOCAL Harbor's
+     EXTERNAL routable host on the standard HTTPS port :443 (#4682). The Cilium
+     Gateway serves `registry.<fqdn>` via a `Service type=LoadBalancer` on :443,
+     so the dfdaemon dials the host directly over public DNS — no ClusterIP
+     hostAlias, no NodePort, no CoreDNS rewrite. The token-realm follow-up
+     Harbor reflects carries the same bare host, so it stays on :443 too.
+    */}}
     harbor_host=$(printf '%s' "${HARBOR_PUBLIC_URL}" | sed -E 's,^https?://,,; s,/$,,')
     local_upstream="https://${harbor_host}"
 
-    # #4652 — the PEM path bp-dragonfly (0.1.1) mounts the Harbor wildcard cert
-    # at on the dfdaemon (+ seed); set as proxy.registryMirror.cert so the Rust
-    # resolver trusts the LE-staging in-cluster Harbor on the back-to-source
-    # pull. Empty when HARBOR_CA_ENABLED is off → addr-only flip (no cert line).
+    {{- /*
+     #4652 — the PEM path bp-dragonfly (0.1.1) mounts the Harbor wildcard cert
+     at on the dfdaemon (+ seed); set as proxy.registryMirror.cert so the Rust
+     resolver trusts the LE-staging in-cluster Harbor on the back-to-source
+     pull. Empty when HARBOR_CA_ENABLED is off → addr-only flip (no cert line).
+    */}}
     local_cert_path="${HARBOR_CA_MOUNT_PATH}/${HARBOR_CA_FILE_NAME}"
-    # The wildcard TLS Secret name = <prefix><fqdn with '.'->'-'> (mirrors the
-    # #3379 helmRepositoryTrust source-secret derivation). The registry-pivot
-    # reads it from HARBOR_CA_SRC_NAMESPACE and materialises HARBOR_CA_DEST_SECRET
-    # (carrying tls.crt) in the dragonfly namespace for the optional mount.
+    {{- /*
+     The wildcard TLS Secret name = <prefix><fqdn with '.'->'-'> (mirrors the
+     #3379 helmRepositoryTrust source-secret derivation). The registry-pivot
+     reads it from HARBOR_CA_SRC_NAMESPACE and materialises HARBOR_CA_DEST_SECRET
+     (carrying tls.crt) in the dragonfly namespace for the optional mount.
+    */}}
     fqdn_dashed=$(printf '%s' "${SOVEREIGN_FQDN}" | tr '.' '-')
     wildcard_secret="${HARBOR_CA_SRC_NAME_PREFIX}${fqdn_dashed}"
 
-    # #4975 (Refs #3379 #3695) — PER-UPSTREAM-HOST containerd certs.d rewrite.
-    #
-    # REPLACES the single `_default/hosts.toml` dfdaemon catch-all. Under the
-    # step-08 deny-egress hold a dfdaemon back-to-source to the flipped upstream
-    # only serves images the dfdaemon already fetched; a workload image that was
-    # never node-cached ImagePullBackOffs. The systemic fix is a COMPLETE local
-    # Harbor mirror (step-03 Phase A3 pushes every image) + per-host containerd
-    # entries that resolve each upstream host DIRECTLY to the exact local path:
-    #   • host with project P → mirror https://<local>/v2/<P> + override_path=true
-    #     so a pull of `<host>/<repo>` resolves to `<local>/v2/<P>/<repo>` (the
-    #     Phase-A3 push dest);
-    #   • MOTHERSHIP host (empty project) → mirror https://<local> WITHOUT
-    #     override_path so the path (which already carries the proxy-<x> segment,
-    #     e.g. proxy-ghcr/cloudnative-pg/postgresql) is PRESERVED — a pure host
-    #     swap harbor.openova.io → registry.<fqdn>.
-    # This OVERRIDES the boot-time per-host `harbor.openova.io` mirror k3s wrote.
-    # Every entry skip_verify=true (the local Harbor serves an LE-staging /
-    # node-untrusted wildcard on a fresh prov — same trust-the-cluster-network
-    # rationale as #4529/#4557). The openova-io host-drop pull path is preserved
-    # by the local-registry self-entry (direct pulls of registry.<fqdn>/openova-io/…).
+    {{- /*
+     #4975 (Refs #3379 #3695) — PER-UPSTREAM-HOST containerd certs.d rewrite.
+
+     REPLACES the single `_default/hosts.toml` dfdaemon catch-all. Under the
+     step-08 deny-egress hold a dfdaemon back-to-source to the flipped upstream
+     only serves images the dfdaemon already fetched; a workload image that was
+     never node-cached ImagePullBackOffs. The systemic fix is a COMPLETE local
+     Harbor mirror (step-03 Phase A3 pushes every image) + per-host containerd
+     entries that resolve each upstream host DIRECTLY to the exact local path:
+       • host with project P → mirror https://<local>/v2/<P> + override_path=true
+         so a pull of `<host>/<repo>` resolves to `<local>/v2/<P>/<repo>` (the
+         Phase-A3 push dest);
+       • MOTHERSHIP host (empty project) → mirror https://<local> WITHOUT
+         override_path so the path (which already carries the proxy-<x> segment,
+         e.g. proxy-ghcr/cloudnative-pg/postgresql) is PRESERVED — a pure host
+         swap harbor.openova.io → registry.<fqdn>.
+     This OVERRIDES the boot-time per-host `harbor.openova.io` mirror k3s wrote.
+     Every entry skip_verify=true (the local Harbor serves an LE-staging /
+     node-untrusted wildcard on a fresh prov — same trust-the-cluster-network
+     rationale as #4529/#4557). The openova-io host-drop pull path is preserved
+     by the local-registry self-entry (direct pulls of registry.<fqdn>/openova-io/…).
+    */}}
     write_offline_mirror_hosts() {
-      # Retire the legacy dfdaemon catch-all (superseded by the per-host entries).
+      {{- /* Retire the legacy dfdaemon catch-all (superseded by the per-host entries). */}}
       rm -f "${certs_d}/_default/hosts.toml" 2>/dev/null || true
-      # Self-entry: trust the local Harbor's cert for DIRECT openova-io host-drop
-      # pulls (registry.<fqdn>/openova-io/…), the pivoted-ref path step-06/07 set.
+      {{- /*
+       Self-entry: trust the local Harbor's cert for DIRECT openova-io host-drop
+       pulls (registry.<fqdn>/openova-io/…), the pivoted-ref path step-06/07 set.
+      */}}
       if [ -n "${LOCAL_REGISTRY_HOST:-}" ]; then
         mkdir -p "${certs_d}/${LOCAL_REGISTRY_HOST}"
         {
@@ -398,7 +446,7 @@ data:
         mv "${certs_d}/${LOCAL_REGISTRY_HOST}/hosts.toml.new" "${certs_d}/${LOCAL_REGISTRY_HOST}/hosts.toml"
         echo "[registry-pivot]   wrote ${LOCAL_REGISTRY_HOST}/hosts.toml (local self-trust) on ${NODE_NAME}"
       fi
-      # Per-upstream-host mirror → the local Harbor project path.
+      {{- /* Per-upstream-host mirror → the local Harbor project path. */}}
       for pair in ${HOST_PROJECT_MAP}; do
         h="${pair%%:*}"
         case "${pair}" in *:*) p="${pair#*:}" ;; *) p="" ;; esac
@@ -406,7 +454,7 @@ data:
         [ "${h}" = "${LOCAL_REGISTRY_HOST}" ] && continue
         mkdir -p "${certs_d}/${h}"
         if [ -z "${p}" ]; then
-          # Mothership host-swap: path preserved (no override_path).
+          {{- /* Mothership host-swap: path preserved (no override_path). */}}
           {
             echo "# managed by bp-self-sovereign-cutover registry-pivot (#4975) — DO NOT EDIT"
             echo "server = \"https://${h}\""
@@ -415,8 +463,10 @@ data:
             echo "  skip_verify = true"
           } > "${certs_d}/${h}/hosts.toml.new"
         else
-          # Upstream host → local Harbor project (override_path so containerd
-          # uses the URL path as the API root instead of appending its own /v2).
+          {{- /*
+           Upstream host → local Harbor project (override_path so containerd
+           uses the URL path as the API root instead of appending its own /v2).
+          */}}
           {
             echo "# managed by bp-self-sovereign-cutover registry-pivot (#4975) — DO NOT EDIT"
             echo "server = \"https://${h}\""
@@ -440,40 +490,46 @@ data:
       echo "[registry-pivot]   removed offline-mirror per-host hosts.toml (rollback) on ${NODE_NAME}"
     }
 
-    # #5007 — resolve the Harbor gateway VIP WITHOUT public DNS. The per-host
-    # certs.d entries above use `server = https://registry.<fqdn>`; containerd
-    # resolves that host via the NODE resolver, which on hw241 returned the DEAD
-    # `*.omantel.biz` wildcard IP → ImagePullBackOff. We instead pin registry.<fqdn>
-    # to the gateway VIP the platform already assigned. Priority (K8s-API only, no
-    # DNS): (1) the cilium-gateway `type=LoadBalancer` Service ingress IP (hcloud-ccm
-    # ExternalIP on Hetzner / CiliumLoadBalancerIPPool VIP on no-CCM Huawei); (2) on
-    # the hostNetwork-gateway provider (Huawei #4706 — cilium-envoy binds node:443
-    # directly, so the Service has NO ingress IP / does not exist) the node's OWN IP,
-    # which serves :443 locally. Echoes the VIP or empty (empty ONLY when the Service
-    # EXISTS but its VIP is still pending, or on a transient API miss → caller defers
-    # + retries; a 404 means hostNetwork → HOST_IP). Word-split $CT is intentional.
+    {{- /*
+     #5007 — resolve the Harbor gateway VIP WITHOUT public DNS. The per-host
+     certs.d entries above use `server = https://registry.<fqdn>`; containerd
+     resolves that host via the NODE resolver, which on hw241 returned the DEAD
+     `*.omantel.biz` wildcard IP → ImagePullBackOff. We instead pin registry.<fqdn>
+     to the gateway VIP the platform already assigned. Priority (K8s-API only, no
+     DNS): (1) the cilium-gateway `type=LoadBalancer` Service ingress IP (hcloud-ccm
+     ExternalIP on Hetzner / CiliumLoadBalancerIPPool VIP on no-CCM Huawei); (2) on
+     the hostNetwork-gateway provider (Huawei #4706 — cilium-envoy binds node:443
+     directly, so the Service has NO ingress IP / does not exist) the node's OWN IP,
+     which serves :443 locally. Echoes the VIP or empty (empty ONLY when the Service
+     EXISTS but its VIP is still pending, or on a transient API miss → caller defers
+     + retries; a 404 means hostNetwork → HOST_IP). Word-split $CT is intentional.
+    */}}
     resolve_gateway_vip() {
-      # No LB Service configured → hostNetwork gateway model: node's own IP serves :443.
+      {{- /* No LB Service configured → hostNetwork gateway model: node's own IP serves :443. */}}
       if [ -z "${GATEWAY_LB_SVC_NAME:-}" ]; then printf '%s' "${HOST_IP:-}"; return; fi
       svc_url="${api}/api/v1/namespaces/${GATEWAY_LB_SVC_NAMESPACE}/services/${GATEWAY_LB_SVC_NAME}"
-      # -w appends the HTTP status on its own trailing line (NOT -f, so a 404 body is
-      # readable to distinguish "absent → hostNetwork" from "present but VIP pending").
+      {{- /*
+       -w appends the HTTP status on its own trailing line (NOT -f, so a 404 body is
+       readable to distinguish "absent → hostNetwork" from "present but VIP pending").
+      */}}
       resp=$(curl -sS ${CT} --cacert "${cacert}" -H "Authorization: Bearer ${token}" \
         -w '\n%{http_code}' "${svc_url}" 2>/dev/null || true)
       code=$(printf '%s' "${resp}" | tail -n1)
       json=$(printf '%s' "${resp}" | sed '$d')
       case "${code}" in
         200)
-          # Service present. Split on .spec.type (#5007 round 2, hw250 live):
-          # - LoadBalancer: use its ingress VIP (or spec.loadBalancerIP); empty =
-          #   VIP pending → caller defers (do NOT fall back to HOST_IP: in the LB
-          #   model node:443 is NOT served by envoy).
-          # - ClusterIP (the §854 ELB-direct model keeps the gateway Service but
-          #   cilium assigns NO VIP EVER): hostNetwork envoy serves node:443 —
-          #   identical serving shape to the 404/absent branch — so pin HOST_IP.
-          #   Without this split the pin DEFERRED FOREVER on every ELB-direct
-          #   prov (hw250: 'LB VIP pending / API miss' on all sweeps all night),
-          #   leaving nodes exposed to the #5007 stale-wildcard defect.
+          {{- /*
+           Service present. Split on .spec.type (#5007 round 2, hw250 live):
+           - LoadBalancer: use its ingress VIP (or spec.loadBalancerIP); empty =
+             VIP pending → caller defers (do NOT fall back to HOST_IP: in the LB
+             model node:443 is NOT served by envoy).
+           - ClusterIP (the §854 ELB-direct model keeps the gateway Service but
+             cilium assigns NO VIP EVER): hostNetwork envoy serves node:443 —
+             identical serving shape to the 404/absent branch — so pin HOST_IP.
+             Without this split the pin DEFERRED FOREVER on every ELB-direct
+             prov (hw250: 'LB VIP pending / API miss' on all sweeps all night),
+             leaving nodes exposed to the #5007 stale-wildcard defect.
+          */}}
           svc_type=$(printf '%s' "${json}" | jq -r '.spec.type // empty' 2>/dev/null || true)
           if [ "${svc_type}" = "LoadBalancer" ]; then
             printf '%s' "$(printf '%s' "${json}" | jq -r '.status.loadBalancer.ingress[0].ip // .spec.loadBalancerIP // empty' 2>/dev/null || true)"
@@ -482,21 +538,23 @@ data:
           fi
           ;;
         404)
-          # Service absent → hostNetwork gateway model: cilium-envoy binds node:443.
+          {{- /* Service absent → hostNetwork gateway model: cilium-envoy binds node:443. */}}
           printf '%s' "${HOST_IP:-}"
           ;;
         *)
-          # Transient (000 / 5xx / 401) → empty so the caller defers + retries.
+          {{- /* Transient (000 / 5xx / 401) → empty so the caller defers + retries. */}}
           printf '%s' ""
           ;;
       esac
     }
 
-    # #5007 — write/refresh the managed `<VIP> registry.<fqdn>` line in the node's
-    # /etc/hosts, stripping ANY prior line for that host (a cloud-init r4() boot pin
-    # that may have baked the dead wildcard IP, or a stale managed line). In-place
-    # truncate-rewrite (NOT mv) so the single-file bind mount inode is preserved.
-    # Idempotent (grep -qxF no-op once pinned). Fail-OPEN on any error.
+    {{- /*
+     #5007 — write/refresh the managed `<VIP> registry.<fqdn>` line in the node's
+     /etc/hosts, stripping ANY prior line for that host (a cloud-init r4() boot pin
+     that may have baked the dead wildcard IP, or a stale managed line). In-place
+     truncate-rewrite (NOT mv) so the single-file bind mount inode is preserved.
+     Idempotent (grep -qxF no-op once pinned). Fail-OPEN on any error.
+    */}}
     write_local_registry_pin() {
       case "${LOCAL_REGISTRY_PIN_ENABLED}" in
         true|True|TRUE|1|yes) : ;;
@@ -511,8 +569,10 @@ data:
       fi
       want="${vip} ${LOCAL_REGISTRY_HOST} ${pin_marker}"
       grep -qxF "${want}" "${etc_hosts}" 2>/dev/null && return 0
-      # Strip EVERY existing line whose host field == LOCAL_REGISTRY_HOST (any IP,
-      # managed or the cloud-init boot pin), then append the authoritative pin.
+      {{- /*
+       Strip EVERY existing line whose host field == LOCAL_REGISTRY_HOST (any IP,
+       managed or the cloud-init boot pin), then append the authoritative pin.
+      */}}
       kept=$(awk -v h="${LOCAL_REGISTRY_HOST}" '{
         drop=0
         for (i=2; i<=NF; i++) if ($i==h) { drop=1; break }
@@ -523,8 +583,10 @@ data:
         || echo "[registry-pivot]   WARN failed to write ${etc_hosts} pin on ${NODE_NAME} (will retry next sweep)"
     }
 
-    # #5007 — rollback: drop the managed pin line so registry.<fqdn> reverts to the
-    # node's pre-pivot DNS resolution. In-place truncate-rewrite; idempotent.
+    {{- /*
+     #5007 — rollback: drop the managed pin line so registry.<fqdn> reverts to the
+     node's pre-pivot DNS resolution. In-place truncate-rewrite; idempotent.
+    */}}
     remove_local_registry_pin() {
       [ -f "${etc_hosts}" ] || return 0
       grep -qF "${pin_marker}" "${etc_hosts}" 2>/dev/null || return 0
@@ -533,16 +595,18 @@ data:
         && echo "[registry-pivot]   removed ${LOCAL_REGISTRY_HOST} /etc/hosts pin (rollback) on ${NODE_NAME}"
     }
 
-    # #4652 (the x509 fix) — materialise the in-cluster Harbor trust anchor in
-    # the dragonfly namespace. Reads the wildcard TLS Secret from
-    # HARBOR_CA_SRC_NAMESPACE (kube-system) and creates/updates an Opaque Secret
-    # HARBOR_CA_DEST_SECRET in DF_NAMESPACE carrying `tls.crt`. bp-dragonfly
-    # (0.1.1) mounts that Secret OPTIONALLY at HARBOR_CA_MOUNT_PATH, so once it
-    # exists the dfdaemon (+ seed) carry the PEM the registryMirror.cert line
-    # points at. Same tls.crt-fallback as #3379 (the wildcard Secret carries
-    # tls.crt+tls.key, NO ca.crt → tls.crt is the real trust bundle). Opaque
-    # (NOT kubernetes.io/tls): only tls.crt is copied; the private key is NEVER
-    # carried into dragonfly. Returns 0 when the dest Secret carries the cert.
+    {{- /*
+     #4652 (the x509 fix) — materialise the in-cluster Harbor trust anchor in
+     the dragonfly namespace. Reads the wildcard TLS Secret from
+     HARBOR_CA_SRC_NAMESPACE (kube-system) and creates/updates an Opaque Secret
+     HARBOR_CA_DEST_SECRET in DF_NAMESPACE carrying `tls.crt`. bp-dragonfly
+     (0.1.1) mounts that Secret OPTIONALLY at HARBOR_CA_MOUNT_PATH, so once it
+     exists the dfdaemon (+ seed) carry the PEM the registryMirror.cert line
+     points at. Same tls.crt-fallback as #3379 (the wildcard Secret carries
+     tls.crt+tls.key, NO ca.crt → tls.crt is the real trust bundle). Opaque
+     (NOT kubernetes.io/tls): only tls.crt is copied; the private key is NEVER
+     carried into dragonfly. Returns 0 when the dest Secret carries the cert.
+    */}}
     src_secret_url="${api}/api/v1/namespaces/${HARBOR_CA_SRC_NAMESPACE}/secrets/${wildcard_secret}"
     dst_secret_url="${api}/api/v1/namespaces/${DF_NAMESPACE}/secrets/${HARBOR_CA_DEST_SECRET}"
     harbor_ca_to_dragonfly_ns() {
@@ -550,20 +614,24 @@ data:
         true|True|TRUE|1|yes) : ;;
         *) return 0 ;;
       esac
-      # Prefer the issuing CA (ca.crt); fall back to the served leaf+chain
-      # (tls.crt) — the wildcard Secret typically has NO ca.crt, so tls.crt is
-      # the path that actually fires (the #3379 finding). base64 (.data.*) is
-      # copied verbatim into the dest Secret's .data so no re-encode is needed.
+      {{- /*
+       Prefer the issuing CA (ca.crt); fall back to the served leaf+chain
+       (tls.crt) — the wildcard Secret typically has NO ca.crt, so tls.crt is
+       the path that actually fires (the #3379 finding). base64 (.data.*) is
+       copied verbatim into the dest Secret's .data so no re-encode is needed.
+      */}}
       ca_b64=$(curl -fsS ${CT} --cacert "${cacert}" -H "Authorization: Bearer ${token}" "${src_secret_url}" 2>/dev/null \
         | jq -r '.data["ca.crt"] // .data["tls.crt"] // empty' 2>/dev/null || true)
       if [ -z "${ca_b64}" ]; then
         echo "[registry-pivot]   WARN ${HARBOR_CA_SRC_NAMESPACE}/${wildcard_secret} has no ca.crt/tls.crt; deferring dfdaemon cert (registryMirror.cert will be skipped this sweep)"
         return 1
       fi
-      # PUT the cert under the `tls.crt` key (the file bp-dragonfly mounts is
-      # <path>/tls.crt). Idempotent create-or-update: read the dest, if its
-      # tls.crt already matches we skip; else apply via server-side apply
-      # (kubectl-less: a strategic create falls back to a merge-patch on 409).
+      {{- /*
+       PUT the cert under the `tls.crt` key (the file bp-dragonfly mounts is
+       <path>/tls.crt). Idempotent create-or-update: read the dest, if its
+       tls.crt already matches we skip; else apply via server-side apply
+       (kubectl-less: a strategic create falls back to a merge-patch on 409).
+      */}}
       cur_b64=$(curl -fsS ${CT} --cacert "${cacert}" -H "Authorization: Bearer ${token}" "${dst_secret_url}" 2>/dev/null \
         | jq -r '.data["tls.crt"] // empty' 2>/dev/null || true)
       if [ "${cur_b64}" = "${ca_b64}" ]; then
@@ -578,7 +646,7 @@ data:
         echo "[registry-pivot]   created ${DF_NAMESPACE}/${HARBOR_CA_DEST_SECRET} (Harbor trust anchor for dfdaemon)"
         return 0
       fi
-      # Already exists → merge-patch the data in place.
+      {{- /* Already exists → merge-patch the data in place. */}}
       patch=$(jq -cn --arg c "${ca_b64}" '{data:{"tls.crt":$c}}')
       if curl -fsS ${CT} -X PATCH --cacert "${cacert}" -H "Authorization: Bearer ${token}" \
           -H "Content-Type: application/merge-patch+json" --data "${patch}" "${dst_secret_url}" >/dev/null 2>&1; then
@@ -592,25 +660,27 @@ data:
       curl -fsS ${CT} -X DELETE --cacert "${cacert}" -H "Authorization: Bearer ${token}" "${dst_secret_url}" >/dev/null 2>&1 || true
     }
 
-    # Patch a dfdaemon-family ConfigMap's dfdaemon.yaml registryMirror.addr to
-    # ${2}, and (when ${3} is non-empty) ensure a sibling registryMirror.cert:
-    # ${3} (the PEM trust anchor for the LE-staging in-cluster Harbor, #4652).
-    # The config is a single YAML string under data."dfdaemon.yaml"; we read it,
-    # rewrite ONLY the registryMirror addr/cert lines, and merge-patch it back.
-    # Idempotent. SCOPING IS LOAD-BEARING: the dfdaemon.yaml carries MULTIPLE
-    # `addr:` keys — `manager.addr: http://dragonfly-manager…:65003` (the gRPC
-    # control-plane the dfdaemon health-checks at boot) AND
-    # `proxy.registryMirror.addr` (the registry upstream we flip). A blanket
-    # `sed s/addr: …/` would ALSO rewrite the manager addr → dfdaemon
-    # ConnectError on startup → CrashLoopBackOff (caught live on the kom4dc
-    # seed-client). So the awk rewrites addr/cert ONLY while inside a
-    # `registryMirror:` block (set the in-block flag on a line ending in
-    # `registryMirror:`; clear it when indentation returns to <= the
-    # registryMirror key's indent). The `cert:` line is emitted at the SAME
-    # indent as `addr` (a sibling under registryMirror) — updated in place if it
-    # already exists in-block, else inserted right after the addr line; cleared
-    # on rollback (want_cert empty). want_addr / want_cert are passed via -v (no
-    # shell interpolation into the awk program → metacharacter-safe).
+    {{- /*
+     Patch a dfdaemon-family ConfigMap's dfdaemon.yaml registryMirror.addr to
+     ${2}, and (when ${3} is non-empty) ensure a sibling registryMirror.cert:
+     ${3} (the PEM trust anchor for the LE-staging in-cluster Harbor, #4652).
+     The config is a single YAML string under data."dfdaemon.yaml"; we read it,
+     rewrite ONLY the registryMirror addr/cert lines, and merge-patch it back.
+     Idempotent. SCOPING IS LOAD-BEARING: the dfdaemon.yaml carries MULTIPLE
+     `addr:` keys — `manager.addr: http://dragonfly-manager…:65003` (the gRPC
+     control-plane the dfdaemon health-checks at boot) AND
+     `proxy.registryMirror.addr` (the registry upstream we flip). A blanket
+     `sed s/addr: …/` would ALSO rewrite the manager addr → dfdaemon
+     ConnectError on startup → CrashLoopBackOff (caught live on the kom4dc
+     seed-client). So the awk rewrites addr/cert ONLY while inside a
+     `registryMirror:` block (set the in-block flag on a line ending in
+     `registryMirror:`; clear it when indentation returns to <= the
+     registryMirror key's indent). The `cert:` line is emitted at the SAME
+     indent as `addr` (a sibling under registryMirror) — updated in place if it
+     already exists in-block, else inserted right after the addr line; cleared
+     on rollback (want_cert empty). want_addr / want_cert are passed via -v (no
+     shell interpolation into the awk program → metacharacter-safe).
+    */}}
     patch_df_configmap_addr() {
       cm_name="$1"; want_addr="$2"; want_cert="${3:-}"
       url="${api}/api/v1/namespaces/${DF_NAMESPACE}/configmaps/${cm_name}"
@@ -618,16 +688,18 @@ data:
         | jq -r '.data["dfdaemon.yaml"] // empty' 2>/dev/null || true)
       [ -z "${cur}" ] && { echo "[registry-pivot]   WARN ${cm_name} dfdaemon.yaml unreadable; deferring upstream flip"; return 1; }
       new=$(printf '%s' "${cur}" | awk -v want="${want_addr}" -v cert="${want_cert}" '
-        # compute leading-space count of a line
+        {{- /* compute leading-space count of a line */}}
         function indent(s,   n){ n=0; while (substr(s,n+1,1)==" ") n++; return n }
         {
           if ($0 ~ /registryMirror:[[:space:]]*$/) { inblk=1; blkind=indent($0); print; next }
           if (inblk) {
             ci=indent($0)
-            # a non-blank line at indent <= the registryMirror key ends the
-            # block. Before leaving, if we owe a cert line and never saw one,
-            # emit it now at the addr indent we recorded (insert before the line
-            # that closes the block).
+            {{- /*
+             a non-blank line at indent <= the registryMirror key ends the
+             block. Before leaving, if we owe a cert line and never saw one,
+             emit it now at the addr indent we recorded (insert before the line
+             that closes the block).
+            */}}
             if ($0 ~ /[^[:space:]]/ && ci <= blkind) {
               if (cert != "" && !cert_done && addrind != "") {
                 printf "%*scert: %s\n", addrind, "", cert
@@ -636,8 +708,10 @@ data:
               inblk=0
             }
           }
-          # In-block existing cert line: update it in place (want set) or drop it
-          # (rollback, want_cert empty) — do NOT print the stale/cleared line.
+          {{- /*
+           In-block existing cert line: update it in place (want set) or drop it
+           (rollback, want_cert empty) — do NOT print the stale/cleared line.
+          */}}
           if (inblk && $0 ~ /^[[:space:]]*cert:[[:space:]]*/) {
             if (cert != "" && !cert_done) {
               printf "%*scert: %s\n", indent($0), "", cert
@@ -649,7 +723,7 @@ data:
             addrind=indent($0)
             sub(/addr:[[:space:]]*https?:\/\/[^[:space:]]+/, "addr: " want)
             print
-            # Insert the cert sibling right after addr if not already emitted.
+            {{- /* Insert the cert sibling right after addr if not already emitted. */}}
             if (cert != "" && !cert_done) {
               printf "%*scert: %s\n", addrind, "", cert
               cert_done=1
@@ -659,8 +733,10 @@ data:
           print
         }
         END {
-          # Block ran to EOF still open and we owe a cert line (registryMirror
-          # was the last block in the doc): emit it at the recorded addr indent.
+          {{- /*
+           Block ran to EOF still open and we owe a cert line (registryMirror
+           was the last block in the doc): emit it at the recorded addr indent.
+          */}}
           if (inblk && cert != "" && !cert_done && addrind != "")
             printf "%*scert: %s\n", addrind, "", cert
         }')
@@ -675,10 +751,12 @@ data:
       return 1
     }
 
-    # Roll dfdaemon (+ seed) so they reload the flipped upstream. This is the
-    # explicit nudge for the addr-only ConfigMap change and is gated by
-    # DF_RESTART_ON_FLIP. Uses the restartedAt annotation (kubectl rollout
-    # restart equivalent) via a strategic-merge patch.
+    {{- /*
+     Roll dfdaemon (+ seed) so they reload the flipped upstream. This is the
+     explicit nudge for the addr-only ConfigMap change and is gated by
+     DF_RESTART_ON_FLIP. Uses the restartedAt annotation (kubectl rollout
+     restart equivalent) via a strategic-merge patch.
+    */}}
     restart_workload() {
       kind="$1"; name="$2"
       [ "${DF_RESTART_ON_FLIP}" = "true" ] || return 0
@@ -692,11 +770,13 @@ data:
         || echo "[registry-pivot]   WARN failed to roll ${kind}/${name}"
     }
 
-    # The cluster-wide dfdaemon upstream flip — performed ONCE.
-    # The status key dragonflyUpstream=local is the cluster-scope guard: the
-    # first node to converge sets it; the rest skip. Returns 0 only when the
-    # full flip (both ConfigMaps) succeeded so the guard is set; a partial
-    # failure leaves the guard unset → a later sweep retries.
+    {{- /*
+     The cluster-wide dfdaemon upstream flip — performed ONCE.
+     The status key dragonflyUpstream=local is the cluster-scope guard: the
+     first node to converge sets it; the rest skip. Returns 0 only when the
+     full flip (both ConfigMaps) succeeded so the guard is set; a partial
+     failure leaves the guard unset → a later sweep retries.
+    */}}
     cm_patch_status() {
       key="$1"; val="$2"
       p=$(jq -cn --arg k "${key}" --arg v "${val}" '{data: {($k): $v}}')
@@ -711,10 +791,12 @@ data:
       fi
       echo "[registry-pivot]   flipping dfdaemon upstream -> ${local_upstream} (external host, :443) on ${NODE_NAME}"
       ok=0
-      # #4652 (x509 fix): materialise the Harbor trust anchor in the dragonfly
-      # namespace; ONLY then set registryMirror.cert (so we never point the
-      # dfdaemon at a non-existent PEM). If the CA cannot be materialised this
-      # sweep, flip addr-only and defer the cert to a later sweep.
+      {{- /*
+       #4652 (x509 fix): materialise the Harbor trust anchor in the dragonfly
+       namespace; ONLY then set registryMirror.cert (so we never point the
+       dfdaemon at a non-existent PEM). If the CA cannot be materialised this
+       sweep, flip addr-only and defer the cert to a later sweep.
+      */}}
       cert_arg=""
       if harbor_ca_to_dragonfly_ns; then
         cert_arg="${local_cert_path}"
@@ -734,7 +816,7 @@ data:
       return 1
     }
     df_revert_to_ghcr() {
-      # Rollback clears the cert (empty 3rd arg) along with the addr.
+      {{- /* Rollback clears the cert (empty 3rd arg) along with the addr. */}}
       patch_df_configmap_addr "${DF_CLIENT_CONFIGMAP}" "https://ghcr.io" "" || true
       if [ -n "${DF_SEED_CONFIGMAP}" ]; then
         patch_df_configmap_addr "${DF_SEED_CONFIGMAP}" "https://ghcr.io" "" || true
@@ -743,39 +825,43 @@ data:
       cm_patch_status dragonflyUpstream ghcr
     }
 
-    # #4637 — the step-07 catalyst-api re-pull GATE. The _default/hosts.toml
-    # catch-all points this node's containerd at the node-local dfdaemon proxy
-    # http://127.0.0.1:${DF_PROXY_PORT}; the dfdaemon is what actually serves
-    # the registry.<fqdn>/openova-io/openova/catalyst-api blob (back-to-source
-    # to its flipped registryMirror.addr). But the dfdaemon DaemonSet
-    # (dragonfly-client) is a SEPARATE workload — if it has 0 Ready pods on this
-    # node (the live #4649 Kyverno-readOnlyRootFilesystem DENY → DESIRED=N
-    # CURRENT=0), the mirror endpoint is dead and a containerd pull through it
-    # gets `dial tcp 127.0.0.1:${DF_PROXY_PORT}: connect: connection refused`.
-    # Writing the v2 node-ack while the proxy is dead lets catalyst-api's
-    # daemonset-wait green PREMATURELY → step-07 fires the catalyst-api HR
-    # image roll → ImagePullBackOff → cutover wedges at 54% (the exact #4637
-    # leg). So probe the LOCAL dfdaemon's registry endpoint BEFORE acking v2:
-    # a reachable proxy answers /v2/ with an HTTP status (200 or a 401/403/404
-    # registry challenge — ANY HTTP response proves the listener is up, no body
-    # parse needed). A connection-refused/timeout returns no status → not yet
-    # serving → defer the ack so the daemonset-wait keeps blocking until the
-    # node mirror is genuinely live (idempotent; retried each 15s sweep).
+    {{- /*
+     #4637 — the step-07 catalyst-api re-pull GATE. The _default/hosts.toml
+     catch-all points this node's containerd at the node-local dfdaemon proxy
+     http://127.0.0.1:${DF_PROXY_PORT}; the dfdaemon is what actually serves
+     the registry.<fqdn>/openova-io/openova/catalyst-api blob (back-to-source
+     to its flipped registryMirror.addr). But the dfdaemon DaemonSet
+     (dragonfly-client) is a SEPARATE workload — if it has 0 Ready pods on this
+     node (the live #4649 Kyverno-readOnlyRootFilesystem DENY → DESIRED=N
+     CURRENT=0), the mirror endpoint is dead and a containerd pull through it
+     gets `dial tcp 127.0.0.1:${DF_PROXY_PORT}: connect: connection refused`.
+     Writing the v2 node-ack while the proxy is dead lets catalyst-api's
+     daemonset-wait green PREMATURELY → step-07 fires the catalyst-api HR
+     image roll → ImagePullBackOff → cutover wedges at 54% (the exact #4637
+     leg). So probe the LOCAL dfdaemon's registry endpoint BEFORE acking v2:
+     a reachable proxy answers /v2/ with an HTTP status (200 or a 401/403/404
+     registry challenge — ANY HTTP response proves the listener is up, no body
+     parse needed). A connection-refused/timeout returns no status → not yet
+     serving → defer the ack so the daemonset-wait keeps blocking until the
+     node mirror is genuinely live (idempotent; retried each 15s sweep).
+    */}}
     dfdaemon_serving() {
-      # curl's -w '%{http_code}' prints the response status, or `000` when the
-      # connection failed (refused/timeout) — and on a dead port curl ALSO exits
-      # non-zero, so do NOT chain `|| echo 000` (that would append a SECOND 000 →
-      # `000000`, which is not the literal `000` we test for → a false "serving"
-      # verdict). `|| true` keeps `set -u`-safe without corrupting the code. A
-      # REAL HTTP response is a 3-digit code whose leading digit is 1-5 (200, or
-      # a 401/403/404 registry challenge — ANY proves the listener is up, no body
-      # parse needed); `000` / empty / anything else = not serving → defer.
-      # Probe the NODE's dfdaemon via HOST_IP, not 127.0.0.1 (#4637 follow-up):
-      # this pod is NOT hostNetwork, so its loopback never reaches the node's
-      # hostNetwork dfdaemon — a 127.0.0.1 probe ALWAYS reads 000 and defers
-      # forever, wedging step-04. The dfdaemon binds 0.0.0.0:${DF_PROXY_PORT} so
-      # HOST_IP is reachable. (containerd still pulls via 127.0.0.1 in the NODE
-      # netns — correct + unchanged.) Fall back to 127.0.0.1 if HOST_IP is unset.
+      {{- /*
+       curl's -w '%{http_code}' prints the response status, or `000` when the
+       connection failed (refused/timeout) — and on a dead port curl ALSO exits
+       non-zero, so do NOT chain `|| echo 000` (that would append a SECOND 000 →
+       `000000`, which is not the literal `000` we test for → a false "serving"
+       verdict). `|| true` keeps `set -u`-safe without corrupting the code. A
+       REAL HTTP response is a 3-digit code whose leading digit is 1-5 (200, or
+       a 401/403/404 registry challenge — ANY proves the listener is up, no body
+       parse needed); `000` / empty / anything else = not serving → defer.
+       Probe the NODE's dfdaemon via HOST_IP, not 127.0.0.1 (#4637 follow-up):
+       this pod is NOT hostNetwork, so its loopback never reaches the node's
+       hostNetwork dfdaemon — a 127.0.0.1 probe ALWAYS reads 000 and defers
+       forever, wedging step-04. The dfdaemon binds 0.0.0.0:${DF_PROXY_PORT} so
+       HOST_IP is reachable. (containerd still pulls via 127.0.0.1 in the NODE
+       netns — correct + unchanged.) Fall back to 127.0.0.1 if HOST_IP is unset.
+      */}}
       probe_host="${HOST_IP:-127.0.0.1}"
       code=$(curl -s -o /dev/null -w '%{http_code}' ${CT} \
         "http://${probe_host}:${DF_PROXY_PORT}/v2/" 2>/dev/null || true)
@@ -785,15 +871,17 @@ data:
       esac
     }
 
-    # #4975 — the step-07 catalyst-api re-pull GATE for the DIRECT path. Post
-    # #4975 containerd resolves each upstream host DIRECTLY to the local Harbor
-    # (registry.<fqdn>), NOT through the node-local dfdaemon, so the ack gate is
-    # "is the LOCAL Harbor serving /v2/" — not "is dfdaemon serving". Probe the
-    # local Harbor external host over :443 (reachable in-cluster via the gateway
-    # LB hairpin, #4682; -k tolerates the LE-staging wildcard). ANY HTTP status
-    # (200 or a 401/403/404 registry challenge) proves the listener is up; a
-    # connection-refused/timeout returns 000 → defer the v2 ack so the
-    # daemonset-wait keeps blocking until the local registry answers.
+    {{- /*
+     #4975 — the step-07 catalyst-api re-pull GATE for the DIRECT path. Post
+     #4975 containerd resolves each upstream host DIRECTLY to the local Harbor
+     (registry.<fqdn>), NOT through the node-local dfdaemon, so the ack gate is
+     "is the LOCAL Harbor serving /v2/" — not "is dfdaemon serving". Probe the
+     local Harbor external host over :443 (reachable in-cluster via the gateway
+     LB hairpin, #4682; -k tolerates the LE-staging wildcard). ANY HTTP status
+     (200 or a 401/403/404 registry challenge) proves the listener is up; a
+     connection-refused/timeout returns 000 → defer the v2 ack so the
+     daemonset-wait keeps blocking until the local registry answers.
+    */}}
     local_registry_serving() {
       code=$(curl -s -o /dev/null -w '%{http_code}' ${CT} -k \
         "https://${LOCAL_REGISTRY_HOST}/v2/" 2>/dev/null || true)
@@ -803,9 +891,11 @@ data:
       esac
     }
 
-    # #3671: per-node ack the daemonset-wait counts (proves EVERY node swapped
-    # its containerd to the dfdaemon mirror, not merely that the DS Pods are
-    # Ready). Key node.<NODE>.registriesYaml. Best-effort; retried each sweep.
+    {{- /*
+     #3671: per-node ack the daemonset-wait counts (proves EVERY node swapped
+     its containerd to the dfdaemon mirror, not merely that the DS Pods are
+     Ready). Key node.<NODE>.registriesYaml. Best-effort; retried each sweep.
+    */}}
     write_node_ack() {
       ack_val="$1"
       ack_key="node.${NODE_NAME}.registriesYaml"
@@ -820,19 +910,25 @@ data:
       desired="$1"
       case "${desired}" in
         v2)
-          # #4975 — per-node: write the PER-UPSTREAM-HOST containerd certs.d
-          # entries that resolve each upstream DIRECTLY to the local Harbor.
+          {{- /*
+           #4975 — per-node: write the PER-UPSTREAM-HOST containerd certs.d
+           entries that resolve each upstream DIRECTLY to the local Harbor.
+          */}}
           write_offline_mirror_hosts
-          # Cluster-wide (guarded): flip the dfdaemon upstream to the local
-          # Harbor too — BEST-EFFORT residual cover for any pull that still
-          # transits dfdaemon (e.g. a host bp-dragonfly dfinit mirrored that
-          # our per-host entries did not override). Not on the critical path.
+          {{- /*
+           Cluster-wide (guarded): flip the dfdaemon upstream to the local
+           Harbor too — BEST-EFFORT residual cover for any pull that still
+           transits dfdaemon (e.g. a host bp-dragonfly dfinit mirrored that
+           our per-host entries did not override). Not on the critical path.
+          */}}
           df_flip_to_local || true
-          # #4975 — ack v2 ONLY once the LOCAL Harbor is actually serving /v2/
-          # (the DIRECT path containerd now uses). Acking while registry.<fqdn>
-          # is unreachable would green the daemonset-wait → step-07 catalyst-api
-          # pull fails. Defer (no ack) so the wait keeps blocking; the reconcile
-          # loop re-probes every sweep (see the v2-ack retry guard).
+          {{- /*
+           #4975 — ack v2 ONLY once the LOCAL Harbor is actually serving /v2/
+           (the DIRECT path containerd now uses). Acking while registry.<fqdn>
+           is unreachable would green the daemonset-wait → step-07 catalyst-api
+           pull fails. Defer (no ack) so the wait keeps blocking; the reconcile
+           loop re-probes every sweep (see the v2-ack retry guard).
+          */}}
           if local_registry_serving; then
             write_node_ack v2
           else
@@ -854,18 +950,22 @@ data:
         || echo "v1")
       desired=${desired:-v1}
 
-      # #5007 — reconcile the local-registry /etc/hosts pin every sweep while v2 is
-      # desired (idempotent; self-heals a node whose /etc/hosts was rewritten, and
-      # completes the pin once the gateway VIP is assigned after the first v2 sweep
-      # — a fast grep no-op once pinned). On v1/rollback apply_state removes it.
+      {{- /*
+       #5007 — reconcile the local-registry /etc/hosts pin every sweep while v2 is
+       desired (idempotent; self-heals a node whose /etc/hosts was rewritten, and
+       completes the pin once the gateway VIP is assigned after the first v2 sweep
+       — a fast grep no-op once pinned). On v1/rollback apply_state removes it.
+      */}}
       [ "${desired}" = "v2" ] && write_local_registry_pin
 
-      # #4639 — re-apply v2 if the cluster-wide dfdaemon flip has not yet been
-      # confirmed (guard dragonflyUpstream != local). apply_state fires only
-      # ONCE per state, so if the upstream flip (e.g. the Harbor CA anchor or a
-      # ConfigMap patch) missed on the first v2 sweep it would be skipped
-      # forever. This retries the flip on a later sweep WITHOUT re-applying every
-      # tick once converged.
+      {{- /*
+       #4639 — re-apply v2 if the cluster-wide dfdaemon flip has not yet been
+       confirmed (guard dragonflyUpstream != local). apply_state fires only
+       ONCE per state, so if the upstream flip (e.g. the Harbor CA anchor or a
+       ConfigMap patch) missed on the first v2 sweep it would be skipped
+       forever. This retries the flip on a later sweep WITHOUT re-applying every
+       tick once converged.
+      */}}
       needs_flip_retry=0
       if [ "${desired}" = "v2" ] && [ "${desired}" = "${last_state}" ]; then
         cur_up=$(curl -fsS ${CT} --cacert "${cacert}" -H "Authorization: Bearer ${token}" "${cm_url}" 2>/dev/null \
@@ -873,15 +973,17 @@ data:
         [ "${cur_up}" != "local" ] && needs_flip_retry=1
       fi
 
-      # #4637 — re-apply v2 if THIS node's v2 ack is still missing (its local
-      # dfdaemon was not serving on the first sweep — the live #4649 condition).
-      # The cluster-wide flip (needs_flip_retry) may already be `local`, so that
-      # guard would NOT re-fire apply_state; without this a node whose dfdaemon
-      # came up late never re-probes/re-acks → its node.<NODE>.registriesYaml
-      # stays absent → catalyst-api's per-node-ack wait never reaches
-      # acks==desired → the cutover stalls at step-04 instead of greening once
-      # the mirror is live. Cheap (one CM GET) and self-limiting (stops the
-      # instant the ack lands).
+      {{- /*
+       #4637 — re-apply v2 if THIS node's v2 ack is still missing (its local
+       dfdaemon was not serving on the first sweep — the live #4649 condition).
+       The cluster-wide flip (needs_flip_retry) may already be `local`, so that
+       guard would NOT re-fire apply_state; without this a node whose dfdaemon
+       came up late never re-probes/re-acks → its node.<NODE>.registriesYaml
+       stays absent → catalyst-api's per-node-ack wait never reaches
+       acks==desired → the cutover stalls at step-04 instead of greening once
+       the mirror is live. Cheap (one CM GET) and self-limiting (stops the
+       instant the ack lands).
+      */}}
       needs_ack_retry=0
       if [ "${desired}" = "v2" ] && [ "${desired}" = "${last_state}" ] && [ "${needs_flip_retry}" = "0" ]; then
         my_ack=$(curl -fsS ${CT} --cacert "${cacert}" -H "Authorization: Bearer ${token}" "${cm_url}" 2>/dev/null \
@@ -899,7 +1001,7 @@ data:
         fi
         apply_state "${desired}"
         last_state="${desired}"
-        # Mark Pod ready after the first successful sync.
+        {{- /* Mark Pod ready after the first successful sync. */}}
         touch /tmp/ready
       fi
 

--- a/platform/self-sovereign-cutover/chart/templates/04-registry-pivot-daemonset.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/04-registry-pivot-daemonset.yaml
@@ -1,6 +1,18 @@
 {{- /*
 Step 04 — registry-pivot (Dragonfly rewrite, #4639 Refs #4637).
 
+THIS FILE KEEPS ITS `#` COMMENTS. #6004 converted whole-line `#` comments to
+Helm block comments across the chart's templates, because a `#` comment is
+stored twice in the Helm release Secret (template bytes + rendered manifest)
+while a Helm comment is stored once. This template is the exception:
+products/catalyst/bootstrap/api/internal/handler/cutover_registry_pivot_mirror_
+test.go slices shell FUNCTIONS out of this file VERBATIM — from
+`    <name>() {` to the matching `    }` — and executes them under /bin/sh with
+no Helm rendering at all. A Helm comment inside a function body is not a comment
+to dash; it is `/bin/sh: Syntax error: "(" unexpected`, and both registry-pivot
+regression tests die on it (proven on PR #6025's first CI run). Comments here
+stay `#` until that test slices the RENDER instead of the template.
+
 This step is a DaemonSet, not a Job. The consumer (catalyst-api,
 issue #792) handles this via mode=daemonset-wait: when the cutover
 hits this step, it waits for the DaemonSet's
@@ -99,13 +111,11 @@ spec:
           env:
             - name: HARBOR_PUBLIC_URL
               value: {{ .Values.sovereign.harborPublicURL | quote }}
-            {{- /*
-             #4975 (Refs #3379 #3695) — the offline-mirror coverage map + the
-             local registry host. The pivot writes PER-UPSTREAM-HOST containerd
-             certs.d entries pointing at registry.<fqdn>/<project> (the exact
-             path step-03 Phase A3 pushed to), replacing the single _default
-             dfdaemon catch-all. Same map step-03/step-08 read.
-            */}}
+            # #4975 (Refs #3379 #3695) — the offline-mirror coverage map + the
+            # local registry host. The pivot writes PER-UPSTREAM-HOST containerd
+            # certs.d entries pointing at registry.<fqdn>/<project> (the exact
+            # path step-03 Phase A3 pushed to), replacing the single _default
+            # dfdaemon catch-all. Same map step-03/step-08 read.
             - name: HOST_PROJECT_MAP
               value: {{ include "bp-self-sovereign-cutover.hostProjectMapInline" . | quote }}
             - name: LOCAL_REGISTRY_HOST
@@ -114,17 +124,13 @@ spec:
               value: {{ .Values.status.configMapName | quote }}
             - name: STATUS_CONFIGMAP_NAMESPACE
               value: {{ .Release.Namespace | quote }}
-            {{- /*
-             ── Dragonfly coordinates (the #4639 rewrite) ──────────────────
-             The dfdaemon proxy every node's containerd mirrors through.
-            */}}
+            # ── Dragonfly coordinates (the #4639 rewrite) ──────────────────
+            # The dfdaemon proxy every node's containerd mirrors through.
             - name: DF_PROXY_PORT
               value: {{ .Values.registryPivot.dragonfly.proxyPort | quote }}
-            {{- /*
-             The bp-dragonfly mesh namespace + the per-node dfdaemon
-             DaemonSet + seed-peer + their config ConfigMaps the upstream
-             flip patch targets.
-            */}}
+            # The bp-dragonfly mesh namespace + the per-node dfdaemon
+            # DaemonSet + seed-peer + their config ConfigMaps the upstream
+            # flip patch targets.
             - name: DF_NAMESPACE
               value: {{ .Values.registryPivot.dragonfly.namespace | quote }}
             - name: DF_CLIENT_DAEMONSET
@@ -137,21 +143,17 @@ spec:
               value: {{ .Values.registryPivot.dragonfly.seedConfigMap | quote }}
             - name: DF_RESTART_ON_FLIP
               value: {{ .Values.registryPivot.dragonfly.restartOnFlip | quote }}
-            {{- /*
-             The Sovereign FQDN — the wildcard-TLS Secret name is
-             <prefix><fqdn-dashed>. Sourced from the chart's sovereign.fqdn
-             (cloud-init substitutes ${SOVEREIGN_FQDN} via the 06a overlay).
-            */}}
+            # The Sovereign FQDN — the wildcard-TLS Secret name is
+            # <prefix><fqdn-dashed>. Sourced from the chart's sovereign.fqdn
+            # (cloud-init substitutes ${SOVEREIGN_FQDN} via the 06a overlay).
             - name: SOVEREIGN_FQDN
               value: {{ .Values.sovereign.fqdn | quote }}
-            {{- /*
-             ── #4652 dfdaemon registryMirror.cert (the x509 fix) ─────────────
-             Read the in-cluster Harbor wildcard TLS Secret, create a dragonfly-
-             namespace Opaque Secret carrying tls.crt (bp-dragonfly 0.1.1 mounts
-             it OPTIONALLY at HARBOR_CA_MOUNT_PATH), and set
-             proxy.registryMirror.cert = <mount>/<file> in the dfdaemon ConfigMap
-             patch that flips registryMirror.addr. Same tls.crt-fallback as #3379.
-            */}}
+            # ── #4652 dfdaemon registryMirror.cert (the x509 fix) ─────────────
+            # Read the in-cluster Harbor wildcard TLS Secret, create a dragonfly-
+            # namespace Opaque Secret carrying tls.crt (bp-dragonfly 0.1.1 mounts
+            # it OPTIONALLY at HARBOR_CA_MOUNT_PATH), and set
+            # proxy.registryMirror.cert = <mount>/<file> in the dfdaemon ConfigMap
+            # patch that flips registryMirror.addr. Same tls.crt-fallback as #3379.
             - name: HARBOR_CA_ENABLED
               value: {{ .Values.registryPivot.dragonfly.harborCA.enabled | quote }}
             - name: HARBOR_CA_SRC_NAMESPACE
@@ -168,65 +170,55 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-            {{- /*
-             #4637 follow-up: the dfdaemon-serving probe must reach the NODE's
-             dfdaemon, but this pod is NOT hostNetwork — so its 127.0.0.1 is the
-             pod loopback, never the node's :DF_PROXY_PORT. The dfdaemon binds
-             0.0.0.0:DF_PROXY_PORT (hostNetwork), so HOST_IP:DF_PROXY_PORT is
-             reachable from this pod. (containerd still pulls via 127.0.0.1 in
-             the NODE netns — that is correct and unchanged.)
-            */}}
+            # #4637 follow-up: the dfdaemon-serving probe must reach the NODE's
+            # dfdaemon, but this pod is NOT hostNetwork — so its 127.0.0.1 is the
+            # pod loopback, never the node's :DF_PROXY_PORT. The dfdaemon binds
+            # 0.0.0.0:DF_PROXY_PORT (hostNetwork), so HOST_IP:DF_PROXY_PORT is
+            # reachable from this pod. (containerd still pulls via 127.0.0.1 in
+            # the NODE netns — that is correct and unchanged.)
             - name: HOST_IP
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
-            {{- /*
-             ── #5007 (Refs #4682 #3379) — NODE /etc/hosts pin for the local
-             registry. containerd resolves registry.<fqdn> via the NODE resolver,
-             which on hw241 returned the DEAD `*.omantel.biz` wildcard IP
-             (49.12.16.160) instead of the live specific record → post-pivot fresh
-             pulls ImagePullBackOff. The pivot pins registry.<fqdn> DIRECTLY to the
-             gateway VIP the platform already knows (derived at runtime, no
-             hardcoded IP), so the local-registry datapath NEVER depends on public
-             DNS. GATEWAY_LB_SVC_* is the cilium-gateway LoadBalancer Service whose
-             ingress IP is the VIP (empty → node-own-IP hostNetwork fallback).
-            */}}
+            # ── #5007 (Refs #4682 #3379) — NODE /etc/hosts pin for the local
+            # registry. containerd resolves registry.<fqdn> via the NODE resolver,
+            # which on hw241 returned the DEAD `*.omantel.biz` wildcard IP
+            # (49.12.16.160) instead of the live specific record → post-pivot fresh
+            # pulls ImagePullBackOff. The pivot pins registry.<fqdn> DIRECTLY to the
+            # gateway VIP the platform already knows (derived at runtime, no
+            # hardcoded IP), so the local-registry datapath NEVER depends on public
+            # DNS. GATEWAY_LB_SVC_* is the cilium-gateway LoadBalancer Service whose
+            # ingress IP is the VIP (empty → node-own-IP hostNetwork fallback).
             - name: LOCAL_REGISTRY_PIN_ENABLED
               value: {{ .Values.registryPivot.localRegistryHostPin.enabled | quote }}
             - name: GATEWAY_LB_SVC_NAME
               value: {{ .Values.registryPivot.localRegistryHostPin.gatewayServiceName | quote }}
             - name: GATEWAY_LB_SVC_NAMESPACE
               value: {{ .Values.registryPivot.localRegistryHostPin.gatewayServiceNamespace | quote }}
-          {{- /*
-           readinessProbe: the script touches /tmp/ready after its first
-           successful reconcile pass. catalyst-api's daemonset-wait
-           then sees numberReady=desired and proceeds.
-          */}}
+          # readinessProbe: the script touches /tmp/ready after its first
+          # successful reconcile pass. catalyst-api's daemonset-wait
+          # then sees numberReady=desired and proceeds.
           readinessProbe:
             exec:
               command: ["/bin/sh", "-c", "test -f /tmp/ready"]
             initialDelaySeconds: 5
             periodSeconds: 5
           volumeMounts:
-            {{- /*
-             #3647/#4639: the containerd certs.d host-mirror dir. The pivot
-             loop writes the `_default/hosts.toml` catch-all that points
-             containerd at the node-local dfdaemon proxy; containerd re-reads
-             it per-pull so the pivot is effective on the RUNNING node.
-            */}}
+            # #3647/#4639: the containerd certs.d host-mirror dir. The pivot
+            # loop writes the `_default/hosts.toml` catch-all that points
+            # containerd at the node-local dfdaemon proxy; containerd re-reads
+            # it per-pull so the pivot is effective on the RUNNING node.
             - name: containerd-certs-d
               mountPath: /host/var/lib/rancher/k3s/agent/etc/containerd/certs.d
             - name: pivot-script
               mountPath: /usr/local/bin/pivot.sh
               subPath: pivot.sh
               readOnly: true
-            {{- /*
-             #5007 — the node's /etc/hosts (single-file bind mount). The pivot
-             maintains a managed `<gateway-VIP> registry.<fqdn>` line so
-             containerd resolves the local registry DIRECTLY to the gateway VIP,
-             never via the public DNS wildcard-vs-specific race (the hw241 dead
-             `*.omantel.biz` 49.12.16.160 ImagePullBackOff).
-            */}}
+            # #5007 — the node's /etc/hosts (single-file bind mount). The pivot
+            # maintains a managed `<gateway-VIP> registry.<fqdn>` line so
+            # containerd resolves the local registry DIRECTLY to the gateway VIP,
+            # never via the public DNS wildcard-vs-specific race (the hw241 dead
+            # `*.omantel.biz` 49.12.16.160 ImagePullBackOff).
             - name: node-etc-hosts
               mountPath: /host/etc/hosts
           command: ["/bin/sh", "/usr/local/bin/pivot.sh"]
@@ -234,13 +226,11 @@ spec:
             requests: { cpu: 25m, memory: 32Mi }
             limits:   { memory: 128Mi }
       volumes:
-        {{- /*
-         #3647/#4639: containerd host-mirror dir (k3s default data-dir; no
-         --data-dir override in cloudinit-control-plane.tftpl). containerd
-         re-reads <ns>/hosts.toml here on every pull, so writing the
-         `_default/hosts.toml` catch-all makes the dfdaemon mirror effective
-         on a RUNNING node — no k3s restart, no node reboot.
-        */}}
+        # #3647/#4639: containerd host-mirror dir (k3s default data-dir; no
+        # --data-dir override in cloudinit-control-plane.tftpl). containerd
+        # re-reads <ns>/hosts.toml here on every pull, so writing the
+        # `_default/hosts.toml` catch-all makes the dfdaemon mirror effective
+        # on a RUNNING node — no k3s restart, no node reboot.
         - name: containerd-certs-d
           hostPath:
             path: /var/lib/rancher/k3s/agent/etc/containerd/certs.d
@@ -249,23 +239,19 @@ spec:
           configMap:
             name: registry-pivot-script
             defaultMode: 0755
-        {{- /*
-         #5007 — node /etc/hosts (type: File bind mount). The pivot rewrites it
-         IN PLACE (truncate, never mv — a single-file bind mount keeps the inode)
-         to pin registry.<fqdn> -> the gateway VIP the platform already knows, so
-         the local-registry pull never depends on public DNS resolution.
-        */}}
+        # #5007 — node /etc/hosts (type: File bind mount). The pivot rewrites it
+        # IN PLACE (truncate, never mv — a single-file bind mount keeps the inode)
+        # to pin registry.<fqdn> -> the gateway VIP the platform already knows, so
+        # the local-registry pull never depends on public DNS resolution.
         - name: node-etc-hosts
           hostPath:
             path: /etc/hosts
             type: File
 ---
-{{- /*
- Step ConfigMap for catalyst-api consumer (mode=daemonset-wait).
- The handler resolves the DaemonSet name from the `bp.openova.io/cutover-daemonset`
- label; we set it explicitly so the lookup is stable even if the cm
- name convention changes.
-*/}}
+# Step ConfigMap for catalyst-api consumer (mode=daemonset-wait).
+# The handler resolves the DaemonSet name from the `bp.openova.io/cutover-daemonset`
+# label; we set it explicitly so the lookup is stable even if the cm
+# name convention changes.
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -279,10 +265,8 @@ metadata:
     bp.openova.io/cutover-daemonset: "registry-pivot"
 data:
   stepName: registry-pivot
-  {{- /*
-   podSpec is intentionally absent — mode=daemonset-wait does NOT use it.
-   Catalyst-api's parser tolerates absent podSpec when mode!=job.
-  */}}
+  # podSpec is intentionally absent — mode=daemonset-wait does NOT use it.
+  # Catalyst-api's parser tolerates absent podSpec when mode!=job.
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -295,47 +279,43 @@ metadata:
 data:
   pivot.sh: |
     #!/bin/sh
-    {{- /*
-     shellcheck disable=SC2086  # ${CT} (= "--max-time 20") is word-split ON PURPOSE so the two tokens become separate curl args; quoting it would pass a single bad arg.
-     registry-pivot reconcile loop (Dragonfly rewrite, #4639 Refs #4637).
-     Reads registriesYamlActive from the cutover-status ConfigMap; when the
-     value changes:
-       v2 → (a) write the containerd `_default/hosts.toml` catch-all that
-                mirrors EVERY registry namespace through the node-local
-                dfdaemon proxy http://127.0.0.1:${DF_PROXY_PORT};
-            (b) ONCE (cluster-wide, guarded): flip the dfdaemon (+ seed)
-                registryMirror.addr ghcr → the local Harbor external host
-                https://registry.<fqdn> (:443 via the Gateway LoadBalancer), set
-                the registryMirror.cert trust anchor, and bounce dfdaemon.
-       v1/rollback → remove the catch-all + revert the dfdaemon upstream.
-
-     NB on `set -u` (NOT `set -eu`): this is a long-running best-effort
-     RECONCILE LOOP — every apiserver call is already individually guarded
-     (--max-time + `|| true` / `&& … || …` fallbacks) and a transient miss is
-     MEANT to be retried on the next 15s sweep, never to abort the loop. Under
-     `errexit` any guarded sub-command that legitimately exits non-zero (a
-     best-effort ack that 409s, a `[ test ]` that is false at the tail of an
-     `&&` chain) would kill the whole DaemonSet pod and the per-node pivot
-     would silently stall. `set -u` keeps unset-variable protection (the real
-     footgun) without the errexit fragility. The daemonset-wait + per-node ack
-     contract is unchanged.
-    */}}
+    # shellcheck disable=SC2086  # ${CT} (= "--max-time 20") is word-split ON PURPOSE so the two tokens become separate curl args; quoting it would pass a single bad arg.
+    # registry-pivot reconcile loop (Dragonfly rewrite, #4639 Refs #4637).
+    # Reads registriesYamlActive from the cutover-status ConfigMap; when the
+    # value changes:
+    #   v2 → (a) write the containerd `_default/hosts.toml` catch-all that
+    #            mirrors EVERY registry namespace through the node-local
+    #            dfdaemon proxy http://127.0.0.1:${DF_PROXY_PORT};
+    #        (b) ONCE (cluster-wide, guarded): flip the dfdaemon (+ seed)
+    #            registryMirror.addr ghcr → the local Harbor external host
+    #            https://registry.<fqdn> (:443 via the Gateway LoadBalancer), set
+    #            the registryMirror.cert trust anchor, and bounce dfdaemon.
+    #   v1/rollback → remove the catch-all + revert the dfdaemon upstream.
+    #
+    # NB on `set -u` (NOT `set -eu`): this is a long-running best-effort
+    # RECONCILE LOOP — every apiserver call is already individually guarded
+    # (--max-time + `|| true` / `&& … || …` fallbacks) and a transient miss is
+    # MEANT to be retried on the next 15s sweep, never to abort the loop. Under
+    # `errexit` any guarded sub-command that legitimately exits non-zero (a
+    # best-effort ack that 409s, a `[ test ]` that is false at the tail of an
+    # `&&` chain) would kill the whole DaemonSet pod and the per-node pivot
+    # would silently stall. `set -u` keeps unset-variable protection (the real
+    # footgun) without the errexit fragility. The daemonset-wait + per-node ack
+    # contract is unchanged.
     set -u
 
-    {{- /*
-     #5191 — the pivot toolchain (curl + jq) is load-bearing: Harbor CA
-     extraction, dragonfly-CA/dfdaemon patch, LB-IP discovery, and the per-node
-     `registriesYaml` acks (write_node_ack / cm_patch_status) all shell out to
-     them. The former `apk add ... || true` SILENTLY proceeded tool-less on an
-     egress miss, so every ack failed (`jq: not found`) and the node never
-     acked v2 — the step-04 daemonset-wait then wedged the WHOLE cutover with
-     NO failed-step flag (observed live: hw268 2 rebooted nodes lost the apk
-     toolchain with no egress to reinstall). Retry, then verify, then FAIL
-     LOUD: a still-missing tool crashes the Pod (a visible CrashLoopBackOff
-     that self-heals the moment apk succeeds), never a silent tool-less
-     proceed. Explicit exit — `set -u` here is deliberate (NOT errexit), so the
-     guard cannot rely on a non-zero apk killing the shell.
-    */}}
+    # #5191 — the pivot toolchain (curl + jq) is load-bearing: Harbor CA
+    # extraction, dragonfly-CA/dfdaemon patch, LB-IP discovery, and the per-node
+    # `registriesYaml` acks (write_node_ack / cm_patch_status) all shell out to
+    # them. The former `apk add ... || true` SILENTLY proceeded tool-less on an
+    # egress miss, so every ack failed (`jq: not found`) and the node never
+    # acked v2 — the step-04 daemonset-wait then wedged the WHOLE cutover with
+    # NO failed-step flag (observed live: hw268 2 rebooted nodes lost the apk
+    # toolchain with no egress to reinstall). Retry, then verify, then FAIL
+    # LOUD: a still-missing tool crashes the Pod (a visible CrashLoopBackOff
+    # that self-heals the moment apk succeeds), never a silent tool-less
+    # proceed. Explicit exit — `set -u` here is deliberate (NOT errexit), so the
+    # guard cannot rely on a non-zero apk killing the shell.
     i=0
     while [ "${i}" -lt 6 ]; do
       apk add --no-cache curl jq >/dev/null 2>&1 && break
@@ -352,88 +332,72 @@ data:
     token=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
     cacert=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
     cm_url="${api}/api/v1/namespaces/${STATUS_CONFIGMAP_NAMESPACE}/configmaps/${STATUS_CONFIGMAP_NAME}"
-    {{- /*
-     EVERY apiserver call carries --max-time so a kom4dc network blip FAIL-FASTs
-     instead of wedging the reconcile loop forever (a stuck-but-alive connection
-     never trips curl's -f). 20s is generous for an in-cluster apiserver call;
-     the 15s sweep retries any miss. Word-split intentionally ($CT not quoted).
-    */}}
+    # EVERY apiserver call carries --max-time so a kom4dc network blip FAIL-FASTs
+    # instead of wedging the reconcile loop forever (a stuck-but-alive connection
+    # never trips curl's -f). 20s is generous for an in-cluster apiserver call;
+    # the 15s sweep retries any miss. Word-split intentionally ($CT not quoted).
     CT="--max-time 20"
 
-    {{- /*
-     containerd host-mirror dir, mounted from the host. containerd re-reads
-     certs.d/<ns>/hosts.toml PER PULL, so writing the `_default` catch-all
-     here makes new pulls hit the local dfdaemon immediately — no k3s restart.
-    */}}
+    # containerd host-mirror dir, mounted from the host. containerd re-reads
+    # certs.d/<ns>/hosts.toml PER PULL, so writing the `_default` catch-all
+    # here makes new pulls hit the local dfdaemon immediately — no k3s restart.
     certs_d=/host/var/lib/rancher/k3s/agent/etc/containerd/certs.d
     df_proxy="http://127.0.0.1:${DF_PROXY_PORT}"
     last_state=""
-    {{- /*
-     #5007 — the node's /etc/hosts (bind-mounted from the host) + the marker that
-     tags the pin line this pivot owns, so it is idempotently re-writeable and
-     cleanly removable on rollback.
-    */}}
+    # #5007 — the node's /etc/hosts (bind-mounted from the host) + the marker that
+    # tags the pin line this pivot owns, so it is idempotently re-writeable and
+    # cleanly removable on rollback.
     etc_hosts=/host/etc/hosts
     pin_marker="# managed by bp-self-sovereign-cutover registry-pivot (#5007) — DO NOT EDIT"
 
-    {{- /* ── helpers ──────────────────────────────────────────────────────────── */}}
+    # ── helpers ────────────────────────────────────────────────────────────
 
-    {{- /*
-     The dfdaemon upstream the cutover flips TO: the cluster-LOCAL Harbor's
-     EXTERNAL routable host on the standard HTTPS port :443 (#4682). The Cilium
-     Gateway serves `registry.<fqdn>` via a `Service type=LoadBalancer` on :443,
-     so the dfdaemon dials the host directly over public DNS — no ClusterIP
-     hostAlias, no NodePort, no CoreDNS rewrite. The token-realm follow-up
-     Harbor reflects carries the same bare host, so it stays on :443 too.
-    */}}
+    # The dfdaemon upstream the cutover flips TO: the cluster-LOCAL Harbor's
+    # EXTERNAL routable host on the standard HTTPS port :443 (#4682). The Cilium
+    # Gateway serves `registry.<fqdn>` via a `Service type=LoadBalancer` on :443,
+    # so the dfdaemon dials the host directly over public DNS — no ClusterIP
+    # hostAlias, no NodePort, no CoreDNS rewrite. The token-realm follow-up
+    # Harbor reflects carries the same bare host, so it stays on :443 too.
     harbor_host=$(printf '%s' "${HARBOR_PUBLIC_URL}" | sed -E 's,^https?://,,; s,/$,,')
     local_upstream="https://${harbor_host}"
 
-    {{- /*
-     #4652 — the PEM path bp-dragonfly (0.1.1) mounts the Harbor wildcard cert
-     at on the dfdaemon (+ seed); set as proxy.registryMirror.cert so the Rust
-     resolver trusts the LE-staging in-cluster Harbor on the back-to-source
-     pull. Empty when HARBOR_CA_ENABLED is off → addr-only flip (no cert line).
-    */}}
+    # #4652 — the PEM path bp-dragonfly (0.1.1) mounts the Harbor wildcard cert
+    # at on the dfdaemon (+ seed); set as proxy.registryMirror.cert so the Rust
+    # resolver trusts the LE-staging in-cluster Harbor on the back-to-source
+    # pull. Empty when HARBOR_CA_ENABLED is off → addr-only flip (no cert line).
     local_cert_path="${HARBOR_CA_MOUNT_PATH}/${HARBOR_CA_FILE_NAME}"
-    {{- /*
-     The wildcard TLS Secret name = <prefix><fqdn with '.'->'-'> (mirrors the
-     #3379 helmRepositoryTrust source-secret derivation). The registry-pivot
-     reads it from HARBOR_CA_SRC_NAMESPACE and materialises HARBOR_CA_DEST_SECRET
-     (carrying tls.crt) in the dragonfly namespace for the optional mount.
-    */}}
+    # The wildcard TLS Secret name = <prefix><fqdn with '.'->'-'> (mirrors the
+    # #3379 helmRepositoryTrust source-secret derivation). The registry-pivot
+    # reads it from HARBOR_CA_SRC_NAMESPACE and materialises HARBOR_CA_DEST_SECRET
+    # (carrying tls.crt) in the dragonfly namespace for the optional mount.
     fqdn_dashed=$(printf '%s' "${SOVEREIGN_FQDN}" | tr '.' '-')
     wildcard_secret="${HARBOR_CA_SRC_NAME_PREFIX}${fqdn_dashed}"
 
-    {{- /*
-     #4975 (Refs #3379 #3695) — PER-UPSTREAM-HOST containerd certs.d rewrite.
-
-     REPLACES the single `_default/hosts.toml` dfdaemon catch-all. Under the
-     step-08 deny-egress hold a dfdaemon back-to-source to the flipped upstream
-     only serves images the dfdaemon already fetched; a workload image that was
-     never node-cached ImagePullBackOffs. The systemic fix is a COMPLETE local
-     Harbor mirror (step-03 Phase A3 pushes every image) + per-host containerd
-     entries that resolve each upstream host DIRECTLY to the exact local path:
-       • host with project P → mirror https://<local>/v2/<P> + override_path=true
-         so a pull of `<host>/<repo>` resolves to `<local>/v2/<P>/<repo>` (the
-         Phase-A3 push dest);
-       • MOTHERSHIP host (empty project) → mirror https://<local> WITHOUT
-         override_path so the path (which already carries the proxy-<x> segment,
-         e.g. proxy-ghcr/cloudnative-pg/postgresql) is PRESERVED — a pure host
-         swap harbor.openova.io → registry.<fqdn>.
-     This OVERRIDES the boot-time per-host `harbor.openova.io` mirror k3s wrote.
-     Every entry skip_verify=true (the local Harbor serves an LE-staging /
-     node-untrusted wildcard on a fresh prov — same trust-the-cluster-network
-     rationale as #4529/#4557). The openova-io host-drop pull path is preserved
-     by the local-registry self-entry (direct pulls of registry.<fqdn>/openova-io/…).
-    */}}
+    # #4975 (Refs #3379 #3695) — PER-UPSTREAM-HOST containerd certs.d rewrite.
+    #
+    # REPLACES the single `_default/hosts.toml` dfdaemon catch-all. Under the
+    # step-08 deny-egress hold a dfdaemon back-to-source to the flipped upstream
+    # only serves images the dfdaemon already fetched; a workload image that was
+    # never node-cached ImagePullBackOffs. The systemic fix is a COMPLETE local
+    # Harbor mirror (step-03 Phase A3 pushes every image) + per-host containerd
+    # entries that resolve each upstream host DIRECTLY to the exact local path:
+    #   • host with project P → mirror https://<local>/v2/<P> + override_path=true
+    #     so a pull of `<host>/<repo>` resolves to `<local>/v2/<P>/<repo>` (the
+    #     Phase-A3 push dest);
+    #   • MOTHERSHIP host (empty project) → mirror https://<local> WITHOUT
+    #     override_path so the path (which already carries the proxy-<x> segment,
+    #     e.g. proxy-ghcr/cloudnative-pg/postgresql) is PRESERVED — a pure host
+    #     swap harbor.openova.io → registry.<fqdn>.
+    # This OVERRIDES the boot-time per-host `harbor.openova.io` mirror k3s wrote.
+    # Every entry skip_verify=true (the local Harbor serves an LE-staging /
+    # node-untrusted wildcard on a fresh prov — same trust-the-cluster-network
+    # rationale as #4529/#4557). The openova-io host-drop pull path is preserved
+    # by the local-registry self-entry (direct pulls of registry.<fqdn>/openova-io/…).
     write_offline_mirror_hosts() {
-      {{- /* Retire the legacy dfdaemon catch-all (superseded by the per-host entries). */}}
+      # Retire the legacy dfdaemon catch-all (superseded by the per-host entries).
       rm -f "${certs_d}/_default/hosts.toml" 2>/dev/null || true
-      {{- /*
-       Self-entry: trust the local Harbor's cert for DIRECT openova-io host-drop
-       pulls (registry.<fqdn>/openova-io/…), the pivoted-ref path step-06/07 set.
-      */}}
+      # Self-entry: trust the local Harbor's cert for DIRECT openova-io host-drop
+      # pulls (registry.<fqdn>/openova-io/…), the pivoted-ref path step-06/07 set.
       if [ -n "${LOCAL_REGISTRY_HOST:-}" ]; then
         mkdir -p "${certs_d}/${LOCAL_REGISTRY_HOST}"
         {
@@ -446,7 +410,7 @@ data:
         mv "${certs_d}/${LOCAL_REGISTRY_HOST}/hosts.toml.new" "${certs_d}/${LOCAL_REGISTRY_HOST}/hosts.toml"
         echo "[registry-pivot]   wrote ${LOCAL_REGISTRY_HOST}/hosts.toml (local self-trust) on ${NODE_NAME}"
       fi
-      {{- /* Per-upstream-host mirror → the local Harbor project path. */}}
+      # Per-upstream-host mirror → the local Harbor project path.
       for pair in ${HOST_PROJECT_MAP}; do
         h="${pair%%:*}"
         case "${pair}" in *:*) p="${pair#*:}" ;; *) p="" ;; esac
@@ -454,7 +418,7 @@ data:
         [ "${h}" = "${LOCAL_REGISTRY_HOST}" ] && continue
         mkdir -p "${certs_d}/${h}"
         if [ -z "${p}" ]; then
-          {{- /* Mothership host-swap: path preserved (no override_path). */}}
+          # Mothership host-swap: path preserved (no override_path).
           {
             echo "# managed by bp-self-sovereign-cutover registry-pivot (#4975) — DO NOT EDIT"
             echo "server = \"https://${h}\""
@@ -463,10 +427,8 @@ data:
             echo "  skip_verify = true"
           } > "${certs_d}/${h}/hosts.toml.new"
         else
-          {{- /*
-           Upstream host → local Harbor project (override_path so containerd
-           uses the URL path as the API root instead of appending its own /v2).
-          */}}
+          # Upstream host → local Harbor project (override_path so containerd
+          # uses the URL path as the API root instead of appending its own /v2).
           {
             echo "# managed by bp-self-sovereign-cutover registry-pivot (#4975) — DO NOT EDIT"
             echo "server = \"https://${h}\""
@@ -490,46 +452,40 @@ data:
       echo "[registry-pivot]   removed offline-mirror per-host hosts.toml (rollback) on ${NODE_NAME}"
     }
 
-    {{- /*
-     #5007 — resolve the Harbor gateway VIP WITHOUT public DNS. The per-host
-     certs.d entries above use `server = https://registry.<fqdn>`; containerd
-     resolves that host via the NODE resolver, which on hw241 returned the DEAD
-     `*.omantel.biz` wildcard IP → ImagePullBackOff. We instead pin registry.<fqdn>
-     to the gateway VIP the platform already assigned. Priority (K8s-API only, no
-     DNS): (1) the cilium-gateway `type=LoadBalancer` Service ingress IP (hcloud-ccm
-     ExternalIP on Hetzner / CiliumLoadBalancerIPPool VIP on no-CCM Huawei); (2) on
-     the hostNetwork-gateway provider (Huawei #4706 — cilium-envoy binds node:443
-     directly, so the Service has NO ingress IP / does not exist) the node's OWN IP,
-     which serves :443 locally. Echoes the VIP or empty (empty ONLY when the Service
-     EXISTS but its VIP is still pending, or on a transient API miss → caller defers
-     + retries; a 404 means hostNetwork → HOST_IP). Word-split $CT is intentional.
-    */}}
+    # #5007 — resolve the Harbor gateway VIP WITHOUT public DNS. The per-host
+    # certs.d entries above use `server = https://registry.<fqdn>`; containerd
+    # resolves that host via the NODE resolver, which on hw241 returned the DEAD
+    # `*.omantel.biz` wildcard IP → ImagePullBackOff. We instead pin registry.<fqdn>
+    # to the gateway VIP the platform already assigned. Priority (K8s-API only, no
+    # DNS): (1) the cilium-gateway `type=LoadBalancer` Service ingress IP (hcloud-ccm
+    # ExternalIP on Hetzner / CiliumLoadBalancerIPPool VIP on no-CCM Huawei); (2) on
+    # the hostNetwork-gateway provider (Huawei #4706 — cilium-envoy binds node:443
+    # directly, so the Service has NO ingress IP / does not exist) the node's OWN IP,
+    # which serves :443 locally. Echoes the VIP or empty (empty ONLY when the Service
+    # EXISTS but its VIP is still pending, or on a transient API miss → caller defers
+    # + retries; a 404 means hostNetwork → HOST_IP). Word-split $CT is intentional.
     resolve_gateway_vip() {
-      {{- /* No LB Service configured → hostNetwork gateway model: node's own IP serves :443. */}}
+      # No LB Service configured → hostNetwork gateway model: node's own IP serves :443.
       if [ -z "${GATEWAY_LB_SVC_NAME:-}" ]; then printf '%s' "${HOST_IP:-}"; return; fi
       svc_url="${api}/api/v1/namespaces/${GATEWAY_LB_SVC_NAMESPACE}/services/${GATEWAY_LB_SVC_NAME}"
-      {{- /*
-       -w appends the HTTP status on its own trailing line (NOT -f, so a 404 body is
-       readable to distinguish "absent → hostNetwork" from "present but VIP pending").
-      */}}
+      # -w appends the HTTP status on its own trailing line (NOT -f, so a 404 body is
+      # readable to distinguish "absent → hostNetwork" from "present but VIP pending").
       resp=$(curl -sS ${CT} --cacert "${cacert}" -H "Authorization: Bearer ${token}" \
         -w '\n%{http_code}' "${svc_url}" 2>/dev/null || true)
       code=$(printf '%s' "${resp}" | tail -n1)
       json=$(printf '%s' "${resp}" | sed '$d')
       case "${code}" in
         200)
-          {{- /*
-           Service present. Split on .spec.type (#5007 round 2, hw250 live):
-           - LoadBalancer: use its ingress VIP (or spec.loadBalancerIP); empty =
-             VIP pending → caller defers (do NOT fall back to HOST_IP: in the LB
-             model node:443 is NOT served by envoy).
-           - ClusterIP (the §854 ELB-direct model keeps the gateway Service but
-             cilium assigns NO VIP EVER): hostNetwork envoy serves node:443 —
-             identical serving shape to the 404/absent branch — so pin HOST_IP.
-             Without this split the pin DEFERRED FOREVER on every ELB-direct
-             prov (hw250: 'LB VIP pending / API miss' on all sweeps all night),
-             leaving nodes exposed to the #5007 stale-wildcard defect.
-          */}}
+          # Service present. Split on .spec.type (#5007 round 2, hw250 live):
+          # - LoadBalancer: use its ingress VIP (or spec.loadBalancerIP); empty =
+          #   VIP pending → caller defers (do NOT fall back to HOST_IP: in the LB
+          #   model node:443 is NOT served by envoy).
+          # - ClusterIP (the §854 ELB-direct model keeps the gateway Service but
+          #   cilium assigns NO VIP EVER): hostNetwork envoy serves node:443 —
+          #   identical serving shape to the 404/absent branch — so pin HOST_IP.
+          #   Without this split the pin DEFERRED FOREVER on every ELB-direct
+          #   prov (hw250: 'LB VIP pending / API miss' on all sweeps all night),
+          #   leaving nodes exposed to the #5007 stale-wildcard defect.
           svc_type=$(printf '%s' "${json}" | jq -r '.spec.type // empty' 2>/dev/null || true)
           if [ "${svc_type}" = "LoadBalancer" ]; then
             printf '%s' "$(printf '%s' "${json}" | jq -r '.status.loadBalancer.ingress[0].ip // .spec.loadBalancerIP // empty' 2>/dev/null || true)"
@@ -538,23 +494,21 @@ data:
           fi
           ;;
         404)
-          {{- /* Service absent → hostNetwork gateway model: cilium-envoy binds node:443. */}}
+          # Service absent → hostNetwork gateway model: cilium-envoy binds node:443.
           printf '%s' "${HOST_IP:-}"
           ;;
         *)
-          {{- /* Transient (000 / 5xx / 401) → empty so the caller defers + retries. */}}
+          # Transient (000 / 5xx / 401) → empty so the caller defers + retries.
           printf '%s' ""
           ;;
       esac
     }
 
-    {{- /*
-     #5007 — write/refresh the managed `<VIP> registry.<fqdn>` line in the node's
-     /etc/hosts, stripping ANY prior line for that host (a cloud-init r4() boot pin
-     that may have baked the dead wildcard IP, or a stale managed line). In-place
-     truncate-rewrite (NOT mv) so the single-file bind mount inode is preserved.
-     Idempotent (grep -qxF no-op once pinned). Fail-OPEN on any error.
-    */}}
+    # #5007 — write/refresh the managed `<VIP> registry.<fqdn>` line in the node's
+    # /etc/hosts, stripping ANY prior line for that host (a cloud-init r4() boot pin
+    # that may have baked the dead wildcard IP, or a stale managed line). In-place
+    # truncate-rewrite (NOT mv) so the single-file bind mount inode is preserved.
+    # Idempotent (grep -qxF no-op once pinned). Fail-OPEN on any error.
     write_local_registry_pin() {
       case "${LOCAL_REGISTRY_PIN_ENABLED}" in
         true|True|TRUE|1|yes) : ;;
@@ -569,10 +523,8 @@ data:
       fi
       want="${vip} ${LOCAL_REGISTRY_HOST} ${pin_marker}"
       grep -qxF "${want}" "${etc_hosts}" 2>/dev/null && return 0
-      {{- /*
-       Strip EVERY existing line whose host field == LOCAL_REGISTRY_HOST (any IP,
-       managed or the cloud-init boot pin), then append the authoritative pin.
-      */}}
+      # Strip EVERY existing line whose host field == LOCAL_REGISTRY_HOST (any IP,
+      # managed or the cloud-init boot pin), then append the authoritative pin.
       kept=$(awk -v h="${LOCAL_REGISTRY_HOST}" '{
         drop=0
         for (i=2; i<=NF; i++) if ($i==h) { drop=1; break }
@@ -583,10 +535,8 @@ data:
         || echo "[registry-pivot]   WARN failed to write ${etc_hosts} pin on ${NODE_NAME} (will retry next sweep)"
     }
 
-    {{- /*
-     #5007 — rollback: drop the managed pin line so registry.<fqdn> reverts to the
-     node's pre-pivot DNS resolution. In-place truncate-rewrite; idempotent.
-    */}}
+    # #5007 — rollback: drop the managed pin line so registry.<fqdn> reverts to the
+    # node's pre-pivot DNS resolution. In-place truncate-rewrite; idempotent.
     remove_local_registry_pin() {
       [ -f "${etc_hosts}" ] || return 0
       grep -qF "${pin_marker}" "${etc_hosts}" 2>/dev/null || return 0
@@ -595,18 +545,16 @@ data:
         && echo "[registry-pivot]   removed ${LOCAL_REGISTRY_HOST} /etc/hosts pin (rollback) on ${NODE_NAME}"
     }
 
-    {{- /*
-     #4652 (the x509 fix) — materialise the in-cluster Harbor trust anchor in
-     the dragonfly namespace. Reads the wildcard TLS Secret from
-     HARBOR_CA_SRC_NAMESPACE (kube-system) and creates/updates an Opaque Secret
-     HARBOR_CA_DEST_SECRET in DF_NAMESPACE carrying `tls.crt`. bp-dragonfly
-     (0.1.1) mounts that Secret OPTIONALLY at HARBOR_CA_MOUNT_PATH, so once it
-     exists the dfdaemon (+ seed) carry the PEM the registryMirror.cert line
-     points at. Same tls.crt-fallback as #3379 (the wildcard Secret carries
-     tls.crt+tls.key, NO ca.crt → tls.crt is the real trust bundle). Opaque
-     (NOT kubernetes.io/tls): only tls.crt is copied; the private key is NEVER
-     carried into dragonfly. Returns 0 when the dest Secret carries the cert.
-    */}}
+    # #4652 (the x509 fix) — materialise the in-cluster Harbor trust anchor in
+    # the dragonfly namespace. Reads the wildcard TLS Secret from
+    # HARBOR_CA_SRC_NAMESPACE (kube-system) and creates/updates an Opaque Secret
+    # HARBOR_CA_DEST_SECRET in DF_NAMESPACE carrying `tls.crt`. bp-dragonfly
+    # (0.1.1) mounts that Secret OPTIONALLY at HARBOR_CA_MOUNT_PATH, so once it
+    # exists the dfdaemon (+ seed) carry the PEM the registryMirror.cert line
+    # points at. Same tls.crt-fallback as #3379 (the wildcard Secret carries
+    # tls.crt+tls.key, NO ca.crt → tls.crt is the real trust bundle). Opaque
+    # (NOT kubernetes.io/tls): only tls.crt is copied; the private key is NEVER
+    # carried into dragonfly. Returns 0 when the dest Secret carries the cert.
     src_secret_url="${api}/api/v1/namespaces/${HARBOR_CA_SRC_NAMESPACE}/secrets/${wildcard_secret}"
     dst_secret_url="${api}/api/v1/namespaces/${DF_NAMESPACE}/secrets/${HARBOR_CA_DEST_SECRET}"
     harbor_ca_to_dragonfly_ns() {
@@ -614,24 +562,20 @@ data:
         true|True|TRUE|1|yes) : ;;
         *) return 0 ;;
       esac
-      {{- /*
-       Prefer the issuing CA (ca.crt); fall back to the served leaf+chain
-       (tls.crt) — the wildcard Secret typically has NO ca.crt, so tls.crt is
-       the path that actually fires (the #3379 finding). base64 (.data.*) is
-       copied verbatim into the dest Secret's .data so no re-encode is needed.
-      */}}
+      # Prefer the issuing CA (ca.crt); fall back to the served leaf+chain
+      # (tls.crt) — the wildcard Secret typically has NO ca.crt, so tls.crt is
+      # the path that actually fires (the #3379 finding). base64 (.data.*) is
+      # copied verbatim into the dest Secret's .data so no re-encode is needed.
       ca_b64=$(curl -fsS ${CT} --cacert "${cacert}" -H "Authorization: Bearer ${token}" "${src_secret_url}" 2>/dev/null \
         | jq -r '.data["ca.crt"] // .data["tls.crt"] // empty' 2>/dev/null || true)
       if [ -z "${ca_b64}" ]; then
         echo "[registry-pivot]   WARN ${HARBOR_CA_SRC_NAMESPACE}/${wildcard_secret} has no ca.crt/tls.crt; deferring dfdaemon cert (registryMirror.cert will be skipped this sweep)"
         return 1
       fi
-      {{- /*
-       PUT the cert under the `tls.crt` key (the file bp-dragonfly mounts is
-       <path>/tls.crt). Idempotent create-or-update: read the dest, if its
-       tls.crt already matches we skip; else apply via server-side apply
-       (kubectl-less: a strategic create falls back to a merge-patch on 409).
-      */}}
+      # PUT the cert under the `tls.crt` key (the file bp-dragonfly mounts is
+      # <path>/tls.crt). Idempotent create-or-update: read the dest, if its
+      # tls.crt already matches we skip; else apply via server-side apply
+      # (kubectl-less: a strategic create falls back to a merge-patch on 409).
       cur_b64=$(curl -fsS ${CT} --cacert "${cacert}" -H "Authorization: Bearer ${token}" "${dst_secret_url}" 2>/dev/null \
         | jq -r '.data["tls.crt"] // empty' 2>/dev/null || true)
       if [ "${cur_b64}" = "${ca_b64}" ]; then
@@ -646,7 +590,7 @@ data:
         echo "[registry-pivot]   created ${DF_NAMESPACE}/${HARBOR_CA_DEST_SECRET} (Harbor trust anchor for dfdaemon)"
         return 0
       fi
-      {{- /* Already exists → merge-patch the data in place. */}}
+      # Already exists → merge-patch the data in place.
       patch=$(jq -cn --arg c "${ca_b64}" '{data:{"tls.crt":$c}}')
       if curl -fsS ${CT} -X PATCH --cacert "${cacert}" -H "Authorization: Bearer ${token}" \
           -H "Content-Type: application/merge-patch+json" --data "${patch}" "${dst_secret_url}" >/dev/null 2>&1; then
@@ -660,27 +604,25 @@ data:
       curl -fsS ${CT} -X DELETE --cacert "${cacert}" -H "Authorization: Bearer ${token}" "${dst_secret_url}" >/dev/null 2>&1 || true
     }
 
-    {{- /*
-     Patch a dfdaemon-family ConfigMap's dfdaemon.yaml registryMirror.addr to
-     ${2}, and (when ${3} is non-empty) ensure a sibling registryMirror.cert:
-     ${3} (the PEM trust anchor for the LE-staging in-cluster Harbor, #4652).
-     The config is a single YAML string under data."dfdaemon.yaml"; we read it,
-     rewrite ONLY the registryMirror addr/cert lines, and merge-patch it back.
-     Idempotent. SCOPING IS LOAD-BEARING: the dfdaemon.yaml carries MULTIPLE
-     `addr:` keys — `manager.addr: http://dragonfly-manager…:65003` (the gRPC
-     control-plane the dfdaemon health-checks at boot) AND
-     `proxy.registryMirror.addr` (the registry upstream we flip). A blanket
-     `sed s/addr: …/` would ALSO rewrite the manager addr → dfdaemon
-     ConnectError on startup → CrashLoopBackOff (caught live on the kom4dc
-     seed-client). So the awk rewrites addr/cert ONLY while inside a
-     `registryMirror:` block (set the in-block flag on a line ending in
-     `registryMirror:`; clear it when indentation returns to <= the
-     registryMirror key's indent). The `cert:` line is emitted at the SAME
-     indent as `addr` (a sibling under registryMirror) — updated in place if it
-     already exists in-block, else inserted right after the addr line; cleared
-     on rollback (want_cert empty). want_addr / want_cert are passed via -v (no
-     shell interpolation into the awk program → metacharacter-safe).
-    */}}
+    # Patch a dfdaemon-family ConfigMap's dfdaemon.yaml registryMirror.addr to
+    # ${2}, and (when ${3} is non-empty) ensure a sibling registryMirror.cert:
+    # ${3} (the PEM trust anchor for the LE-staging in-cluster Harbor, #4652).
+    # The config is a single YAML string under data."dfdaemon.yaml"; we read it,
+    # rewrite ONLY the registryMirror addr/cert lines, and merge-patch it back.
+    # Idempotent. SCOPING IS LOAD-BEARING: the dfdaemon.yaml carries MULTIPLE
+    # `addr:` keys — `manager.addr: http://dragonfly-manager…:65003` (the gRPC
+    # control-plane the dfdaemon health-checks at boot) AND
+    # `proxy.registryMirror.addr` (the registry upstream we flip). A blanket
+    # `sed s/addr: …/` would ALSO rewrite the manager addr → dfdaemon
+    # ConnectError on startup → CrashLoopBackOff (caught live on the kom4dc
+    # seed-client). So the awk rewrites addr/cert ONLY while inside a
+    # `registryMirror:` block (set the in-block flag on a line ending in
+    # `registryMirror:`; clear it when indentation returns to <= the
+    # registryMirror key's indent). The `cert:` line is emitted at the SAME
+    # indent as `addr` (a sibling under registryMirror) — updated in place if it
+    # already exists in-block, else inserted right after the addr line; cleared
+    # on rollback (want_cert empty). want_addr / want_cert are passed via -v (no
+    # shell interpolation into the awk program → metacharacter-safe).
     patch_df_configmap_addr() {
       cm_name="$1"; want_addr="$2"; want_cert="${3:-}"
       url="${api}/api/v1/namespaces/${DF_NAMESPACE}/configmaps/${cm_name}"
@@ -688,18 +630,16 @@ data:
         | jq -r '.data["dfdaemon.yaml"] // empty' 2>/dev/null || true)
       [ -z "${cur}" ] && { echo "[registry-pivot]   WARN ${cm_name} dfdaemon.yaml unreadable; deferring upstream flip"; return 1; }
       new=$(printf '%s' "${cur}" | awk -v want="${want_addr}" -v cert="${want_cert}" '
-        {{- /* compute leading-space count of a line */}}
+        # compute leading-space count of a line
         function indent(s,   n){ n=0; while (substr(s,n+1,1)==" ") n++; return n }
         {
           if ($0 ~ /registryMirror:[[:space:]]*$/) { inblk=1; blkind=indent($0); print; next }
           if (inblk) {
             ci=indent($0)
-            {{- /*
-             a non-blank line at indent <= the registryMirror key ends the
-             block. Before leaving, if we owe a cert line and never saw one,
-             emit it now at the addr indent we recorded (insert before the line
-             that closes the block).
-            */}}
+            # a non-blank line at indent <= the registryMirror key ends the
+            # block. Before leaving, if we owe a cert line and never saw one,
+            # emit it now at the addr indent we recorded (insert before the line
+            # that closes the block).
             if ($0 ~ /[^[:space:]]/ && ci <= blkind) {
               if (cert != "" && !cert_done && addrind != "") {
                 printf "%*scert: %s\n", addrind, "", cert
@@ -708,10 +648,8 @@ data:
               inblk=0
             }
           }
-          {{- /*
-           In-block existing cert line: update it in place (want set) or drop it
-           (rollback, want_cert empty) — do NOT print the stale/cleared line.
-          */}}
+          # In-block existing cert line: update it in place (want set) or drop it
+          # (rollback, want_cert empty) — do NOT print the stale/cleared line.
           if (inblk && $0 ~ /^[[:space:]]*cert:[[:space:]]*/) {
             if (cert != "" && !cert_done) {
               printf "%*scert: %s\n", indent($0), "", cert
@@ -723,7 +661,7 @@ data:
             addrind=indent($0)
             sub(/addr:[[:space:]]*https?:\/\/[^[:space:]]+/, "addr: " want)
             print
-            {{- /* Insert the cert sibling right after addr if not already emitted. */}}
+            # Insert the cert sibling right after addr if not already emitted.
             if (cert != "" && !cert_done) {
               printf "%*scert: %s\n", addrind, "", cert
               cert_done=1
@@ -733,10 +671,8 @@ data:
           print
         }
         END {
-          {{- /*
-           Block ran to EOF still open and we owe a cert line (registryMirror
-           was the last block in the doc): emit it at the recorded addr indent.
-          */}}
+          # Block ran to EOF still open and we owe a cert line (registryMirror
+          # was the last block in the doc): emit it at the recorded addr indent.
           if (inblk && cert != "" && !cert_done && addrind != "")
             printf "%*scert: %s\n", addrind, "", cert
         }')
@@ -751,12 +687,10 @@ data:
       return 1
     }
 
-    {{- /*
-     Roll dfdaemon (+ seed) so they reload the flipped upstream. This is the
-     explicit nudge for the addr-only ConfigMap change and is gated by
-     DF_RESTART_ON_FLIP. Uses the restartedAt annotation (kubectl rollout
-     restart equivalent) via a strategic-merge patch.
-    */}}
+    # Roll dfdaemon (+ seed) so they reload the flipped upstream. This is the
+    # explicit nudge for the addr-only ConfigMap change and is gated by
+    # DF_RESTART_ON_FLIP. Uses the restartedAt annotation (kubectl rollout
+    # restart equivalent) via a strategic-merge patch.
     restart_workload() {
       kind="$1"; name="$2"
       [ "${DF_RESTART_ON_FLIP}" = "true" ] || return 0
@@ -770,13 +704,11 @@ data:
         || echo "[registry-pivot]   WARN failed to roll ${kind}/${name}"
     }
 
-    {{- /*
-     The cluster-wide dfdaemon upstream flip — performed ONCE.
-     The status key dragonflyUpstream=local is the cluster-scope guard: the
-     first node to converge sets it; the rest skip. Returns 0 only when the
-     full flip (both ConfigMaps) succeeded so the guard is set; a partial
-     failure leaves the guard unset → a later sweep retries.
-    */}}
+    # The cluster-wide dfdaemon upstream flip — performed ONCE.
+    # The status key dragonflyUpstream=local is the cluster-scope guard: the
+    # first node to converge sets it; the rest skip. Returns 0 only when the
+    # full flip (both ConfigMaps) succeeded so the guard is set; a partial
+    # failure leaves the guard unset → a later sweep retries.
     cm_patch_status() {
       key="$1"; val="$2"
       p=$(jq -cn --arg k "${key}" --arg v "${val}" '{data: {($k): $v}}')
@@ -791,12 +723,10 @@ data:
       fi
       echo "[registry-pivot]   flipping dfdaemon upstream -> ${local_upstream} (external host, :443) on ${NODE_NAME}"
       ok=0
-      {{- /*
-       #4652 (x509 fix): materialise the Harbor trust anchor in the dragonfly
-       namespace; ONLY then set registryMirror.cert (so we never point the
-       dfdaemon at a non-existent PEM). If the CA cannot be materialised this
-       sweep, flip addr-only and defer the cert to a later sweep.
-      */}}
+      # #4652 (x509 fix): materialise the Harbor trust anchor in the dragonfly
+      # namespace; ONLY then set registryMirror.cert (so we never point the
+      # dfdaemon at a non-existent PEM). If the CA cannot be materialised this
+      # sweep, flip addr-only and defer the cert to a later sweep.
       cert_arg=""
       if harbor_ca_to_dragonfly_ns; then
         cert_arg="${local_cert_path}"
@@ -816,7 +746,7 @@ data:
       return 1
     }
     df_revert_to_ghcr() {
-      {{- /* Rollback clears the cert (empty 3rd arg) along with the addr. */}}
+      # Rollback clears the cert (empty 3rd arg) along with the addr.
       patch_df_configmap_addr "${DF_CLIENT_CONFIGMAP}" "https://ghcr.io" "" || true
       if [ -n "${DF_SEED_CONFIGMAP}" ]; then
         patch_df_configmap_addr "${DF_SEED_CONFIGMAP}" "https://ghcr.io" "" || true
@@ -825,43 +755,39 @@ data:
       cm_patch_status dragonflyUpstream ghcr
     }
 
-    {{- /*
-     #4637 — the step-07 catalyst-api re-pull GATE. The _default/hosts.toml
-     catch-all points this node's containerd at the node-local dfdaemon proxy
-     http://127.0.0.1:${DF_PROXY_PORT}; the dfdaemon is what actually serves
-     the registry.<fqdn>/openova-io/openova/catalyst-api blob (back-to-source
-     to its flipped registryMirror.addr). But the dfdaemon DaemonSet
-     (dragonfly-client) is a SEPARATE workload — if it has 0 Ready pods on this
-     node (the live #4649 Kyverno-readOnlyRootFilesystem DENY → DESIRED=N
-     CURRENT=0), the mirror endpoint is dead and a containerd pull through it
-     gets `dial tcp 127.0.0.1:${DF_PROXY_PORT}: connect: connection refused`.
-     Writing the v2 node-ack while the proxy is dead lets catalyst-api's
-     daemonset-wait green PREMATURELY → step-07 fires the catalyst-api HR
-     image roll → ImagePullBackOff → cutover wedges at 54% (the exact #4637
-     leg). So probe the LOCAL dfdaemon's registry endpoint BEFORE acking v2:
-     a reachable proxy answers /v2/ with an HTTP status (200 or a 401/403/404
-     registry challenge — ANY HTTP response proves the listener is up, no body
-     parse needed). A connection-refused/timeout returns no status → not yet
-     serving → defer the ack so the daemonset-wait keeps blocking until the
-     node mirror is genuinely live (idempotent; retried each 15s sweep).
-    */}}
+    # #4637 — the step-07 catalyst-api re-pull GATE. The _default/hosts.toml
+    # catch-all points this node's containerd at the node-local dfdaemon proxy
+    # http://127.0.0.1:${DF_PROXY_PORT}; the dfdaemon is what actually serves
+    # the registry.<fqdn>/openova-io/openova/catalyst-api blob (back-to-source
+    # to its flipped registryMirror.addr). But the dfdaemon DaemonSet
+    # (dragonfly-client) is a SEPARATE workload — if it has 0 Ready pods on this
+    # node (the live #4649 Kyverno-readOnlyRootFilesystem DENY → DESIRED=N
+    # CURRENT=0), the mirror endpoint is dead and a containerd pull through it
+    # gets `dial tcp 127.0.0.1:${DF_PROXY_PORT}: connect: connection refused`.
+    # Writing the v2 node-ack while the proxy is dead lets catalyst-api's
+    # daemonset-wait green PREMATURELY → step-07 fires the catalyst-api HR
+    # image roll → ImagePullBackOff → cutover wedges at 54% (the exact #4637
+    # leg). So probe the LOCAL dfdaemon's registry endpoint BEFORE acking v2:
+    # a reachable proxy answers /v2/ with an HTTP status (200 or a 401/403/404
+    # registry challenge — ANY HTTP response proves the listener is up, no body
+    # parse needed). A connection-refused/timeout returns no status → not yet
+    # serving → defer the ack so the daemonset-wait keeps blocking until the
+    # node mirror is genuinely live (idempotent; retried each 15s sweep).
     dfdaemon_serving() {
-      {{- /*
-       curl's -w '%{http_code}' prints the response status, or `000` when the
-       connection failed (refused/timeout) — and on a dead port curl ALSO exits
-       non-zero, so do NOT chain `|| echo 000` (that would append a SECOND 000 →
-       `000000`, which is not the literal `000` we test for → a false "serving"
-       verdict). `|| true` keeps `set -u`-safe without corrupting the code. A
-       REAL HTTP response is a 3-digit code whose leading digit is 1-5 (200, or
-       a 401/403/404 registry challenge — ANY proves the listener is up, no body
-       parse needed); `000` / empty / anything else = not serving → defer.
-       Probe the NODE's dfdaemon via HOST_IP, not 127.0.0.1 (#4637 follow-up):
-       this pod is NOT hostNetwork, so its loopback never reaches the node's
-       hostNetwork dfdaemon — a 127.0.0.1 probe ALWAYS reads 000 and defers
-       forever, wedging step-04. The dfdaemon binds 0.0.0.0:${DF_PROXY_PORT} so
-       HOST_IP is reachable. (containerd still pulls via 127.0.0.1 in the NODE
-       netns — correct + unchanged.) Fall back to 127.0.0.1 if HOST_IP is unset.
-      */}}
+      # curl's -w '%{http_code}' prints the response status, or `000` when the
+      # connection failed (refused/timeout) — and on a dead port curl ALSO exits
+      # non-zero, so do NOT chain `|| echo 000` (that would append a SECOND 000 →
+      # `000000`, which is not the literal `000` we test for → a false "serving"
+      # verdict). `|| true` keeps `set -u`-safe without corrupting the code. A
+      # REAL HTTP response is a 3-digit code whose leading digit is 1-5 (200, or
+      # a 401/403/404 registry challenge — ANY proves the listener is up, no body
+      # parse needed); `000` / empty / anything else = not serving → defer.
+      # Probe the NODE's dfdaemon via HOST_IP, not 127.0.0.1 (#4637 follow-up):
+      # this pod is NOT hostNetwork, so its loopback never reaches the node's
+      # hostNetwork dfdaemon — a 127.0.0.1 probe ALWAYS reads 000 and defers
+      # forever, wedging step-04. The dfdaemon binds 0.0.0.0:${DF_PROXY_PORT} so
+      # HOST_IP is reachable. (containerd still pulls via 127.0.0.1 in the NODE
+      # netns — correct + unchanged.) Fall back to 127.0.0.1 if HOST_IP is unset.
       probe_host="${HOST_IP:-127.0.0.1}"
       code=$(curl -s -o /dev/null -w '%{http_code}' ${CT} \
         "http://${probe_host}:${DF_PROXY_PORT}/v2/" 2>/dev/null || true)
@@ -871,17 +797,15 @@ data:
       esac
     }
 
-    {{- /*
-     #4975 — the step-07 catalyst-api re-pull GATE for the DIRECT path. Post
-     #4975 containerd resolves each upstream host DIRECTLY to the local Harbor
-     (registry.<fqdn>), NOT through the node-local dfdaemon, so the ack gate is
-     "is the LOCAL Harbor serving /v2/" — not "is dfdaemon serving". Probe the
-     local Harbor external host over :443 (reachable in-cluster via the gateway
-     LB hairpin, #4682; -k tolerates the LE-staging wildcard). ANY HTTP status
-     (200 or a 401/403/404 registry challenge) proves the listener is up; a
-     connection-refused/timeout returns 000 → defer the v2 ack so the
-     daemonset-wait keeps blocking until the local registry answers.
-    */}}
+    # #4975 — the step-07 catalyst-api re-pull GATE for the DIRECT path. Post
+    # #4975 containerd resolves each upstream host DIRECTLY to the local Harbor
+    # (registry.<fqdn>), NOT through the node-local dfdaemon, so the ack gate is
+    # "is the LOCAL Harbor serving /v2/" — not "is dfdaemon serving". Probe the
+    # local Harbor external host over :443 (reachable in-cluster via the gateway
+    # LB hairpin, #4682; -k tolerates the LE-staging wildcard). ANY HTTP status
+    # (200 or a 401/403/404 registry challenge) proves the listener is up; a
+    # connection-refused/timeout returns 000 → defer the v2 ack so the
+    # daemonset-wait keeps blocking until the local registry answers.
     local_registry_serving() {
       code=$(curl -s -o /dev/null -w '%{http_code}' ${CT} -k \
         "https://${LOCAL_REGISTRY_HOST}/v2/" 2>/dev/null || true)
@@ -891,11 +815,9 @@ data:
       esac
     }
 
-    {{- /*
-     #3671: per-node ack the daemonset-wait counts (proves EVERY node swapped
-     its containerd to the dfdaemon mirror, not merely that the DS Pods are
-     Ready). Key node.<NODE>.registriesYaml. Best-effort; retried each sweep.
-    */}}
+    # #3671: per-node ack the daemonset-wait counts (proves EVERY node swapped
+    # its containerd to the dfdaemon mirror, not merely that the DS Pods are
+    # Ready). Key node.<NODE>.registriesYaml. Best-effort; retried each sweep.
     write_node_ack() {
       ack_val="$1"
       ack_key="node.${NODE_NAME}.registriesYaml"
@@ -910,25 +832,19 @@ data:
       desired="$1"
       case "${desired}" in
         v2)
-          {{- /*
-           #4975 — per-node: write the PER-UPSTREAM-HOST containerd certs.d
-           entries that resolve each upstream DIRECTLY to the local Harbor.
-          */}}
+          # #4975 — per-node: write the PER-UPSTREAM-HOST containerd certs.d
+          # entries that resolve each upstream DIRECTLY to the local Harbor.
           write_offline_mirror_hosts
-          {{- /*
-           Cluster-wide (guarded): flip the dfdaemon upstream to the local
-           Harbor too — BEST-EFFORT residual cover for any pull that still
-           transits dfdaemon (e.g. a host bp-dragonfly dfinit mirrored that
-           our per-host entries did not override). Not on the critical path.
-          */}}
+          # Cluster-wide (guarded): flip the dfdaemon upstream to the local
+          # Harbor too — BEST-EFFORT residual cover for any pull that still
+          # transits dfdaemon (e.g. a host bp-dragonfly dfinit mirrored that
+          # our per-host entries did not override). Not on the critical path.
           df_flip_to_local || true
-          {{- /*
-           #4975 — ack v2 ONLY once the LOCAL Harbor is actually serving /v2/
-           (the DIRECT path containerd now uses). Acking while registry.<fqdn>
-           is unreachable would green the daemonset-wait → step-07 catalyst-api
-           pull fails. Defer (no ack) so the wait keeps blocking; the reconcile
-           loop re-probes every sweep (see the v2-ack retry guard).
-          */}}
+          # #4975 — ack v2 ONLY once the LOCAL Harbor is actually serving /v2/
+          # (the DIRECT path containerd now uses). Acking while registry.<fqdn>
+          # is unreachable would green the daemonset-wait → step-07 catalyst-api
+          # pull fails. Defer (no ack) so the wait keeps blocking; the reconcile
+          # loop re-probes every sweep (see the v2-ack retry guard).
           if local_registry_serving; then
             write_node_ack v2
           else
@@ -950,22 +866,18 @@ data:
         || echo "v1")
       desired=${desired:-v1}
 
-      {{- /*
-       #5007 — reconcile the local-registry /etc/hosts pin every sweep while v2 is
-       desired (idempotent; self-heals a node whose /etc/hosts was rewritten, and
-       completes the pin once the gateway VIP is assigned after the first v2 sweep
-       — a fast grep no-op once pinned). On v1/rollback apply_state removes it.
-      */}}
+      # #5007 — reconcile the local-registry /etc/hosts pin every sweep while v2 is
+      # desired (idempotent; self-heals a node whose /etc/hosts was rewritten, and
+      # completes the pin once the gateway VIP is assigned after the first v2 sweep
+      # — a fast grep no-op once pinned). On v1/rollback apply_state removes it.
       [ "${desired}" = "v2" ] && write_local_registry_pin
 
-      {{- /*
-       #4639 — re-apply v2 if the cluster-wide dfdaemon flip has not yet been
-       confirmed (guard dragonflyUpstream != local). apply_state fires only
-       ONCE per state, so if the upstream flip (e.g. the Harbor CA anchor or a
-       ConfigMap patch) missed on the first v2 sweep it would be skipped
-       forever. This retries the flip on a later sweep WITHOUT re-applying every
-       tick once converged.
-      */}}
+      # #4639 — re-apply v2 if the cluster-wide dfdaemon flip has not yet been
+      # confirmed (guard dragonflyUpstream != local). apply_state fires only
+      # ONCE per state, so if the upstream flip (e.g. the Harbor CA anchor or a
+      # ConfigMap patch) missed on the first v2 sweep it would be skipped
+      # forever. This retries the flip on a later sweep WITHOUT re-applying every
+      # tick once converged.
       needs_flip_retry=0
       if [ "${desired}" = "v2" ] && [ "${desired}" = "${last_state}" ]; then
         cur_up=$(curl -fsS ${CT} --cacert "${cacert}" -H "Authorization: Bearer ${token}" "${cm_url}" 2>/dev/null \
@@ -973,17 +885,15 @@ data:
         [ "${cur_up}" != "local" ] && needs_flip_retry=1
       fi
 
-      {{- /*
-       #4637 — re-apply v2 if THIS node's v2 ack is still missing (its local
-       dfdaemon was not serving on the first sweep — the live #4649 condition).
-       The cluster-wide flip (needs_flip_retry) may already be `local`, so that
-       guard would NOT re-fire apply_state; without this a node whose dfdaemon
-       came up late never re-probes/re-acks → its node.<NODE>.registriesYaml
-       stays absent → catalyst-api's per-node-ack wait never reaches
-       acks==desired → the cutover stalls at step-04 instead of greening once
-       the mirror is live. Cheap (one CM GET) and self-limiting (stops the
-       instant the ack lands).
-      */}}
+      # #4637 — re-apply v2 if THIS node's v2 ack is still missing (its local
+      # dfdaemon was not serving on the first sweep — the live #4649 condition).
+      # The cluster-wide flip (needs_flip_retry) may already be `local`, so that
+      # guard would NOT re-fire apply_state; without this a node whose dfdaemon
+      # came up late never re-probes/re-acks → its node.<NODE>.registriesYaml
+      # stays absent → catalyst-api's per-node-ack wait never reaches
+      # acks==desired → the cutover stalls at step-04 instead of greening once
+      # the mirror is live. Cheap (one CM GET) and self-limiting (stops the
+      # instant the ack lands).
       needs_ack_retry=0
       if [ "${desired}" = "v2" ] && [ "${desired}" = "${last_state}" ] && [ "${needs_flip_retry}" = "0" ]; then
         my_ack=$(curl -fsS ${CT} --cacert "${cacert}" -H "Authorization: Bearer ${token}" "${cm_url}" 2>/dev/null \
@@ -1001,7 +911,7 @@ data:
         fi
         apply_state "${desired}"
         last_state="${desired}"
-        {{- /* Mark Pod ready after the first successful sync. */}}
+        # Mark Pod ready after the first successful sync.
         touch /tmp/ready
       fi
 

--- a/platform/self-sovereign-cutover/chart/templates/05-flux-gitrepository-patch-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/05-flux-gitrepository-patch-job.yaml
@@ -97,18 +97,22 @@ data:
             value: {{ printf "%s/%s/%s" .Values.sovereign.giteaInternalURL .Values.gitea.org .Values.gitea.repo | quote }}
           - name: BRANCH
             value: {{ .Values.upstream.branch | quote }}
-          # Issue #891 — the GitRepository ignore filter must be widened to
-          # include the Sovereign's own clusters/<sov-fqdn>/ subtree, or
-          # source-controller filters out every Sovereign-specific manifest
-          # (incl. Organization tenant overlays at clusters/<sov-fqdn>/org-tenants/
-          # <tenant-id>/) and Flux Kustomizations downstream all hit
-          # "kustomization path not found".
+          {{- /*
+           Issue #891 — the GitRepository ignore filter must be widened to
+           include the Sovereign's own clusters/<sov-fqdn>/ subtree, or
+           source-controller filters out every Sovereign-specific manifest
+           (incl. Organization tenant overlays at clusters/<sov-fqdn>/org-tenants/
+           <tenant-id>/) and Flux Kustomizations downstream all hit
+           "kustomization path not found".
+          */}}
           - name: SOVEREIGN_FQDN
             value: {{ .Values.sovereign.fqdn | quote }}
-          # #3536 — secretRef wiring inputs. The destination basic-auth
-          # Secret is created in the GitRepository's namespace; the source
-          # PAT (`catalyst-gitea-token`) is read from catalyst-system where
-          # bp-catalyst-platform's pre-install hook minted it at bootstrap.
+          {{- /*
+           #3536 — secretRef wiring inputs. The destination basic-auth
+           Secret is created in the GitRepository's namespace; the source
+           PAT (`catalyst-gitea-token`) is read from catalyst-system where
+           bp-catalyst-platform's pre-install hook minted it at bootstrap.
+          */}}
           - name: GIT_AUTH_SECRET_NAME
             value: {{ .Values.gitRepositorySecretRef.destSecretName | quote }}
           - name: PAT_SOURCE_NAMESPACE
@@ -119,24 +123,28 @@ data:
             value: {{ .Values.gitRepositorySecretRef.patSourceKey | quote }}
           - name: GIT_AUTH_USERNAME
             value: {{ .Values.gitRepositorySecretRef.username | quote }}
-          # #5359 — secondary-region leg inputs. SECONDARY_GITEA_URL non-empty
-          # pins the candidate chain to exactly that URL (explicit operator
-          # intent, e.g. the qaTestEnabled LE-staging case where the public
-          # door is x509-hostile). Empty (default) = the chain is the door
-          # below. STATUS_CONFIGMAP receives the per-region
-          # step.<step>.region.<key>.* tracking keys.
+          {{- /*
+           #5359 — secondary-region leg inputs. SECONDARY_GITEA_URL non-empty
+           pins the candidate chain to exactly that URL (explicit operator
+           intent, e.g. the qaTestEnabled LE-staging case where the public
+           door is x509-hostile). Empty (default) = the chain is the door
+           below. STATUS_CONFIGMAP receives the per-region
+           step.<step>.region.<key>.* tracking keys.
+          */}}
           - name: SECONDARY_GITEA_URL
             value: {{ if .Values.secondaryRegions.giteaURL }}{{ printf "%s/%s/%s" (.Values.secondaryRegions.giteaURL | trimSuffix "/") .Values.gitea.org .Values.gitea.repo | quote }}{{ else }}""{{ end }}
-          # #5359 — the DEFAULT pivot target for secondaries: the Sovereign's
-          # OWN external Gitea door. On-Sovereign (its own gateway VIP — it
-          # satisfies the step-08 source-host lint's *.<fqdn> exemption, and
-          # the step-08 secondary hold carves out that gateway's public IPs)
-          # and the only path live-proven to serve region-A's pivoted repo
-          # from region-B (hw292: HEAD 7bcd1d59..., byte-identical to
-          # region-A's in-cluster Gitea). The in-cluster mesh URL is retired
-          # from the default chain — see the leg header. The env name keeps
-          # its historical FALLBACK spelling so pinned values files and the
-          # contract tests stay stable across the 0.1.166 default flip.
+          {{- /*
+           #5359 — the DEFAULT pivot target for secondaries: the Sovereign's
+           OWN external Gitea door. On-Sovereign (its own gateway VIP — it
+           satisfies the step-08 source-host lint's *.<fqdn> exemption, and
+           the step-08 secondary hold carves out that gateway's public IPs)
+           and the only path live-proven to serve region-A's pivoted repo
+           from region-B (hw292: HEAD 7bcd1d59..., byte-identical to
+           region-A's in-cluster Gitea). The in-cluster mesh URL is retired
+           from the default chain — see the leg header. The env name keeps
+           its historical FALLBACK spelling so pinned values files and the
+           contract tests stay stable across the 0.1.166 default flip.
+          */}}
           - name: SECONDARY_GITEA_FALLBACK_URL
             value: {{ if .Values.secondaryRegions.giteaFallbackURL }}{{ printf "%s/%s/%s" (.Values.secondaryRegions.giteaFallbackURL | trimSuffix "/") .Values.gitea.org .Values.gitea.repo | quote }}{{ else if .Values.secondaryRegions.giteaFallbackToPublicDoor }}{{ printf "https://gitea.%s/%s/%s" .Values.sovereign.fqdn .Values.gitea.org .Values.gitea.repo | quote }}{{ else }}""{{ end }}
           - name: SECONDARY_GITREPO_READY_SECONDS
@@ -151,26 +159,28 @@ data:
             set -eu
             echo "[flux-gitrepository-patch] target=${GITREPO_NAMESPACE}/${GITREPO_NAME} -> ${LOCAL_GITEA_URL} (branch=${BRANCH})"
 
-            # ── #3536: wire a basic-auth secretRef BEFORE flipping the URL ──
-            #
-            # bp-gitea sets REQUIRE_SIGNIN_VIEW=true → an anonymous clone of
-            # the local Gitea 401s even for a public repo. The cloud-init
-            # bootstrap GitRepository has NO secretRef (it cloned public
-            # github.com anonymously). So we must give source-controller a
-            # credential, or every reconcile after the URL flip fails
-            # "authentication required" and step 08 can never converge.
-            #
-            # Credential = the `catalyst-gitea-token` PAT minted at BOOTSTRAP
-            # by bp-catalyst-platform (in ${PAT_SOURCE_NAMESPACE}). A Gitea
-            # PAT is accepted as the HTTP git password. Flux secretRef takes
-            # only a name resolved in the GitRepository's own namespace, so
-            # we read the cross-namespace PAT and write a basic-auth Secret
-            # (keys username/password) into ${GITREPO_NAMESPACE}.
-            #
-            # The PAT Secret exists from bootstrap, but its `token` byte may
-            # be momentarily empty if the minter Job is mid-flight; wait
-            # (bounded) for a non-empty value before proceeding — a cutover
-            # that wired an empty password would re-introduce the 401.
+            {{- /*
+             ── #3536: wire a basic-auth secretRef BEFORE flipping the URL ──
+
+             bp-gitea sets REQUIRE_SIGNIN_VIEW=true → an anonymous clone of
+             the local Gitea 401s even for a public repo. The cloud-init
+             bootstrap GitRepository has NO secretRef (it cloned public
+             github.com anonymously). So we must give source-controller a
+             credential, or every reconcile after the URL flip fails
+             "authentication required" and step 08 can never converge.
+
+             Credential = the `catalyst-gitea-token` PAT minted at BOOTSTRAP
+             by bp-catalyst-platform (in ${PAT_SOURCE_NAMESPACE}). A Gitea
+             PAT is accepted as the HTTP git password. Flux secretRef takes
+             only a name resolved in the GitRepository's own namespace, so
+             we read the cross-namespace PAT and write a basic-auth Secret
+             (keys username/password) into ${GITREPO_NAMESPACE}.
+
+             The PAT Secret exists from bootstrap, but its `token` byte may
+             be momentarily empty if the minter Job is mid-flight; wait
+             (bounded) for a non-empty value before proceeding — a cutover
+             that wired an empty password would re-introduce the 401.
+            */}}
             echo "[flux-gitrepository-patch] reading PAT ${PAT_SOURCE_NAMESPACE}/${PAT_SOURCE_SECRET_NAME}.${PAT_SOURCE_KEY}"
             pat=""
             for i in $(seq 1 30); do
@@ -188,10 +198,12 @@ data:
               exit 1
             fi
 
-            # Create/update the basic-auth Secret in the GitRepository's
-            # namespace. Apply via stdin manifest so the PAT never lands in
-            # argv (visible to other namespaces' process listings). stringData
-            # lets the apiserver base64-encode for us.
+            {{- /*
+             Create/update the basic-auth Secret in the GitRepository's
+             namespace. Apply via stdin manifest so the PAT never lands in
+             argv (visible to other namespaces' process listings). stringData
+             lets the apiserver base64-encode for us.
+            */}}
             echo "[flux-gitrepository-patch] materialising basic-auth Secret ${GITREPO_NAMESPACE}/${GIT_AUTH_SECRET_NAME}"
             cat >/tmp/git-auth-secret.yaml <<EOF
             apiVersion: v1
@@ -212,12 +224,14 @@ data:
             kubectl apply -f /tmp/git-auth-secret.yaml
             echo "[flux-gitrepository-patch] basic-auth Secret applied"
 
-            # Issue #891 — apply the patch via a YAML strategic-merge file
-            # so the multi-line ignore filter is shipped verbatim. JSON-
-            # patching a multi-line string from sh is a rabbit-hole of
-            # quoting; YAML lets us write it as a literal block.
-            # #3536 — the patch ALSO sets spec.secretRef.name so the
-            # post-flip GitRepository authenticates to the local Gitea.
+            {{- /*
+             Issue #891 — apply the patch via a YAML strategic-merge file
+             so the multi-line ignore filter is shipped verbatim. JSON-
+             patching a multi-line string from sh is a rabbit-hole of
+             quoting; YAML lets us write it as a literal block.
+             #3536 — the patch ALSO sets spec.secretRef.name so the
+             post-flip GitRepository authenticates to the local Gitea.
+            */}}
             cat >/tmp/patch.yaml <<EOF
             spec:
               url: ${LOCAL_GITEA_URL}
@@ -241,40 +255,48 @@ data:
               "reconcile.fluxcd.io/requestedAt=$(date +%s)"
             echo "[flux-gitrepository-patch] control-plane region done"
 
-            # ── #5359: SECONDARY-REGION legs ─────────────────────────────
-            # /secondary-kubeconfigs is the optional:true mount of the
-            # cutover-secondary-kubeconfigs Secret (one <regionKey>.yaml per
-            # secondary region, materialised by catalyst-api at run start).
-            # Empty/absent = single-region Sovereign = this whole block
-            # no-ops (pre-#5359 behavior byte-identical).
-            #
-            # #5359 CANDIDATE URL CHAIN (hw292, dep 1c56518035a83e03). The
-            # DEFAULT chain for a secondary is the Sovereign's OWN external
-            # Gitea door (SECONDARY_GITEA_FALLBACK_URL,
-            # https://gitea.<fqdn>/...): on-Sovereign, world-reachable through
-            # the Sovereign's own gateway VIP with no cross-region Service-DNS
-            # assumption, and the only target live-proven to serve region-A's
-            # pivoted repo from a secondary — hw292 region-b fetched HEAD
-            # 7bcd1d59... through it, byte-identical to region-A's in-cluster
-            # Gitea, while the in-cluster name served zero refs.
-            #
-            # LOCAL_GITEA_URL (gitea-http.gitea.svc) is region-A's OWN patch
-            # target only — it is NOT in the default secondary chain any more.
-            # From a secondary that name resolves to the secondary's own empty
-            # bp-gitea (both Services headless, so the ClusterMesh
-            # global-Service annotation is inert — see the leg header), proven
-            # on hw292 as "pkt-line 3: EOF" on every fetch, generation=2 /
-            # observedGeneration=1 for 22h behind a result=success stamp.
-            # Keeping it as a leading candidate would burn
-            # gitRepositoryReadySeconds per region on a target that
-            # structurally cannot converge there.
-            #
-            # The only honest prober is the secondary's OWN source-controller:
-            # it dials the exact URL, from the right cluster, with the right
-            # credential. Each candidate is patched in and given a bounded
-            # window to CONVERGE (below); the first that converges wins, and
-            # exhausting the chain — or having NO candidate configured — is
-            # fatal, never a soft skip.
+            {{- /*
+             ── #5359: SECONDARY-REGION legs ─────────────────────────────
+             /secondary-kubeconfigs is the optional:true mount of the
+             cutover-secondary-kubeconfigs Secret (one <regionKey>.yaml per
+             secondary region, materialised by catalyst-api at run start).
+             Empty/absent = single-region Sovereign = this whole block
+             no-ops (pre-#5359 behavior byte-identical).
+
+             CANDIDATE URL CHAIN — see the `#5359 CANDIDATE URL CHAIN` marker
+             emitted below, which chart/tests/step05-secondary-chain.sh awk-slices
+             the secondary leg out of the render by.
+             The DEFAULT chain for a secondary is the Sovereign's OWN external
+             Gitea door (SECONDARY_GITEA_FALLBACK_URL,
+             https://gitea.<fqdn>/...): on-Sovereign, world-reachable through
+             the Sovereign's own gateway VIP with no cross-region Service-DNS
+             assumption, and the only target live-proven to serve region-A's
+             pivoted repo from a secondary — hw292 region-b fetched HEAD
+             7bcd1d59... through it, byte-identical to region-A's in-cluster
+             Gitea, while the in-cluster name served zero refs.
+
+             LOCAL_GITEA_URL (gitea-http.gitea.svc) is region-A's OWN patch
+             target only — it is NOT in the default secondary chain any more.
+             From a secondary that name resolves to the secondary's own empty
+             bp-gitea (both Services headless, so the ClusterMesh
+             global-Service annotation is inert — see the leg header), proven
+             on hw292 as "pkt-line 3: EOF" on every fetch, generation=2 /
+             observedGeneration=1 for 22h behind a result=success stamp.
+             Keeping it as a leading candidate would burn
+             gitRepositoryReadySeconds per region on a target that
+             structurally cannot converge there.
+
+             The only honest prober is the secondary's OWN source-controller:
+             it dials the exact URL, from the right cluster, with the right
+             credential. Each candidate is patched in and given a bounded
+             window to CONVERGE (below); the first that converges wins, and
+             exhausting the chain — or having NO candidate configured — is
+             fatal, never a soft skip.
+            */}}
+            # #5359 CANDIDATE URL CHAIN — region-start marker. Kept as a `#`
+            # comment because chart/tests/step05-secondary-chain.sh awk-slices
+            # the secondary leg out of the RENDER from here to the closing
+            # `[flux-gitrepository-patch] done`.
             sec_url_chain="${SECONDARY_GITEA_URL:-}"
             if [ -z "${sec_url_chain}" ]; then
               sec_url_chain="${SECONDARY_GITEA_FALLBACK_URL:-}"
@@ -289,22 +311,28 @@ data:
                   -p "{\"data\":{\"step.flux-gitrepository-patch.region.${region}.result\":\"failed\",\"step.flux-gitrepository-patch.region.${region}.finishedAt\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",\"step.flux-gitrepository-patch.region.${region}.lastError\":\"no candidate pivot URL configured\"}}" || true
                 exit 1
               fi
-              # ${sec_url_chain}, NOT ${sec_url}: the single-URL variable
-              # exists only inside the candidate loop below, and this line runs
-              # before it. Under the Job's `set -u` a stale reference here is
-              # not a cosmetic log bug — it aborts the leg on the FIRST
-              # secondary region, before any pivot, for every 2-region
-              # Sovereign.
+              {{- /*
+               ${sec_url_chain}, NOT ${sec_url}: the single-URL variable
+               exists only inside the candidate loop below, and this line runs
+               before it. Under the Job's `set -u` a stale reference here is
+               not a cosmetic log bug — it aborts the leg on the FIRST
+               secondary region, before any pivot, for every 2-region
+               Sovereign.
+              */}}
               echo "[flux-gitrepository-patch] #5359 secondary region ${region}: pivoting its GitRepository, candidates -> ${sec_url_chain}"
 
-              # 1. Basic-auth Secret in the secondary's flux-system (same PAT
-              # bytes written to /tmp/git-auth-secret.yaml above). The door
-              # terminates on the same Gitea behind the same
-              # REQUIRE_SIGNIN_VIEW=true, so the same PAT authenticates it.
+              {{- /*
+               1. Basic-auth Secret in the secondary's flux-system (same PAT
+               bytes written to /tmp/git-auth-secret.yaml above). The door
+               terminates on the same Gitea behind the same
+               REQUIRE_SIGNIN_VIEW=true, so the same PAT authenticates it.
+              */}}
               kubectl --kubeconfig "${skc}" apply -f /tmp/git-auth-secret.yaml
 
-              # 2. Same patch shape as region-A (URL from the candidate
-              # chain; secondaryRegions.giteaURL pins it).
+              {{- /*
+               2. Same patch shape as region-A (URL from the candidate
+               chain; secondaryRegions.giteaURL pins it).
+              */}}
               if ! kubectl --kubeconfig "${skc}" get gitrepository "${GITREPO_NAME}" -n "${GITREPO_NAMESPACE}" >/dev/null 2>&1; then
                 echo "[flux-gitrepository-patch] #5359 secondary ${region}: GitRepository ${GITREPO_NAMESPACE}/${GITREPO_NAME} absent — no flux git tether to pivot in this region; recording skipped"
                 kubectl -n "${CUTOVER_NAMESPACE}" patch configmap "${STATUS_CONFIGMAP}" --type=merge \
@@ -337,29 +365,31 @@ data:
                   -n "${GITREPO_NAMESPACE}" \
                   "reconcile.fluxcd.io/requestedAt=$(date +%s)"
 
-                # 3. FAIL-LOUD readiness. #5359 (hw292): the predicate here USED
-                # to be `Ready == True && spec.url == sec_url`, and both halves
-                # were unsound.
-                #
-                #   * `spec.url` is the value this leg had just WRITTEN one line
-                #     earlier, so that half is a tautology — it can never be
-                #     false and it proves nothing about the fetch.
-                #   * `Ready` is a STATUS field, and immediately after a patch it
-                #     still describes the PREVIOUS spec. On hw292 the object went
-                #     into the loop carrying Ready=True from its last successful
-                #     clone of PUBLIC github.com, so the very first iteration
-                #     matched and the leg recorded result=success at 07:39:48Z —
-                #     the same second the Ready condition actually flipped to
-                #     False. The controller then never advanced past
-                #     observedGeneration=1 while metadata.generation stayed 2,
-                #     and 22h later it was still serving that pre-pivot GitHub
-                #     artifact.
-                #
-                # The sound predicate is CONVERGENCE: source-controller has
-                # processed THIS generation (observedGeneration == generation)
-                # and the outcome was success (Ready=True). Nothing else can
-                # distinguish "fetched from the new URL" from "still holding what
-                # it fetched from the old one".
+                {{- /*
+                 3. FAIL-LOUD readiness. #5359 (hw292): the predicate here USED
+                 to be `Ready == True && spec.url == sec_url`, and both halves
+                 were unsound.
+
+                   * `spec.url` is the value this leg had just WRITTEN one line
+                     earlier, so that half is a tautology — it can never be
+                     false and it proves nothing about the fetch.
+                   * `Ready` is a STATUS field, and immediately after a patch it
+                     still describes the PREVIOUS spec. On hw292 the object went
+                     into the loop carrying Ready=True from its last successful
+                     clone of PUBLIC github.com, so the very first iteration
+                     matched and the leg recorded result=success at 07:39:48Z —
+                     the same second the Ready condition actually flipped to
+                     False. The controller then never advanced past
+                     observedGeneration=1 while metadata.generation stayed 2,
+                     and 22h later it was still serving that pre-pivot GitHub
+                     artifact.
+
+                 The sound predicate is CONVERGENCE: source-controller has
+                 processed THIS generation (observedGeneration == generation)
+                 and the outcome was success (Ready=True). Nothing else can
+                 distinguish "fetched from the new URL" from "still holding what
+                 it fetched from the old one".
+                */}}
                 sg_deadline=$(( $(date +%s) + ${SECONDARY_GITREPO_READY_SECONDS} ))
                 while [ "$(date +%s)" -lt "${sg_deadline}" ]; do
                   sg_json=$(kubectl --kubeconfig "${skc}" get gitrepository "${GITREPO_NAME}" -n "${GITREPO_NAMESPACE}" \
@@ -388,10 +418,12 @@ data:
                 exit 1
               fi
 
-              # 4. Per-region durable tracking (#5359). giteaURL records WHICH
-              # candidate converged, so an operator can see from the status
-              # ConfigMap alone whether the secondary took the in-cluster mesh
-              # path or the Sovereign's external Gitea door.
+              {{- /*
+               4. Per-region durable tracking (#5359). giteaURL records WHICH
+               candidate converged, so an operator can see from the status
+               ConfigMap alone whether the secondary took the in-cluster mesh
+               path or the Sovereign's external Gitea door.
+              */}}
               kubectl -n "${CUTOVER_NAMESPACE}" patch configmap "${STATUS_CONFIGMAP}" --type=merge \
                 -p "{\"data\":{\"step.flux-gitrepository-patch.region.${region}.result\":\"success\",\"step.flux-gitrepository-patch.region.${region}.finishedAt\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",\"step.flux-gitrepository-patch.region.${region}.giteaURL\":\"${sg_chosen}\"}}" || true
               echo "[flux-gitrepository-patch] #5359 secondary region ${region}: GitRepository CONVERGED on ${sg_chosen} (observedGeneration==generation, Ready=True)"
@@ -407,22 +439,28 @@ data:
           readOnlyRootFilesystem: true
           capabilities:
             drop: ["ALL"]
-        # Issue #891 — /tmp emptyDir for the kubectl patch-file
-        # (readOnlyRootFilesystem blocks writes to /tmp without it).
+        {{- /*
+         Issue #891 — /tmp emptyDir for the kubectl patch-file
+         (readOnlyRootFilesystem blocks writes to /tmp without it).
+        */}}
         volumeMounts:
           - name: tmp
             mountPath: /tmp
-          # #5359 — optional secondary-region kubeconfigs (empty on a
-          # single-region Sovereign; the leg no-ops).
+          {{- /*
+           #5359 — optional secondary-region kubeconfigs (empty on a
+           single-region Sovereign; the leg no-ops).
+          */}}
           - name: secondary-kubeconfigs
             mountPath: /secondary-kubeconfigs
             readOnly: true
     volumes:
       - name: tmp
         emptyDir: {}
-      # #5359 — materialised by catalyst-api (cutover.go runCutover) from its
-      # on-PVC secondary kubeconfig store at every run start; optional:true
-      # so a single-region Sovereign (no Secret) schedules unchanged.
+      {{- /*
+       #5359 — materialised by catalyst-api (cutover.go runCutover) from its
+       on-PVC secondary kubeconfig store at every run start; optional:true
+       so a single-region Sovereign (no Secret) schedules unchanged.
+      */}}
       - name: secondary-kubeconfigs
         secret:
           secretName: {{ .Values.secondaryRegions.kubeconfigSecretName }}

--- a/platform/self-sovereign-cutover/chart/templates/06-helmrepository-patches-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/06-helmrepository-patches-job.yaml
@@ -81,92 +81,101 @@ data:
     {{- range .Values.helmRepositories.names }}
     {{ . }}
     {{- end }}
-  # #5593 — Phase 2c of the step script, mounted and exec (`.`-sourced) FROM
-  # FILE. Step-06 renders within a few hundred bytes of the 110000-byte inline
-  # arg budget, so this block MUST NOT move back into podSpec.args. Its
-  # extraction markers are also what chart/tests/loft-pivot-regions.sh drives.
+  {{- /*
+   #5593 — Phase 2c of the step script, mounted and exec (`.`-sourced) FROM
+   FILE. Step-06 renders within a few hundred bytes of the 110000-byte inline
+   arg budget, so this block MUST NOT move back into podSpec.args. Its
+   extraction markers are also what chart/tests/loft-pivot-regions.sh drives.
+  */}}
   phase2c.sh: |
+    {{- /* The two ---- markers below stay `#` comments ON PURPOSE: they are
+    the region delimiters chart/tests/loft-pivot-regions.sh awk-slices out of
+    the RENDERED manifest. Prose moves into Helm block comments to stay out of
+    the release Secret (#6004); a marker a test navigates by does not. */}}
     # ---- Phase 2c (#5650): vcluster loft chart-source pivot ----
-    #
-    # The one Flux source the Phase-1/2 URL-pivot cannot reach. The
-    # bp-vcluster-helmrepo slot installs HelmRepository
-    # vcluster-system/loft at https://charts.loft.sh — a TRADITIONAL
-    # index.yaml source (spec.type default, NOT oci) in vcluster-system
-    # (NOT flux-system = HELMREPO_NAMESPACE). Phase-1 walks flux-system
-    # and matches only the openova-io OCI UPSTREAM_PREFIX, so it misses
-    # loft on both axes; post-cutover the org-controller's per-Org
-    # vcluster HelmReleases keep re-fetching charts.loft.sh on the HR's
-    # 15m interval — the residual tether #5650 found live on hw292,
-    # invisible to the timed step-08 hold (a 15m interval can straddle
-    # the 600s window). charts.loft.sh is an index.yaml repo no OpenOva
-    # registry mirrors, and the source default must stay upstream for
-    # non-Sovereign / pre-cutover installs, so the pivot is a RUNTIME
-    # cutover step (step-10 philosophy: keep chart defaults, rewrite
-    # POST-handover):
-    #   1. MIRROR — helm pull the upstream vcluster chart (egress still
-    #      open here) + helm push it OCI into local Harbor openova-io.
-    #   2. PIVOT  — patch the loft HR to type=oci +
-    #      url=oci://registry.<fqdn>/openova-io + secretRef=ghcr-pull
-    #      (Phase-0's registry.<fqdn> auth) + certSecretRef (Harbor CA),
-    #      replicating both secrets into vcluster-system where
-    #      source-controller reads them. Tenant HRs resolve chart=
-    #      vcluster version=0.33.* against the mirrored OCI tag unchanged.
-    #   3. DURABLE — suspend the bp-vcluster-helmrepo HelmRelease (live +
-    #      spec.suspend:true in the Gitea slot) so the 15m reconcile does
-    #      not re-render loft back to charts.loft.sh.
-    # FAIL-CLOSED: any sub-step that cannot complete leaves loft on
-    # charts.loft.sh and FATALs — step-08's fluxSourceHostLint (empty
-    # allowHosts) then fails the cutover on it rather than stamping a
-    # false cutoverComplete=true. See .Values.helmRepositories
-    # .vclusterLoftPivot and the fluxSourceHostLint HISTORY note.
-    #
-    # ── #5650 SECONDARY-REGION LEG (measured on hw292 2026-08-06) ──
-    #
-    # 0.1.168 shipped this pivot as a PRIMARY-ONLY block: every kubectl
-    # in it ran against the Job's own in-cluster context. But slot 60
-    # installs the loft HelmRepository in EVERY region, so on a 2-region
-    # Sovereign the tether is TWO objects, not one. Live on hw292 (dep
-    # 1c56518035a83e03), ~63h after cutoverComplete=true was stamped,
-    # source-controller in BOTH regions was still fetching it on the 15m
-    # interval — sampled across 75 minutes, i.e. an interval strictly
-    # longer than the actor's period, because a single sample inside a
-    # window proves nothing about a periodic actor:
-    #   region-a 23:36:44Z  stored fetched index of size 3.893MB from 'https://charts.loft.sh'
-    #   region-b 23:24:43Z  stored fetched index of size 3.893MB from 'https://charts.loft.sh'
-    # Region-b's copy is not even referenced by a HelmRelease there and
-    # it still reconciles: source-controller drives a HelmRepository on
-    # its own interval regardless of consumers, so "nothing uses it" is
-    # not "it does not dial out".
-    #
-    # And the consequence is worse than half a tether. Step-08's
-    # fluxSourceHostLint runs PER REGION (#5359) over the SAME target
-    # list, and its allowHosts is now EMPTY — so a primary-only pivot
-    # makes the region-b lint fail and the cutover can never reach
-    # cutoverComplete=true on the multi-region topology the DoD requires.
-    # The pivot must cover exactly the regions the lint measures; those
-    # two target lists are built the same way on purpose.
-    #
-    # SHARED vs PER-REGION. The Harbor mirror (one registry endpoint for
-    # the Sovereign) and the durable Gitea slot edit (one Gitea, which
-    # the secondaries also reconcile from after step-05) are
-    # SOVEREIGN-WIDE and run ONCE. Only the live patch — secret
-    # replication + HelmRepository patch + HelmRelease suspend + the
-    # read-back — is per-region.
-    #
-    # The `_lp_kubectl` shim is written on ONE line on purpose:
-    # chart/tests/loft-pivot-regions.sh extracts this function out of the
-    # RENDER with an awk range that terminates on the first bare `}`
-    # line, so a nested multi-line function definition would silently
-    # truncate the function under test (the #5646 drift shape).
+    {{- /*
+     The one Flux source the Phase-1/2 URL-pivot cannot reach. The
+     bp-vcluster-helmrepo slot installs HelmRepository
+     vcluster-system/loft at https://charts.loft.sh — a TRADITIONAL
+     index.yaml source (spec.type default, NOT oci) in vcluster-system
+     (NOT flux-system = HELMREPO_NAMESPACE). Phase-1 walks flux-system
+     and matches only the openova-io OCI UPSTREAM_PREFIX, so it misses
+     loft on both axes; post-cutover the org-controller's per-Org
+     vcluster HelmReleases keep re-fetching charts.loft.sh on the HR's
+     15m interval — the residual tether #5650 found live on hw292,
+     invisible to the timed step-08 hold (a 15m interval can straddle
+     the 600s window). charts.loft.sh is an index.yaml repo no OpenOva
+     registry mirrors, and the source default must stay upstream for
+     non-Sovereign / pre-cutover installs, so the pivot is a RUNTIME
+     cutover step (step-10 philosophy: keep chart defaults, rewrite
+     POST-handover):
+       1. MIRROR — helm pull the upstream vcluster chart (egress still
+          open here) + helm push it OCI into local Harbor openova-io.
+       2. PIVOT  — patch the loft HR to type=oci +
+          url=oci://registry.<fqdn>/openova-io + secretRef=ghcr-pull
+          (Phase-0's registry.<fqdn> auth) + certSecretRef (Harbor CA),
+          replicating both secrets into vcluster-system where
+          source-controller reads them. Tenant HRs resolve chart=
+          vcluster version=0.33.* against the mirrored OCI tag unchanged.
+       3. DURABLE — suspend the bp-vcluster-helmrepo HelmRelease (live +
+          spec.suspend:true in the Gitea slot) so the 15m reconcile does
+          not re-render loft back to charts.loft.sh.
+     FAIL-CLOSED: any sub-step that cannot complete leaves loft on
+     charts.loft.sh and FATALs — step-08's fluxSourceHostLint (empty
+     allowHosts) then fails the cutover on it rather than stamping a
+     false cutoverComplete=true. See .Values.helmRepositories
+     .vclusterLoftPivot and the fluxSourceHostLint HISTORY note.
+
+     ── #5650 SECONDARY-REGION LEG (measured on hw292 2026-08-06) ──
+
+     0.1.168 shipped this pivot as a PRIMARY-ONLY block: every kubectl
+     in it ran against the Job's own in-cluster context. But slot 60
+     installs the loft HelmRepository in EVERY region, so on a 2-region
+     Sovereign the tether is TWO objects, not one. Live on hw292 (dep
+     1c56518035a83e03), ~63h after cutoverComplete=true was stamped,
+     source-controller in BOTH regions was still fetching it on the 15m
+     interval — sampled across 75 minutes, i.e. an interval strictly
+     longer than the actor's period, because a single sample inside a
+     window proves nothing about a periodic actor:
+       region-a 23:36:44Z  stored fetched index of size 3.893MB from 'https://charts.loft.sh'
+       region-b 23:24:43Z  stored fetched index of size 3.893MB from 'https://charts.loft.sh'
+     Region-b's copy is not even referenced by a HelmRelease there and
+     it still reconciles: source-controller drives a HelmRepository on
+     its own interval regardless of consumers, so "nothing uses it" is
+     not "it does not dial out".
+
+     And the consequence is worse than half a tether. Step-08's
+     fluxSourceHostLint runs PER REGION (#5359) over the SAME target
+     list, and its allowHosts is now EMPTY — so a primary-only pivot
+     makes the region-b lint fail and the cutover can never reach
+     cutoverComplete=true on the multi-region topology the DoD requires.
+     The pivot must cover exactly the regions the lint measures; those
+     two target lists are built the same way on purpose.
+
+     SHARED vs PER-REGION. The Harbor mirror (one registry endpoint for
+     the Sovereign) and the durable Gitea slot edit (one Gitea, which
+     the secondaries also reconcile from after step-05) are
+     SOVEREIGN-WIDE and run ONCE. Only the live patch — secret
+     replication + HelmRepository patch + HelmRelease suspend + the
+     read-back — is per-region.
+
+     The `_lp_kubectl` shim is written on ONE line on purpose:
+     chart/tests/loft-pivot-regions.sh extracts this function out of the
+     RENDER with an awk range that terminates on the first bare `}`
+     line, so a nested multi-line function definition would silently
+     truncate the function under test (the #5646 drift shape).
+    */}}
     loft_pivot_region() {
       _lp_region="${1:-primary}"
       _LP_KUBECONFIG="${2:-}"
       _lp_kubectl() { if [ -n "${_LP_KUBECONFIG:-}" ]; then kubectl --kubeconfig="${_LP_KUBECONFIG}" "$@"; else kubectl "$@"; fi; }
       _lp_kubectl create namespace "${VCL_LOFT_NAMESPACE}" >/dev/null 2>&1 || true
-      # 1. Pull auth. source-controller reads spec.secretRef from the
-      #    HR's OWN namespace, in the HR's OWN cluster — so the bytes
-      #    captured once from the primary must be applied into every
-      #    region, not just this Job's.
+      {{- /*
+       1. Pull auth. source-controller reads spec.secretRef from the
+          HR's OWN namespace, in the HR's OWN cluster — so the bytes
+          captured once from the primary must be applied into every
+          region, not just this Job's.
+      */}}
       if [ ! -s "${LOFT_GHCR_SECRET_JSON}" ]; then
         echo "[helmrepository-patches] FATAL: Phase-2c [${_lp_region}]: no ${GHCR_PULL_SECRET_NAME} bytes were captured from the primary — the pivoted loft HR would 401 (#5650)" >&2
         return 1
@@ -177,7 +186,7 @@ data:
         echo "[helmrepository-patches] FATAL: Phase-2c [${_lp_region}]: could not replicate ${GHCR_PULL_SECRET_NAME} into ${VCL_LOFT_NAMESPACE} — the pivoted loft HR would 401 (#5650)" >&2
         return 1
       fi
-      # 2. Harbor CA trust (optional — absent on a public-CA Harbor).
+      {{- /* 2. Harbor CA trust (optional — absent on a public-CA Harbor). */}}
       _lp_certref=""
       if [ -n "${LOFT_TRUST_SECRET}" ] && [ -n "${LOFT_CA_B64}" ]; then
         if printf 'apiVersion: v1\nkind: Secret\nmetadata:\n  name: %s\n  namespace: %s\n  labels:\n    app.kubernetes.io/managed-by: self-sovereign-cutover\n    bp.openova.io/cutover-step: helmrepository-patches\ntype: Opaque\ndata:\n  ca.crt: %s\n' "${LOFT_TRUST_SECRET}" "${VCL_LOFT_NAMESPACE}" "${LOFT_CA_B64}" | _lp_kubectl apply -f - >/dev/null 2>&1; then
@@ -187,7 +196,7 @@ data:
           echo "[helmrepository-patches] Phase-2c WARN [${_lp_region}]: could not apply trust CA into ${VCL_LOFT_NAMESPACE} — pivoting WITHOUT certSecretRef (needs a public-CA Harbor cert)"
         fi
       fi
-      # 3. LIVE-PATCH the loft HR in THIS region: index.yaml -> local OCI.
+      {{- /* 3. LIVE-PATCH the loft HR in THIS region: index.yaml -> local OCI. */}}
       if [ -n "${_lp_certref}" ]; then
         _lp_patch=$(printf '{"spec":{"type":"oci","url":"%s","secretRef":{"name":"%s"},"certSecretRef":{"name":"%s"}}}' "${LOFT_LOCAL_URL}" "${GHCR_PULL_SECRET_NAME}" "${_lp_certref}")
       else
@@ -200,10 +209,12 @@ data:
         echo "[helmrepository-patches] FATAL: Phase-2c [${_lp_region}]: kubectl patch of loft HR failed (#5650)" >&2
         return 1
       fi
-      # 4. Suspend the bp-vcluster-helmrepo HelmRelease IN THIS REGION so
-      #    its next reconcile does not re-render loft back to
-      #    charts.loft.sh. Slot 60 lands in every region, so the reverting
-      #    actor exists in every region too.
+      {{- /*
+       4. Suspend the bp-vcluster-helmrepo HelmRelease IN THIS REGION so
+          its next reconcile does not re-render loft back to
+          charts.loft.sh. Slot 60 lands in every region, so the reverting
+          actor exists in every region too.
+      */}}
       if _lp_kubectl get helmrelease "${VCL_LOFT_RELEASE}" -n "${VCL_LOFT_RELEASE_NS}" >/dev/null 2>&1; then
         if _lp_kubectl patch helmrelease "${VCL_LOFT_RELEASE}" -n "${VCL_LOFT_RELEASE_NS}" --type=merge --patch '{"spec":{"suspend":true}}' >/dev/null 2>&1; then
           echo "[helmrepository-patches] Phase-2c OK [${_lp_region}]: suspended ${VCL_LOFT_RELEASE_NS}/${VCL_LOFT_RELEASE} (live) so the loft pivot is not reverted"
@@ -213,12 +224,14 @@ data:
       else
         echo "[helmrepository-patches] Phase-2c [${_lp_region}]: HelmRelease ${VCL_LOFT_RELEASE_NS}/${VCL_LOFT_RELEASE} absent — nothing to suspend (loft HR may be operator-managed)"
       fi
-      # 5. READ-BACK. `kubectl patch` exiting 0 is not the same as the
-      #    object carrying the new URL — an admission webhook or a
-      #    competing controller can revert it inside the same second, and
-      #    a Job that logged OK on an un-pivoted region is precisely the
-      #    single-region-sample failure this leg exists to end. Assert on
-      #    the DECLARATION we just wrote, in the region we wrote it to.
+      {{- /*
+       5. READ-BACK. `kubectl patch` exiting 0 is not the same as the
+          object carrying the new URL — an admission webhook or a
+          competing controller can revert it inside the same second, and
+          a Job that logged OK on an un-pivoted region is precisely the
+          single-region-sample failure this leg exists to end. Assert on
+          the DECLARATION we just wrote, in the region we wrote it to.
+      */}}
       _lp_after=$(_lp_kubectl get helmrepository "${VCL_LOFT_HR_NAME}" -n "${VCL_LOFT_NAMESPACE}" -o jsonpath='{.spec.url}' 2>/dev/null || echo "")
       if [ "${_lp_after}" != "${LOFT_LOCAL_URL}" ]; then
         echo "[helmrepository-patches] FATAL: Phase-2c [${_lp_region}]: read-back shows spec.url='${_lp_after}', expected '${LOFT_LOCAL_URL}' — the pivot did not stick and this region would keep fetching ${VCL_LOFT_UPSTREAM_REPO} on its 15m interval (#5650)" >&2
@@ -232,22 +245,26 @@ data:
       LOFT_GHCR_SECRET_JSON="/tmp/.loft-ghcr-pull.json"
       LOFT_TRUST_SECRET=""
       LOFT_CA_B64=""
-      # ---- Target list: the SAME construction step-08's per-region
-      #      fluxSourceHostLint uses (primary + every mounted secondary
-      #      kubeconfig). If these two lists diverge, the lint measures a
-      #      region the pivot never touched — which IS this defect.
-      # SECONDARY_KUBECONFIG_DIR defaults to the Job's real mount and is
-      # overridable ONLY so chart/tests/loft-pivot-regions.sh can drive
-      # this block with a stub region set — the same seam WORK_DIR gives
-      # the step-08 lints. Nothing in the chart ever sets it.
+      {{- /*
+       ---- Target list: the SAME construction step-08's per-region
+            fluxSourceHostLint uses (primary + every mounted secondary
+            kubeconfig). If these two lists diverge, the lint measures a
+            region the pivot never touched — which IS this defect.
+       SECONDARY_KUBECONFIG_DIR defaults to the Job's real mount and is
+       overridable ONLY so chart/tests/loft-pivot-regions.sh can drive
+       this block with a stub region set — the same seam WORK_DIR gives
+       the step-08 lints. Nothing in the chart ever sets it.
+      */}}
       loft_targets="primary="
       for lt_kc in "${SECONDARY_KUBECONFIG_DIR:-/secondary-kubeconfigs}"/*.yaml; do
         [ -e "${lt_kc}" ] || continue
         loft_targets="${loft_targets} $(basename "${lt_kc}" .yaml)=${lt_kc}"
       done
-      # ---- Classify every region: absent / already-oci / needs-pivot.
-      #      A region that cannot be READ is fail-closed: indistinguishable
-      #      from a pivoted one only in the log (#5359).
+      {{- /*
+       ---- Classify every region: absent / already-oci / needs-pivot.
+            A region that cannot be READ is fail-closed: indistinguishable
+            from a pivoted one only in the log (#5359).
+      */}}
       loft_need=""
       for lt in ${loft_targets}; do
         lt_region="${lt%%=*}"
@@ -264,8 +281,10 @@ data:
         lt_url=$(jq -r '.spec.url // ""' /tmp/.loft-probe.json 2>/dev/null)
         lt_type=$(jq -r '.spec.type // ""' /tmp/.loft-probe.json 2>/dev/null)
         if [ "${lt_type}" = "oci" ]; then
-          # Already OCI (idempotent re-run, or an operator overlay). The
-          # step-08 fluxSourceHostLint judges locality either way; leave it.
+          {{- /*
+           Already OCI (idempotent re-run, or an operator overlay). The
+           step-08 fluxSourceHostLint judges locality either way; leave it.
+          */}}
           echo "[helmrepository-patches] Phase-2c SKIP [${lt_region}]: loft HR is already type=oci (${lt_url}) — idempotent re-run / operator overlay (#5650)"
           continue
         fi
@@ -276,15 +295,17 @@ data:
         echo "[helmrepository-patches] Phase-2c: no region needs the loft pivot (absent or already local) — nothing to do (#5650)"
       else
         echo "[helmrepository-patches] Phase-2c: pivoting loft chart source -> ${LOFT_LOCAL_URL} in region(s):${loft_need} (#5650)"
-        # In-cluster Harbor serves an LE-staging (node-untrusted) cert on
-        # a fresh prov; the Job Pod has no node trust store. Mirror the
-        # same insecure-flag discipline Phase-3a uses (login vs pull take
-        # DIFFERENT flag spellings on helm v3.16.x).
+        {{- /*
+         In-cluster Harbor serves an LE-staging (node-untrusted) cert on
+         a fresh prov; the Job Pod has no node trust store. Mirror the
+         same insecure-flag discipline Phase-3a uses (login vs pull take
+         DIFFERENT flag spellings on helm v3.16.x).
+        */}}
         case "${HELM_IN_CLUSTER_TLS_VERIFY:-false}" in
           true|True|TRUE|1|yes) VCL_LFLAG=""; VCL_PFLAG="" ;;
           *) VCL_LFLAG="--insecure"; VCL_PFLAG="--insecure-skip-tls-verify" ;;
         esac
-        # 1. MIRROR (ONCE — one Harbor endpoint serves every region).
+        {{- /* 1. MIRROR (ONCE — one Harbor endpoint serves every region). */}}
         helm registry login "${harbor_endpoint}" ${VCL_LFLAG} \
           -u "${HARBOR_USERNAME:-admin}" -p "${HARBOR_PASSWORD}" >/dev/null 2>&1 \
           && echo "[helmrepository-patches] Phase-2c: helm registry login ${harbor_endpoint} OK" \
@@ -317,8 +338,10 @@ data:
           exit 1
         fi
         echo "[helmrepository-patches] Phase-2c OK: mirrored ${VCL_LOFT_CHART} ${VCL_LOFT_VERSION} -> ${LOFT_LOCAL_URL}/${VCL_LOFT_CHART}"
-        # 2. Capture the auth + trust material ONCE from the primary, then
-        #    replicate it into every region that needs the pivot.
+        {{- /*
+         2. Capture the auth + trust material ONCE from the primary, then
+            replicate it into every region that needs the pivot.
+        */}}
         gp_src_ns="${GHCR_PULL_SECRET_NAMESPACE}"
         kubectl get secret "${GHCR_PULL_SECRET_NAME}" -n "${gp_src_ns}" >/dev/null 2>&1 || gp_src_ns="flux-system"
         if ! kubectl get secret "${GHCR_PULL_SECRET_NAME}" -n "${gp_src_ns}" -o json >"${LOFT_GHCR_SECRET_JSON}" 2>/dev/null; then
@@ -329,9 +352,11 @@ data:
           LOFT_CA_B64=$(kubectl get secret "${trust_secret}" -n "${HELMREPO_NAMESPACE}" -o json 2>/dev/null | jq -r '.data["ca.crt"] // empty')
           [ -n "${LOFT_CA_B64}" ] && LOFT_TRUST_SECRET="${trust_secret}"
         fi
-        # 3. PIVOT every queued region. One failing region FATALs the
-        #    step: a partially-pivoted Sovereign that reports success is
-        #    the exact shape of the defect (#5359 #5596 #5650).
+        {{- /*
+         3. PIVOT every queued region. One failing region FATALs the
+            step: a partially-pivoted Sovereign that reports success is
+            the exact shape of the defect (#5359 #5596 #5650).
+        */}}
         loft_pivoted=0
         for ln in ${loft_need}; do
           ln_region="${ln%%=*}"
@@ -343,9 +368,11 @@ data:
           loft_pivoted=$((loft_pivoted + 1))
         done
         echo "[helmrepository-patches] Phase-2c OK: ${loft_pivoted} region(s) pivoted off ${VCL_LOFT_UPSTREAM_REPO} onto ${LOFT_LOCAL_URL} (#5650)"
-        # 4. DURABLE (ONCE): set spec.suspend=true on the slot file in the
-        #    Gitea clone so the bootstrap-kit reconcile keeps loft
-        #    suspended. One Gitea serves every region after step-05.
+        {{- /*
+         4. DURABLE (ONCE): set spec.suspend=true on the slot file in the
+            Gitea clone so the bootstrap-kit reconcile keeps loft
+            suspended. One Gitea serves every region after step-05.
+        */}}
         if [ -f "${VCL_LOFT_SLOT_FILE}" ]; then
           vcl_yq=""
           if command -v yq >/dev/null 2>&1; then
@@ -378,19 +405,23 @@ data:
     serviceAccountName: {{ include "bp-self-sovereign-cutover.serviceAccountName" . }}
     restartPolicy: Never
     activeDeadlineSeconds: {{ .Values.stepTimeouts.helmRepositoryPatchesSeconds }}
-    # #5214 — re-assert gitea-admin-secret in the release namespace at step
-    # execution time (durable close of the #4557/#4558/#4661 recurrence class:
-    # the install-time bridge copy was deleted between install and this step on
-    # hw271, wedging the secretKeyRef below). See _helpers.tpl.
+    {{- /*
+     #5214 — re-assert gitea-admin-secret in the release namespace at step
+     execution time (durable close of the #4557/#4558/#4661 recurrence class:
+     the install-time bridge copy was deleted between install and this step on
+     hw271, wedging the secretKeyRef below). See _helpers.tpl.
+    */}}
     initContainers:
       {{- include "bp-self-sovereign-cutover.giteaSecretSelfHealInitContainer" (dict "ctx" . "phase" "post") | nindent 6 }}
     containers:
       - name: helmrepository-patches
-        # alpine/k8s ships kubectl + git so we can both patch the live
-        # K8s object AND push the YAML edit to local Gitea (#970).
-        # Fix #163 (2026-05-11, MIRROR-EVERYTHING): explicit
-        # harbor.openova.io/proxy-dockerhub prefix per CLAUDE.md
-        # inviolable rule.
+        {{- /*
+         alpine/k8s ships kubectl + git so we can both patch the live
+         K8s object AND push the YAML edit to local Gitea (#970).
+         Fix #163 (2026-05-11, MIRROR-EVERYTHING): explicit
+         harbor.openova.io/proxy-dockerhub prefix per CLAUDE.md
+         inviolable rule.
+        */}}
         image: harbor.openova.io/proxy-dockerhub/alpine/k8s:1.31.4
         imagePullPolicy: IfNotPresent
         env:
@@ -418,14 +449,16 @@ data:
             value: {{ .Values.gitea.org | quote }}
           - name: GITEA_REPO
             value: {{ .Values.gitea.repo | quote }}
-          # #4967 (Refs #3379 #4885) — self-healing re-assert of the Gitea
-          # admin password before the demirror PATCH + git push. The live DB
-          # password can DRIFT from gitea-admin-secret when step-04 rolls the
-          # gitea image and the init container's keepUpdated re-sync races /
-          # no-ops (hw236 wedge: demirror 401 `user's password is invalid
-          # [uid:1 name:gitea_admin]`). The Phase-1.4 block execs
-          # `gitea admin user change-password` in the live gitea Pod to force
-          # the DB row to match the Secret. See .Values.gitea.adminPasswordReassert.
+          {{- /*
+           #4967 (Refs #3379 #4885) — self-healing re-assert of the Gitea
+           admin password before the demirror PATCH + git push. The live DB
+           password can DRIFT from gitea-admin-secret when step-04 rolls the
+           gitea image and the init container's keepUpdated re-sync races /
+           no-ops (hw236 wedge: demirror 401 `user's password is invalid
+           [uid:1 name:gitea_admin]`). The Phase-1.4 block execs
+           `gitea admin user change-password` in the live gitea Pod to force
+           the DB row to match the Secret. See .Values.gitea.adminPasswordReassert.
+          */}}
           - name: GITEA_ADMIN_PASSWORD_REASSERT
             value: {{ .Values.gitea.adminPasswordReassert.enabled | default true | quote }}
           - name: GITEA_NAMESPACE
@@ -434,10 +467,12 @@ data:
             value: {{ .Values.gitea.adminPasswordReassert.podSelector | default "app.kubernetes.io/name=gitea,app.kubernetes.io/instance=gitea" | quote }}
           - name: GITEA_CONTAINER
             value: {{ .Values.gitea.adminPasswordReassert.containerName | default "gitea" | quote }}
-          # Phase 0 (#1184) — harbor.<sov-fqdn> auth merge into ghcr-pull.
-          # HARBOR_PASSWORD comes from the Reflector-mirrored
-          # harbor-admin Secret in this namespace (bp-harbor 1.2.14+
-          # emits it in the harbor ns with allowed-namespaces=catalyst).
+          {{- /*
+           Phase 0 (#1184) — harbor.<sov-fqdn> auth merge into ghcr-pull.
+           HARBOR_PASSWORD comes from the Reflector-mirrored
+           harbor-admin Secret in this namespace (bp-harbor 1.2.14+
+           emits it in the harbor ns with allowed-namespaces=catalyst).
+          */}}
           - name: HARBOR_USERNAME
             valueFrom:
               secretKeyRef:
@@ -455,104 +490,122 @@ data:
             value: {{ .Values.harbor.ghcrSecretRef.namespace | quote }}
           - name: GHCR_PULL_SECRET_KEY
             value: {{ .Values.harbor.ghcrSecretRef.dockerConfigKey | quote }}
-          # Phase-0 strip targets (TBD-V24 MISS-2, chart 0.1.35). Comma-
-          # separated list of mothership-side auth keys to REMOVE from
-          # `.dockerconfigjson` once the local Harbor entry is in place.
-          # See .Values.harbor.mothershipAuthsToStrip for the canonical
-          # source and rationale.
+          {{- /*
+           Phase-0 strip targets (TBD-V24 MISS-2, chart 0.1.35). Comma-
+           separated list of mothership-side auth keys to REMOVE from
+           `.dockerconfigjson` once the local Harbor entry is in place.
+           See .Values.harbor.mothershipAuthsToStrip for the canonical
+           source and rationale.
+          */}}
           - name: MOTHERSHIP_AUTHS_TO_STRIP
             value: {{ join "," .Values.harbor.mothershipAuthsToStrip | quote }}
-          # Phase -1 gateway-wait inputs (issue #1871, chart 0.1.32).
-          # The cutover URL rewrite (Phase 1 below) MUST NOT fire until
-          # the Cilium Gateway in kube-system is Programmed=True; that
-          # condition is the operator-facing proxy for "registry.<sov-
-          # fqdn> serves TLS, source-controller pulls won't EOF". See
-          # the Phase -1 block in args: below for the full wait loop.
+          {{- /*
+           Phase -1 gateway-wait inputs (issue #1871, chart 0.1.32).
+           The cutover URL rewrite (Phase 1 below) MUST NOT fire until
+           the Cilium Gateway in kube-system is Programmed=True; that
+           condition is the operator-facing proxy for "registry.<sov-
+           fqdn> serves TLS, source-controller pulls won't EOF". See
+           the Phase -1 block in args: below for the full wait loop.
+          */}}
           - name: GATEWAY_NAMESPACE
             value: {{ .Values.gateway.namespace | quote }}
           - name: GATEWAY_NAME
             value: {{ .Values.gateway.name | quote }}
           - name: GATEWAY_WAIT_TIMEOUT_SECONDS
             value: {{ .Values.gateway.waitTimeoutSeconds | quote }}
-          # Phase-3 strip-before-pivot fix (Refs #3379 #3526). The
-          # mothership-auth strip (ghcr.io / harbor.openova.io) waits up to
-          # this long for every local-Harbor HelmRepository to reach
-          # Ready=True before removing the ghcr.io fallback. If the pivot
-          # never converges, the strip is SKIPPED (Job exits non-zero with
-          # ghcr.io auth intact → recoverable). See
-          # .Values.stepTimeouts.stripReadinessSeconds.
+          {{- /*
+           Phase-3 strip-before-pivot fix (Refs #3379 #3526). The
+           mothership-auth strip (ghcr.io / harbor.openova.io) waits up to
+           this long for every local-Harbor HelmRepository to reach
+           Ready=True before removing the ghcr.io fallback. If the pivot
+           never converges, the strip is SKIPPED (Job exits non-zero with
+           ghcr.io auth intact → recoverable). See
+           .Values.stepTimeouts.stripReadinessSeconds.
+          */}}
           - name: STRIP_READINESS_TIMEOUT_SECONDS
             value: {{ .Values.stepTimeouts.stripReadinessSeconds | quote }}
-          # Phase-3a pull-probe sample size (Refs #3627). The strip is gated on
-          # a successful authenticated `helm pull` of a representative sample of
-          # the pivoted local-Harbor charts (NOT on a non-existent
-          # HelmRepository .status.Ready). bp-catalyst-platform is always probed
-          # when present; this caps the rest of the sample so the gate stays
-          # fast while still proving Harbor serves charts + auth works.
+          {{- /*
+           Phase-3a pull-probe sample size (Refs #3627). The strip is gated on
+           a successful authenticated `helm pull` of a representative sample of
+           the pivoted local-Harbor charts (NOT on a non-existent
+           HelmRepository .status.Ready). bp-catalyst-platform is always probed
+           when present; this caps the rest of the sample so the gate stays
+           fast while still proving Harbor serves charts + auth works.
+          */}}
           - name: HELM_PROBE_SAMPLE_SIZE
             value: {{ .Values.helmReadinessProbe.sampleSize | quote }}
-          # #5237 (Refs #5007): union-warm-on-drift. Phase-3a samples the LIVE
-          # chart version off each pivoted HelmRelease (deployed
-          # `.status.history[0].chartVersion` // desired `.spec.chart.spec
-          # .version`). If a `bp-catalyst-platform` release is published to
-          # ghcr AFTER step-03 harbor-prewarm finishes (a mid-cutover merge's
-          # deploy-bot bump), flux redeploys the umbrella to the newer
-          # concrete pin BEFORE this step runs — so the sampled version is a
-          # tag prewarm never mirrored (catalog-latest drifted one bump ahead;
-          # neither the deployed NOR the desired tag was warmed). When true
-          # (default), a sampled chart that is absent from local Harbor is
-          # TOP-UP-WARMED from the still-reachable upstream (this step runs
-          # BEFORE the step-08 deny-egress hold) into local Harbor, then
-          # re-probed — self-healing the drift instead of stalling
-          # stripReadinessSeconds and parking the cutover. A genuinely-absent
-          # chart (unpullable from BOTH local Harbor AND upstream) still
-          # FATALs at the deadline (fail-loud preserved). Set false to restore
-          # pure fail-loud (no upstream top-up).
-          # NB: bare `| quote` (NOT `| default true`) — sprig `default` treats a
-          # literal `false` as empty and would flip an explicit disable back to
-          # true (feedback_rbac_create_no_resourcenames.md sprig_default_bool_unsafe).
-          # The values.yaml default (true) supplies the on-state; a nil renders
-          # "" and the script's `: "${UNION_WARM_ON_DRIFT:=true}"` restores true.
+          {{- /*
+           #5237 (Refs #5007): union-warm-on-drift. Phase-3a samples the LIVE
+           chart version off each pivoted HelmRelease (deployed
+           `.status.history[0].chartVersion` // desired `.spec.chart.spec
+           .version`). If a `bp-catalyst-platform` release is published to
+           ghcr AFTER step-03 harbor-prewarm finishes (a mid-cutover merge's
+           deploy-bot bump), flux redeploys the umbrella to the newer
+           concrete pin BEFORE this step runs — so the sampled version is a
+           tag prewarm never mirrored (catalog-latest drifted one bump ahead;
+           neither the deployed NOR the desired tag was warmed). When true
+           (default), a sampled chart that is absent from local Harbor is
+           TOP-UP-WARMED from the still-reachable upstream (this step runs
+           BEFORE the step-08 deny-egress hold) into local Harbor, then
+           re-probed — self-healing the drift instead of stalling
+           stripReadinessSeconds and parking the cutover. A genuinely-absent
+           chart (unpullable from BOTH local Harbor AND upstream) still
+           FATALs at the deadline (fail-loud preserved). Set false to restore
+           pure fail-loud (no upstream top-up).
+           NB: bare `| quote` (NOT `| default true`) — sprig `default` treats a
+           literal `false` as empty and would flip an explicit disable back to
+           true (feedback_rbac_create_no_resourcenames.md sprig_default_bool_unsafe).
+           The values.yaml default (true) supplies the on-state; a nil renders
+           "" and the script's `: "${UNION_WARM_ON_DRIFT:=true}"` restores true.
+          */}}
           - name: UNION_WARM_ON_DRIFT
             value: {{ .Values.helmReadinessProbe.unionWarmOnDrift | quote }}
-          # #5237 round 2 (Refs #5007): Phase 3a-pin — before the sampled
-          # pull-probe (and the irreversible Phase-3b strip), assert EVERY
-          # bootstrap-kit-pinned chart version from the Phase-2 clone of the
-          # local Gitea mirror (the frozen commit flux consumes post-pivot)
-          # is durably present in local Harbor; top-up-warm a missing one
-          # from the still-reachable upstream, and FATAL with the full
-          # missing list otherwise (auth intact — recoverable). Same bare
-          # `| quote` sprig-bool discipline as UNION_WARM_ON_DRIFT above.
+          {{- /*
+           #5237 round 2 (Refs #5007): Phase 3a-pin — before the sampled
+           pull-probe (and the irreversible Phase-3b strip), assert EVERY
+           bootstrap-kit-pinned chart version from the Phase-2 clone of the
+           local Gitea mirror (the frozen commit flux consumes post-pivot)
+           is durably present in local Harbor; top-up-warm a missing one
+           from the still-reachable upstream, and FATAL with the full
+           missing list otherwise (auth intact — recoverable). Same bare
+           `| quote` sprig-bool discipline as UNION_WARM_ON_DRIFT above.
+          */}}
           - name: PIN_PRESENCE_GATE
             value: {{ .Values.helmReadinessProbe.pinPresenceGate | quote }}
-          # #5237 round 2 — the in-cluster Harbor Service URL for the
-          # Phase 3a-pin durable-presence probe (artifact API served by
-          # Harbor CORE against its DB — never pull-through, the #5030
-          # discipline; the SAME endpoint step-03's dest_already_current
-          # dials).
+          {{- /*
+           #5237 round 2 — the in-cluster Harbor Service URL for the
+           Phase 3a-pin durable-presence probe (artifact API served by
+           Harbor CORE against its DB — never pull-through, the #5030
+           discipline; the SAME endpoint step-03's dest_already_current
+           dials).
+          */}}
           - name: HARBOR_INTERNAL_URL
             value: {{ .Values.sovereign.harborInternalURL | quote }}
-          # #4557 (Refs #3379): TLS-verify on the Phase-3a helm-CLI probe
-          # DESTINATION (the in-cluster Harbor `registry.<sov-fqdn>` =
-          # harbor_host). DEFAULT false — the in-cluster Harbor serves an
-          # LE-STAGING (untrusted) wildcard on a fresh prov + the helm binary
-          # in a Job Pod has no node trust store. See
-          # .Values.helmReadinessProbe.inClusterTLSVerify. When false, both
-          # `helm registry login` and `helm pull` (in-cluster target) carry
-          # `--insecure-skip-tls-verify`. The ONLY external (ghcr/upstream)
-          # helm calls this step makes are the #5237 union-warm top-up pulls,
-          # which target the public-CA-signed ghcr.io and keep verify ON — the
-          # in-cluster skip is only ever applied to the cluster's own registry.
+          {{- /*
+           #4557 (Refs #3379): TLS-verify on the Phase-3a helm-CLI probe
+           DESTINATION (the in-cluster Harbor `registry.<sov-fqdn>` =
+           harbor_host). DEFAULT false — the in-cluster Harbor serves an
+           LE-STAGING (untrusted) wildcard on a fresh prov + the helm binary
+           in a Job Pod has no node trust store. See
+           .Values.helmReadinessProbe.inClusterTLSVerify. When false, both
+           `helm registry login` and `helm pull` (in-cluster target) carry
+           `--insecure-skip-tls-verify`. The ONLY external (ghcr/upstream)
+           helm calls this step makes are the #5237 union-warm top-up pulls,
+           which target the public-CA-signed ghcr.io and keep verify ON — the
+           in-cluster skip is only ever applied to the cluster's own registry.
+          */}}
           - name: HELM_IN_CLUSTER_TLS_VERIFY
             value: {{ .Values.helmReadinessProbe.inClusterTLSVerify | default false | quote }}
-          # Refs #3379 — source-controller TLS-trust for the pivoted
-          # HelmRepositories. Phase-0.5 extracts the in-cluster Harbor
-          # serving cert's CA from the wildcard TLS Secret and creates a
-          # ca.crt-only Secret in HELMREPO_NAMESPACE; Phase-1 patches every
-          # pivoted HelmRepository's spec.certSecretRef to it so
-          # source-controller trusts the LE-staging in-cluster registry.
-          # Flux OCI HelmRepository has NO insecureSkipVerify — certSecretRef
-          # is the only mechanism (see .Values.helmRepositoryTrust).
+          {{- /*
+           Refs #3379 — source-controller TLS-trust for the pivoted
+           HelmRepositories. Phase-0.5 extracts the in-cluster Harbor
+           serving cert's CA from the wildcard TLS Secret and creates a
+           ca.crt-only Secret in HELMREPO_NAMESPACE; Phase-1 patches every
+           pivoted HelmRepository's spec.certSecretRef to it so
+           source-controller trusts the LE-staging in-cluster registry.
+           Flux OCI HelmRepository has NO insecureSkipVerify — certSecretRef
+           is the only mechanism (see .Values.helmRepositoryTrust).
+          */}}
           - name: HELMREPO_TRUST_ENABLED
             value: {{ .Values.helmRepositoryTrust.enabled | default false | quote }}
           - name: HELMREPO_TRUST_SRC_NAMESPACE
@@ -561,38 +614,42 @@ data:
             value: {{ .Values.helmRepositoryTrust.sourceSecretNamePrefix | quote }}
           - name: HELMREPO_TRUST_DEST_SECRET
             value: {{ .Values.helmRepositoryTrust.destSecretName | quote }}
-          # #5359 — per-region status tracking for the secondary-region leg.
+          {{- /* #5359 — per-region status tracking for the secondary-region leg. */}}
           - name: STATUS_CONFIGMAP
             value: {{ .Values.status.configMapName | quote }}
           - name: CUTOVER_NAMESPACE
             value: {{ .Release.Namespace | quote }}
-          # #5436 — region-A pivot READ-BACK assert inputs. Until this
-          # landed, region-A's only failure signal was the Phase-1 `fail`
-          # counter, which counts `kubectl patch` invocations that returned
-          # non-zero — NOT the state of the cluster afterwards. See the
-          # assert_region_a_pivot block in args: below.
-          #
-          # readbackExcludeNames MUST stay a superset-tolerant mirror of the
-          # slot-managed self-reference whitelist step-08's own offender scan
-          # applies (08-egress-block-test-job.yaml count_offenders). This
-          # assert must never be STRICTER than the step-08 gate that follows
-          # it, or a cutover step-08 would pass dies here instead.
+          {{- /*
+           #5436 — region-A pivot READ-BACK assert inputs. Until this
+           landed, region-A's only failure signal was the Phase-1 `fail`
+           counter, which counts `kubectl patch` invocations that returned
+           non-zero — NOT the state of the cluster afterwards. See the
+           assert_region_a_pivot block in args: below.
+
+           readbackExcludeNames MUST stay a superset-tolerant mirror of the
+           slot-managed self-reference whitelist step-08's own offender scan
+           applies (08-egress-block-test-job.yaml count_offenders). This
+           assert must never be STRICTER than the step-08 gate that follows
+           it, or a cutover step-08 would pass dies here instead.
+          */}}
           - name: HELMREPO_READBACK_EXCLUDE
             value: {{ join "," .Values.helmRepositories.readbackExcludeNames | quote }}
           - name: HELMREPO_READBACK_KUSTOMIZATIONS
             value: {{ join " " .Values.helmRepositories.readbackReconcileKustomizations | quote }}
           - name: HELMREPO_READBACK_BUDGET_SECONDS
             value: {{ .Values.stepTimeouts.pivotReadbackSeconds | quote }}
-          # #5596 — SECONDARY-region DURABLE pivot assert inputs. The #5359
-          # read-back was single-shot and fired seconds after the patch loop,
-          # so it measured the PATCH and never the PIVOT: region-B's own
-          # kustomize-controller re-applied its (pre-cutover) artifact ~55s
-          # later and put all 64 HelmRepositories back on ghcr.io while the
-          # step had already recorded success. The assert now POKES the
-          # secondary's own GitRepository + HR-owning Kustomizations and will
-          # not certify until one of them has HANDLED that poke — i.e. the
-          # actor that would revert the pivot has already run. See
-          # assert_secondary_pivot_durable in args: below.
+          {{- /*
+           #5596 — SECONDARY-region DURABLE pivot assert inputs. The #5359
+           read-back was single-shot and fired seconds after the patch loop,
+           so it measured the PATCH and never the PIVOT: region-B's own
+           kustomize-controller re-applied its (pre-cutover) artifact ~55s
+           later and put all 64 HelmRepositories back on ghcr.io while the
+           step had already recorded success. The assert now POKES the
+           secondary's own GitRepository + HR-owning Kustomizations and will
+           not certify until one of them has HANDLED that poke — i.e. the
+           actor that would revert the pivot has already run. See
+           assert_secondary_pivot_durable in args: below.
+          */}}
           - name: GITOPS_REPO_NAME
             value: {{ .Values.gitopsRepository.name | quote }}
           - name: GITOPS_REPO_NAMESPACE
@@ -603,11 +660,13 @@ data:
             value: {{ .Values.secondaryRegions.pivotReadbackSettleSamples | quote }}
           - name: SECONDARY_READBACK_INTERVAL_SECONDS
             value: {{ .Values.secondaryRegions.pivotReadbackIntervalSeconds | quote }}
-          # #5650 — vcluster loft chart-source pivot (Phase-2c). Mirrors the
-          # upstream vcluster chart into local Harbor + repoints the
-          # index.yaml loft HelmRepository (vcluster-system) to the local OCI
-          # copy so it is no longer a residual charts.loft.sh tether. See
-          # .Values.helmRepositories.vclusterLoftPivot.
+          {{- /*
+           #5650 — vcluster loft chart-source pivot (Phase-2c). Mirrors the
+           upstream vcluster chart into local Harbor + repoints the
+           index.yaml loft HelmRepository (vcluster-system) to the local OCI
+           copy so it is no longer a residual charts.loft.sh tether. See
+           .Values.helmRepositories.vclusterLoftPivot.
+          */}}
           - name: VCL_LOFT_PIVOT_ENABLED
             value: {{ eq (toString .Values.helmRepositories.vclusterLoftPivot.enabled) "true" | quote }}
           - name: VCL_LOFT_HR_NAME
@@ -637,14 +696,16 @@ data:
           - name: bootstrap-kit-pins
             mountPath: /pin-extractor
             readOnly: true
-          # #5593 — Phase 2c of the step script, `.`-sourced from here.
+          {{- /* #5593 — Phase 2c of the step script, `.`-sourced from here. */}}
           - name: phase2c-script
             mountPath: /phase2c
             readOnly: true
           - name: tmp
             mountPath: /tmp
-          # #5359 — optional secondary-region kubeconfigs (empty on a
-          # single-region Sovereign; the leg no-ops).
+          {{- /*
+           #5359 — optional secondary-region kubeconfigs (empty on a
+           single-region Sovereign; the leg no-ops).
+          */}}
           - name: secondary-kubeconfigs
             mountPath: /secondary-kubeconfigs
             readOnly: true
@@ -654,69 +715,77 @@ data:
             set -eu
             harbor_host=$(printf '%s' "${HARBOR_PUBLIC_URL}" | sed -E 's,^https?://,,; s,/$,,')
 
-            # #4682 — the registry is reached ONLY via its EXTERNAL routable host
-            # `registry.<fqdn>` on the standard HTTPS port :443, through the
-            # Cilium Gateway `Service type=LoadBalancer`. hostNetwork is OFF so
-            # the gateway serves plain :443 (no NodePort, no high-port append, no
-            # CoreDNS ClusterIP rewrite). The pivoted HelmRepository url is the
-            # bare host `oci://registry.<fqdn>/openova-io` — the same host every
-            # node resolves via public DNS, and the port source-controller + the
-            # Phase-3a probe implicitly use is :443. `harbor_endpoint` is kept as
-            # an alias of the bare host so downstream references (auth key, probe,
-            # strip-host guard) stay uniform.
+            {{- /*
+             #4682 — the registry is reached ONLY via its EXTERNAL routable host
+             `registry.<fqdn>` on the standard HTTPS port :443, through the
+             Cilium Gateway `Service type=LoadBalancer`. hostNetwork is OFF so
+             the gateway serves plain :443 (no NodePort, no high-port append, no
+             CoreDNS ClusterIP rewrite). The pivoted HelmRepository url is the
+             bare host `oci://registry.<fqdn>/openova-io` — the same host every
+             node resolves via public DNS, and the port source-controller + the
+             Phase-3a probe implicitly use is :443. `harbor_endpoint` is kept as
+             an alias of the bare host so downstream references (auth key, probe,
+             strip-host guard) stay uniform.
+            */}}
             harbor_endpoint="${harbor_host}"
             local_prefix="oci://${harbor_endpoint}/openova-io"
 
             echo "[helmrepository-patches] upstream=${UPSTREAM_PREFIX} -> local=${local_prefix} (harbor_host=${harbor_host})"
 
-            # ---- Phase -1: wait for Cilium Gateway Programmed=True (issue #1871) ----
-            #
-            # The URL rewrite in Phase 1 below makes every HelmRepository
-            # OCI pull dependent on `registry.${SOVEREIGN_FQDN}` answering
-            # TLS. That hostname is served by bp-harbor's HTTPRoute
-            # attached to `gateway.networking.k8s.io/v1.Gateway
-            # cilium-gateway` in `kube-system` (installed by
-            # `clusters/_template/sovereign-tls/cilium-gateway.yaml`).
-            # If we rewrite URLs BEFORE the Gateway is Programmed=True
-            # (= listener bound, wildcard cert wired), source-controller
-            # hits TLS handshake EOF on every reconcile, bp-catalyst-
-            # platform flips Ready=False, bootstrap-kit Ks Reconciling,
-            # sovereign-tls Ks DependencyNotReady on bootstrap-kit,
-            # Gateway never installed → infinite deadlock.
-            #
-            # Discovered on t26 zero-touch 2026-05-18 (99bb823cb0513f4b,
-            # A55 diagnostic). The previous attempt (PR #1875) added
-            # `sovereign-tls` to the HR dependsOn but Flux HR.dependsOn
-            # cannot reference Kustomizations — helm-controller logged
-            # `helmreleases.helm.toolkit.fluxcd.io "sovereign-tls" not
-            # found` forever (A84 test on t27). This in-Job wait is the
-            # correct seam: cross-kind ordering enforced by polling, not
-            # by Flux's HR-only dependsOn graph.
-            #
-            # `kubectl wait` would suffice in principle but does not
-            # tolerate the resource being absent at start (only Not-Yet-
-            # Condition). The Gateway CR is itself installed by the
-            # sovereign-tls Kustomization that only fires AFTER
-            # bootstrap-kit reconciles Ready — and bootstrap-kit lists
-            # this chart, so the Gateway CR genuinely does NOT exist
-            # when catalyst-api stamps this Job in the trigger path. We
-            # therefore poll in a shell loop with a get-or-skip prelude
-            # before transitioning to `kubectl wait` once the resource
-            # is materialised.
+            {{- /*
+             ---- Phase -1: wait for Cilium Gateway Programmed=True (issue #1871) ----
+
+             The URL rewrite in Phase 1 below makes every HelmRepository
+             OCI pull dependent on `registry.${SOVEREIGN_FQDN}` answering
+             TLS. That hostname is served by bp-harbor's HTTPRoute
+             attached to `gateway.networking.k8s.io/v1.Gateway
+             cilium-gateway` in `kube-system` (installed by
+             `clusters/_template/sovereign-tls/cilium-gateway.yaml`).
+             If we rewrite URLs BEFORE the Gateway is Programmed=True
+             (= listener bound, wildcard cert wired), source-controller
+             hits TLS handshake EOF on every reconcile, bp-catalyst-
+             platform flips Ready=False, bootstrap-kit Ks Reconciling,
+             sovereign-tls Ks DependencyNotReady on bootstrap-kit,
+             Gateway never installed → infinite deadlock.
+
+             Discovered on t26 zero-touch 2026-05-18 (99bb823cb0513f4b,
+             A55 diagnostic). The previous attempt (PR #1875) added
+             `sovereign-tls` to the HR dependsOn but Flux HR.dependsOn
+             cannot reference Kustomizations — helm-controller logged
+             `helmreleases.helm.toolkit.fluxcd.io "sovereign-tls" not
+             found` forever (A84 test on t27). This in-Job wait is the
+             correct seam: cross-kind ordering enforced by polling, not
+             by Flux's HR-only dependsOn graph.
+
+             `kubectl wait` would suffice in principle but does not
+             tolerate the resource being absent at start (only Not-Yet-
+             Condition). The Gateway CR is itself installed by the
+             sovereign-tls Kustomization that only fires AFTER
+             bootstrap-kit reconciles Ready — and bootstrap-kit lists
+             this chart, so the Gateway CR genuinely does NOT exist
+             when catalyst-api stamps this Job in the trigger path. We
+             therefore poll in a shell loop with a get-or-skip prelude
+             before transitioning to `kubectl wait` once the resource
+             is materialised.
+            */}}
             echo "[helmrepository-patches] Phase -1: waiting for Gateway ${GATEWAY_NAMESPACE}/${GATEWAY_NAME} Programmed=True (timeout ${GATEWAY_WAIT_TIMEOUT_SECONDS}s)"
             gw_deadline=$(( $(date +%s) + GATEWAY_WAIT_TIMEOUT_SECONDS ))
             gw_ready="false"
             while [ "$(date +%s)" -lt "${gw_deadline}" ]; do
-              # Check existence first — `kubectl wait` errors out on
-              # a missing resource rather than waiting for it.
+              {{- /*
+               Check existence first — `kubectl wait` errors out on
+               a missing resource rather than waiting for it.
+              */}}
               if kubectl get gateway.gateway.networking.k8s.io "${GATEWAY_NAME}" \
                    -n "${GATEWAY_NAMESPACE}" >/dev/null 2>&1; then
-                # Resource exists — read the Programmed condition status
-                # directly. Avoid `kubectl wait --for=condition=` because
-                # the gateway.networking.k8s.io API uses condition.type=
-                # `Programmed` (capital P, per Gateway API v1) and some
-                # kubectl builds compare case-insensitively, masking real
-                # status. jsonpath read is unambiguous.
+                {{- /*
+                 Resource exists — read the Programmed condition status
+                 directly. Avoid `kubectl wait --for=condition=` because
+                 the gateway.networking.k8s.io API uses condition.type=
+                 `Programmed` (capital P, per Gateway API v1) and some
+                 kubectl builds compare case-insensitively, masking real
+                 status. jsonpath read is unambiguous.
+                */}}
                 programmed=$(kubectl get gateway.gateway.networking.k8s.io "${GATEWAY_NAME}" \
                   -n "${GATEWAY_NAMESPACE}" \
                   -o jsonpath='{.status.conditions[?(@.type=="Programmed")].status}' \
@@ -726,14 +795,16 @@ data:
                   echo "[helmrepository-patches] Phase -1 OK: Gateway ${GATEWAY_NAMESPACE}/${GATEWAY_NAME} Programmed=True"
                   break
                 fi
-                # hostNetwork gateway mode (#4708): cilium assigns NO LB
-                # address, so Programmed stays False FOREVER while envoy
-                # serves node:443 directly (live: hw220 both Gateways
-                # AddressNotAssigned with console answering 200). Probe the
-                # ACTUAL invariant the rewrite depends on instead:
-                # registry.<fqdn> answering TLS. Any HTTP code (401/200/404)
-                # proves TCP+TLS+HTTP through the gateway; only a transport
-                # failure (000) keeps waiting.
+                {{- /*
+                 hostNetwork gateway mode (#4708): cilium assigns NO LB
+                 address, so Programmed stays False FOREVER while envoy
+                 serves node:443 directly (live: hw220 both Gateways
+                 AddressNotAssigned with console answering 200). Probe the
+                 ACTUAL invariant the rewrite depends on instead:
+                 registry.<fqdn> answering TLS. Any HTTP code (401/200/404)
+                 proves TCP+TLS+HTTP through the gateway; only a transport
+                 failure (000) keeps waiting.
+                */}}
                 reg_code=$(curl -sk -o /dev/null -w '%{http_code}' --connect-timeout 5 --max-time 15 "https://registry.${SOVEREIGN_FQDN}/v2/" 2>/dev/null || echo "000")
                 if [ "${reg_code}" != "000" ]; then
                   gw_ready="true"
@@ -753,76 +824,87 @@ data:
               exit 1
             fi
 
+            {{- /* Marker line, deliberately still a `#` comment: cutover-
+            contract.sh Case 17 asserts `Phase 0: ADD harbor` is present in the
+            RENDER, which is how it distinguishes the additive Phase-0 from the
+            destructive Phase-3 strip (#3379 #3526). */}}
             # ---- Phase 0: ADD harbor.<sov-fqdn> auth to ghcr-pull (#1184) ----
-            #
-            # source-controller pulls Helm OCI charts from
-            # oci://harbor.<sov-fqdn>/openova-io using the imagePullSecret
-            # named on each HelmRepository (`secretRef.name: ghcr-pull`,
-            # see clusters/_template/bootstrap-kit/*.yaml). The ghcr-pull
-            # Secret ships from cloud-init carrying ghcr.io +
-            # harbor.openova.io auth only — it has NO entry for
-            # harbor.<sov-fqdn>. Once Phase-1 below pivots HelmRepository
-            # URLs, every reconcile against the local Harbor 401s.
-            #
-            # ── STRIP-BEFORE-PIVOT FIX (Refs #3379 #3526, hw139 half-pivot) ──
-            # Phase-0 is now PURELY ADDITIVE — it merges the local Harbor
-            # auth and NOTHING ELSE. The DESTRUCTIVE removal of the
-            # mothership-side ghcr.io / harbor.openova.io auth entries
-            # (TBD-V24 MISS-2 credential hygiene) was MOVED to the new
-            # Phase 3 at the END of this Job — see that block for the full
-            # rationale. The invariant the move enforces: NEVER strip
-            # ghcr.io creds until every HelmRepository is already pivoted to
-            # local Harbor AND reconciling Ready from it. On hw139 the strip
-            # ran in Phase-0 (BEFORE the Phase-1 URL pivot); a later step
-            # wedged, leaving ghcr.io creds gone while the on-disk Gitea
-            # YAML / live HR sources still pointed at ghcr.io → every
-            # reconcile failed "no auth config for 'ghcr.io' in the
-            # docker-registry Secret 'ghcr-pull'" and the half-pivot was
-            # permanent + unrecoverable zero-touch (8 HRs wedged 10h,
-            # blocking the unrelated bp-newapi #3564 roll). Adding Harbor
-            # auth early is safe (purely additive, idempotent); removing
-            # ghcr.io auth is the irreversible act that MUST come last.
-            #
-            # Manual fix done on omantel 2026-05-10 (session 5c468708):
-            #   HARBOR_AUTH=$(echo -n "admin:${HADMIN_PW}" | base64 -w0)
-            #   NEW=$(jq --arg auth "$HARBOR_AUTH" \
-            #           '.auths["harbor.omantel.biz"] = {
-            #              "username":"admin","auth":$auth }' <existing>)
-            #   kubectl patch secret ghcr-pull -n flux-system \
+            {{- /*
+             source-controller pulls Helm OCI charts from
+             oci://harbor.<sov-fqdn>/openova-io using the imagePullSecret
+             named on each HelmRepository (`secretRef.name: ghcr-pull`,
+             see clusters/_template/bootstrap-kit/*.yaml). The ghcr-pull
+             Secret ships from cloud-init carrying ghcr.io +
+             harbor.openova.io auth only — it has NO entry for
+             harbor.<sov-fqdn>. Once Phase-1 below pivots HelmRepository
+             URLs, every reconcile against the local Harbor 401s.
+
+             ── STRIP-BEFORE-PIVOT FIX (Refs #3379 #3526, hw139 half-pivot) ──
+             Phase-0 is now PURELY ADDITIVE — it merges the local Harbor
+             auth and NOTHING ELSE. The DESTRUCTIVE removal of the
+             mothership-side ghcr.io / harbor.openova.io auth entries
+             (TBD-V24 MISS-2 credential hygiene) was MOVED to the new
+             Phase 3 at the END of this Job — see that block for the full
+             rationale. The invariant the move enforces: NEVER strip
+             ghcr.io creds until every HelmRepository is already pivoted to
+             local Harbor AND reconciling Ready from it. On hw139 the strip
+             ran in Phase-0 (BEFORE the Phase-1 URL pivot); a later step
+             wedged, leaving ghcr.io creds gone while the on-disk Gitea
+             YAML / live HR sources still pointed at ghcr.io → every
+             reconcile failed "no auth config for 'ghcr.io' in the
+             docker-registry Secret 'ghcr-pull'" and the half-pivot was
+             permanent + unrecoverable zero-touch (8 HRs wedged 10h,
+             blocking the unrelated bp-newapi #3564 roll). Adding Harbor
+             auth early is safe (purely additive, idempotent); removing
+             ghcr.io auth is the irreversible act that MUST come last.
+
+             Manual fix done on omantel 2026-05-10 (session 5c468708):
+               HARBOR_AUTH=$(echo -n "admin:${HADMIN_PW}" | base64 -w0)
+               NEW=$(jq --arg auth "$HARBOR_AUTH" \
+                       '.auths["harbor.omantel.biz"] = {
+                          "username":"admin","auth":$auth }' <existing>)
+               kubectl patch secret ghcr-pull -n flux-system \
+            */}}
             #     --type=merge -p "{\"data\":{...}}"
-            #
-            # Phase 0 codifies that patch so the next fresh `tofu apply`
-            # comes up GREEN without operator intervention.
+            {{- /*
+
+             Phase 0 codifies that patch so the next fresh `tofu apply`
+             comes up GREEN without operator intervention.
+            */}}
             : "${HARBOR_USERNAME:=admin}"
             if [ -z "${HARBOR_PASSWORD:-}" ]; then
               echo "[helmrepository-patches] FATAL: HARBOR_PASSWORD env empty — cannot derive harbor.${harbor_host} auth" >&2
               exit 1
             fi
 
-            # Read the dockerconfigjson via `-o json | jq` (NOT kubectl
-            # jsonpath bracket-form). kubectl jsonpath interprets the
-            # leading dot in `.dockerconfigjson` as a child accessor
-            # INSIDE the bracket, returning empty even though the key
-            # exists. Fix #77 (Gap A) — caught live on omantel prov #7
-            # 2026-05-10: Job logged
-            # `FATAL: ghcr-pull Secret has no .dockerconfigjson key`
-            # despite `kubectl get secret ... -o yaml` clearly showing
-            # the key present. Confirmed reproducer:
-            #   kubectl get secret ghcr-pull -n flux-system \
-            #     -o "jsonpath={.data['.dockerconfigjson']}"   → empty
-            #   kubectl get secret ghcr-pull -n flux-system \
-            #     -o "jsonpath={.data['\.dockerconfigjson']}"  → b64
-            # Using `-o json | jq` avoids the escape ambiguity entirely
-            # and works regardless of the literal key name.
-            #
-            # Wait-loop (up to 60s) handles the case where Reflector has
-            # not yet propagated the Secret into ${GHCR_PULL_SECRET_NAMESPACE}
-            # when this Job stamps. Falls back to the source namespace
-            # (flux-system, where cloud-init writes the original) if the
-            # local copy is still missing after the timeout.
+            {{- /*
+             Read the dockerconfigjson via `-o json | jq` (NOT kubectl
+             jsonpath bracket-form). kubectl jsonpath interprets the
+             leading dot in `.dockerconfigjson` as a child accessor
+             INSIDE the bracket, returning empty even though the key
+             exists. Fix #77 (Gap A) — caught live on omantel prov #7
+             2026-05-10: Job logged
+             `FATAL: ghcr-pull Secret has no .dockerconfigjson key`
+             despite `kubectl get secret ... -o yaml` clearly showing
+             the key present. Confirmed reproducer:
+               kubectl get secret ghcr-pull -n flux-system \
+                 -o "jsonpath={.data['.dockerconfigjson']}"   → empty
+               kubectl get secret ghcr-pull -n flux-system \
+                 -o "jsonpath={.data['\.dockerconfigjson']}"  → b64
+             Using `-o json | jq` avoids the escape ambiguity entirely
+             and works regardless of the literal key name.
+
+             Wait-loop (up to 60s) handles the case where Reflector has
+             not yet propagated the Secret into ${GHCR_PULL_SECRET_NAMESPACE}
+             when this Job stamps. Falls back to the source namespace
+             (flux-system, where cloud-init writes the original) if the
+             local copy is still missing after the timeout.
+            */}}
             read_secret_key() {
-              # $1 = namespace
-              # Echoes base64 value of GHCR_PULL_SECRET_KEY or empty.
+              {{- /*
+               $1 = namespace
+               Echoes base64 value of GHCR_PULL_SECRET_KEY or empty.
+              */}}
               kubectl get secret "${GHCR_PULL_SECRET_NAME}" -n "$1" -o json 2>/dev/null \
                 | jq -r --arg k "${GHCR_PULL_SECRET_KEY}" '.data[$k] // empty'
             }
@@ -837,10 +919,12 @@ data:
               sleep 5
             done
             if [ -z "${existing_b64}" ] && [ "${target_ns}" != "flux-system" ]; then
-              # Fallback: read from the source ns (flux-system) where
-              # cloud-init wrote the original. Reflector copies into
-              # ${GHCR_PULL_SECRET_NAMESPACE} but the source is always
-              # readable by the runner ClusterRole.
+              {{- /*
+               Fallback: read from the source ns (flux-system) where
+               cloud-init wrote the original. Reflector copies into
+               ${GHCR_PULL_SECRET_NAMESPACE} but the source is always
+               readable by the runner ClusterRole.
+              */}}
               echo "[helmrepository-patches] Phase-0: falling back to flux-system/${GHCR_PULL_SECRET_NAME} (Reflector lag suspected)"
               target_ns="flux-system"
               existing_b64=$(read_secret_key "${target_ns}")
@@ -852,27 +936,29 @@ data:
 
             existing_json=$(printf '%s' "${existing_b64}" | base64 -d)
 
-            # Idempotency guard: the ADD is a no-op when harbor.<sov-fqdn>
-            # already maps to the expected auth. Re-runs of step-06
-            # (catalyst-api may retry / the engine may re-fire) MUST NOT
-            # churn the Secret resourceVersion when there's nothing to add
-            # — that triggers a noisy reflector cascade.
-            #
-            # NOTE (Refs #3379 #3526): Phase-0 NO LONGER strips the
-            # mothership ghcr.io / harbor.openova.io auth — that is deferred
-            # to Phase 3 (end of Job, gated on the pivot being Ready). So
-            # the idempotency check here is the simple "is the Harbor auth
-            # already present" test; the strip's own idempotency lives in
-            # Phase 3.
-            # #4682: the auth entry is keyed on the bare external host
-            # `registry.<fqdn>` — the SAME host the pivoted HelmRepository urls
-            # carry (oci://registry.<fqdn>/openova-io, implicit :443 via the
-            # Gateway LoadBalancer). Docker/OCI auth lookup is an EXACT host[:port]
-            # string match; since every pivoted url now uses the bare host, a
-            # single bare-host key is exactly what source-controller + the
-            # Phase-3a probe look up (no high-port endpoint key — that NodePort
-            # workaround is gone). source-controller reads THIS ghcr-pull
-            # dockerconfigjson for the pivoted pull.
+            {{- /*
+             Idempotency guard: the ADD is a no-op when harbor.<sov-fqdn>
+             already maps to the expected auth. Re-runs of step-06
+             (catalyst-api may retry / the engine may re-fire) MUST NOT
+             churn the Secret resourceVersion when there's nothing to add
+             — that triggers a noisy reflector cascade.
+
+             NOTE (Refs #3379 #3526): Phase-0 NO LONGER strips the
+             mothership ghcr.io / harbor.openova.io auth — that is deferred
+             to Phase 3 (end of Job, gated on the pivot being Ready). So
+             the idempotency check here is the simple "is the Harbor auth
+             already present" test; the strip's own idempotency lives in
+             Phase 3.
+             #4682: the auth entry is keyed on the bare external host
+             `registry.<fqdn>` — the SAME host the pivoted HelmRepository urls
+             carry (oci://registry.<fqdn>/openova-io, implicit :443 via the
+             Gateway LoadBalancer). Docker/OCI auth lookup is an EXACT host[:port]
+             string match; since every pivoted url now uses the bare host, a
+             single bare-host key is exactly what source-controller + the
+             Phase-3a probe look up (no high-port endpoint key — that NodePort
+             workaround is gone). source-controller reads THIS ghcr-pull
+             dockerconfigjson for the pivoted pull.
+            */}}
             already=$(printf '%s' "${existing_json}" | jq -r --arg h "${harbor_host}" \
               '.auths[$h].auth // empty')
             harbor_auth=$(printf '%s:%s' "${HARBOR_USERNAME}" "${HARBOR_PASSWORD}" | base64 -w0)
@@ -880,27 +966,31 @@ data:
             if [ -n "${already}" ] && [ "${already}" = "${harbor_auth}" ]; then
               echo "[helmrepository-patches] Phase-0 skip: ghcr-pull already carries auth for ${harbor_host} (strip deferred to Phase 3)"
             else
-              # Single jq pass: ADD registry.<fqdn> auth under the bare host key.
-              # This is the PURELY ADDITIVE half of the old combined pipeline —
-              # the destructive `del(.auths[...])` arms were moved to Phase 3 (see
-              # the strip-before-pivot fix). Adding Harbor auth early is the
-              # precondition that lets Phase-1's pivoted HelmRepositories pull from
-              # local Harbor; it leaves the ghcr.io fallback intact so a wedge
-              # before Phase 3 is recoverable.
-              #
-              # `--arg` ALWAYS treats its value as a string (no shell
-              # interpolation), so the Harbor password is never re-parsed
-              # by the shell.
+              {{- /*
+               Single jq pass: ADD registry.<fqdn> auth under the bare host key.
+               This is the PURELY ADDITIVE half of the old combined pipeline —
+               the destructive `del(.auths[...])` arms were moved to Phase 3 (see
+               the strip-before-pivot fix). Adding Harbor auth early is the
+               precondition that lets Phase-1's pivoted HelmRepositories pull from
+               local Harbor; it leaves the ghcr.io fallback intact so a wedge
+               before Phase 3 is recoverable.
+
+               `--arg` ALWAYS treats its value as a string (no shell
+               interpolation), so the Harbor password is never re-parsed
+               by the shell.
+              */}}
               new_json=$(printf '%s' "${existing_json}" | jq \
                 --arg h "${harbor_host}" \
                 --arg user "${HARBOR_USERNAME}" \
                 --arg auth "${harbor_auth}" \
                 '.auths[$h] = {"username":$user,"auth":$auth}')
               new_b64=$(printf '%s' "${new_json}" | base64 -w0)
-              # Merge-patch the data field. Quoting note: ${GHCR_PULL_SECRET_KEY}
-              # is `.dockerconfigjson` which is a literal key (the leading
-              # dot is part of the field name); JSON merge-patch treats it
-              # as a single key, no path traversal.
+              {{- /*
+               Merge-patch the data field. Quoting note: ${GHCR_PULL_SECRET_KEY}
+               is `.dockerconfigjson` which is a literal key (the leading
+               dot is part of the field name); JSON merge-patch treats it
+               as a single key, no path traversal.
+              */}}
               patch_payload=$(printf '{"data":{"%s":"%s"}}' "${GHCR_PULL_SECRET_KEY}" "${new_b64}")
               if kubectl patch secret "${GHCR_PULL_SECRET_NAME}" \
                   -n "${GHCR_PULL_SECRET_NAMESPACE}" \
@@ -910,11 +1000,13 @@ data:
                 echo "[helmrepository-patches] FATAL: kubectl patch ${GHCR_PULL_SECRET_NAME} failed" >&2
                 exit 1
               fi
-              # Trigger an immediate refresh of every HelmRepository so
-              # source-controller re-loads the Secret on next pull.
-              # Phase 1 below only annotates HRs in HELMREPO_NAMESPACE
-              # whose URL it pivots — but the auth merge benefits every
-              # HR pulling from harbor.<sov-fqdn>, so kick all of them.
+              {{- /*
+               Trigger an immediate refresh of every HelmRepository so
+               source-controller re-loads the Secret on next pull.
+               Phase 1 below only annotates HRs in HELMREPO_NAMESPACE
+               whose URL it pivots — but the auth merge benefits every
+               HR pulling from harbor.<sov-fqdn>, so kick all of them.
+              */}}
               now_ts=$(date +%s)
               kubectl get helmrepositories -A \
                 -o jsonpath='{range .items[*]}{.metadata.namespace}{" "}{.metadata.name}{"\n"}{end}' \
@@ -925,39 +1017,43 @@ data:
               done || true
             fi
 
-            # ---- Phase 0.5: build the source-controller TLS-trust Secret (Refs #3379) ----
-            #
-            # THE LAST LEG OF THE CUTOVER CERT-TAIL. After Phase-1 pivots each
-            # HelmRepository URL to oci://${harbor_host}/openova-io, the Flux
-            # SOURCE-CONTROLLER pulls those OCI charts from the in-cluster
-            # Harbor — whose wildcard `*.${SOVEREIGN_FQDN}` cert is served by
-            # the bootstrap LE-STAGING issuer on a fresh / qaTestEnabled prov.
-            # source-controller carries only the public CA bundle → every
-            # pivoted pull fails `tls: x509: certificate signed by unknown
-            # authority` → the pivot never reconciles → Phase-3a's strip-
-            # readiness gate never converges → the cutover never reaches the
-            # 600s deny-egress hold → cutoverComplete never set (live dep
-            # 00720a7a). Flux OCI HelmRepository has NO insecureSkipVerify; the
-            # ONLY trust mechanism is spec.certSecretRef → a Secret whose
-            # `ca.crt` verifies the registry cert. This phase materialises that
-            # Secret in ${HELMREPO_NAMESPACE}; Phase-1 wires each pivoted HR's
-            # certSecretRef to it; Phase-2 makes both durable in Gitea.
-            #
-            # Fail-OPEN: if trust is disabled, or the wildcard Secret / CA
-            # cannot be read, we log and continue WITHOUT a certSecretRef
-            # (preserving the prior behaviour for a public-CA-trusted Harbor)
-            # rather than wedging the whole cutover on the trust seam.
+            {{- /*
+             ---- Phase 0.5: build the source-controller TLS-trust Secret (Refs #3379) ----
+
+             THE LAST LEG OF THE CUTOVER CERT-TAIL. After Phase-1 pivots each
+             HelmRepository URL to oci://${harbor_host}/openova-io, the Flux
+             SOURCE-CONTROLLER pulls those OCI charts from the in-cluster
+             Harbor — whose wildcard `*.${SOVEREIGN_FQDN}` cert is served by
+             the bootstrap LE-STAGING issuer on a fresh / qaTestEnabled prov.
+             source-controller carries only the public CA bundle → every
+             pivoted pull fails `tls: x509: certificate signed by unknown
+             authority` → the pivot never reconciles → Phase-3a's strip-
+             readiness gate never converges → the cutover never reaches the
+             600s deny-egress hold → cutoverComplete never set (live dep
+             00720a7a). Flux OCI HelmRepository has NO insecureSkipVerify; the
+             ONLY trust mechanism is spec.certSecretRef → a Secret whose
+             `ca.crt` verifies the registry cert. This phase materialises that
+             Secret in ${HELMREPO_NAMESPACE}; Phase-1 wires each pivoted HR's
+             certSecretRef to it; Phase-2 makes both durable in Gitea.
+
+             Fail-OPEN: if trust is disabled, or the wildcard Secret / CA
+             cannot be read, we log and continue WITHOUT a certSecretRef
+             (preserving the prior behaviour for a public-CA-trusted Harbor)
+             rather than wedging the whole cutover on the trust seam.
+            */}}
             trust_secret=""
             case "${HELMREPO_TRUST_ENABLED:-false}" in
               true|True|TRUE|1|yes)
-                # Wildcard TLS Secret name = <prefix><fqdn with '.'->'-'>.
+                {{- /* Wildcard TLS Secret name = <prefix><fqdn with '.'->'-'>. */}}
                 fqdn_dashed=$(printf '%s' "${SOVEREIGN_FQDN}" | tr '.' '-')
                 wc_secret="${HELMREPO_TRUST_SRC_NAME_PREFIX}${fqdn_dashed}"
                 echo "[helmrepository-patches] Phase-0.5: building source-controller trust Secret from ${HELMREPO_TRUST_SRC_NAMESPACE}/${wc_secret}"
-                # Prefer the issuing CA (`ca.crt`); fall back to the served
-                # leaf+chain (`tls.crt`) used as a self-trust bundle when the
-                # issuer did not populate ca.crt. Read via `-o json | jq` to
-                # dodge the jsonpath dotted-key ambiguity (Fix #77 shape).
+                {{- /*
+                 Prefer the issuing CA (`ca.crt`); fall back to the served
+                 leaf+chain (`tls.crt`) used as a self-trust bundle when the
+                 issuer did not populate ca.crt. Read via `-o json | jq` to
+                 dodge the jsonpath dotted-key ambiguity (Fix #77 shape).
+                */}}
                 ca_b64=$(kubectl get secret "${wc_secret}" -n "${HELMREPO_TRUST_SRC_NAMESPACE}" -o json 2>/dev/null \
                   | jq -r '.data["ca.crt"] // empty')
                 if [ -z "${ca_b64}" ]; then
@@ -968,11 +1064,13 @@ data:
                 if [ -z "${ca_b64}" ]; then
                   echo "[helmrepository-patches] Phase-0.5 WARN: could not read ca.crt or tls.crt from ${HELMREPO_TRUST_SRC_NAMESPACE}/${wc_secret} — pivoting HelmRepository URLs WITHOUT a certSecretRef (source-controller will need a public-CA-trusted Harbor cert)"
                 else
-                  # Create/replace the ca.crt-only Secret in the HelmRepository
-                  # namespace. Opaque (not kubernetes.io/tls): source-controller
-                  # reads only the `ca.crt` key for certSecretRef; the private
-                  # key is deliberately NEVER copied. `kubectl apply` is
-                  # idempotent (re-runs converge; a CA rotation re-applies).
+                  {{- /*
+                   Create/replace the ca.crt-only Secret in the HelmRepository
+                   namespace. Opaque (not kubernetes.io/tls): source-controller
+                   reads only the `ca.crt` key for certSecretRef; the private
+                   key is deliberately NEVER copied. `kubectl apply` is
+                   idempotent (re-runs converge; a CA rotation re-applies).
+                  */}}
                   trust_manifest=$(printf 'apiVersion: v1\nkind: Secret\nmetadata:\n  name: %s\n  namespace: %s\n  labels:\n    app.kubernetes.io/managed-by: self-sovereign-cutover\n    bp.openova.io/cutover-step: helmrepository-patches\ntype: Opaque\ndata:\n  ca.crt: %s\n' \
                     "${HELMREPO_TRUST_DEST_SECRET}" "${HELMREPO_NAMESPACE}" "${ca_b64}")
                   if printf '%s' "${trust_manifest}" | kubectl apply -f - >/dev/null 2>&1; then
@@ -988,34 +1086,36 @@ data:
                 ;;
             esac
 
-            # ---- Phase 0.9 (#4885): union curated names with live upstream HRs ----
-            #
-            # The curated .Values.helmRepositories.names list (materialised into
-            # /work/helmrepository-names.txt) is HAND-MAINTAINED and always drifts
-            # behind the per-Org / marketplace TENANT-blueprint HelmRepositories the
-            # catalyst-api org-tenant pipeline seeds at Org-provisioning time —
-            # bp-agenity / bp-openclaw / bp-stalwart-tenant / bp-wordpress-tenant
-            # (+ the shared bp-keycloak / bp-cnpg / bp-newapi), declared in
-            # products/catalyst/bootstrap/api/internal/handler/organization_gitops.go
-            # (orgTenantSharedHelmRepositories) + core/services/provisioning/gitops/
-            # helmrelease_apps.go (helmRepoBlock), both hardcoded to
-            # oci://ghcr.io/openova-io. Those names are NEVER in the curated list, so
-            # step-06 left them on ghcr.io and step-08's `-A` offender scan
-            # (count_offenders) wedged the deny-egress PRE-CHECK on them → the 600s
-            # hold never ran → cutoverComplete unreachable (PROVEN hw232, #4885 10:36
-            # residual).
-            #
-            # FIX: union the curated list with EVERY live HelmRepository in
-            # HELMREPO_NAMESPACE whose spec.url still points at the upstream OCI
-            # prefix, so the Phase-1 pivot is DRIFT-PROOF and covers tenant/catalog
-            # blueprint repos present at cutover time — the SAME live∪declared
-            # discipline step-03 Phase-A2 (#4573 F4) already applies to the chart-
-            # mirror set. (Phase-2b below rewrites their org-tenants Gitea source so
-            # the live patch is durable. Repos SEEDED AFTER this step — Orgs
-            # provisioned post-cutover — additionally need the org-tenant pipeline to
-            # emit local URLs at source; tracked as the #4885 durable-source
-            # follow-on. This covers everything present when the cutover runs, which
-            # is the proven wedge.)
+            {{- /*
+             ---- Phase 0.9 (#4885): union curated names with live upstream HRs ----
+
+             The curated .Values.helmRepositories.names list (materialised into
+             /work/helmrepository-names.txt) is HAND-MAINTAINED and always drifts
+             behind the per-Org / marketplace TENANT-blueprint HelmRepositories the
+             catalyst-api org-tenant pipeline seeds at Org-provisioning time —
+             bp-agenity / bp-openclaw / bp-stalwart-tenant / bp-wordpress-tenant
+             (+ the shared bp-keycloak / bp-cnpg / bp-newapi), declared in
+             products/catalyst/bootstrap/api/internal/handler/organization_gitops.go
+             (orgTenantSharedHelmRepositories) + core/services/provisioning/gitops/
+             helmrelease_apps.go (helmRepoBlock), both hardcoded to
+             oci://ghcr.io/openova-io. Those names are NEVER in the curated list, so
+             step-06 left them on ghcr.io and step-08's `-A` offender scan
+             (count_offenders) wedged the deny-egress PRE-CHECK on them → the 600s
+             hold never ran → cutoverComplete unreachable (PROVEN hw232, #4885 10:36
+             residual).
+
+             FIX: union the curated list with EVERY live HelmRepository in
+             HELMREPO_NAMESPACE whose spec.url still points at the upstream OCI
+             prefix, so the Phase-1 pivot is DRIFT-PROOF and covers tenant/catalog
+             blueprint repos present at cutover time — the SAME live∪declared
+             discipline step-03 Phase-A2 (#4573 F4) already applies to the chart-
+             mirror set. (Phase-2b below rewrites their org-tenants Gitea source so
+             the live patch is durable. Repos SEEDED AFTER this step — Orgs
+             provisioned post-cutover — additionally need the org-tenant pipeline to
+             emit local URLs at source; tracked as the #4885 durable-source
+             follow-on. This covers everything present when the cutover runs, which
+             is the proven wedge.)
+            */}}
             combined_names=/tmp/hr-names-combined.txt
             sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' /work/helmrepository-names.txt \
               | grep -v '^$' > "${combined_names}" || true
@@ -1023,65 +1123,69 @@ data:
               -o jsonpath='{range .items[*]}{.metadata.name}={.spec.url}{"\n"}{end}' 2>/dev/null \
               | awk -F= -v p="${UPSTREAM_PREFIX}" 'NF>=2 && index($2,p)==1 {print $1}' \
               >> "${combined_names}" || true
-            # De-dup (stable sort) so an HR in both the curated list and the live
-            # upstream set is patched exactly once.
+            {{- /*
+             De-dup (stable sort) so an HR in both the curated list and the live
+             upstream set is patched exactly once.
+            */}}
             sort -u "${combined_names}" -o "${combined_names}"
             echo "[helmrepository-patches] Phase-1 input: $(grep -c . "${combined_names}") HelmRepository name(s) (curated ∪ live-upstream)"
 
-            # ---- #5436: region-A HelmRepository pivot READ-BACK assert ----
-            #
-            # THE DEFECT THIS CLOSES. Before this block, region-A's ONLY
-            # failure signal was Phase-1's `fail` counter — which counts
-            # `kubectl patch` invocations that returned non-zero, NOT the
-            # state of the cluster afterwards. Every HelmRepository that
-            # Phase-0.9's enumeration never saw (seeded by the catalyst-api
-            # org-tenant pipeline AFTER the enumeration ran) or that Flux
-            # reverted from a durable source Phase-2/2b did not rewrite is
-            # therefore INVISIBLE to this step: zero patch calls fail,
-            # `fail` stays 0, the Job exits 0, and catalyst-api records
-            # `step.helmrepository-patches.result=success` on a Sovereign
-            # whose charts still resolve to the mothership. Live on hw290
-            # 2026-07-27: SIX flux-system HelmRepositories still on
-            # oci://ghcr.io/openova-io (bp-agenity / bp-keycloak /
-            # bp-newapi / bp-openclaw / bp-stalwart-tenant /
-            # bp-wordpress-tenant) with the step green and the Job
-            # succeeded=1. That makes `cutoverComplete=true` reachable on a
-            # still-tethered environment — the sovereignty claim would be
-            # false while the evidence trail said otherwise.
-            #
-            # The SECONDARY-region leg has had a read-back of this SHAPE since
-            # #5359 — but a SINGLE-SHOT one, with no convergence budget and no
-            # reconcile re-poke, so it could only ever sample the seconds
-            # between the patch and region-B's next Kustomization re-apply
-            # (#5596; see assert_secondary_pivot_durable below). Region-A never
-            # had one at all. This is that assertion, with a budget, for the
-            # region that matters most.
-            #
-            # Scope: HELMREPO_NAMESPACE (the namespace Phase-1 patches) —
-            # the same scope the #5359 secondary read-back uses, and where
-            # every hw290 offender lived. Step-08's `-A` scan remains the
-            # wider net; this assert deliberately fails EARLIER and closer
-            # to the code that could have fixed it.
-            #
-            # $1 = phase label for the log.
-            # $2 = bounded convergence budget in seconds (0 = single-shot).
-            #      The budget exists for the post-Phase-2 call: a durable
-            #      rewrite has to be pulled by the `openova` GitRepository
-            #      and re-applied by the bootstrap-kit / org-tenants
-            #      Kustomizations before a Flux-reverted URL settles back on
-            #      local Harbor — the same revert-race #3526 documents for
-            #      step-08. Reconciles are re-poked each cycle so a missed
-            #      request cannot strand the poll. The Phase-1.5 call is
-            #      single-shot: Phase-1's patches are synchronous API
-            #      writes, so there is nothing to converge.
-            #
-            # NB: the offender list is written to a FILE and grepped from
-            # the file — never `printf '%s' "$big" | grep -q`. Under
-            # `set -o pipefail` (which a future edit may add) grep closing
-            # the pipe on its first match SIGPIPEs the upstream writer and
-            # fails the whole script; that shape has bitten this repo twice
-            # (#5370, #5406) and once in this chart's own test harness
-            # (#4969, see tests/cutover-contract.sh Case 16c).
+            {{- /*
+             ---- #5436: region-A HelmRepository pivot READ-BACK assert ----
+
+             THE DEFECT THIS CLOSES. Before this block, region-A's ONLY
+             failure signal was Phase-1's `fail` counter — which counts
+             `kubectl patch` invocations that returned non-zero, NOT the
+             state of the cluster afterwards. Every HelmRepository that
+             Phase-0.9's enumeration never saw (seeded by the catalyst-api
+             org-tenant pipeline AFTER the enumeration ran) or that Flux
+             reverted from a durable source Phase-2/2b did not rewrite is
+             therefore INVISIBLE to this step: zero patch calls fail,
+             `fail` stays 0, the Job exits 0, and catalyst-api records
+             `step.helmrepository-patches.result=success` on a Sovereign
+             whose charts still resolve to the mothership. Live on hw290
+             2026-07-27: SIX flux-system HelmRepositories still on
+             oci://ghcr.io/openova-io (bp-agenity / bp-keycloak /
+             bp-newapi / bp-openclaw / bp-stalwart-tenant /
+             bp-wordpress-tenant) with the step green and the Job
+             succeeded=1. That makes `cutoverComplete=true` reachable on a
+             still-tethered environment — the sovereignty claim would be
+             false while the evidence trail said otherwise.
+
+             The SECONDARY-region leg has had a read-back of this SHAPE since
+             #5359 — but a SINGLE-SHOT one, with no convergence budget and no
+             reconcile re-poke, so it could only ever sample the seconds
+             between the patch and region-B's next Kustomization re-apply
+             (#5596; see assert_secondary_pivot_durable below). Region-A never
+             had one at all. This is that assertion, with a budget, for the
+             region that matters most.
+
+             Scope: HELMREPO_NAMESPACE (the namespace Phase-1 patches) —
+             the same scope the #5359 secondary read-back uses, and where
+             every hw290 offender lived. Step-08's `-A` scan remains the
+             wider net; this assert deliberately fails EARLIER and closer
+             to the code that could have fixed it.
+
+             $1 = phase label for the log.
+             $2 = bounded convergence budget in seconds (0 = single-shot).
+                  The budget exists for the post-Phase-2 call: a durable
+                  rewrite has to be pulled by the `openova` GitRepository
+                  and re-applied by the bootstrap-kit / org-tenants
+                  Kustomizations before a Flux-reverted URL settles back on
+                  local Harbor — the same revert-race #3526 documents for
+                  step-08. Reconciles are re-poked each cycle so a missed
+                  request cannot strand the poll. The Phase-1.5 call is
+                  single-shot: Phase-1's patches are synchronous API
+                  writes, so there is nothing to converge.
+
+             NB: the offender list is written to a FILE and grepped from
+             the file — never `printf '%s' "$big" | grep -q`. Under
+             `set -o pipefail` (which a future edit may add) grep closing
+             the pipe on its first match SIGPIPEs the upstream writer and
+             fails the whole script; that shape has bitten this repo twice
+             (#5370, #5406) and once in this chart's own test harness
+             (#4969, see tests/cutover-contract.sh Case 16c).
+            */}}
             assert_region_a_pivot() {
               ra_label="$1"
               ra_budget="${2:-0}"
@@ -1096,9 +1200,11 @@ data:
                   [ -n "${ra_line}" ] || continue
                   ra_name="${ra_line%%=*}"
                   ra_url="${ra_line#*=}"
-                  # Only the upstream prefix counts as an offender — a
-                  # non-default URL (an operator overlay pointing somewhere
-                  # else entirely) is not this step's business.
+                  {{- /*
+                   Only the upstream prefix counts as an offender — a
+                   non-default URL (an operator overlay pointing somewhere
+                   else entirely) is not this step's business.
+                  */}}
                   case "${ra_url}" in
                     "${UPSTREAM_PREFIX}"*) : ;;
                     *) continue ;;
@@ -1130,7 +1236,7 @@ data:
               return 0
             }
 
-            # ---- Phase 1: live K8s patches (immediate) ----
+            {{- /* ---- Phase 1: live K8s patches (immediate) ---- */}}
             ok=0
             skip=0
             fail=0
@@ -1150,12 +1256,14 @@ data:
 
               new_url=$(printf '%s' "${cur_url}" | sed -e "s,${UPSTREAM_PREFIX},${local_prefix},")
               if [ "${new_url}" = "${cur_url}" ]; then
-                # URL is already pivoted (or non-default). On a re-run the URL
-                # may already point at local Harbor while the certSecretRef is
-                # still absent — apply the trust ref so an already-pivoted HR
-                # is not left x509-failing source-controller (Refs #3379). Only
-                # acts when the URL is genuinely the local-Harbor host AND a
-                # trust secret was built AND the ref is not already present.
+                {{- /*
+                 URL is already pivoted (or non-default). On a re-run the URL
+                 may already point at local Harbor while the certSecretRef is
+                 still absent — apply the trust ref so an already-pivoted HR
+                 is not left x509-failing source-controller (Refs #3379). Only
+                 acts when the URL is genuinely the local-Harbor host AND a
+                 trust secret was built AND the ref is not already present.
+                */}}
                 case "${cur_url}" in
                   "${local_prefix}"|"${local_prefix}/"*)
                     if [ -n "${trust_secret}" ]; then
@@ -1184,13 +1292,15 @@ data:
                 continue
               fi
 
-              # Wire the source-controller TLS-trust certSecretRef alongside
-              # the URL pivot (Refs #3379). Without it, source-controller
-              # x509-fails the very first pull against the LE-staging
-              # in-cluster Harbor. The certSecretRef is added in the SAME
-              # merge-patch so the URL never lands trust-less even for a
-              # reconcile tick. When trust_secret is empty (disabled or the CA
-              # was unreadable) we pivot the URL only — prior behaviour.
+              {{- /*
+               Wire the source-controller TLS-trust certSecretRef alongside
+               the URL pivot (Refs #3379). Without it, source-controller
+               x509-fails the very first pull against the LE-staging
+               in-cluster Harbor. The certSecretRef is added in the SAME
+               merge-patch so the URL never lands trust-less even for a
+               reconcile tick. When trust_secret is empty (disabled or the CA
+               was unreadable) we pivot the URL only — prior behaviour.
+              */}}
               if [ -n "${trust_secret}" ]; then
                 patch=$(printf '{"spec":{"url":"%s","certSecretRef":{"name":"%s"}}}' "${new_url}" "${trust_secret}")
               else
@@ -1213,33 +1323,37 @@ data:
             echo "[helmrepository-patches] live-K8s ok=${ok} skip=${skip} fail=${fail}"
             [ "${fail}" -eq 0 ] || exit 1
 
-            # ---- Phase 1.5 (#5436): read back what Phase-1 actually did ----
-            # `fail=0` only means every patch CALL returned zero. Assert the
-            # cluster state directly, single-shot (Phase-1's writes are
-            # synchronous) — an HR seeded between the Phase-0.9 enumeration
-            # and now, or one whose patch silently no-op'd, fails HERE
-            # instead of shipping a green step on a half-pivoted Sovereign.
+            {{- /*
+             ---- Phase 1.5 (#5436): read back what Phase-1 actually did ----
+             `fail=0` only means every patch CALL returned zero. Assert the
+             cluster state directly, single-shot (Phase-1's writes are
+             synchronous) — an HR seeded between the Phase-0.9 enumeration
+             and now, or one whose patch silently no-op'd, fails HERE
+             instead of shipping a green step on a half-pivoted Sovereign.
+            */}}
             assert_region_a_pivot "Phase-1.5 read-back" 0 || exit 1
 
-            # ---- Phase 1.6: parent HelmRelease values override for openova-catalog (TBD-C19) ----
-            #
-            # `openova-catalog` is rendered by the bp-catalyst-platform Helm
-            # chart (products/catalyst/chart/templates/openova-catalog-
-            # helmrepository.yaml) from `.Values.catalog.helmRepository.url`.
-            # Phase-1's live HR patch above is reverted within ~1 min when
-            # helm-controller's next reconcile re-runs `helm upgrade` and
-            # re-emits the HR from the chart's default URL (oci://ghcr.io/
-            # openova-io). Step-08's egress-block-test then catches
-            # `openova-catalog` as the lone OFFENDER and FAILs cutover.
-            #
-            # Fix: patch the parent HelmRelease's `spec.values.catalog.
-            # helmRepository.url` so the NEXT chart reconcile re-renders
-            # the HR with the local Harbor URL — durable across the chart
-            # upgrade cycle. Merge-patch preserves any other
-            # spec.values.catalog.* siblings (e.g. catalog.helmRepository.
-            # interval, .name, .namespace).
-            #
-            # Caught live on t22.omantel.biz 2026-05-18.
+            {{- /*
+             ---- Phase 1.6: parent HelmRelease values override for openova-catalog (TBD-C19) ----
+
+             `openova-catalog` is rendered by the bp-catalyst-platform Helm
+             chart (products/catalyst/chart/templates/openova-catalog-
+             helmrepository.yaml) from `.Values.catalog.helmRepository.url`.
+             Phase-1's live HR patch above is reverted within ~1 min when
+             helm-controller's next reconcile re-runs `helm upgrade` and
+             re-emits the HR from the chart's default URL (oci://ghcr.io/
+             openova-io). Step-08's egress-block-test then catches
+             `openova-catalog` as the lone OFFENDER and FAILs cutover.
+
+             Fix: patch the parent HelmRelease's `spec.values.catalog.
+             helmRepository.url` so the NEXT chart reconcile re-renders
+             the HR with the local Harbor URL — durable across the chart
+             upgrade cycle. Merge-patch preserves any other
+             spec.values.catalog.* siblings (e.g. catalog.helmRepository.
+             interval, .name, .namespace).
+
+             Caught live on t22.omantel.biz 2026-05-18.
+            */}}
             cur_catalog_url=$(kubectl get helmrelease bp-catalyst-platform -n "${HELMREPO_NAMESPACE}" \
               -o jsonpath='{.spec.values.catalog.helmRepository.url}' 2>/dev/null || echo "")
             if [ "${cur_catalog_url}" = "${local_prefix}" ]; then
@@ -1250,9 +1364,11 @@ data:
                   -n "${HELMREPO_NAMESPACE}" \
                   --type=merge --patch "${merge_patch}" >/dev/null 2>&1; then
                 echo "[helmrepository-patches] Phase-1.6 OK: bp-catalyst-platform spec.values.catalog.helmRepository.url -> ${local_prefix}"
-                # Trigger immediate Flux reconcile so the chart re-
-                # renders openova-catalog HR with the new URL before
-                # step-08's window opens.
+                {{- /*
+                 Trigger immediate Flux reconcile so the chart re-
+                 renders openova-catalog HR with the new URL before
+                 step-08's window opens.
+                */}}
                 kubectl annotate --overwrite helmrelease bp-catalyst-platform \
                   -n "${HELMREPO_NAMESPACE}" \
                   "reconcile.fluxcd.io/requestedAt=$(date +%s)" >/dev/null 2>&1 || true
@@ -1261,80 +1377,90 @@ data:
               fi
             fi
 
-            # G96 (Refs #2643, 2026-06-01) — Phase 1.9 RETIRED.
-            # G75 (Refs #2622, chart 0.1.48) made Step 01 finalize
-            # delete the gitea-mirror-resync cronjob entirely + patch
-            # the HR enabled=false in the IaC. By the time Step 06
-            # Phase 2 runs, the cronjob no longer exists — the
-            # kubectl-patch-suspend was a no-op that took an unused
-            # code path. Per Principle 9 (no defensive backstop for
-            # scenarios that can't happen) the dead code is removed.
+            {{- /*
+             G96 (Refs #2643, 2026-06-01) — Phase 1.9 RETIRED.
+             G75 (Refs #2622, chart 0.1.48) made Step 01 finalize
+             delete the gitea-mirror-resync cronjob entirely + patch
+             the HR enabled=false in the IaC. By the time Step 06
+             Phase 2 runs, the cronjob no longer exists — the
+             kubectl-patch-suspend was a no-op that took an unused
+             code path. Per Principle 9 (no defensive backstop for
+             scenarios that can't happen) the dead code is removed.
+            */}}
 
-            # ---- Phase 2: push YAML edit to local Gitea (#970) ----
-            #
-            # The kubectl patches above flip the live HelmRepository
-            # objects. But the bootstrap-kit Kustomization reconciles
-            # YAML from the Sovereign's local Gitea every minute, and
-            # those YAML files still declare `url: oci://ghcr.io/openova-io`.
-            # Without this phase, Flux reverts every patch within ~1m,
-            # and Step-08's verify catches the regression as "OFFENDER".
-            #
-            # Fix: clone the local Gitea, sed-rewrite every
-            # clusters/_template/bootstrap-kit/*.yaml that declares the
-            # upstream URL, commit, push. Subsequent reconciles pick up
-            # the local Harbor URL as the steady-state.
+            {{- /*
+             ---- Phase 2: push YAML edit to local Gitea (#970) ----
+
+             The kubectl patches above flip the live HelmRepository
+             objects. But the bootstrap-kit Kustomization reconciles
+             YAML from the Sovereign's local Gitea every minute, and
+             those YAML files still declare `url: oci://ghcr.io/openova-io`.
+             Without this phase, Flux reverts every patch within ~1m,
+             and Step-08's verify catches the regression as "OFFENDER".
+
+             Fix: clone the local Gitea, sed-rewrite every
+             clusters/_template/bootstrap-kit/*.yaml that declares the
+             upstream URL, commit, push. Subsequent reconciles pick up
+             the local Harbor URL as the steady-state.
+            */}}
             export HOME=/tmp
             git config --global user.name "self-sovereign-cutover"
             git config --global user.email "cutover@${SOVEREIGN_FQDN}"
             git config --global advice.detachedHead false
 
-            # gitea-http is headless (#968); wait for DNS just in case.
+            {{- /* gitea-http is headless (#968); wait for DNS just in case. */}}
             gitea_host="$(printf '%s' "${GITEA_INTERNAL_URL}" | sed -E 's|^https?://||' | cut -d: -f1 | cut -d/ -f1)"
             for i in $(seq 1 30); do
               if nslookup "${gitea_host}" >/dev/null 2>&1; then break; fi
               sleep 5
             done
 
-            # ---- Phase 1.4 (#4967, Refs #3379 #4885): RE-ASSERT gitea admin ----
-            #                password BEFORE any authenticated Gitea call
-            #
-            # Root cause (hw236 live cutover step-06 demirror 401): the demirror
-            # PATCH and the git clone/push below authenticate to Gitea with
-            # BasicAuth gitea_admin:<gitea-admin-secret.password>. step-04
-            # registry-pivot rolls the gitea image ~minutes earlier; on any gitea
-            # Pod restart the init container is SUPPOSED to re-seed the admin
-            # password from gitea-admin-secret (GITEA_ADMIN_PASSWORD_MODE=
-            # keepUpdated). If that re-sync races / no-ops / is reverted by a CNPG
-            # restore, the LIVE DB password DRIFTS from the Secret and EVERY
-            # admin-API auth 401s `user's password is invalid [uid:1 name:
-            # gitea_admin]` — the exact fault that wedged the hw236 cutover here.
-            # The bp-gitea admin-secret Helm-lookup pin + bp-reloader annotation
-            # (#4885) SHRINK the drift window but do NOT close it (a roll can
-            # complete with the DB row still stale).
-            #
-            # Self-heal: force the DB row to match the Secret by execing
-            # `gitea admin user change-password` in the live gitea Pod. The CLI
-            # writes the users table directly (no admin session needed) so it
-            # works even while the API is 401ing. Idempotent — re-setting to the
-            # same value is harmless. Best-effort: if the gitea Pod cannot be
-            # resolved we log + fall through to the PATCH, which either succeeds
-            # (no drift) or fails with the same clear 401 as before — no
-            # regression. RBAC already grants pods/exec (rbac.yaml #4652 leg).
+            {{- /*
+             ---- Phase 1.4 (#4967, Refs #3379 #4885): RE-ASSERT gitea admin ----
+                            password BEFORE any authenticated Gitea call
+
+             Root cause (hw236 live cutover step-06 demirror 401): the demirror
+             PATCH and the git clone/push below authenticate to Gitea with
+             BasicAuth gitea_admin:<gitea-admin-secret.password>. step-04
+             registry-pivot rolls the gitea image ~minutes earlier; on any gitea
+             Pod restart the init container is SUPPOSED to re-seed the admin
+             password from gitea-admin-secret (GITEA_ADMIN_PASSWORD_MODE=
+             keepUpdated). If that re-sync races / no-ops / is reverted by a CNPG
+             restore, the LIVE DB password DRIFTS from the Secret and EVERY
+             admin-API auth 401s `user's password is invalid [uid:1 name:
+             gitea_admin]` — the exact fault that wedged the hw236 cutover here.
+             The bp-gitea admin-secret Helm-lookup pin + bp-reloader annotation
+             (#4885) SHRINK the drift window but do NOT close it (a roll can
+             complete with the DB row still stale).
+
+             Self-heal: force the DB row to match the Secret by execing
+             `gitea admin user change-password` in the live gitea Pod. The CLI
+             writes the users table directly (no admin session needed) so it
+             works even while the API is 401ing. Idempotent — re-setting to the
+             same value is harmless. Best-effort: if the gitea Pod cannot be
+             resolved we log + fall through to the PATCH, which either succeeds
+             (no drift) or fails with the same clear 401 as before — no
+             regression. RBAC already grants pods/exec (rbac.yaml #4652 leg).
+            */}}
             if [ "${GITEA_ADMIN_PASSWORD_REASSERT:-true}" = "true" ]; then
               echo "[helmrepository-patches] re-asserting gitea admin password (drift-heal, Refs #3379 #4885)"
-              # Upstream gitea 10.5.0 renders a Deployment (pod gitea-<hash>-<id>),
-              # so resolve by label selector, not a StatefulSet index. Take the
-              # first Running+Ready Pod (same idiom as bp-gitea sso-configure #2818).
+              {{- /*
+               Upstream gitea 10.5.0 renders a Deployment (pod gitea-<hash>-<id>),
+               so resolve by label selector, not a StatefulSet index. Take the
+               first Running+Ready Pod (same idiom as bp-gitea sso-configure #2818).
+              */}}
               reassert_pod="$(kubectl get pod -n "${GITEA_NAMESPACE}" \
                 -l "${GITEA_POD_SELECTOR}" \
                 -o jsonpath='{range .items[?(@.status.phase=="Running")]}{.metadata.name}{"\t"}{range .status.conditions[?(@.type=="Ready")]}{.status}{end}{"\n"}{end}' \
                 2>/dev/null \
                 | awk -F '\t' '$2=="True" {print $1; exit}' || true)"
               if [ -n "${reassert_pod}" ]; then
-                # --must-change-password=false so the admin user is NOT forced
-                # into a change-on-next-login flow (this credential is only ever
-                # used non-interactively). The password is passed as an in-Pod CLI
-                # arg and never echoed to this Job's stdout; stderr is redacted.
+                {{- /*
+                 --must-change-password=false so the admin user is NOT forced
+                 into a change-on-next-login flow (this credential is only ever
+                 used non-interactively). The password is passed as an in-Pod CLI
+                 arg and never echoed to this Job's stdout; stderr is redacted.
+                */}}
                 if kubectl exec -n "${GITEA_NAMESPACE}" "${reassert_pod}" -c "${GITEA_CONTAINER}" -- \
                      gitea admin user change-password \
                      --username "${GITEA_USERNAME}" \
@@ -1345,7 +1471,7 @@ data:
                      gitea admin user change-password \
                      --username "${GITEA_USERNAME}" \
                      --password "${GITEA_PASSWORD}" >/tmp/.reassert.log 2>&1; then
-                  # Older gitea builds lack --must-change-password on this subcommand.
+                  {{- /* Older gitea builds lack --must-change-password on this subcommand. */}}
                   echo "[helmrepository-patches] gitea admin password re-asserted on pod ${reassert_pod} (legacy flag set)"
                 else
                   echo "[helmrepository-patches] WARN: gitea admin password re-assert failed; continuing to PATCH (may still 401 if drifted):" >&2
@@ -1356,24 +1482,28 @@ data:
               fi
             fi
 
-            # URL with embedded basic auth — credential goes to git via
-            # URL only, never echoed to stdout.
+            {{- /*
+             URL with embedded basic auth — credential goes to git via
+             URL only, never echoed to stdout.
+            */}}
             push_url=$(printf '%s' "${GITEA_INTERNAL_URL}" | sed -E "s,^(https?://),\1${GITEA_USERNAME}:${GITEA_PASSWORD}@,")"/${GITEA_ORG}/${GITEA_REPO}.git"
             redacted=$(printf '%s' "${GITEA_INTERNAL_URL}/${GITEA_ORG}/${GITEA_REPO}.git")
 
-            # ---- Phase 1.5: convert pull-mirror to standalone (#1028) ----
-            #
-            # Step-01 created openova/openova as a Gitea pull-mirror so the
-            # Sovereign's local Gitea tracks upstream during early
-            # bootstrap. After cutover the Sovereign is self-hosted and
-            # MUST diverge from upstream — but Gitea blocks pushes to a
-            # mirror with HTTP 403 "remote: mirror repository is read-only".
-            # PATCH the repo to flip mirror=false BEFORE git push so
-            # subsequent push commands write to the now-standalone repo.
-            #
-            # Without this conversion, Step-06's git push (added in #970)
-            # always failed on 403, blocking handover. Caught on otech125
-            # 2026-05-05.
+            {{- /*
+             ---- Phase 1.5: convert pull-mirror to standalone (#1028) ----
+
+             Step-01 created openova/openova as a Gitea pull-mirror so the
+             Sovereign's local Gitea tracks upstream during early
+             bootstrap. After cutover the Sovereign is self-hosted and
+             MUST diverge from upstream — but Gitea blocks pushes to a
+             mirror with HTTP 403 "remote: mirror repository is read-only".
+             PATCH the repo to flip mirror=false BEFORE git push so
+             subsequent push commands write to the now-standalone repo.
+
+             Without this conversion, Step-06's git push (added in #970)
+             always failed on 403, blocking handover. Caught on otech125
+             2026-05-05.
+            */}}
             api="${GITEA_INTERNAL_URL%/}/api/v1/repos/${GITEA_ORG}/${GITEA_REPO}"
             demirror_code=$(curl -sS -o /tmp/.demirror.json -w '%{http_code}' \
               -u "${GITEA_USERNAME}:${GITEA_PASSWORD}" \
@@ -1394,9 +1524,11 @@ data:
             git clone --depth 1 --branch main "${push_url}" repo >/dev/null 2>&1
             cd repo
 
-            # Find every HelmRepository YAML that declares the upstream
-            # URL under clusters/_template/bootstrap-kit/. Rewrite to
-            # the local Harbor prefix in-place.
+            {{- /*
+             Find every HelmRepository YAML that declares the upstream
+             URL under clusters/_template/bootstrap-kit/. Rewrite to
+             the local Harbor prefix in-place.
+            */}}
             target_dir="clusters/_template/bootstrap-kit"
             if [ ! -d "${target_dir}" ]; then
               echo "[helmrepository-patches] FATAL: ${target_dir} not present in local mirror" >&2
@@ -1410,22 +1542,24 @@ data:
             done
             echo "[helmrepository-patches] sed edited ${edited} bootstrap-kit file(s)"
 
-            # ---- Phase 2b (#4885): pivot the per-Org TENANT shared HelmRepositories ----
-            #
-            # The catalyst-api org-tenant pipeline writes the shared bp-* tenant
-            # HelmRepositories to clusters/<sov-fqdn>/org-tenants/helmrepositories.yaml
-            # (+ per-tenant overlay files under .../org-tenants/<org-id>/), in THIS
-            # same openova/openova gitops repo, reconciled by the org-tenants PARENT
-            # Flux Kustomization — a DIFFERENT durable source than the bootstrap-kit
-            # slots above. So the Phase-1 live patch of these HRs is REVERTED ~1
-            # reconcile later unless their Gitea source is rewritten here too (the
-            # exact #970/#3526 revert-race, one directory over). Rewrite every
-            # org-tenants YAML that still declares the upstream url
-            # (bp-agenity / bp-openclaw / bp-stalwart-tenant / bp-wordpress-tenant /
-            # bp-keycloak / bp-cnpg / bp-newapi) to the local Harbor prefix so
-            # step-08's `-A` offender scan converges durably. Guarded on the tree
-            # existing (a Sovereign with no customer Orgs has no org-tenants dir →
-            # 0 edits, harmless no-op).
+            {{- /*
+             ---- Phase 2b (#4885): pivot the per-Org TENANT shared HelmRepositories ----
+
+             The catalyst-api org-tenant pipeline writes the shared bp-* tenant
+             HelmRepositories to clusters/<sov-fqdn>/org-tenants/helmrepositories.yaml
+             (+ per-tenant overlay files under .../org-tenants/<org-id>/), in THIS
+             same openova/openova gitops repo, reconciled by the org-tenants PARENT
+             Flux Kustomization — a DIFFERENT durable source than the bootstrap-kit
+             slots above. So the Phase-1 live patch of these HRs is REVERTED ~1
+             reconcile later unless their Gitea source is rewritten here too (the
+             exact #970/#3526 revert-race, one directory over). Rewrite every
+             org-tenants YAML that still declares the upstream url
+             (bp-agenity / bp-openclaw / bp-stalwart-tenant / bp-wordpress-tenant /
+             bp-keycloak / bp-cnpg / bp-newapi) to the local Harbor prefix so
+             step-08's `-A` offender scan converges durably. Guarded on the tree
+             existing (a Sovereign with no customer Orgs has no org-tenants dir →
+             0 edits, harmless no-op).
+            */}}
             tenant_edited=0
             for f in $(grep -rlE "^[[:space:]]*url:[[:space:]]*${UPSTREAM_PREFIX}[[:space:]]*$" clusters 2>/dev/null | grep '/org-tenants/' || true); do
               sed -i -E "s,^([[:space:]]*url:[[:space:]]*)${UPSTREAM_PREFIX}([[:space:]]*)$,\1${local_prefix}\2," "${f}"
@@ -1435,40 +1569,48 @@ data:
             done
             echo "[helmrepository-patches] sed edited ${tenant_edited} org-tenant HelmRepository file(s)"
 
-            # Phase-2 trust durability (Refs #3379): inject `certSecretRef:`
-            # into every HelmRepository spec whose url was just pivoted to the
-            # local Harbor, at the SAME indent as the `url:` line, so the
-            # bootstrap-kit Kustomization reconcile keeps the source-controller
-            # trust ref instead of reverting Phase-1's live certSecretRef patch
-            # (~1 min later) and re-x509-failing every pivoted pull. Idempotent:
-            # if a certSecretRef referencing trust_secret already sits in the
-            # same HelmRepository spec we leave it; awk only injects when the
-            # pivoted url line has no matching certSecretRef immediately after.
-            # Only runs when a trust secret was actually built (Phase-0.5).
+            {{- /*
+             Phase-2 trust durability (Refs #3379): inject `certSecretRef:`
+             into every HelmRepository spec whose url was just pivoted to the
+             local Harbor, at the SAME indent as the `url:` line, so the
+             bootstrap-kit Kustomization reconcile keeps the source-controller
+             trust ref instead of reverting Phase-1's live certSecretRef patch
+             (~1 min later) and re-x509-failing every pivoted pull. Idempotent:
+             if a certSecretRef referencing trust_secret already sits in the
+             same HelmRepository spec we leave it; awk only injects when the
+             pivoted url line has no matching certSecretRef immediately after.
+             Only runs when a trust secret was actually built (Phase-0.5).
+            */}}
             if [ -n "${trust_secret}" ]; then
               trust_edited=0
-              # #4885: union the bootstrap-kit slot files with the org-tenants HR
-              # files (Phase-2b) so the pivoted TENANT HelmRepositories carry the
-              # source-controller trust ref too — else they x509-fail pulling the
-              # LE-staging in-cluster Harbor once the org-tenants Kustomization
-              # reconciles the durable local url. Collect both into a temp file
-              # (avoids an unindented continuation line inside this YAML block scalar).
+              {{- /*
+               #4885: union the bootstrap-kit slot files with the org-tenants HR
+               files (Phase-2b) so the pivoted TENANT HelmRepositories carry the
+               source-controller trust ref too — else they x509-fail pulling the
+               LE-staging in-cluster Harbor once the org-tenants Kustomization
+               reconciles the durable local url. Collect both into a temp file
+               (avoids an unindented continuation line inside this YAML block scalar).
+              */}}
               trust_list=/tmp/cutover-trust-targets.txt
               : > "${trust_list}"
               grep -lE "^[[:space:]]*url:[[:space:]]*${local_prefix}([[:space:]]*|/.*)$" "${target_dir}"/*.yaml 2>/dev/null >> "${trust_list}" || true
               grep -rlE "^[[:space:]]*url:[[:space:]]*${local_prefix}([[:space:]]*|/.*)$" clusters 2>/dev/null | grep '/org-tenants/' >> "${trust_list}" || true
               for f in $(awk 'NF' "${trust_list}" | sort -u); do
                 awk -v ref="${trust_secret}" -v lp="${local_prefix}" '
-                  # Match a pivoted `url:` line (local Harbor prefix). Capture
-                  # its leading whitespace so the injected block aligns with the
-                  # sibling keys (type/interval/url/secretRef) under spec:.
+                  {{- /*
+                   Match a pivoted `url:` line (local Harbor prefix). Capture
+                   its leading whitespace so the injected block aligns with the
+                   sibling keys (type/interval/url/secretRef) under spec:.
+                  */}}
                   {
                     line=$0
                     if (match(line, /^[[:space:]]*url:[[:space:]]*/)) {
                       val=line; sub(/^[[:space:]]*url:[[:space:]]*/, "", val)
-                      # Only the local-Harbor url lines (this file may also
-                      # carry an unrelated url: e.g. a GitRepository) — gate on
-                      # the value starting with the local prefix.
+                      {{- /*
+                       Only the local-Harbor url lines (this file may also
+                       carry an unrelated url: e.g. a GitRepository) — gate on
+                       the value starting with the local prefix.
+                      */}}
                       if (index(val, lp) == 1) {
                         indent=line; sub(/url:.*/, "", indent)
                         print line
@@ -1478,10 +1620,12 @@ data:
                         next
                       }
                     }
-                    # Drop a pre-existing certSecretRef block that immediately
-                    # follows our just-printed url (avoids a duplicate on
-                    # re-run). A line at the url indent starting `certSecretRef:`
-                    # right after an injection is the stale one.
+                    {{- /*
+                     Drop a pre-existing certSecretRef block that immediately
+                     follows our just-printed url (avoids a duplicate on
+                     re-run). A line at the url indent starting `certSecretRef:`
+                     right after an injection is the stale one.
+                    */}}
                     if (injected_here==1 && match(line, /^[[:space:]]*certSecretRef:[[:space:]]*$/)) {
                       injected_here=2   # swallow this line + its `name:` child
                       next
@@ -1503,40 +1647,46 @@ data:
               fi
             fi
 
-            # Phase-2.5 (TBD-C19, 2026-05-18): inject openova-catalog URL
-            # override into 13-bp-catalyst-platform.yaml's
-            # `spec.values.sovereign:` block. Why this seam: the
-            # openova-catalog HelmRepository is rendered by the catalyst-
-            # platform Helm chart (see Phase-1.6 above) so the durable URL
-            # lives in the parent HelmRelease's spec.values rather than as
-            # its own `url:` line in bootstrap-kit. Without this injection
-            # the bootstrap-kit Kustomization reconciles the HelmRelease
-            # YAML from Gitea every minute and reverts Phase-1.6's live
-            # patch — chart re-render then puts openova-catalog HR back
-            # at oci://ghcr.io/openova-io and Step-08 catches it.
-            #
-            # Idempotency: if the file already declares
-            # `catalog.helmRepository.url:` under spec.values, replace
-            # the URL value with the current local prefix (handles
-            # re-runs with a different harbor host). Otherwise inject the
-            # full 3-line block above the existing `sovereign:` key
-            # (every chart >= 1.4.117 ships that key under spec.values
-            # — the catalyst-platform values.yaml `sovereign:` block was
-            # added in PR #1569 for D22 settings identity fields).
+            {{- /*
+             Phase-2.5 (TBD-C19, 2026-05-18): inject openova-catalog URL
+             override into 13-bp-catalyst-platform.yaml's
+             `spec.values.sovereign:` block. Why this seam: the
+             openova-catalog HelmRepository is rendered by the catalyst-
+             platform Helm chart (see Phase-1.6 above) so the durable URL
+             lives in the parent HelmRelease's spec.values rather than as
+             its own `url:` line in bootstrap-kit. Without this injection
+             the bootstrap-kit Kustomization reconciles the HelmRelease
+             YAML from Gitea every minute and reverts Phase-1.6's live
+             patch — chart re-render then puts openova-catalog HR back
+             at oci://ghcr.io/openova-io and Step-08 catches it.
+
+             Idempotency: if the file already declares
+             `catalog.helmRepository.url:` under spec.values, replace
+             the URL value with the current local prefix (handles
+             re-runs with a different harbor host). Otherwise inject the
+             full 3-line block above the existing `sovereign:` key
+             (every chart >= 1.4.117 ships that key under spec.values
+             — the catalyst-platform values.yaml `sovereign:` block was
+             added in PR #1569 for D22 settings identity fields).
+            */}}
             catalyst_yaml="${target_dir}/13-bp-catalyst-platform.yaml"
             if [ -f "${catalyst_yaml}" ]; then
-              # The catalyst-platform HelmRelease has:
-              #   spec:
-              #     values:
-              #       sovereign:   <-- 4 spaces
-              #         orgEmail:  <-- 6 spaces
-              # So a `catalog:` block under spec.values lives at 4
-              # spaces, `helmRepository:` at 6, `url:` at 8.
+              {{- /*
+               The catalyst-platform HelmRelease has:
+                 spec:
+                   values:
+                     sovereign:   <-- 4 spaces
+                       orgEmail:  <-- 6 spaces
+               So a `catalog:` block under spec.values lives at 4
+               spaces, `helmRepository:` at 6, `url:` at 8.
+              */}}
               if grep -qE '^[[:space:]]{4}catalog:[[:space:]]*$' "${catalyst_yaml}" \
                  && grep -A 3 -E '^[[:space:]]{4}catalog:[[:space:]]*$' "${catalyst_yaml}" \
                     | grep -qE '^[[:space:]]{6}helmRepository:[[:space:]]*$'; then
-                # Existing block — rewrite the url: value at 8-space
-                # indent within the catalog: block boundary.
+                {{- /*
+                 Existing block — rewrite the url: value at 8-space
+                 indent within the catalog: block boundary.
+                */}}
                 if sed -i -E "/^[[:space:]]{4}catalog:[[:space:]]*\$/,/^[[:space:]]{0,4}[a-zA-Z]/{s,^([[:space:]]{8}url:[[:space:]]*).*\$,\1${local_prefix}," "${catalyst_yaml}" 2>/dev/null; then
                   echo "[helmrepository-patches] Phase-2.5 OK: rewrote existing catalog.helmRepository.url in ${catalyst_yaml} -> ${local_prefix}"
                   edited=$((edited+1))
@@ -1544,20 +1694,22 @@ data:
                   echo "[helmrepository-patches] Phase-2.5 WARN: sed rewrite of existing block failed; Phase-1.6 K8s patch remains durable for one upgrade cycle"
                 fi
               else
-                # No existing block — inject above the `sovereign:` key
-                # under spec.values. The catalyst-platform HR layout
-                # (PR #1569 +) has:
-                #   spec:
-                #     values:
-                #       global: {...}
-                #       ingress: {...}
-                #       parentZones: ...
-                #       wildcardCert: {...}
-                #       sovereign:        <-- inject before this line
-                # The `sovereign:` key sits at 4-space indent (under
-                # spec.values which is 2-space). Match the 4-space form
-                # specifically to avoid the unrelated
-                # `catalyst.openova.io/sovereign:` label at 4-space.
+                {{- /*
+                 No existing block — inject above the `sovereign:` key
+                 under spec.values. The catalyst-platform HR layout
+                 (PR #1569 +) has:
+                   spec:
+                     values:
+                       global: {...}
+                       ingress: {...}
+                       parentZones: ...
+                       wildcardCert: {...}
+                       sovereign:        <-- inject before this line
+                 The `sovereign:` key sits at 4-space indent (under
+                 spec.values which is 2-space). Match the 4-space form
+                 specifically to avoid the unrelated
+                 `catalyst.openova.io/sovereign:` label at 4-space.
+                */}}
                 if grep -qE '^[[:space:]]{4}sovereign:[[:space:]]*$' "${catalyst_yaml}"; then
                   awk -v prefix="${local_prefix}" '
                     /^[[:space:]]{4}sovereign:[[:space:]]*$/ && !done {
@@ -1586,22 +1738,26 @@ data:
               echo "[helmrepository-patches] Phase-2.5 SKIP: ${catalyst_yaml} not present in local mirror"
             fi
 
-            # Phase 2c (#5650) — the vcluster loft chart-source pivot, sourced
-            # FROM FILE rather than inlined. It is ~10 KiB of shell and step-06
-            # already renders within a few hundred bytes of the 110000-byte
-            # MAX_ARG_STRLEN early-warning budget (#5593): inlining it dies at
-            # exec with "argument list too long" before a single line runs. Same
-            # `.`-source discipline as step-03 run.sh / resolver.sh — it runs in
-            # THIS shell, so ${edited}, ${harbor_endpoint} and ${trust_secret}
-            # are visible to it and its `exit 1` FATALs the whole step.
+            {{- /*
+             Phase 2c (#5650) — the vcluster loft chart-source pivot, sourced
+             FROM FILE rather than inlined. It is ~10 KiB of shell and step-06
+             already renders within a few hundred bytes of the 110000-byte
+             MAX_ARG_STRLEN early-warning budget (#5593): inlining it dies at
+             exec with "argument list too long" before a single line runs. Same
+             `.`-source discipline as step-03 run.sh / resolver.sh — it runs in
+             THIS shell, so ${edited}, ${harbor_endpoint} and ${trust_secret}
+             are visible to it and its `exit 1` FATALs the whole step.
+            */}}
             . /phase2c/phase2c.sh
 
-            # NOTE (Refs #3379 #3526): the two "nothing to push" paths below
-            # must FALL THROUGH to Phase 3 (the readiness-gated strip), NOT
-            # `exit 0` early — even when there is no Gitea edit to commit,
-            # the live HelmRepository pivot (Phase-1) may have happened and
-            # the ghcr.io strip still has to run AFTER the pivot is Ready. So
-            # they only skip the commit/push, then continue.
+            {{- /*
+             NOTE (Refs #3379 #3526): the two "nothing to push" paths below
+             must FALL THROUGH to Phase 3 (the readiness-gated strip), NOT
+             `exit 0` early — even when there is no Gitea edit to commit,
+             the live HelmRepository pivot (Phase-1) may have happened and
+             the ghcr.io strip still has to run AFTER the pivot is Ready. So
+             they only skip the commit/push, then continue.
+            */}}
             if [ "${edited}" -eq 0 ]; then
               echo "[helmrepository-patches] no edits — already pivoted in Gitea or upstream prefix not present (continuing to Phase 3)"
             else
@@ -1612,36 +1768,42 @@ data:
                 git commit -m "cutover: pivot ${edited} HelmRepository URLs to local Harbor" >/dev/null
                 push_err=$(git push origin main 2>&1) || {
                   echo "[helmrepository-patches] FATAL: git push failed" >&2
-                  # Surface the actual git stderr so operators can diagnose
-                  # auth / branch-protection / hook rejections without re-
-                  # running the Job. The output is git's own stderr — does
-                  # NOT contain the embedded credential (those live in the
-                  # remote URL only and git redacts them in error messages).
+                  {{- /*
+                   Surface the actual git stderr so operators can diagnose
+                   auth / branch-protection / hook rejections without re-
+                   running the Job. The output is git's own stderr — does
+                   NOT contain the embedded credential (those live in the
+                   remote URL only and git redacts them in error messages).
+                  */}}
                   printf '%s\n' "$push_err" >&2
                   exit 1
                 }
                 echo "[helmrepository-patches] pushed to ${redacted} (commit will reconcile via bootstrap-kit Kustomization)"
 
-                # Trigger an immediate Flux reconciliation so the new YAML
-                # lands without waiting for the polling interval.
+                {{- /*
+                 Trigger an immediate Flux reconciliation so the new YAML
+                 lands without waiting for the polling interval.
+                */}}
                 kubectl annotate --overwrite gitrepository openova \
                   -n flux-system \
                   "reconcile.fluxcd.io/requestedAt=$(date +%s)" >/dev/null || true
               fi
             fi
 
-            # ====================================================================
-            # #5359 — SECONDARY-REGION HelmRepository pivot legs
-            # ====================================================================
-            # Runs BEFORE Phase 3 on purpose: the secondaries get the MERGED
-            # (local-Harbor-added, mothership-retained) ghcr-pull bytes now, so
-            # their pivoted HRs can authenticate while region-A's Phase-3a
-            # proves local Harbor is pullable; the STRIPPED bytes are re-synced
-            # after Phase-3b (sync_secondary_ghcr_pull is called again there) —
-            # strip-before-proof is the hw139 half-pivot lesson, applied
-            # per-region.
+            {{- /*
+             ====================================================================
+             #5359 — SECONDARY-REGION HelmRepository pivot legs
+             ====================================================================
+             Runs BEFORE Phase 3 on purpose: the secondaries get the MERGED
+             (local-Harbor-added, mothership-retained) ghcr-pull bytes now, so
+             their pivoted HRs can authenticate while region-A's Phase-3a
+             proves local Harbor is pullable; the STRIPPED bytes are re-synced
+             after Phase-3b (sync_secondary_ghcr_pull is called again there) —
+             strip-before-proof is the hw139 half-pivot lesson, applied
+             per-region.
+            */}}
             sync_secondary_ghcr_pull() {
-              # No secondaries configured → genuine no-op (single-region).
+              {{- /* No secondaries configured → genuine no-op (single-region). */}}
               sy_have_secondary=0
               for sy_probe in /secondary-kubeconfigs/*.yaml; do
                 [ -e "${sy_probe}" ] || continue
@@ -1651,13 +1813,15 @@ data:
               if [ "${sy_have_secondary}" = "0" ]; then
                 return 0
               fi
-              # Read via read_secret_key (json+jq), NEVER kubectl jsonpath:
+              {{- /* Read via read_secret_key (json+jq), NEVER kubectl jsonpath: */}}
               # jsonpath={.data.${GHCR_PULL_SECRET_KEY}} with the literal key
-              # ".dockerconfigjson" expands to {.data..dockerconfigjson}
-              # (recursive descent) → always empty → the sync silently
-              # no-ops and region-B HRs auth-fail AFTER the read-back
-              # passes — the exact fail-silent hole #5359 exists to close.
-              # (Same Fix-#77 trap Phase-0 documents above.)
+              {{- /*
+               ".dockerconfigjson" expands to {.data..dockerconfigjson}
+               (recursive descent) → always empty → the sync silently
+               no-ops and region-B HRs auth-fail AFTER the read-back
+               passes — the exact fail-silent hole #5359 exists to close.
+               (Same Fix-#77 trap Phase-0 documents above.)
+              */}}
               sy_b64=$(read_secret_key "${GHCR_PULL_SECRET_NAMESPACE}")
               if [ -z "${sy_b64}" ]; then
                 sy_b64=$(read_secret_key "flux-system")
@@ -1693,33 +1857,37 @@ data:
               return 0
             }
 
-            # ---- #5596: secondary-region DURABLE pivot assert ----
-            #
-            # #5359's read-back re-read the secondary's HR set ONCE, right after
-            # the patch loop: it measured the PATCH, never the PIVOT. region-B
-            # re-applies its OWN artifact of the gitops repo, and if that
-            # artifact is the PRE-cutover one every URL goes back upstream
-            # minutes after this step recorded success. hw292: clean read-back
-            # + result=success at 07:41:13Z, region-b kustomize-controller Apply
-            # at 07:42:08Z put all 64 HRs back on ghcr.io, cc=true at 08:12:30Z,
-            # still 64/65 on ghcr 3 days later. 55s is the whole window the old
-            # assert could see. Full forensics in Chart.yaml 0.1.171.
-            #
-            # THE FIX: make the reverting actor run INSIDE the assert — poke the
-            # secondary's GitRepository + HR-owning Kustomizations and refuse to
-            # certify until one of them HANDLED that exact token
-            # (status.lastHandledReconcileAt == token: the re-apply HAPPENED,
-            # not merely that we asked), read-back clean on every sample up to
-            # that point. Offender scope + tolerations are IDENTICAL to
-            # assert_region_a_pivot, so this is never stricter than step-08.
-            #
-            # NB: offenders go to a FILE and are grepped from it — never
-            # `printf | grep -q` (the #5370/#5406/#4969 SIGPIPE shape).
+            {{- /*
+             ---- #5596: secondary-region DURABLE pivot assert ----
+
+             #5359's read-back re-read the secondary's HR set ONCE, right after
+             the patch loop: it measured the PATCH, never the PIVOT. region-B
+             re-applies its OWN artifact of the gitops repo, and if that
+             artifact is the PRE-cutover one every URL goes back upstream
+             minutes after this step recorded success. hw292: clean read-back
+             + result=success at 07:41:13Z, region-b kustomize-controller Apply
+             at 07:42:08Z put all 64 HRs back on ghcr.io, cc=true at 08:12:30Z,
+             still 64/65 on ghcr 3 days later. 55s is the whole window the old
+             assert could see. Full forensics in Chart.yaml 0.1.171.
+
+             THE FIX: make the reverting actor run INSIDE the assert — poke the
+             secondary's GitRepository + HR-owning Kustomizations and refuse to
+             certify until one of them HANDLED that exact token
+             (status.lastHandledReconcileAt == token: the re-apply HAPPENED,
+             not merely that we asked), read-back clean on every sample up to
+             that point. Offender scope + tolerations are IDENTICAL to
+             assert_region_a_pivot, so this is never stricter than step-08.
+
+             NB: offenders go to a FILE and are grepped from it — never
+             `printf | grep -q` (the #5370/#5406/#4969 SIGPIPE shape).
+            */}}
             secondary_offenders() {
-              # $1 = kubeconfig. Writes offenders to /tmp/.sd-offenders.txt.
-              # Returns non-zero when the ENUMERATION ITSELF failed — an
-              # unreadable region is NOT "zero offenders", and conflating the
-              # two is how a leg certifies a region it never saw.
+              {{- /*
+               $1 = kubeconfig. Writes offenders to /tmp/.sd-offenders.txt.
+               Returns non-zero when the ENUMERATION ITSELF failed — an
+               unreadable region is NOT "zero offenders", and conflating the
+               two is how a leg certifies a region it never saw.
+              */}}
               so_kc="$1"
               if ! kubectl --kubeconfig "${so_kc}" get helmrepository -n "${HELMREPO_NAMESPACE}" \
                   -o jsonpath='{range .items[*]}{.metadata.name}={.spec.url}{"\n"}{end}' \
@@ -1744,8 +1912,10 @@ data:
             }
 
             secondary_source_diagnosis() {
-              # Best-effort operator context for a failure message: WHY the
-              # secondary would revert (its gitops source state).
+              {{- /*
+               Best-effort operator context for a failure message: WHY the
+               secondary would revert (its gitops source state).
+              */}}
               sg_kc="$1"
               sg_ready=$(kubectl --kubeconfig "${sg_kc}" get gitrepository "${GITOPS_REPO_NAME}" \
                 -n "${GITOPS_REPO_NAMESPACE}" \
@@ -1770,13 +1940,15 @@ data:
               sd_deadline=$(( $(date +%s) + sd_budget ))
               sd_token=$(date +%s)
 
-              # Which HR-owning Kustomizations actually EXIST in this region —
-              # only those can revert the pivot, and only those can be required
-              # to handle the poke. A region with none of them has nothing that
-              # re-applies HelmRepositories from a durable source, so the plain
-              # read-back is already the whole truth there (single-region-shaped
-              # secondaries, and any topology where the operator moved the slot
-              # Kustomizations, must not fail on an absence).
+              {{- /*
+               Which HR-owning Kustomizations actually EXIST in this region —
+               only those can revert the pivot, and only those can be required
+               to handle the poke. A region with none of them has nothing that
+               re-applies HelmRepositories from a durable source, so the plain
+               read-back is already the whole truth there (single-region-shaped
+               secondaries, and any topology where the operator moved the slot
+               Kustomizations, must not fail on an absence).
+              */}}
               : > /tmp/.sd-ks.txt
               for sd_ks in ${HELMREPO_READBACK_KUSTOMIZATIONS:-}; do
                 if kubectl --kubeconfig "${sd_kc}" get kustomization "${sd_ks}" \
@@ -1786,9 +1958,11 @@ data:
               done
               sd_ks_count=$(grep -c . /tmp/.sd-ks.txt || true)
 
-              # Poke: force the durable source + every HR-owning Kustomization
-              # to re-apply NOW, so a revert lands inside this window instead of
-              # 55 seconds after the Job exits (the hw292 shape).
+              {{- /*
+               Poke: force the durable source + every HR-owning Kustomization
+               to re-apply NOW, so a revert lands inside this window instead of
+               55 seconds after the Job exits (the hw292 shape).
+              */}}
               kubectl --kubeconfig "${sd_kc}" annotate --overwrite gitrepository "${GITOPS_REPO_NAME}" \
                 -n "${GITOPS_REPO_NAMESPACE}" \
                 "reconcile.fluxcd.io/requestedAt=${sd_token}" >/dev/null 2>&1 || true
@@ -1802,8 +1976,10 @@ data:
 
               sd_clean=0
               sd_handled=0
-              # NB: `[ … ] && sd_handled=1` would exit the whole step under the
-              # script's `set -e` whenever the test is false. Use an if.
+              {{- /*
+               NB: `[ … ] && sd_handled=1` would exit the whole step under the
+               script's `set -e` whenever the test is false. Use an if.
+              */}}
               if [ "${sd_ks_count}" -eq 0 ]; then
                 echo "[helmrepository-patches] #5596 secondary ${sd_region}: none of the HR-owning Kustomizations (${HELMREPO_READBACK_KUSTOMIZATIONS:-<none>}) exist here — nothing in this region re-applies HelmRepositories from a durable source, so the read-back alone is the whole truth"
                 sd_handled=1
@@ -1851,11 +2027,13 @@ data:
                 [ -e "${pv_probe}" ] || continue
                 pv_regions=$((pv_regions+1))
               done
-              # #5596 — say WHICH of the two zero-work states this is. "No
-              # secondary regions exist" (single-region Sovereign) is a
-              # legitimate no-op; "secondary regions exist and were not
-              # pivoted" is the false positive this leg exists to prevent, and
-              # every path below now has to record a per-region verdict.
+              {{- /*
+               #5596 — say WHICH of the two zero-work states this is. "No
+               secondary regions exist" (single-region Sovereign) is a
+               legitimate no-op; "secondary regions exist and were not
+               pivoted" is the false positive this leg exists to prevent, and
+               every path below now has to record a per-region verdict.
+              */}}
               if [ "${pv_regions}" -eq 0 ]; then
                 echo "[helmrepository-patches] #5359 no secondary-region kubeconfigs mounted — single-region Sovereign, secondary leg is inert (not a skipped pivot)"
                 return 0
@@ -1866,9 +2044,11 @@ data:
                 pv_region=$(basename "${pv_kc}" .yaml)
                 echo "[helmrepository-patches] #5359 secondary region ${pv_region}: pivoting its HelmRepositories ${UPSTREAM_PREFIX} -> ${local_prefix}"
 
-                # Trust anchor for the LE-staging in-cluster registry — same
-                # certSecretRef mechanism as Phase-1 (Flux OCI HRs have no
-                # insecureSkipVerify).
+                {{- /*
+                 Trust anchor for the LE-staging in-cluster registry — same
+                 certSecretRef mechanism as Phase-1 (Flux OCI HRs have no
+                 insecureSkipVerify).
+                */}}
                 if [ -n "${trust_secret}" ]; then
                   if kubectl -n "${HELMREPO_NAMESPACE}" get secret "${trust_secret}" -o json 2>/dev/null \
                     | jq '{apiVersion, kind, type, metadata: {name: .metadata.name, namespace: .metadata.namespace, labels: {"app.kubernetes.io/managed-by": "self-sovereign-cutover"}}, data: (.data // {})}' \
@@ -1879,16 +2059,18 @@ data:
                   fi
                 fi
 
-                # Enumerate the secondary's LIVE HR set (drift-proof — its own
-                # set is authoritative, exactly the Phase-0.9 union discipline).
-                #
-                # #5596 — the enumeration's EXIT STATUS is load-bearing. It used
-                # to be `2>/dev/null || true`, which made "the API call failed"
-                # (unreachable region, expired credential, CRD absent) produce
-                # the SAME empty file as "this region genuinely has no
-                # HelmRepositories" — and the empty file recorded `skipped` and
-                # moved on. A region we could not read is not a region we
-                # pivoted; only a SUCCESSFUL listing that is empty may skip.
+                {{- /*
+                 Enumerate the secondary's LIVE HR set (drift-proof — its own
+                 set is authoritative, exactly the Phase-0.9 union discipline).
+
+                 #5596 — the enumeration's EXIT STATUS is load-bearing. It used
+                 to be `2>/dev/null || true`, which made "the API call failed"
+                 (unreachable region, expired credential, CRD absent) produce
+                 the SAME empty file as "this region genuinely has no
+                 HelmRepositories" — and the empty file recorded `skipped` and
+                 moved on. A region we could not read is not a region we
+                 pivoted; only a SUCCESSFUL listing that is empty may skip.
+                */}}
                 if kubectl --kubeconfig "${pv_kc}" get helmrepository -n "${HELMREPO_NAMESPACE}" \
                     -o jsonpath='{range .items[*]}{.metadata.name}={.spec.url}{"\n"}{end}' \
                     > /tmp/sec_hrs.txt 2>/tmp/sec_hrs.err; then
@@ -1946,12 +2128,14 @@ data:
                   return 1
                 fi
 
-                # Read-back assert (#5359, made DURABLE by #5596): ZERO
-                # upstream-prefixed HRs may remain — and they must still be zero
-                # after the secondary's own HR-owning Kustomizations have
-                # re-applied, which the assert forces rather than waits for. A
-                # partially-pivoted secondary succeeding anyway IS the #5359
-                # false positive; a fully-pivoted-then-reverted one is #5596.
+                {{- /*
+                 Read-back assert (#5359, made DURABLE by #5596): ZERO
+                 upstream-prefixed HRs may remain — and they must still be zero
+                 after the secondary's own HR-owning Kustomizations have
+                 re-applied, which the assert forces rather than waits for. A
+                 partially-pivoted secondary succeeding anyway IS the #5359
+                 false positive; a fully-pivoted-then-reverted one is #5596.
+                */}}
                 if ! assert_secondary_pivot_durable "${pv_kc}" "${pv_region}"; then
                   kubectl -n "${CUTOVER_NAMESPACE}" patch configmap "${STATUS_CONFIGMAP}" --type=merge \
                     -p "{\"data\":{\"step.helmrepository-patches.region.${pv_region}.result\":\"failed\",\"step.helmrepository-patches.region.${pv_region}.finishedAt\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",\"step.helmrepository-patches.region.${pv_region}.lastError\":\"pivot not durable — see Job log\"}}" || true
@@ -1973,57 +2157,63 @@ data:
               exit 1
             fi
 
+            {{- /* The Phase-3 header below stays a `#` comment: cutover-
+            contract.sh Case 17b compares its LINE NUMBER in the render against
+            the line of the executable `del(.auths[...])` jq filter to prove the
+            destructive strip runs after the pivot, never before it. Convert it
+            and that ordering guard silently loses its anchor. */}}
             # ====================================================================
             # Phase 3 — readiness-gated mothership-auth STRIP (Refs #3379 #3526)
             # ====================================================================
-            #
-            # THE STRIP-BEFORE-PIVOT FIX. This block performs the destructive
-            # credential-hygiene removal (TBD-V24 MISS-2) that USED to live in
-            # Phase-0. It is the LAST thing Step-06 does, and it runs ONLY
-            # after a bounded wait that PROVES every pivoted HelmRepository
-            # actually reconciles Ready from local Harbor.
-            #
-            # WHY THE MOVE (hw139 half-pivot, 8 HRs wedged 10h):
-            #   Phase-0 ran the strip BEFORE the Phase-1 URL pivot. Between
-            #   those two acts — and any time a LATER cutover step wedged
-            #   (step-05/08/10 have all wedged at various points; see Chart.yaml
-            #   changelog) — the cluster was in the lethal intermediate state:
-            #   ghcr.io creds GONE, but the live HR sources + the on-disk Gitea
-            #   YAML still `oci://ghcr.io/openova-io`. Every reconcile then
-            #   failed `no auth config for 'ghcr.io' in the docker-registry
-            #   Secret 'ghcr-pull'`, the half-pivot was permanent, and the
-            #   cutover engine (which strips again on every re-run because the
-            #   ADD+strip were one jq pass) could never recover zero-touch.
-            #
-            # THE INVARIANT THIS ENFORCES:
-            #   ghcr.io / harbor.openova.io auth is removed from ghcr-pull ONLY
-            #   when every HelmRepository this Job pivoted is already Ready=True
-            #   pulling from registry.<sov-fqdn>. If readiness does not converge
-            #   within the budget, this block EXITS NON-ZERO with the mothership
-            #   auth STILL INTACT — so the HRs keep pulling from ghcr.io and the
-            #   step is cleanly recoverable (the engine deletes the timed-out /
-            #   failed Job and re-runs; Phase-0's ADD + Phase-1's pivot are
-            #   idempotent, and this Phase-3 strip is idempotent too).
-            #
-            # Idempotency: if every strip target is already absent, the block
-            # is a pure no-op (no Secret churn). A re-run after a partial strip
-            # (jq del of a missing key is a no-op) re-converges cleanly.
-            #
-            # ── #5436: region-A read-back, second call ──
-            # Placed at the HEAD of Phase 3 so it runs on EVERY path,
-            # including the MOTHERSHIP_AUTHS_TO_STRIP-empty early exit
-            # directly below. Two invariants ride on it:
-            #   (a) the Phase-2/2b durable Gitea rewrite actually held —
-            #       this call runs after the git push AND after the
-            #       secondary-region legs, so a non-durable pivot has had a
-            #       Flux reconcile tick to revert and be caught. Bounded
-            #       convergence budget (HELMREPO_READBACK_BUDGET_SECONDS)
-            #       absorbs the #3526 revert-race rather than fail-fasting
-            #       into it.
-            #   (b) the strip below NEVER removes the ghcr.io fallback while
-            #       a region-A HelmRepository still points at ghcr.io — that
-            #       combination is the hw139 half-pivot that wedged 8 HRs
-            #       for 10h on "no auth config for 'ghcr.io'".
+            {{- /*
+             THE STRIP-BEFORE-PIVOT FIX. This block performs the destructive
+             credential-hygiene removal (TBD-V24 MISS-2) that USED to live in
+             Phase-0. It is the LAST thing Step-06 does, and it runs ONLY
+             after a bounded wait that PROVES every pivoted HelmRepository
+             actually reconciles Ready from local Harbor.
+
+             WHY THE MOVE (hw139 half-pivot, 8 HRs wedged 10h):
+               Phase-0 ran the strip BEFORE the Phase-1 URL pivot. Between
+               those two acts — and any time a LATER cutover step wedged
+               (step-05/08/10 have all wedged at various points; see Chart.yaml
+               changelog) — the cluster was in the lethal intermediate state:
+               ghcr.io creds GONE, but the live HR sources + the on-disk Gitea
+               YAML still `oci://ghcr.io/openova-io`. Every reconcile then
+               failed `no auth config for 'ghcr.io' in the docker-registry
+               Secret 'ghcr-pull'`, the half-pivot was permanent, and the
+               cutover engine (which strips again on every re-run because the
+               ADD+strip were one jq pass) could never recover zero-touch.
+
+             THE INVARIANT THIS ENFORCES:
+               ghcr.io / harbor.openova.io auth is removed from ghcr-pull ONLY
+               when every HelmRepository this Job pivoted is already Ready=True
+               pulling from registry.<sov-fqdn>. If readiness does not converge
+               within the budget, this block EXITS NON-ZERO with the mothership
+               auth STILL INTACT — so the HRs keep pulling from ghcr.io and the
+               step is cleanly recoverable (the engine deletes the timed-out /
+               failed Job and re-runs; Phase-0's ADD + Phase-1's pivot are
+               idempotent, and this Phase-3 strip is idempotent too).
+
+             Idempotency: if every strip target is already absent, the block
+             is a pure no-op (no Secret churn). A re-run after a partial strip
+             (jq del of a missing key is a no-op) re-converges cleanly.
+
+             ── #5436: region-A read-back, second call ──
+             Placed at the HEAD of Phase 3 so it runs on EVERY path,
+             including the MOTHERSHIP_AUTHS_TO_STRIP-empty early exit
+             directly below. Two invariants ride on it:
+               (a) the Phase-2/2b durable Gitea rewrite actually held —
+                   this call runs after the git push AND after the
+                   secondary-region legs, so a non-durable pivot has had a
+                   Flux reconcile tick to revert and be caught. Bounded
+                   convergence budget (HELMREPO_READBACK_BUDGET_SECONDS)
+                   absorbs the #3526 revert-race rather than fail-fasting
+                   into it.
+               (b) the strip below NEVER removes the ghcr.io fallback while
+                   a region-A HelmRepository still points at ghcr.io — that
+                   combination is the hw139 half-pivot that wedged 8 HRs
+                   for 10h on "no auth config for 'ghcr.io'".
+            */}}
             assert_region_a_pivot "Phase-3 pre-strip read-back" "${HELMREPO_READBACK_BUDGET_SECONDS:-300}" || exit 1
 
             if [ -z "${MOTHERSHIP_AUTHS_TO_STRIP:-}" ]; then
@@ -2032,40 +2222,42 @@ data:
               exit 0
             fi
 
-            # ---- Phase 3a: prove pivoted charts are PULLABLE from local Harbor ----
-            #
-            # We gate the strip on the HelmRepositories whose URL now points at
-            # the LOCAL Harbor host (harbor_host) — the ones this cutover
-            # pivoted. The proof that it is SAFE to drop the ghcr.io fallback is
-            # a successful AUTHENTICATED OCI PULL of a representative set of the
-            # pivoted charts from registry.<fqdn>: that proves (a) Harbor serves
-            # the chart artifact (Phase A2 of step-03 mirrored it) and (b) the
-            # Phase-0 Harbor auth works — exactly the precondition for stripping
-            # ghcr.io. If the probe does NOT succeed within the budget, this
-            # block leaves ready_ok=false → the FATAL/REFUSE path below exits
-            # non-zero with mothership auth INTACT (recoverable on re-run).
-            #
-            # WHY NOT read the HelmRepository .status Ready condition (the
-            # PREVIOUS gate, Refs #3568): for spec.type=oci HelmRepositories
-            # Flux source-controller does NOT reconcile them and sets NO
-            # .status.conditions AT ALL — they are static pointers consumed
-            # lazily by the consuming HelmReleases (no HelmChart / OCIRepository
-            # object is ever created for them). On hw146 (source-controller
-            # v1.4.1) all 61 pivoted HelmRepositories were type=oci with EMPTY
-            # .status.conditions (Ready=<none>), so the old gate's Ready could
-            # NEVER become True → it FATAL-refused the strip every run and the
-            # cutover wedged at step-06 forever (also the hw144 "loops at 0/0"
-            # shape, Refs #3588 — the same wrong-object read). The real proof is
-            # an actual authenticated pull, NOT a non-existent status field.
-            #
-            # The probe runs from the writable /tmp emptyDir (the Pod is
-            # readOnlyRootFilesystem:true) by pointing HOME + the HELM_*_HOME
-            # vars there before `helm registry login` / `helm pull`.
+            {{- /*
+             ---- Phase 3a: prove pivoted charts are PULLABLE from local Harbor ----
+
+             We gate the strip on the HelmRepositories whose URL now points at
+             the LOCAL Harbor host (harbor_host) — the ones this cutover
+             pivoted. The proof that it is SAFE to drop the ghcr.io fallback is
+             a successful AUTHENTICATED OCI PULL of a representative set of the
+             pivoted charts from registry.<fqdn>: that proves (a) Harbor serves
+             the chart artifact (Phase A2 of step-03 mirrored it) and (b) the
+             Phase-0 Harbor auth works — exactly the precondition for stripping
+             ghcr.io. If the probe does NOT succeed within the budget, this
+             block leaves ready_ok=false → the FATAL/REFUSE path below exits
+             non-zero with mothership auth INTACT (recoverable on re-run).
+
+             WHY NOT read the HelmRepository .status Ready condition (the
+             PREVIOUS gate, Refs #3568): for spec.type=oci HelmRepositories
+             Flux source-controller does NOT reconcile them and sets NO
+             .status.conditions AT ALL — they are static pointers consumed
+             lazily by the consuming HelmReleases (no HelmChart / OCIRepository
+             object is ever created for them). On hw146 (source-controller
+             v1.4.1) all 61 pivoted HelmRepositories were type=oci with EMPTY
+             .status.conditions (Ready=<none>), so the old gate's Ready could
+             NEVER become True → it FATAL-refused the strip every run and the
+             cutover wedged at step-06 forever (also the hw144 "loops at 0/0"
+             shape, Refs #3588 — the same wrong-object read). The real proof is
+             an actual authenticated pull, NOT a non-existent status field.
+
+             The probe runs from the writable /tmp emptyDir (the Pod is
+             readOnlyRootFilesystem:true) by pointing HOME + the HELM_*_HOME
+             vars there before `helm registry login` / `helm pull`.
+            */}}
             strip_wait_deadline=$(( $(date +%s) + STRIP_READINESS_TIMEOUT_SECONDS ))
             echo "[helmrepository-patches] Phase-3a: proving pivoted charts are pullable from ${harbor_host} (up to ${STRIP_READINESS_TIMEOUT_SECONDS}s) before stripping mothership auth"
             ready_ok="false"
 
-            # Writable helm home (root FS is read-only).
+            {{- /* Writable helm home (root FS is read-only). */}}
             export HOME=/tmp/helm-home
             export HELM_CACHE_HOME=/tmp/helm-home/cache
             export HELM_CONFIG_HOME=/tmp/helm-home/config
@@ -2073,24 +2265,26 @@ data:
             export HELM_REGISTRY_CONFIG=/tmp/helm-home/config/registry.json
             mkdir -p "${HELM_CACHE_HOME}" "${HELM_CONFIG_HOME}" "${HELM_DATA_HOME}" /tmp/helm-pull
 
-            # #4557: the Phase-3a probe targets the cluster's OWN in-cluster
-            # Harbor (registry.<sov-fqdn> = harbor_host), whose wildcard cert
-            # is LE-STAGING (untrusted) on a fresh prov + the helm binary in a
-            # Job Pod carries no node trust store → both `helm registry login`
-            # and `helm pull` x509-fail without a skip. HELM_IN_CLUSTER_TLS_VERIFY
-            # (default "false") gates a deliberate, documented IN-CLUSTER-ONLY
-            # skip — this step makes NO external (ghcr/upstream) helm call, so
-            # the flag only ever relaxes verify for the local registry. Same
-            # seam as step-03 skopeo --dest-tls-verify=false (#4529).
-            #
-            # NOTE the two helm subcommands take DIFFERENT skip flags (verified
-            # against helm v3.16.x): `helm registry login` accepts `--insecure`
-            # ("allow connections to TLS registry without certs"); `helm pull`
-            # accepts `--insecure-skip-tls-verify` ("skip tls certificate
-            # checks for the chart download") — `helm registry login` does NOT
-            # know `--insecure-skip-tls-verify` (it errors unknown-flag, the
-            # login silently no-ops, and the subsequent pull then 401s "no
-            # basic auth credentials"). So gate two distinct flag vars.
+            {{- /*
+             #4557: the Phase-3a probe targets the cluster's OWN in-cluster
+             Harbor (registry.<sov-fqdn> = harbor_host), whose wildcard cert
+             is LE-STAGING (untrusted) on a fresh prov + the helm binary in a
+             Job Pod carries no node trust store → both `helm registry login`
+             and `helm pull` x509-fail without a skip. HELM_IN_CLUSTER_TLS_VERIFY
+             (default "false") gates a deliberate, documented IN-CLUSTER-ONLY
+             skip — this step makes NO external (ghcr/upstream) helm call, so
+             the flag only ever relaxes verify for the local registry. Same
+             seam as step-03 skopeo --dest-tls-verify=false (#4529).
+
+             NOTE the two helm subcommands take DIFFERENT skip flags (verified
+             against helm v3.16.x): `helm registry login` accepts `--insecure`
+             ("allow connections to TLS registry without certs"); `helm pull`
+             accepts `--insecure-skip-tls-verify` ("skip tls certificate
+             checks for the chart download") — `helm registry login` does NOT
+             know `--insecure-skip-tls-verify` (it errors unknown-flag, the
+             login silently no-ops, and the subsequent pull then 401s "no
+             basic auth credentials"). So gate two distinct flag vars.
+            */}}
             HELM_LOGIN_INSECURE_FLAG=""
             HELM_PULL_INSECURE_FLAG=""
             case "${HELM_IN_CLUSTER_TLS_VERIFY:-false}" in
@@ -2106,11 +2300,13 @@ data:
             fi
             echo "[helmrepository-patches] Phase-3a: helm $(helm version --short 2>/dev/null || echo '?')"
 
-            # Build the probe list: (chart, version) for every HelmRelease whose
-            # sourceRef.kind=HelmRepository and whose referenced HelmRepository's
-            # LIVE spec.url host is harbor_host (i.e. already pivoted to local
-            # Harbor). This mirrors step-03 Phase A2's enumeration (the charts it
-            # mirrored) and the old gate's "only local-Harbor HRs" selection.
+            {{- /*
+             Build the probe list: (chart, version) for every HelmRelease whose
+             sourceRef.kind=HelmRepository and whose referenced HelmRepository's
+             LIVE spec.url host is harbor_host (i.e. already pivoted to local
+             Harbor). This mirrors step-03 Phase A2's enumeration (the charts it
+             mirrored) and the old gate's "only local-Harbor HRs" selection.
+            */}}
             local_hr_file=/tmp/.local-harbor-hrs.txt
             kubectl get helmrepositories -A \
               -o jsonpath='{range .items[*]}{.metadata.name}{" "}{.spec.url}{"\n"}{end}' \
@@ -2123,11 +2319,13 @@ data:
               done | sort -u > "${local_hr_file}" || : > "${local_hr_file}"
 
             probe_file=/tmp/.chart-probe.txt
-            # #4870-followup: probe the DEPLOYED chart version
-            # (.status.history[0].chartVersion), matching what step-03
-            # harbor-prewarm mirrors. Reading the mutable desired
-            # .spec.chart.spec.version here races the deploybot catalog bump
-            # and wedges the pivot when prewarm mirrored a different version.
+            {{- /*
+             #4870-followup: probe the DEPLOYED chart version
+             (.status.history[0].chartVersion), matching what step-03
+             harbor-prewarm mirrors. Reading the mutable desired
+             .spec.chart.spec.version here races the deploybot catalog bump
+             and wedges the pivot when prewarm mirrored a different version.
+            */}}
             kubectl get helmreleases -A -o json 2>/dev/null | \
               jq -r '.items[]
                 | .spec.chart.spec as $cs
@@ -2142,10 +2340,12 @@ data:
               done | sort -u > "${probe_file}" || : > "${probe_file}"
 
             probe_total=$(grep -c . "${probe_file}" || true)
-            # Probe a REPRESENTATIVE sample (cap to keep the gate fast) — a
-            # successful pull of any pivoted chart proves Harbor serves charts
-            # + the auth works; always include bp-catalyst-platform (the
-            # keystone HR) when present so the probe is never trivially small.
+            {{- /*
+             Probe a REPRESENTATIVE sample (cap to keep the gate fast) — a
+             successful pull of any pivoted chart proves Harbor serves charts
+             + the auth works; always include bp-catalyst-platform (the
+             keystone HR) when present so the probe is never trivially small.
+            */}}
             sample_file=/tmp/.chart-probe-sample.txt
             : > "${sample_file}"
             grep -E '^bp-catalyst-platform[[:space:]]' "${probe_file}" >> "${sample_file}" 2>/dev/null || true
@@ -2155,40 +2355,48 @@ data:
             sample_total=$(grep -c . "${sample_file}" || true)
             echo "[helmrepository-patches] Phase-3a: ${probe_total} pivoted chart(s) on ${harbor_endpoint}; probing a sample of ${sample_total}"
 
-            # #4682: login to the bare external host `registry.<fqdn>` (:443 via
-            # the Gateway LoadBalancer), the same host the pivoted OCI urls carry
-            # — `helm registry login` keys its stored auth on the registry host
-            # string, so the login host must match the pull host exactly or the
-            # pull is UNAUTHENTICATED (401 "no basic auth credentials").
+            {{- /*
+             #4682: login to the bare external host `registry.<fqdn>` (:443 via
+             the Gateway LoadBalancer), the same host the pivoted OCI urls carry
+             — `helm registry login` keys its stored auth on the registry host
+             string, so the login host must match the pull host exactly or the
+             pull is UNAUTHENTICATED (401 "no basic auth credentials").
+            */}}
             helm registry login "${harbor_endpoint}" ${HELM_LOGIN_INSECURE_FLAG} \
               -u "${HARBOR_USERNAME:-admin}" -p "${HARBOR_PASSWORD}" >/dev/null 2>&1 \
               && echo "[helmrepository-patches] Phase-3a: helm registry login ${harbor_endpoint} OK" \
               || echo "[helmrepository-patches] Phase-3a WARN: helm registry login ${harbor_endpoint} returned non-zero (will retry inside the pull loop)"
 
-            # ---- #5237 union-warm-on-drift setup (Refs #5007) ----
-            # Derive the upstream (ghcr) host/project from the SAME value
-            # Phase-1 pivots FROM (oci://ghcr.io/openova-io). If a sampled chart
-            # drifted ahead of step-03 prewarm (a mid-cutover deploy-bot bump
-            # publishes bp-catalyst-platform:<N+1> AFTER prewarm mirrored :<N>
-            # and flux redeploys the umbrella to :<N+1> before THIS step), the
-            # local pull below 404s. This step runs BEFORE the step-08
-            # deny-egress hold, so the drifted tag is still pullable upstream —
-            # warm it into local Harbor on demand (helm pull upstream + helm
-            # push local), self-healing the catalog-latest-vs-prewarm race.
+            {{- /*
+             ---- #5237 union-warm-on-drift setup (Refs #5007) ----
+             Derive the upstream (ghcr) host/project from the SAME value
+             Phase-1 pivots FROM (oci://ghcr.io/openova-io). If a sampled chart
+             drifted ahead of step-03 prewarm (a mid-cutover deploy-bot bump
+             publishes bp-catalyst-platform:<N+1> AFTER prewarm mirrored :<N>
+             and flux redeploys the umbrella to :<N+1> before THIS step), the
+             local pull below 404s. This step runs BEFORE the step-08
+             deny-egress hold, so the drifted tag is still pullable upstream —
+             warm it into local Harbor on demand (helm pull upstream + helm
+             push local), self-healing the catalog-latest-vs-prewarm race.
+            */}}
             up_ref=$(printf '%s' "${UPSTREAM_PREFIX}" | sed -e 's,^oci://,,' -e 's,/*$,,')
             up_host=${up_ref%%/*}
             up_proj=${up_ref#*/}
             : "${UNION_WARM_ON_DRIFT:=true}"
-            # Cap upstream top-up attempts per distinct chart:ver so a
-            # genuinely-absent tag cannot spin the upstream every 15s until the
-            # deadline (the stripReadinessSeconds deadline is the fail-loud
-            # guard); 3 attempts absorb a transient ghcr blip.
+            {{- /*
+             Cap upstream top-up attempts per distinct chart:ver so a
+             genuinely-absent tag cannot spin the upstream every 15s until the
+             deadline (the stripReadinessSeconds deadline is the fail-loud
+             guard); 3 attempts absorb a transient ghcr blip.
+            */}}
             : "${UNION_WARM_MAX_ATTEMPTS:=3}"
             if [ "${UNION_WARM_ON_DRIFT}" = "true" ]; then
-              # ghcr auth from the SAME ghcr-pull dockerconfig Phase-0 read
-              # (openova-io chart packages are PRIVATE); fall through to
-              # anonymous if absent. Upstream ghcr.io is public-CA-signed →
-              # verify stays ON for the upstream pull (no insecure flag).
+              {{- /*
+               ghcr auth from the SAME ghcr-pull dockerconfig Phase-0 read
+               (openova-io chart packages are PRIVATE); fall through to
+               anonymous if absent. Upstream ghcr.io is public-CA-signed →
+               verify stays ON for the upstream pull (no insecure flag).
+              */}}
               up_auth_b64=$(printf '%s' "${existing_json:-}" | jq -r --arg h "${up_host}" '.auths[$h].auth // empty' 2>/dev/null || true)
               if [ -n "${up_auth_b64}" ]; then
                 up_userpass=$(printf '%s' "${up_auth_b64}" | base64 -d 2>/dev/null || true)
@@ -2206,11 +2414,13 @@ data:
               echo "[helmrepository-patches] Phase-3a: #5237 union-warm-on-drift DISABLED (UNION_WARM_ON_DRIFT=${UNION_WARM_ON_DRIFT}) — pure fail-loud on a drifted catalog-latest"
             fi
 
-            # Top-up-warm ONE sampled chart:ver from the upstream into local
-            # Harbor. Called from the pull loop's fail branch; the next poll
-            # pass re-pulls it locally. Bounded per chart:ver; returns non-zero
-            # (no-op) when disabled, capped, or the warm fails — the deadline
-            # stays the fail-loud guard for a genuinely-absent chart.
+            {{- /*
+             Top-up-warm ONE sampled chart:ver from the upstream into local
+             Harbor. Called from the pull loop's fail branch; the next poll
+             pass re-pulls it locally. Bounded per chart:ver; returns non-zero
+             (no-op) when disabled, capped, or the warm fails — the deadline
+             stays the fail-loud guard for a genuinely-absent chart.
+            */}}
             warm_chart_from_upstream() {
               w_chart="$1"; w_ver="$2"
               [ "${UNION_WARM_ON_DRIFT}" = "true" ] || return 1
@@ -2235,9 +2445,11 @@ data:
                 echo "[helmrepository-patches] Phase-3a union-warm WARN: no chart tarball produced for ${w_chart}:${w_ver}" >&2
                 return 1
               fi
-              # Push to the SAME openova-io path the probe pulls from; local
-              # Harbor is the in-cluster LE-staging target → carry the same
-              # in-cluster skip flag the local pull uses.
+              {{- /*
+               Push to the SAME openova-io path the probe pulls from; local
+               Harbor is the in-cluster LE-staging target → carry the same
+               in-cluster skip flag the local pull uses.
+              */}}
               if helm push "${w_tgz}" "oci://${harbor_endpoint}/openova-io" ${HELM_PULL_INSECURE_FLAG} \
                    >/tmp/.warm-push.log 2>&1; then
                 echo "[helmrepository-patches] Phase-3a union-warm OK (#5237): ${w_chart}:${w_ver} pushed to ${harbor_endpoint}/openova-io — local Harbor now serves the drifted catalog-latest; re-probing"
@@ -2248,29 +2460,31 @@ data:
               return 1
             }
 
-            # ---- Phase 3a-pin (#5237 round 2, Refs #5007): FULL pin-presence gate ----
-            #
-            # The Phase-3a loop below proves a SAMPLE of pivoted charts pulls.
-            # This gate proves the WHOLE frozen pin set exists: every chart
-            # version the bootstrap-kit slots pin in the Phase-2 clone at
-            # /tmp/repo — the EXACT local-Gitea-mirror commit flux consumes
-            # post-step-05, immune to anything a mid-cutover merge published
-            # upstream — must be durably present in local Harbor BEFORE the
-            # irreversible Phase-3b mothership-auth strip. Enumeration is the
-            # shared cutover-bootstrap-kit-pins extractor (03b) — the SAME
-            # parser step-03 Phase A2-pins mirrors from (and the #5265 Day-2
-            # reconciler reuses), so the mirror and this gate can never
-            # disagree about what "the pins" are. Presence is the Harbor
-            # ARTIFACT API on the in-cluster Service (Harbor CORE against its
-            # DB — never pull-through, the #5030 discipline): ~65 cheap GETs,
-            # seconds. A missing version is first top-up-warmed from the
-            # still-reachable upstream (warm_chart_from_upstream above —
-            # egress is open until step-08); anything STILL missing FATALs
-            # with the FULL missing list and the ghcr.io auth intact — a
-            # clear, recoverable step-06 failure (re-run; a step-03 re-run
-            # with Phase A2-pins also heals) instead of HelmReleases wedging
-            # on `does not have an artifact` after the strip (the hw274
-            # class, dep d51a69f885872a81).
+            {{- /*
+             ---- Phase 3a-pin (#5237 round 2, Refs #5007): FULL pin-presence gate ----
+
+             The Phase-3a loop below proves a SAMPLE of pivoted charts pulls.
+             This gate proves the WHOLE frozen pin set exists: every chart
+             version the bootstrap-kit slots pin in the Phase-2 clone at
+             /tmp/repo — the EXACT local-Gitea-mirror commit flux consumes
+             post-step-05, immune to anything a mid-cutover merge published
+             upstream — must be durably present in local Harbor BEFORE the
+             irreversible Phase-3b mothership-auth strip. Enumeration is the
+             shared cutover-bootstrap-kit-pins extractor (03b) — the SAME
+             parser step-03 Phase A2-pins mirrors from (and the #5265 Day-2
+             reconciler reuses), so the mirror and this gate can never
+             disagree about what "the pins" are. Presence is the Harbor
+             ARTIFACT API on the in-cluster Service (Harbor CORE against its
+             DB — never pull-through, the #5030 discipline): ~65 cheap GETs,
+             seconds. A missing version is first top-up-warmed from the
+             still-reachable upstream (warm_chart_from_upstream above —
+             egress is open until step-08); anything STILL missing FATALs
+             with the FULL missing list and the ghcr.io auth intact — a
+             clear, recoverable step-06 failure (re-run; a step-03 re-run
+             with Phase A2-pins also heals) instead of HelmReleases wedging
+             on `does not have an artifact` after the strip (the hw274
+             class, dep d51a69f885872a81).
+            */}}
             : "${PIN_PRESENCE_GATE:=true}"
             if [ "${PIN_PRESENCE_GATE}" = "true" ]; then
               pin_src_dir=/tmp/repo/clusters/_template/bootstrap-kit
@@ -2287,9 +2501,11 @@ data:
                 exit 1
               fi
               echo "[helmrepository-patches] Phase 3a-pin (#5237): asserting all ${pin_total} frozen bootstrap-kit pin(s) are durably present in local Harbor (artifact API, in-cluster) before the strip"
-              # Durable-presence probe: 200 from the artifact API = the chart
-              # OCI artifact is in Harbor's own store. Chart repos are single-
-              # segment under openova-io, so no %2F encoding is needed.
+              {{- /*
+               Durable-presence probe: 200 from the artifact API = the chart
+               OCI artifact is in Harbor's own store. Chart repos are single-
+               segment under openova-io, so no %2F encoding is needed.
+              */}}
               pin_present() {
                 _pp_code=$(curl -sk -o /dev/null -w '%{http_code}' --max-time 30 \
                   -u "${HARBOR_USERNAME:-admin}:${HARBOR_PASSWORD}" \
@@ -2307,8 +2523,10 @@ data:
                 fi
                 echo "[helmrepository-patches] Phase 3a-pin: ${pg_chart}:${pg_ver} pinned by the frozen bootstrap-kit but ABSENT from local Harbor — top-up-warming from the still-reachable upstream (#5237)"
                 warm_chart_from_upstream "${pg_chart}" "${pg_ver}" || true
-                # Bounded re-probe: a direct helm push records via the
-                # registry hook near-synchronously; allow a short settle.
+                {{- /*
+                 Bounded re-probe: a direct helm push records via the
+                 registry hook near-synchronously; allow a short settle.
+                */}}
                 pg_found=0
                 for pg_i in $(seq 1 6); do
                   if pin_present "${pg_chart}" "${pg_ver}"; then pg_found=1; break; fi
@@ -2332,14 +2550,18 @@ data:
 
             # Re-arm the sample-probe deadline so a warm-heavy Phase 3a-pin
             # pass cannot eat the pull-probe's stripReadinessSeconds budget.
+            # (Kept as a `#` comment — cutover-contract.sh Case 68 asserts this
+            # re-arm is present in the render, #5237.)
             strip_wait_deadline=$(( $(date +%s) + STRIP_READINESS_TIMEOUT_SECONDS ))
 
             while [ "$(date +%s)" -lt "${strip_wait_deadline}" ]; do
               if [ "${sample_total}" -eq 0 ]; then
-                # No pivoted-chart HelmRelease found yet — Phase-1's URL pivot
-                # may not have rendered onto the consuming HRs. Re-poke the HR
-                # reconciles + re-derive the sample; never strip on an empty
-                # sample (that is the half-pivot guard).
+                {{- /*
+                 No pivoted-chart HelmRelease found yet — Phase-1's URL pivot
+                 may not have rendered onto the consuming HRs. Re-poke the HR
+                 reconciles + re-derive the sample; never strip on an empty
+                 sample (that is the half-pivot guard).
+                */}}
                 echo "[helmrepository-patches] Phase-3a: no pivoted-chart HelmRelease observed yet; re-poking reconciles + retrying in 15s"
                 kubectl get helmrepositories -A \
                   -o jsonpath='{range .items[*]}{.metadata.namespace}{" "}{.metadata.name}{"\n"}{end}' 2>/dev/null \
@@ -2348,7 +2570,7 @@ data:
                       kubectl annotate --overwrite -n "${rns}" "helmrepository/${rname}" \
                         "reconcile.fluxcd.io/requestedAt=$(date +%s)" >/dev/null 2>&1 || true
                     done || true
-                # Re-derive on the next loop (cheap): recompute local HRs + sample.
+                {{- /* Re-derive on the next loop (cheap): recompute local HRs + sample. */}}
                 kubectl get helmrepositories -A \
                   -o jsonpath='{range .items[*]}{.metadata.name}{" "}{.spec.url}{"\n"}{end}' 2>/dev/null \
                   | while read -r hrname hrurl; do
@@ -2384,20 +2606,24 @@ data:
               pull_fail_names=""
               while IFS="$(printf '\t')" read -r p_chart p_ver; do
                 [ -z "${p_chart}" ] && continue
-                # #4682: pull from the bare external host `registry.<fqdn>` on
-                # :443 (the Gateway LoadBalancer) — the same host source-controller
-                # uses for the live pivoted pull.
+                {{- /*
+                 #4682: pull from the bare external host `registry.<fqdn>` on
+                 :443 (the Gateway LoadBalancer) — the same host source-controller
+                 uses for the live pivoted pull.
+                */}}
                 if helm pull "oci://${harbor_endpoint}/openova-io/${p_chart}" ${HELM_PULL_INSECURE_FLAG} \
                      --version "${p_ver}" -d /tmp/helm-pull >/tmp/.helm-pull.log 2>&1; then
                   pull_ok=$((pull_ok+1))
                 else
                   pull_fail=$((pull_fail+1))
                   pull_fail_names="${pull_fail_names}${p_chart}:${p_ver} "
-                  # #5237: the local pull 404'd — if this is a catalog-latest
-                  # drift (tag published AFTER step-03 prewarm), top-up-warm it
-                  # from the still-reachable upstream so the next poll pass finds
-                  # it locally. Bounded per chart:ver; no-op when disabled or at
-                  # the attempt cap. `|| true` keeps `set -e` happy.
+                  {{- /*
+                   #5237: the local pull 404'd — if this is a catalog-latest
+                   drift (tag published AFTER step-03 prewarm), top-up-warm it
+                   from the still-reachable upstream so the next poll pass finds
+                   it locally. Bounded per chart:ver; no-op when disabled or at
+                   the attempt cap. `|| true` keeps `set -e` happy.
+                  */}}
                   warm_chart_from_upstream "${p_chart}" "${p_ver}" || true
                 fi
               done < "${sample_file}"
@@ -2417,13 +2643,15 @@ data:
               exit 1
             fi
 
-            # ---- Phase 3b: strip the mothership auth (now safe) ----
-            #
-            # Re-read the Secret fresh (Phase-0's ADD + reflector may have
-            # bumped its resourceVersion) and del() every strip target. The
-            # local harbor host is NEVER stripped (defence-in-depth, even if an
-            # operator overlay erroneously lists it). `--arg` keeps every host
-            # a verbatim JSON string (no shell interpolation / injection).
+            {{- /*
+             ---- Phase 3b: strip the mothership auth (now safe) ----
+
+             Re-read the Secret fresh (Phase-0's ADD + reflector may have
+             bumped its resourceVersion) and del() every strip target. The
+             local harbor host is NEVER stripped (defence-in-depth, even if an
+             operator overlay erroneously lists it). `--arg` keeps every host
+             a verbatim JSON string (no shell interpolation / injection).
+            */}}
             strip_b64=$(read_secret_key "${target_ns}")
             if [ -z "${strip_b64}" ]; then
               echo "[helmrepository-patches] FATAL: Phase-3b cannot re-read ${target_ns}/${GHCR_PULL_SECRET_NAME} ${GHCR_PULL_SECRET_KEY}" >&2
@@ -2431,7 +2659,7 @@ data:
             fi
             strip_json=$(printf '%s' "${strip_b64}" | base64 -d)
 
-            # Determine which targets are still present (no-op if none).
+            {{- /* Determine which targets are still present (no-op if none). */}}
             strip_remaining=""
             rem="${MOTHERSHIP_AUTHS_TO_STRIP},"
             while [ -n "${rem}" ] && [ "${rem}" != "," ]; do
@@ -2439,9 +2667,11 @@ data:
               rem="${rem#*,}"
               strip_host=$(printf '%s' "${strip_host}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
               [ -z "${strip_host}" ] && continue
-              # #4682: never strip the local Harbor external host — Phase-0 writes
-              # the local-Harbor auth under this bare-host key, so an overlay that
-              # erroneously lists it must never remove it.
+              {{- /*
+               #4682: never strip the local Harbor external host — Phase-0 writes
+               the local-Harbor auth under this bare-host key, so an overlay that
+               erroneously lists it must never remove it.
+              */}}
               if [ "${strip_host}" = "${harbor_host}" ] || [ "${strip_host}" = "${harbor_endpoint}" ]; then
                 echo "[helmrepository-patches] Phase-3b WARN: refusing to strip ${strip_host} (matches local harbor host); check .Values.harbor.mothershipAuthsToStrip overlay"
                 continue
@@ -2452,15 +2682,19 @@ data:
 
             if [ -z "${strip_remaining}" ]; then
               echo "[helmrepository-patches] Phase-3b skip: mothership auth entries already absent from ghcr-pull"
-              # #5359 — region-A's bytes are already stripped; re-sync them so
-              # a re-run also converges every secondary onto the stripped set.
+              {{- /*
+               #5359 — region-A's bytes are already stripped; re-sync them so
+               a re-run also converges every secondary onto the stripped set.
+              */}}
               sync_secondary_ghcr_pull || exit 1
               echo "[helmrepository-patches] step complete"
               exit 0
             fi
 
-            # Build the `del(.auths[$sN])` jq filter + matching --arg list via
-            # POSIX positional params (no bash arrays).
+            {{- /*
+             Build the `del(.auths[$sN])` jq filter + matching --arg list via
+             POSIX positional params (no bash arrays).
+            */}}
             jq_filter='.'
             strip_idx=0
             set --
@@ -2470,7 +2704,7 @@ data:
               rem="${rem#*,}"
               strip_host=$(printf '%s' "${strip_host}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
               [ -z "${strip_host}" ] && continue
-              # #4682: never strip the local Harbor external host.
+              {{- /* #4682: never strip the local Harbor external host. */}}
               if [ "${strip_host}" = "${harbor_host}" ] || [ "${strip_host}" = "${harbor_endpoint}" ]; then
                 continue
               fi
@@ -2491,9 +2725,11 @@ data:
               exit 1
             fi
 
-            # #5359 — propagate the now-STRIPPED auth bytes to every secondary
-            # region so region-B sheds the mothership creds under the same
-            # proven-pullable gate that just cleared region-A.
+            {{- /*
+             #5359 — propagate the now-STRIPPED auth bytes to every secondary
+             region so region-B sheds the mothership creds under the same
+             proven-pullable gate that just cleared region-A.
+            */}}
             sync_secondary_ghcr_pull || exit 1
 
             echo "[helmrepository-patches] step complete"
@@ -2520,7 +2756,7 @@ data:
           items:
             - key: extract-pins.sh
               path: extract-pins.sh
-      # #5593 — the same step-06 ConfigMap, exposing ONLY the phase2c.sh key.
+      {{- /* #5593 — the same step-06 ConfigMap, exposing ONLY the phase2c.sh key. */}}
       - name: phase2c-script
         configMap:
           name: cutover-step-06-helmrepository-patches
@@ -2529,11 +2765,13 @@ data:
               path: phase2c.sh
       - name: tmp
         emptyDir: {}
-      # #5359 — materialised by catalyst-api (cutover.go runCutover) from its
-      # on-PVC secondary kubeconfig store at every run start; optional:true
-      # so a single-region Sovereign (no Secret) schedules unchanged.
+      {{- /*
+       #5359 — materialised by catalyst-api (cutover.go runCutover) from its
+       on-PVC secondary kubeconfig store at every run start; optional:true
+       so a single-region Sovereign (no Secret) schedules unchanged.
+      */}}
       - name: secondary-kubeconfigs
         secret:
           secretName: {{ .Values.secondaryRegions.kubeconfigSecretName }}
           optional: true
-# re-publish 0.1.145 (Blueprint Release for #5238 failed transiently — #5237 union-warm fix)
+{{- /* re-publish 0.1.145 (Blueprint Release for #5238 failed transiently — #5237 union-warm fix) */}}

--- a/platform/self-sovereign-cutover/chart/templates/07-catalyst-api-env-patch-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/07-catalyst-api-env-patch-job.yaml
@@ -88,9 +88,11 @@ data:
     serviceAccountName: {{ include "bp-self-sovereign-cutover.serviceAccountName" . }}
     restartPolicy: Never
     activeDeadlineSeconds: {{ .Values.stepTimeouts.catalystAPIEnvPatchSeconds }}
-    # #5214 — re-assert gitea-admin-secret in the release namespace at step
-    # execution time (durable close of the #4557/#4558/#4661 recurrence class).
-    # See _helpers.tpl.
+    {{- /*
+     #5214 — re-assert gitea-admin-secret in the release namespace at step
+     execution time (durable close of the #4557/#4558/#4661 recurrence class).
+     See _helpers.tpl.
+    */}}
     initContainers:
       {{- include "bp-self-sovereign-cutover.giteaSecretSelfHealInitContainer" (dict "ctx" . "phase" "post") | nindent 6 }}
     containers:
@@ -106,34 +108,42 @@ data:
             value: {{ .Values.catalystAPI.envVar | quote }}
           - name: ENV_VAR_VALUE
             value: {{ printf "%s/%s/%s" .Values.sovereign.giteaInternalURL .Values.gitea.org .Values.gitea.repo | quote }}
-          # G61 (#2612): HR patch inputs.
+          {{- /* G61 (#2612): HR patch inputs. */}}
           - name: HR_NAME
             value: "bp-catalyst-platform"
           - name: HR_NAMESPACE
             value: "flux-system"
           - name: HARBOR_PUBLIC_URL
             value: {{ .Values.sovereign.harborPublicURL | quote }}
-          # #5527 Phase 3d: the org-services provisioning Deployment (per-Org
-          # GitOps tree generator) to stamp with the local OCI base.
+          {{- /*
+           #5527 Phase 3d: the org-services provisioning Deployment (per-Org
+           GitOps tree generator) to stamp with the local OCI base.
+          */}}
           - name: ORG_PROVISIONING_DEPLOYMENT
             value: {{ .Values.orgProvisioning.deploymentName | quote }}
           - name: ORG_PROVISIONING_NAMESPACE
             value: {{ .Values.orgProvisioning.namespace | quote }}
-          # #5439 Phase 3e: the Sovereign FQDN the local IMAGE registry host is
-          # derived from — harbor.<fqdn>, byte-identical to step-10's
-          # `target_host="harbor.${SOVEREIGN_FQDN}"`.
+          {{- /*
+           #5439 Phase 3e: the Sovereign FQDN the local IMAGE registry host is
+           derived from — harbor.<fqdn>, byte-identical to step-10's
+           `target_host="harbor.${SOVEREIGN_FQDN}"`.
+          */}}
           - name: SOVEREIGN_FQDN
             value: {{ .Values.sovereign.fqdn | quote }}
-          # #5439 Phase 3e: the org-controller Deployment — the generator that
-          # writes per-Org `vcluster/vcluster.yaml`. It is the writer that still
-          # held harbor.openova.io in HelmRelease uatco/vcluster on hw292 AFTER
-          # cutoverComplete=true, because no cutover step ever stamped it.
+          {{- /*
+           #5439 Phase 3e: the org-controller Deployment — the generator that
+           writes per-Org `vcluster/vcluster.yaml`. It is the writer that still
+           held harbor.openova.io in HelmRelease uatco/vcluster on hw292 AFTER
+           cutoverComplete=true, because no cutover step ever stamped it.
+          */}}
           - name: ORG_CONTROLLER_DEPLOYMENT
             value: {{ .Values.orgController.deploymentName | quote }}
           - name: ORG_CONTROLLER_NAMESPACE
             value: {{ .Values.orgController.namespace | quote }}
-          # G62 (#2613): Gitea persistence inputs — durable source-of-truth
-          # edit so Flux Kustomization doesn't revert the HR patch.
+          {{- /*
+           G62 (#2613): Gitea persistence inputs — durable source-of-truth
+           edit so Flux Kustomization doesn't revert the HR patch.
+          */}}
           - name: GITEA_INTERNAL_URL
             value: {{ .Values.sovereign.giteaInternalURL | quote }}
           - name: GITEA_USERNAME
@@ -150,18 +160,22 @@ data:
             value: {{ .Values.gitea.org | quote }}
           - name: GITEA_REPO
             value: {{ .Values.gitea.repo | quote }}
-          # #2940 Phase 3 (2026-06-03): the Sovereign's own public
-          # console URL — the pivot target for the catalyst-api env
-          # seams (pin/handover-JWT issuers + runtime-config console +
-          # api-public URLs). Overlay supplies
-          # https://console.${SOVEREIGN_FQDN} (same convention as
-          # sovereign.harborPublicURL / giteaPublicURL above).
+          {{- /*
+           #2940 Phase 3 (2026-06-03): the Sovereign's own public
+           console URL — the pivot target for the catalyst-api env
+           seams (pin/handover-JWT issuers + runtime-config console +
+           api-public URLs). Overlay supplies
+           https://console.${SOVEREIGN_FQDN} (same convention as
+           sovereign.harborPublicURL / giteaPublicURL above).
+          */}}
           - name: CONSOLE_PUBLIC_URL
             value: {{ .Values.sovereign.consolePublicURL | quote }}
-          # #4996 (Refs #4972 #4885) — pre-roll safety gate inputs.
-          # Harbor admin creds so the image-warmed gate can HEAD the PRIVATE
-          # openova-io project manifest before pivoting catalyst-api's registry
-          # (same Reflector-mirrored harbor-admin Secret steps 02/03 already use).
+          {{- /*
+           #4996 (Refs #4972 #4885) — pre-roll safety gate inputs.
+           Harbor admin creds so the image-warmed gate can HEAD the PRIVATE
+           openova-io project manifest before pivoting catalyst-api's registry
+           (same Reflector-mirrored harbor-admin Secret steps 02/03 already use).
+          */}}
           - name: HARBOR_USERNAME
             valueFrom:
               secretKeyRef:
@@ -185,25 +199,29 @@ data:
             value: {{ .Values.catalystAPI.rollSafety.evsGate.enabled | quote }}
           - name: EVS_CSI_ZONE_LABEL
             value: {{ .Values.catalystAPI.rollSafety.evsGate.zoneLabel | quote }}
-          # #4973 #4975 #4961 — pod-spec image sweep (COMPREHENSIVE registry pivot).
-          # The G61/#4563/#4885 HR patches above only reach images a chart routes
-          # THROUGH global.imageRegistry. Sidecar images pinned by full ref
-          # (evs-csi CSI sidecars #4973), controller/init images set OUTSIDE
-          # global.imageRegistry (continuum's prerequisite-check initContainer
-          # #4975), and emitter images (#4961) keep a NON-local pod-spec ref, which
-          # step-08's roll-set then rolls under deny-egress → ImagePullBackOff →
-          # cutoverComplete never sets. This sweep is the SUSPENDERS to the HR-pivot
-          # BELT: after the HR pivots, rewrite the registry host of EVERY container +
-          # initContainer of every external-registry workload to registry.<fqdn>
-          # using the SAME offline-mirror resolver step-03/04/08 share (no per-image
-          # / per-workload allowlist to drift). Same env the resolver needs.
+          {{- /*
+           #4973 #4975 #4961 — pod-spec image sweep (COMPREHENSIVE registry pivot).
+           The G61/#4563/#4885 HR patches above only reach images a chart routes
+           THROUGH global.imageRegistry. Sidecar images pinned by full ref
+           (evs-csi CSI sidecars #4973), controller/init images set OUTSIDE
+           global.imageRegistry (continuum's prerequisite-check initContainer
+           #4975), and emitter images (#4961) keep a NON-local pod-spec ref, which
+           step-08's roll-set then rolls under deny-egress → ImagePullBackOff →
+           cutoverComplete never sets. This sweep is the SUSPENDERS to the HR-pivot
+           BELT: after the HR pivots, rewrite the registry host of EVERY container +
+           initContainer of every external-registry workload to registry.<fqdn>
+           using the SAME offline-mirror resolver step-03/04/08 share (no per-image
+           / per-workload allowlist to drift). Same env the resolver needs.
+          */}}
           - name: PODSPEC_SWEEP
             value: {{ eq (toString .Values.imageRegistryPivot.podSpecSweep.enabled) "true" | quote }}
           - name: PODSPEC_SWEEP_EXCLUDE
             value: {{ .Values.imageRegistryPivot.podSpecSweep.excludeWorkloadSubstring | default "catalyst-api" | quote }}
-          # #5215 — "<ns>/<name>" storage/CSI-driver workloads the sweep MUST NOT
-          # roll (rolling csi-evs-node drops NodeStage globalmount for in-use EVS
-          # PVCs → catalyst-api wedges; step-04 containerd rewrite covers the pull).
+          {{- /*
+           #5215 — "<ns>/<name>" storage/CSI-driver workloads the sweep MUST NOT
+           roll (rolling csi-evs-node drops NodeStage globalmount for in-use EVS
+           PVCs → catalyst-api wedges; step-04 containerd rewrite covers the pull).
+          */}}
           - name: PODSPEC_SWEEP_EXCLUDE_WORKLOADS
             value: {{ .Values.imageRegistryPivot.podSpecSweep.excludeWorkloads | default (list) | join " " | quote }}
           - name: PODSPEC_SWEEP_PRESENCE_GATE
@@ -222,12 +240,14 @@ data:
             set -eu
             echo "[catalyst-api-env-patch] target=${DEPLOYMENT_NAMESPACE}/${DEPLOYMENT_NAME}"
 
-            # #4973 #4975 #4961 — the offline-mirror image→local-path resolver
-            # (shared with step-03/step-08). Defines offlinemirror_local_paths over
-            # the SAME HOST_PROJECT_MAP / EXCLUDED_* / LOCAL_REGISTRY_HOST env, so the
-            # pod-spec sweep (Phase 4 below) rewrites each container image to the EXACT
-            # local Harbor path step-03 pushed it to. Guard the source so a missing
-            # mount degrades to "sweep disabled" (fail-open), never a wedged step.
+            {{- /*
+             #4973 #4975 #4961 — the offline-mirror image→local-path resolver
+             (shared with step-03/step-08). Defines offlinemirror_local_paths over
+             the SAME HOST_PROJECT_MAP / EXCLUDED_* / LOCAL_REGISTRY_HOST env, so the
+             pod-spec sweep (Phase 4 below) rewrites each container image to the EXACT
+             local Harbor path step-03 pushed it to. Guard the source so a missing
+             mount degrades to "sweep disabled" (fail-open), never a wedged step.
+            */}}
             if [ -r /resolver/resolver.sh ]; then
               . /resolver/resolver.sh
             else
@@ -235,35 +255,41 @@ data:
               PODSPEC_SWEEP="false"
             fi
 
-            # ═══ #4973 #4975 #4961 pod-spec image sweep helpers ═══════════════
-            # The COMPREHENSIVE registry pivot. The HR global.imageRegistry patches
-            # below only reach images a chart routes through that value; these
-            # helpers rewrite the registry host of EVERY container + initContainer
-            # of every external-registry workload directly in its live pod-spec, so
-            # the fix does not depend on each chart helper being registry-aware
-            # (the recurring whack-a-mole: evs-csi CSI sidecars #4973, continuum's
-            # prerequisite-check initContainer #4975, flow-emitter #4961). Defined
-            # here; CALLED as Phase 4 after the HR pivots below.
+            {{- /*
+             ═══ #4973 #4975 #4961 pod-spec image sweep helpers ═══════════════
+             The COMPREHENSIVE registry pivot. The HR global.imageRegistry patches
+             below only reach images a chart routes through that value; these
+             helpers rewrite the registry host of EVERY container + initContainer
+             of every external-registry workload directly in its live pod-spec, so
+             the fix does not depend on each chart helper being registry-aware
+             (the recurring whack-a-mole: evs-csi CSI sidecars #4973, continuum's
+             prerequisite-check initContainer #4975, flow-emitter #4961). Defined
+             here; CALLED as Phase 4 after the HR pivots below.
+            */}}
 
-            # podspec_pivot_ref IMAGE -> the local-Harbor ref this image pivots to,
-            # or EMPTY to leave it alone (already local / excluded / unmapped). Reuses
-            # offlinemirror_local_paths so the target path is byte-identical to what
-            # step-03 pushed + step-08's completeness gate HEADs. For an openova-io
-            # ghcr ref the resolver returns BOTH the proxy-ghcr path AND the host-drop
-            # openova-io/<path>; we prefer the host-drop convention (what step-06/07
-            # produce, registry.<fqdn>/openova-io/…), else the single mapped path.
+            {{- /*
+             podspec_pivot_ref IMAGE -> the local-Harbor ref this image pivots to,
+             or EMPTY to leave it alone (already local / excluded / unmapped). Reuses
+             offlinemirror_local_paths so the target path is byte-identical to what
+             step-03 pushed + step-08's completeness gate HEADs. For an openova-io
+             ghcr ref the resolver returns BOTH the proxy-ghcr path AND the host-drop
+             openova-io/<path>; we prefer the host-drop convention (what step-06/07
+             produce, registry.<fqdn>/openova-io/…), else the single mapped path.
+            */}}
             podspec_pivot_ref() {
               _pi_img="$1"
               [ -n "${_pi_img}" ] || { printf ''; return 0; }
-              # Already on the local registry → nothing to do (idempotent).
+              {{- /* Already on the local registry → nothing to do (idempotent). */}}
               case "${_pi_img}" in
                 "${LOCAL_REGISTRY_HOST}"/*) printf ''; return 0 ;;
               esac
-              # Only pivot images with an EXPLICIT external registry host (dotted /
-              # :port / localhost) — mirrors step-08's roll-set exactly. A bare
-              # `name[:tag]` or an implicit-docker.io `ns/name` (first segment has no
-              # dot) is NOT in step-08's roll-set and is already handled by the
-              # containerd mirror, so pivoting it would add needless rollout churn.
+              {{- /*
+               Only pivot images with an EXPLICIT external registry host (dotted /
+               :port / localhost) — mirrors step-08's roll-set exactly. A bare
+               `name[:tag]` or an implicit-docker.io `ns/name` (first segment has no
+               dot) is NOT in step-08's roll-set and is already handled by the
+               containerd mirror, so pivoting it would add needless rollout churn.
+              */}}
               case "${_pi_img}" in
                 */*)
                   _pi_host="${_pi_img%%/*}"
@@ -289,11 +315,13 @@ data:
               printf '%s/%s' "${LOCAL_REGISTRY_HOST}" "${_pi_chosen}"
             }
 
-            # podspec_local_present LOCAL_REF -> 0 iff the local Harbor already serves
-            # this manifest. Never pivot a pod-spec onto an image the mirror cannot
-            # serve — leave it for step-08's completeness gate to name as the real
-            # offender rather than introducing a sweep-induced ImagePullBackOff.
-            # Handles both :tag and @digest refs (same split step-08 uses).
+            {{- /*
+             podspec_local_present LOCAL_REF -> 0 iff the local Harbor already serves
+             this manifest. Never pivot a pod-spec onto an image the mirror cannot
+             serve — leave it for step-08's completeness gate to name as the real
+             offender rather than introducing a sweep-induced ImagePullBackOff.
+             Handles both :tag and @digest refs (same split step-08 uses).
+            */}}
             podspec_local_present() {
               _pl_hp="${1#*/}"                       # drop the local host
               case "${_pl_hp}" in
@@ -307,18 +335,20 @@ data:
               case "${_pl_code}" in 200|301|302) return 0 ;; *) return 1 ;; esac
             }
 
-            # sweep_one_workload KIND NS NAME — rewrite every container + initContainer
-            # image of ONE workload to its local-Harbor ref via a strategic-merge patch
-            # (merge key = container name → only .image changes). Records the pre-sweep
-            # images in the bp.openova.io/cutover-podspec-preimage annotation so the
-            # pivot is auditable + reversible on rollback. Best-effort/idempotent.
+            {{- /*
+             sweep_one_workload KIND NS NAME — rewrite every container + initContainer
+             image of ONE workload to its local-Harbor ref via a strategic-merge patch
+             (merge key = container name → only .image changes). Records the pre-sweep
+             images in the bp.openova.io/cutover-podspec-preimage annotation so the
+             pivot is auditable + reversible on rollback. Best-effort/idempotent.
+            */}}
             sweep_one_workload() {
               _sw_kind="$1"; _sw_ns="$2"; _sw_name="$3"
               _sw_json=$(kubectl get "${_sw_kind}" "${_sw_name}" -n "${_sw_ns}" -o json 2>/dev/null || true)
               [ -n "${_sw_json}" ] || return 0
               _sw_changes="/tmp/podspec-sweep-${_sw_kind}-${_sw_ns}-${_sw_name}.$$"
               : > "${_sw_changes}"
-              # Rows: "<containers|initContainers>\t<name>\t<image>"
+              {{- /* Rows: "<containers|initContainers>\t<name>\t<image>" */}}
               printf '%s' "${_sw_json}" | jq -r '
                 (.spec.template.spec.containers // [])[]     | "containers\t\(.name)\t\(.image)",
                 (.spec.template.spec.initContainers // [])[] | "initContainers\t\(.name)\t\(.image)"
@@ -334,7 +364,7 @@ data:
                 printf '%s\t%s\t%s\t%s\n' "${_sw_ctype}" "${_sw_cname}" "${_sw_cimg}" "${_sw_new}" >> "${_sw_changes}"
               done
               if [ ! -s "${_sw_changes}" ]; then rm -f "${_sw_changes}"; return 0; fi
-              # Build the strategic-merge patch + pre-image annotation from the changes.
+              {{- /* Build the strategic-merge patch + pre-image annotation from the changes. */}}
               _sw_patch=$(jq -Rn '
                 [inputs | split("\t") | {ctype: .[0], name: .[1], old: .[2], new: .[3]}]
                 | {
@@ -361,12 +391,14 @@ data:
               rm -f "${_sw_changes}"
             }
 
-            # sweep_workload_podspec_images — discover every external-registry workload
-            # (Deployment/DaemonSet/StatefulSet, any ns) EXACTLY as step-08's roll-set
-            # does, and pivot each one's pod-spec images to local. After this, step-08
-            # finds no external-registry workload left to roll (or every remaining one
-            # is a real un-mirrored offender its completeness gate already named). Not
-            # an allowlist — the discovery is generic; the exclusions mirror step-08's.
+            {{- /*
+             sweep_workload_podspec_images — discover every external-registry workload
+             (Deployment/DaemonSet/StatefulSet, any ns) EXACTLY as step-08's roll-set
+             does, and pivot each one's pod-spec images to local. After this, step-08
+             finds no external-registry workload left to roll (or every remaining one
+             is a real un-mirrored offender its completeness gate already named). Not
+             an allowlist — the discovery is generic; the exclusions mirror step-08's.
+            */}}
             sweep_workload_podspec_images() {
               [ "${PODSPEC_SWEEP:-true}" = "true" ] || { echo "[catalyst-api-env-patch] #4973/#4975/#4961 pod-spec image sweep DISABLED (PODSPEC_SWEEP=${PODSPEC_SWEEP:-})"; return 0; }
               command -v offlinemirror_local_paths >/dev/null 2>&1 || { echo "[catalyst-api-env-patch] WARN resolver not sourced — pod-spec sweep skipped"; return 0; }
@@ -378,20 +410,24 @@ data:
                   -o jsonpath='{range .items[*]}{.metadata.namespace}{" "}{.metadata.name}{"\n"}{end}' 2>/dev/null \
                 | while IFS=' ' read -r _sw_ns _sw_name; do
                     [ -n "${_sw_ns}" ] && [ -n "${_sw_name}" ] || continue
-                    # Never sweep the cutover engine's own catalyst-api (pivoted via
-                    # the bp-catalyst-platform HR + env roll below).
+                    {{- /*
+                     Never sweep the cutover engine's own catalyst-api (pivoted via
+                     the bp-catalyst-platform HR + env roll below).
+                    */}}
                     if [ -n "${PODSPEC_SWEEP_EXCLUDE:-}" ]; then
                       case "${_sw_name}" in *"${PODSPEC_SWEEP_EXCLUDE}"*) continue ;; esac
                     fi
-                    # #5215 — never sweep a storage/CSI-driver workload. Rewriting
-                    # its pod-spec image rolls the driver Pod (csi-evs-node
-                    # DaemonSet), which drops the node-side NodeStage globalmount for
-                    # already-attached EVS volumes → every EVS-backed pod that
-                    # remounts on that node fails `globalmount does not exist` (exit
-                    # 32) and catalyst-api (RWO-EVS, also rolling in step-07) wedges.
-                    # step-04's containerd certs.d rewrite already resolves the CSI
-                    # images to local WITHOUT a roll; step-08 excludes the same
-                    # drivers (#5074). Exact "<ns>/<name>" match.
+                    {{- /*
+                     #5215 — never sweep a storage/CSI-driver workload. Rewriting
+                     its pod-spec image rolls the driver Pod (csi-evs-node
+                     DaemonSet), which drops the node-side NodeStage globalmount for
+                     already-attached EVS volumes → every EVS-backed pod that
+                     remounts on that node fails `globalmount does not exist` (exit
+                     32) and catalyst-api (RWO-EVS, also rolling in step-07) wedges.
+                     step-04's containerd certs.d rewrite already resolves the CSI
+                     images to local WITHOUT a roll; step-08 excludes the same
+                     drivers (#5074). Exact "<ns>/<name>" match.
+                    */}}
                     _sw_skip=0
                     for _sw_x in ${PODSPEC_SWEEP_EXCLUDE_WORKLOADS:-}; do
                       if [ "${_sw_ns}/${_sw_name}" = "${_sw_x}" ]; then _sw_skip=1; break; fi
@@ -406,28 +442,34 @@ data:
               echo "[catalyst-api-env-patch] #4973/#4975/#4961 pod-spec image sweep complete"
             }
 
-            # ═══ #4996 (Refs #4972 #4885) pre-roll safety gates ═══════════════
-            # Step-07 pivots catalyst-api's imageRegistry → local Harbor then rolls
-            # the Deployment (Recreate). On kom4dc that wedged TWO ways (hw240):
-            #   (a) the pivoted image wasn't cleanly pullable from local Harbor
-            #       during a transient gateway blip → ImagePullBackOff cascade;
-            #   (b) the old Recreate pod's RWO-EVS PVCs didn't detach (worse on a
-            #       broken-CSI node with no topology.evs.csi.huaweicloud.com/zone),
-            #       so the new pod hit Multi-Attach and never scheduled (#4972).
-            # These gates make the roll bounded + self-healing + idempotent. ALL
-            # are toggle-able + FAIL-OPEN: a tooling gap never wedges the cutover
-            # worse than the prior blind roll. They are DEFINED here and CALLED
-            # just before the imageRegistry pivot / around each rollout wait below.
+            {{- /*
+             ═══ #4996 (Refs #4972 #4885) pre-roll safety gates ═══════════════
+             Step-07 pivots catalyst-api's imageRegistry → local Harbor then rolls
+             the Deployment (Recreate). On kom4dc that wedged TWO ways (hw240):
+               (a) the pivoted image wasn't cleanly pullable from local Harbor
+                   during a transient gateway blip → ImagePullBackOff cascade;
+               (b) the old Recreate pod's RWO-EVS PVCs didn't detach (worse on a
+                   broken-CSI node with no topology.evs.csi.huaweicloud.com/zone),
+                   so the new pod hit Multi-Attach and never scheduled (#4972).
+             These gates make the roll bounded + self-healing + idempotent. ALL
+             are toggle-able + FAIL-OPEN: a tooling gap never wedges the cutover
+             worse than the prior blind roll. They are DEFINED here and CALLED
+             just before the imageRegistry pivot / around each rollout wait below.
+            */}}
 
-            # Newest live image the catalyst-api Deployment declares (chart-pinned;
-            # the pivot keeps the SAME tag, only the registry host changes).
+            {{- /*
+             Newest live image the catalyst-api Deployment declares (chart-pinned;
+             the pivot keeps the SAME tag, only the registry host changes).
+            */}}
             ca_current_image() {
               kubectl get deploy "${DEPLOYMENT_NAME}" -n "${DEPLOYMENT_NAMESPACE}" \
                 -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null || true
             }
-            # HEAD a manifest against local Harbor (authenticated — the openova-io
-            # project is PRIVATE). ANY 200/redirect = present. -k tolerates the
-            # LE-staging wildcard on a fresh prov.
+            {{- /*
+             HEAD a manifest against local Harbor (authenticated — the openova-io
+             project is PRIVATE). ANY 200/redirect = present. -k tolerates the
+             LE-staging wildcard on a fresh prov.
+            */}}
             harbor_manifest_present() {
               _hm_ref="$1"; _hm_hp="${_hm_ref#*/}"; _hm_path="${_hm_hp%:*}"; _hm_tag="${_hm_hp##*:}"
               _hm_code=$(curl -sk -o /dev/null -w '%{http_code}' \
@@ -436,16 +478,20 @@ data:
                 -I "${HARBOR_PUBLIC_URL}/v2/${_hm_path}/manifests/${_hm_tag}" 2>/dev/null || true)
               case "${_hm_code}" in 200|301|302) return 0 ;; *) return 1 ;; esac
             }
-            # (a) image-warmed gate: refuse to pivot catalyst-api onto an image the
-            # local Harbor cannot yet serve. Bounded poll (step-03 pushes it, so it
-            # is normally already present); FATAL loudly on a genuine miss so the
-            # cutover stays PRE-PIVOT/recoverable instead of half-pivoted+wedged.
+            {{- /*
+             (a) image-warmed gate: refuse to pivot catalyst-api onto an image the
+             local Harbor cannot yet serve. Bounded poll (step-03 pushes it, so it
+             is normally already present); FATAL loudly on a genuine miss so the
+             cutover stays PRE-PIVOT/recoverable instead of half-pivoted+wedged.
+            */}}
             image_warmed_gate() {
               [ "${IMAGE_WARMED_GATE:-true}" = "true" ] || { echo "[catalyst-api-env-patch] #4996 image-warmed gate DISABLED"; return 0; }
               _iw_img=$(ca_current_image)
               [ -z "${_iw_img}" ] && { echo "[catalyst-api-env-patch] #4996 image-warmed gate: cannot read catalyst-api image — skipping (fail-open)"; return 0; }
-              # host-drop the registry prefix (the openova-io host-drop convention
-              # step-03 Phase A pushed to + the chart re-renders post-pivot).
+              {{- /*
+               host-drop the registry prefix (the openova-io host-drop convention
+               step-03 Phase A pushed to + the chart re-renders post-pivot).
+              */}}
               _iw_rest="${_iw_img}"
               case "${_iw_img%%/*}" in *.*|*:*|localhost) _iw_rest="${_iw_img#*/}" ;; esac
               _iw_local="${HARBOR_HOST}/${_iw_rest}"
@@ -465,8 +511,10 @@ data:
               done
             }
 
-            # catalyst-api's PVC-backed volumes → the PV names a Recreate roll must
-            # re-attach (the RWO-EVS Multi-Attach surface).
+            {{- /*
+             catalyst-api's PVC-backed volumes → the PV names a Recreate roll must
+             re-attach (the RWO-EVS Multi-Attach surface).
+            */}}
             ca_pv_names() {
               for _c in $(kubectl get deploy "${DEPLOYMENT_NAME}" -n "${DEPLOYMENT_NAMESPACE}" \
                   -o jsonpath='{range .spec.template.spec.volumes[*]}{.persistentVolumeClaim.claimName}{"\n"}{end}' 2>/dev/null); do
@@ -475,12 +523,14 @@ data:
                 echo
               done | grep -v '^$' | sort -u || true
             }
-            # (b) EVS detach-gate: force-delete VolumeAttachments that bind
-            # catalyst-api's OWN PVs to a node that NO LONGER runs a catalyst-api
-            # pod. Such an attachment is unambiguously STALE (the pod that needed it
-            # is gone) and is the Multi-Attach deadlock source (#4972). SAFE by
-            # construction — it never touches an attachment on a node with a live
-            # catalyst-api pod, nor any non-catalyst-api PV.
+            {{- /*
+             (b) EVS detach-gate: force-delete VolumeAttachments that bind
+             catalyst-api's OWN PVs to a node that NO LONGER runs a catalyst-api
+             pod. Such an attachment is unambiguously STALE (the pod that needed it
+             is gone) and is the Multi-Attach deadlock source (#4972). SAFE by
+             construction — it never touches an attachment on a node with a live
+             catalyst-api pod, nor any non-catalyst-api PV.
+            */}}
             evs_detach_gate() {
               [ "${EVS_GATE:-true}" = "true" ] || return 0
               _dg_pvs=$(ca_pv_names)
@@ -500,12 +550,14 @@ data:
                   done
             }
 
-            # (c) broken-CSI node gate: on a Huawei-EVS cluster a node missing the
-            # EVS zone label cannot attach EVS volumes — a Recreate roll landing
-            # catalyst-api there Multi-Attach-deadlocks (#4972 wd2ab90). Cordon
-            # every such node BEFORE the roll so the scheduler places the new pod on
-            # a healthy node, and drain catalyst-api off a broken node first. No-op
-            # off Huawei (no node carries the zone label → Hetzner hcloud-csi path).
+            {{- /*
+             (c) broken-CSI node gate: on a Huawei-EVS cluster a node missing the
+             EVS zone label cannot attach EVS volumes — a Recreate roll landing
+             catalyst-api there Multi-Attach-deadlocks (#4972 wd2ab90). Cordon
+             every such node BEFORE the roll so the scheduler places the new pod on
+             a healthy node, and drain catalyst-api off a broken node first. No-op
+             off Huawei (no node carries the zone label → Hetzner hcloud-csi path).
+            */}}
             preroll_node_prep() {
               [ "${EVS_GATE:-true}" = "true" ] || return 0
               [ -n "${EVS_CSI_ZONE_LABEL:-}" ] || return 0
@@ -528,10 +580,12 @@ data:
                 echo "[catalyst-api-env-patch] #4996 EVS gate: cordoning broken-CSI node ${_n} (missing ${EVS_CSI_ZONE_LABEL}; RWO-EVS attach would Multi-Attach deadlock the roll — #4972)"
                 kubectl cordon "${_n}" >/dev/null 2>&1 || echo "[catalyst-api-env-patch] #4996 WARN cordon ${_n} failed (best-effort)"
               done
-              # drain-old-pod-first: if the current catalyst-api pod is on a broken
-              # node, delete it now so its EVS detaches + it reschedules onto a
-              # healthy node BEFORE the Recreate roll (so its stale attachment can't
-              # then linger to Multi-Attach the new pod).
+              {{- /*
+               drain-old-pod-first: if the current catalyst-api pod is on a broken
+               node, delete it now so its EVS detaches + it reschedules onto a
+               healthy node BEFORE the Recreate roll (so its stale attachment can't
+               then linger to Multi-Attach the new pod).
+              */}}
               kubectl get pods -n "${DEPLOYMENT_NAMESPACE}" \
                 -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.spec.nodeName}{"\n"}{end}' 2>/dev/null \
                 | grep -E "^${DEPLOYMENT_NAME}-" \
@@ -545,16 +599,18 @@ data:
                       fi
                     done
                   done
-              # a freshly-drained pod leaves a stale attachment for a beat — clear it.
+              {{- /* a freshly-drained pod leaves a stale attachment for a beat — clear it. */}}
               evs_detach_gate
             }
 
-            # Deadlock-aware replacement for the blind `kubectl rollout status
-            # --timeout=300s`. Distinguishes ImagePullBackOff (image is confirmed in
-            # local Harbor by the warmed gate → self-heals, keep waiting) from a
-            # volume-attach deadlock (run the safe detach-gate after a grace period).
-            # Bounded by ROLL_BUDGET_SECONDS; a final blocking status check drives
-            # the step's pass/fail so a genuine failure is a clean recoverable exit.
+            {{- /*
+             Deadlock-aware replacement for the blind `kubectl rollout status
+             --timeout=300s`. Distinguishes ImagePullBackOff (image is confirmed in
+             local Harbor by the warmed gate → self-heals, keep waiting) from a
+             volume-attach deadlock (run the safe detach-gate after a grace period).
+             Bounded by ROLL_BUDGET_SECONDS; a final blocking status check drives
+             the step's pass/fail so a genuine failure is a clean recoverable exit.
+            */}}
             roll_and_wait_catalyst_api() {
               _rw_why="$1"
               if [ "${ROLL_SAFETY:-true}" != "true" ]; then
@@ -569,7 +625,7 @@ data:
                   echo "[catalyst-api-env-patch] #4996 rollout complete (${_rw_why})"
                   return 0
                 fi
-                # newest catalyst-api pod (ISO8601 creationTimestamp sorts chrono).
+                {{- /* newest catalyst-api pod (ISO8601 creationTimestamp sorts chrono). */}}
                 _rw_pod=$(kubectl get pods -n "${DEPLOYMENT_NAMESPACE}" \
                   -o jsonpath='{range .items[*]}{.metadata.creationTimestamp}{"\t"}{.metadata.name}{"\n"}{end}' 2>/dev/null \
                   | grep -E "${DEPLOYMENT_NAME}-" | sort | tail -1 | awk -F'\t' '{print $2}')
@@ -580,10 +636,12 @@ data:
                     *ImagePullBackOff*|*ErrImagePull*)
                       echo "[catalyst-api-env-patch] #4996 rollout wait: ${_rw_pod} pulling image (${_rw_wait% }); image confirmed in local Harbor by the warmed gate — pull self-heals, keep waiting" ;;
                     *)
-                      # Not an image-pull stall. After a grace period (so a HEALTHY
-                      # roll that completes in <grace is never touched), run the
-                      # safe detach-gate — it only deletes provably-stale
-                      # catalyst-api attachments (the #4972 Multi-Attach un-stick).
+                      {{- /*
+                       Not an image-pull stall. After a grace period (so a HEALTHY
+                       roll that completes in <grace is never touched), run the
+                       safe detach-gate — it only deletes provably-stale
+                       catalyst-api attachments (the #4972 Multi-Attach un-stick).
+                      */}}
                       if [ $(( $(date +%s) - _rw_start )) -gt "${ROLL_DETACH_GRACE:-60}" ]; then
                         evs_detach_gate
                       fi ;;
@@ -598,38 +656,44 @@ data:
               done
             }
 
-            # ─── #4996 gates fire BEFORE the imageRegistry pivot (which rolls
-            # catalyst-api via Flux) so nothing pivots onto an unpullable image or
-            # onto a broken-CSI node. image_warmed_gate FATALs pre-pivot on a
-            # genuine miss; preroll_node_prep is best-effort.
+            {{- /*
+             ─── #4996 gates fire BEFORE the imageRegistry pivot (which rolls
+             catalyst-api via Flux) so nothing pivots onto an unpullable image or
+             onto a broken-CSI node. image_warmed_gate FATALs pre-pivot on a
+             genuine miss; preroll_node_prep is best-effort.
+            */}}
             HARBOR_HOST=$(echo "${HARBOR_PUBLIC_URL}" | sed -e 's|^https\?://||' -e 's|/.*$||')
             image_warmed_gate || exit 1
             preroll_node_prep || true
 
-            # G61 Phase 1: patch HR.spec.values.global.imageRegistry
-            # so Flux helm-controller upgrades catalyst-api Deployment
-            # to the Sovereign-local Harbor proxy image. Without this,
-            # the chart's templated images would render with the
-            # default ghcr.io registry and post-cutover Pod CREATE
-            # would be denied by harbor-proxy-pull policy (verified
-            # live hw68 v17 G60 admission test).
+            {{- /*
+             G61 Phase 1: patch HR.spec.values.global.imageRegistry
+             so Flux helm-controller upgrades catalyst-api Deployment
+             to the Sovereign-local Harbor proxy image. Without this,
+             the chart's templated images would render with the
+             default ghcr.io registry and post-cutover Pod CREATE
+             would be denied by harbor-proxy-pull policy (verified
+             live hw68 v17 G60 admission test).
+            */}}
             HARBOR_HOST=$(echo "${HARBOR_PUBLIC_URL}" | sed -e 's|^https\?://||' -e 's|/.*$||')
-            # G66 #2615 (2026-05-31): REGISTRY is `${HARBOR_HOST}` BARE —
-            # NO `/proxy-ghcr/` suffix. Step 03 Phase A skopeo-pushes
-            # openova-io images NATIVELY into local Harbor at path
-            # ${HARBOR_HOST}/openova-io/openova/<svc>:<tag>. Chart
-            # templates render image as
-            # ${global.imageRegistry}/${images.organization}/<comp>:<tag>
-            # — with REGISTRY=${HARBOR_HOST} and images.organization=
-            # openova-io/openova, the final path matches Phase A's
-            # pushed path exactly. The previous `/proxy-ghcr/` suffix
-            # required Harbor proxy-cache adapter to auth ghcr.io —
-            # which doesn't work (Harbor github-ghcr adapter cannot do
-            # the 2-step token-endpoint flow ghcr.io requires for
-            # private packages; 45min validation hw73 2026-05-30).
-            # Phase A native push eliminates the dependency entirely;
-            # Sovereign carries IMMUTABLE pushed images post-cutover
-            # (docs/DOD.md Pillar 5 sovereignty target-state).
+            {{- /*
+             G66 #2615 (2026-05-31): REGISTRY is `${HARBOR_HOST}` BARE —
+             NO `/proxy-ghcr/` suffix. Step 03 Phase A skopeo-pushes
+             openova-io images NATIVELY into local Harbor at path
+             ${HARBOR_HOST}/openova-io/openova/<svc>:<tag>. Chart
+             templates render image as
+             ${global.imageRegistry}/${images.organization}/<comp>:<tag>
+             — with REGISTRY=${HARBOR_HOST} and images.organization=
+             openova-io/openova, the final path matches Phase A's
+             pushed path exactly. The previous `/proxy-ghcr/` suffix
+             required Harbor proxy-cache adapter to auth ghcr.io —
+             which doesn't work (Harbor github-ghcr adapter cannot do
+             the 2-step token-endpoint flow ghcr.io requires for
+             private packages; 45min validation hw73 2026-05-30).
+             Phase A native push eliminates the dependency entirely;
+             Sovereign carries IMMUTABLE pushed images post-cutover
+             (docs/DOD.md Pillar 5 sovereignty target-state).
+            */}}
             REGISTRY="${HARBOR_HOST}"
             echo "[catalyst-api-env-patch] G61 HR patch ${HR_NAMESPACE}/${HR_NAME} spec.values.global.imageRegistry=${REGISTRY}"
             PATCH=$(printf '{"spec":{"values":{"global":{"imageRegistry":"%s"}}}}' "${REGISTRY}")
@@ -638,18 +702,20 @@ data:
               --type=merge \
               -p "${PATCH}" || echo "[catalyst-api-env-patch] HR patch failed (non-fatal; will retry on next cutover)"
 
-            # G62 (#2613) DURABLE PASS: edit local Gitea source-of-truth
-            # so Flux Kustomization doesn't revert the live HR patch.
-            # Architectural rule per #2613: every cutover live-patch MUST
-            # persist to local Gitea source-of-truth, not just to live
-            # cluster API. Mirrors Step-06 Phase 2.5's Gitea-edit pattern.
-            #
-            # bootstrap-kit `13-bp-catalyst-platform.yaml` ships
-            # `imageRegistry: ''` (empty literal) at spec.values.global
-            # so Phase 1 (pre-cutover) renders empty → chart falls back
-            # to images.registry (ghcr.io). Post-cutover sed-replaces
-            # the empty string with REGISTRY so Flux Kustomization
-            # reconciles see the harbor URL on every cycle.
+            {{- /*
+             G62 (#2613) DURABLE PASS: edit local Gitea source-of-truth
+             so Flux Kustomization doesn't revert the live HR patch.
+             Architectural rule per #2613: every cutover live-patch MUST
+             persist to local Gitea source-of-truth, not just to live
+             cluster API. Mirrors Step-06 Phase 2.5's Gitea-edit pattern.
+
+             bootstrap-kit `13-bp-catalyst-platform.yaml` ships
+             `imageRegistry: ''` (empty literal) at spec.values.global
+             so Phase 1 (pre-cutover) renders empty → chart falls back
+             to images.registry (ghcr.io). Post-cutover sed-replaces
+             the empty string with REGISTRY so Flux Kustomization
+             reconciles see the harbor URL on every cycle.
+            */}}
             cd /tmp
             rm -rf repo
             push_url=$(printf '%s' "${GITEA_INTERNAL_URL}" | sed -E "s,^(https?://),\1${GITEA_USERNAME}:${GITEA_PASSWORD}@,")"/${GITEA_ORG}/${GITEA_REPO}.git"
@@ -659,10 +725,12 @@ data:
               git config user.name  "self-sovereign-cutover (G62 imageRegistry patch)"
               target="clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml"
               if [ -f "${target}" ]; then
-                # Match `imageRegistry: ''` at 6-space indent under
-                # global: block. Replace with the harbor URL.
-                # Idempotent: re-runs against an already-edited file
-                # rewrite the URL value (handles harbor host changes).
+                {{- /*
+                 Match `imageRegistry: ''` at 6-space indent under
+                 global: block. Replace with the harbor URL.
+                 Idempotent: re-runs against an already-edited file
+                 rewrite the URL value (handles harbor host changes).
+                */}}
                 if sed -i -E "s|^([[:space:]]{6}imageRegistry:[[:space:]]*)['\"]?[^'\"]*['\"]?[[:space:]]*\$|\1'${REGISTRY}'|" "${target}" 2>/dev/null; then
                   if ! git diff --quiet "${target}"; then
                     git add "${target}"
@@ -687,15 +755,19 @@ data:
               echo "[catalyst-api-env-patch] G62 WARN: git clone of local Gitea failed (URL=${GITEA_INTERNAL_URL}); live HR-patch durability not guaranteed" >&2
             fi
 
-            # Force-reconcile so Flux picks up the change immediately
-            # (HR default interval is 15m, too slow for cutover SLA).
+            {{- /*
+             Force-reconcile so Flux picks up the change immediately
+             (HR default interval is 15m, too slow for cutover SLA).
+            */}}
             kubectl annotate hr "${HR_NAME}" \
               -n "${HR_NAMESPACE}" \
               "reconcile.fluxcd.io/requestedAt=$(date +%s)" \
               --overwrite || true
 
-            # Wait for Helm upgrade to start (HR Reconciling reason
-            # transitions). Up to 30s for Flux to observe the patch.
+            {{- /*
+             Wait for Helm upgrade to start (HR Reconciling reason
+             transitions). Up to 30s for Flux to observe the patch.
+            */}}
             for i in $(seq 1 15); do
               READY=$(kubectl get hr "${HR_NAME}" -n "${HR_NAMESPACE}" \
                 -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || echo "?")
@@ -711,17 +783,19 @@ data:
               sleep 2
             done
 
-            # ---- #4563 (Refs #3379): pivot bp-openova-flow-server ----
-            # openova-flow-server is a SEPARATE HelmRelease (slot 56)
-            # whose chart helper honours global.imageRegistry the same
-            # way bp-catalyst-platform does, but step-07 above only
-            # patches the catalyst-platform HR. Without this block the
-            # flow-server Deployment keeps its literal ghcr.io image →
-            # under the 600s deny-egress hold the anonymous-token fetch
-            # to ghcr.io is blocked → 401 ImagePullBackOff → step-08
-            # fresh-pull proof FATALs. Mirror the catalyst-platform
-            # live-HR-patch + durable-Gitea-edit pattern above so the
-            # pivot survives Flux reconciles.
+            {{- /*
+             ---- #4563 (Refs #3379): pivot bp-openova-flow-server ----
+             openova-flow-server is a SEPARATE HelmRelease (slot 56)
+             whose chart helper honours global.imageRegistry the same
+             way bp-catalyst-platform does, but step-07 above only
+             patches the catalyst-platform HR. Without this block the
+             flow-server Deployment keeps its literal ghcr.io image →
+             under the 600s deny-egress hold the anonymous-token fetch
+             to ghcr.io is blocked → 401 ImagePullBackOff → step-08
+             fresh-pull proof FATALs. Mirror the catalyst-platform
+             live-HR-patch + durable-Gitea-edit pattern above so the
+             pivot survives Flux reconciles.
+            */}}
             FLOW_HR_NAME="bp-openova-flow-server"
             FLOW_HR_NAMESPACE="flux-system"
             if kubectl get hr "${FLOW_HR_NAME}" -n "${FLOW_HR_NAMESPACE}" >/dev/null 2>&1; then
@@ -732,8 +806,10 @@ data:
                 --type=merge \
                 -p "${FLOW_PATCH}" || echo "[catalyst-api-env-patch] #4563 flow-server HR patch failed (non-fatal; will retry on next cutover)"
 
-              # Durable Gitea edit on the slot-56 source-of-truth so Flux
-              # Kustomization doesn't revert the live patch (same #2613 rule).
+              {{- /*
+               Durable Gitea edit on the slot-56 source-of-truth so Flux
+               Kustomization doesn't revert the live patch (same #2613 rule).
+              */}}
               cd /tmp
               rm -rf flowrepo
               flow_push_url=$(printf '%s' "${GITEA_INTERNAL_URL}" | sed -E "s,^(https?://),\1${GITEA_USERNAME}:${GITEA_PASSWORD}@,")"/${GITEA_ORG}/${GITEA_REPO}.git"
@@ -743,8 +819,10 @@ data:
                 git config user.name  "self-sovereign-cutover (#4563 flow-server imageRegistry patch)"
                 flow_target="clusters/_template/bootstrap-kit/56-bp-openova-flow-server.yaml"
                 if [ -f "${flow_target}" ]; then
-                  # Match `imageRegistry: ''` at 6-space indent under the
-                  # global: block. Replace with the harbor host. Idempotent.
+                  {{- /*
+                   Match `imageRegistry: ''` at 6-space indent under the
+                   global: block. Replace with the harbor host. Idempotent.
+                  */}}
                   if sed -i -E "s|^([[:space:]]{6}imageRegistry:[[:space:]]*)['\"]?[^'\"]*['\"]?[[:space:]]*\$|\1'${REGISTRY}'|" "${flow_target}" 2>/dev/null; then
                     if ! git diff --quiet "${flow_target}"; then
                       git add "${flow_target}"
@@ -777,24 +855,26 @@ data:
               echo "[catalyst-api-env-patch] #4563 SKIP: HR ${FLOW_HR_NAMESPACE}/${FLOW_HR_NAME} not present (flow-server not installed on this Sovereign)"
             fi
 
-            # ---- #4885 (Refs #3379): pivot the REMAINING openova-io HRs ----
-            # whose chart honours global.imageRegistry. bp-catalyst-platform
-            # (above) + bp-openova-flow-server (above) were the ONLY two HRs
-            # step-07 pivoted; every OTHER openova-io-image HR that honours
-            # global.imageRegistry stayed on ghcr.io and 401'd under the
-            # step-08 deny-egress hold → the hold never went green →
-            # cutoverComplete never set (live wedge hw232, dep d71ca7ee89fd4451).
-            # The curated set (.Values.imageRegistryPivot.additionalHRs) is
-            # pivoted here with the SAME live-HR-patch + durable-Gitea-edit
-            # pattern as the two blocks above. ONLY charts VERIFIED to template
-            # their images through global.imageRegistry are listed (values.yaml
-            # carries the set + rationale) — patching an HR whose chart ignores
-            # the value is a SILENT NO-OP. bp-guacamole / bp-huawei-evs-csi /
-            # bp-newapi / bp-sandbox were made registry-aware in #4892;
-            # org-services marketplace/auth in #4899; and the last two offenders
-            # bp-openova-flow-emitter (slot 57) + bp-k8s-ws-proxy (slot 51) in
-            # #4961 — so the default additionalHRs set now covers every
-            # openova-io-image HR and NO residual remains (was the #4885 wedge).
+            {{- /*
+             ---- #4885 (Refs #3379): pivot the REMAINING openova-io HRs ----
+             whose chart honours global.imageRegistry. bp-catalyst-platform
+             (above) + bp-openova-flow-server (above) were the ONLY two HRs
+             step-07 pivoted; every OTHER openova-io-image HR that honours
+             global.imageRegistry stayed on ghcr.io and 401'd under the
+             step-08 deny-egress hold → the hold never went green →
+             cutoverComplete never set (live wedge hw232, dep d71ca7ee89fd4451).
+             The curated set (.Values.imageRegistryPivot.additionalHRs) is
+             pivoted here with the SAME live-HR-patch + durable-Gitea-edit
+             pattern as the two blocks above. ONLY charts VERIFIED to template
+             their images through global.imageRegistry are listed (values.yaml
+             carries the set + rationale) — patching an HR whose chart ignores
+             the value is a SILENT NO-OP. bp-guacamole / bp-huawei-evs-csi /
+             bp-newapi / bp-sandbox were made registry-aware in #4892;
+             org-services marketplace/auth in #4899; and the last two offenders
+             bp-openova-flow-emitter (slot 57) + bp-k8s-ws-proxy (slot 51) in
+             #4961 — so the default additionalHRs set now covers every
+             openova-io-image HR and NO residual remains (was the #4885 wedge).
+            */}}
             pivot_extra_hr() {
               _hr_name="$1"; _hr_ns="$2"; _slot="$3"
               if ! kubectl get hr "${_hr_name}" -n "${_hr_ns}" >/dev/null 2>&1; then
@@ -808,10 +888,12 @@ data:
                 --type=merge \
                 -p "${_patch}" || echo "[catalyst-api-env-patch] #4885 ${_hr_name} HR patch failed (non-fatal; will retry on next cutover)"
 
-              # Durable Gitea edit of the slot file so Flux Kustomization
-              # doesn't revert the live patch (same #2613 rule as the two
-              # blocks above). The slot MUST carry `imageRegistry: ''` at
-              # 6-space indent under its values.global block.
+              {{- /*
+               Durable Gitea edit of the slot file so Flux Kustomization
+               doesn't revert the live patch (same #2613 rule as the two
+               blocks above). The slot MUST carry `imageRegistry: ''` at
+               6-space indent under its values.global block.
+              */}}
               cd /tmp
               rm -rf xhrrepo
               _push_url=$(printf '%s' "${GITEA_INTERNAL_URL}" | sed -E "s,^(https?://),\1${GITEA_USERNAME}:${GITEA_PASSWORD}@,")"/${GITEA_ORG}/${GITEA_REPO}.git"
@@ -849,6 +931,10 @@ data:
                 "reconcile.fluxcd.io/requestedAt=$(date +%s)" \
                 --overwrite || true
             }
+            {{- /* These four lines stay `#` comments: cutover-contract.sh Case 64
+            requires the CSI exclusion to be AUDITABLE IN THE RENDERED MANIFEST
+            ("not just absent") — it greps `NEVER pivoted here` and then the
+            excluded names within the next three lines (#5215). */}}
             # #5215 — storage/CSI-driver HelmReleases NEVER pivoted here (rolling a
             # CSI driver rolls its csi-evs-node DaemonSet → drops NodeStage globalmount
             # for in-use EVS PVCs → catalyst-api wedges; step-04 containerd rewrite
@@ -862,59 +948,69 @@ data:
 {{- end }}
 {{- end }}
 
-            # G61 Phase 2 (was Step 07 pre-G61): set env on the
-            # catalyst-api Deployment so it routes GitOps queries to
-            # the local Gitea mirror.
+            {{- /*
+             G61 Phase 2 (was Step 07 pre-G61): set env on the
+             catalyst-api Deployment so it routes GitOps queries to
+             the local Gitea mirror.
+            */}}
             echo "[catalyst-api-env-patch] ${ENV_VAR_NAME}=${ENV_VAR_VALUE}"
             kubectl set env "deploy/${DEPLOYMENT_NAME}" \
               -n "${DEPLOYMENT_NAMESPACE}" \
               "${ENV_VAR_NAME}=${ENV_VAR_VALUE}"
-            # #4996: deadlock-aware wait (image-pull tolerant + EVS detach-gate)
-            # replaces the blind 300s rollout status that wedged hw240.
+            {{- /*
+             #4996: deadlock-aware wait (image-pull tolerant + EVS detach-gate)
+             replaces the blind 300s rollout status that wedged hw240.
+            */}}
             if ! roll_and_wait_catalyst_api "gitops-repo-url + image pivot"; then
               echo "[catalyst-api-env-patch] #4996 FATAL: catalyst-api rollout did not converge (gitops-repo-url + image pivot) — see the EVS/image-pull diagnostics above; step exits for a clean recoverable re-run" >&2
               exit 1
             fi
 
-            # ---- Phase 3 (#2940, 2026-06-03): pivot the remaining ----
-            # catalyst-api mothership env seams. The VERIFIED-PARTIAL
-            # review found that Phases 1-2 only flip the image registry
-            # + the GitOps repo URL: the PIN/handover-JWT issuers and
-            # the runtime-config console/api-public URLs kept their
-            # mothership back-compat defaults, so the 10-min
-            # deny-egress hold could pass while tokens still carried a
-            # mothership `iss` and CORS/public-URL pointed home. Each
-            # pivot below ends in a read-back assert (Step-10-Phase-1c
-            # pattern): any openova.io residue is FATAL — Pillar 5
-            # independence not met.
+            {{- /*
+             ---- Phase 3 (#2940, 2026-06-03): pivot the remaining ----
+             catalyst-api mothership env seams. The VERIFIED-PARTIAL
+             review found that Phases 1-2 only flip the image registry
+             + the GitOps repo URL: the PIN/handover-JWT issuers and
+             the runtime-config console/api-public URLs kept their
+             mothership back-compat defaults, so the 10-min
+             deny-egress hold could pass while tokens still carried a
+             mothership `iss` and CORS/public-URL pointed home. Each
+             pivot below ends in a read-back assert (Step-10-Phase-1c
+             pattern): any openova.io residue is FATAL — Pillar 5
+             independence not met.
+            */}}
             if [ -z "${CONSOLE_PUBLIC_URL}" ] || echo "${CONSOLE_PUBLIC_URL}" | grep -q "example.local"; then
               echo "[catalyst-api-env-patch] FATAL Phase 3: sovereign.consolePublicURL not overlaid (got '${CONSOLE_PUBLIC_URL}') — supply https://console.<sovereign-fqdn>" >&2
               exit 1
             fi
 
-            # 3a. runtime-config ConfigMap keys (CORS_ORIGIN +
-            # CATALYST_SOVEREIGN_URL read sovereign-console-url;
-            # CATALYST_API_PUBLIC_URL reads sovereign-api-public-url —
-            # all via configMapKeyRef, so the CM is the single seam).
+            {{- /*
+             3a. runtime-config ConfigMap keys (CORS_ORIGIN +
+             CATALYST_SOVEREIGN_URL read sovereign-console-url;
+             CATALYST_API_PUBLIC_URL reads sovereign-api-public-url —
+             all via configMapKeyRef, so the CM is the single seam).
+            */}}
             kubectl patch configmap catalyst-runtime-config \
               -n "${DEPLOYMENT_NAMESPACE}" \
               --type merge \
               -p "{\"data\":{\"sovereign-console-url\":\"${CONSOLE_PUBLIC_URL}\",\"sovereign-api-public-url\":\"${CONSOLE_PUBLIC_URL}/sovereign\"}}"
 
-            # 3b. issuer envs (auth.go pinIssuer + main.go handover-JWT
-            # issuer read these; the in-code openova.io constants are
-            # fallbacks ONLY when the env is unset).
+            {{- /*
+             3b. issuer envs (auth.go pinIssuer + main.go handover-JWT
+             issuer read these; the in-code openova.io constants are
+             fallbacks ONLY when the env is unset).
+            */}}
             kubectl set env "deploy/${DEPLOYMENT_NAME}" \
               -n "${DEPLOYMENT_NAMESPACE}" \
               "CATALYST_PIN_ISSUER=${CONSOLE_PUBLIC_URL}" \
               "CATALYST_HANDOVER_JWT_ISSUER=${CONSOLE_PUBLIC_URL}"
-            # #4996: deadlock-aware wait for the issuer-env roll too.
+            {{- /* #4996: deadlock-aware wait for the issuer-env roll too. */}}
             if ! roll_and_wait_catalyst_api "issuer envs"; then
               echo "[catalyst-api-env-patch] #4996 FATAL: catalyst-api rollout did not converge (issuer envs) — see the EVS/image-pull diagnostics above; step exits for a clean recoverable re-run" >&2
               exit 1
             fi
 
-            # 3c. Read-back asserts — live values, not intentions.
+            {{- /* 3c. Read-back asserts — live values, not intentions. */}}
             for KEY in sovereign-console-url sovereign-api-public-url; do
               LIVE=$(kubectl get configmap catalyst-runtime-config \
                 -n "${DEPLOYMENT_NAMESPACE}" \
@@ -938,34 +1034,36 @@ data:
               echo "[catalyst-api-env-patch] Phase 3 OK: ${VAR}=${LIVE}"
             done
 
-            # ---- Phase 3d (#5527): pivot the per-Org GitOps tree generator ----
-            # The org-services provisioning Deployment regenerates the per-Org
-            # trees (HelmRepository blocks included) on EVERY org mutation. Its
-            # emitters are cutover-aware (core/services/provisioning/gitops/
-            # cutover_aware_5527.go) but the fact must be stamped HERE: without
-            # it, the next org mutation after cutover re-emits
-            # oci://ghcr.io/openova-io and Flux drift-corrects the step-06
-            # object pivot straight back (the hw291 step-08 OFFENDER wedge,
-            # recurring silently post-cutover — Pillar 5). The stamped value is
-            # the SAME base step-06 patches the live objects to:
-            # oci://<harbor-host>/openova-io. The set-env rolls the Deployment
-            # (tiny, prewarmed image — step-03 mirrors every workload image),
-            # so the regenerating process always carries the fact.
-            #
-            # Deployment-absent is a SKIP (a Sovereign without the marketplace
-            # tier has no per-Org generator to re-tether); present-but-unstamped
-            # is FATAL (fail-open here IS the #5527 defect). The rollout wait is
-            # best-effort: the fact lives in the pod TEMPLATE (durable across
-            # restarts + helm 3-way merges), and step-08's roll-set re-rolls
-            # this workload under deny-egress anyway — a slow roll here must
-            # not add a new cutover wedge-class.
+            {{- /*
+             ---- Phase 3d (#5527): pivot the per-Org GitOps tree generator ----
+             The org-services provisioning Deployment regenerates the per-Org
+             trees (HelmRepository blocks included) on EVERY org mutation. Its
+             emitters are cutover-aware (core/services/provisioning/gitops/
+             cutover_aware_5527.go) but the fact must be stamped HERE: without
+             it, the next org mutation after cutover re-emits
+             oci://ghcr.io/openova-io and Flux drift-corrects the step-06
+             object pivot straight back (the hw291 step-08 OFFENDER wedge,
+             recurring silently post-cutover — Pillar 5). The stamped value is
+             the SAME base step-06 patches the live objects to:
+             oci://<harbor-host>/openova-io. The set-env rolls the Deployment
+             (tiny, prewarmed image — step-03 mirrors every workload image),
+             so the regenerating process always carries the fact.
+
+             Deployment-absent is a SKIP (a Sovereign without the marketplace
+             tier has no per-Org generator to re-tether); present-but-unstamped
+             is FATAL (fail-open here IS the #5527 defect). The rollout wait is
+             best-effort: the fact lives in the pod TEMPLATE (durable across
+             restarts + helm 3-way merges), and step-08's roll-set re-rolls
+             this workload under deny-egress anyway — a slow roll here must
+             not add a new cutover wedge-class.
+            */}}
             LOCAL_OCI_BASE="oci://$(printf '%s' "${HARBOR_PUBLIC_URL}" | sed -e 's,^https\?://,,' -e 's,/*$,,')/openova-io"
             if kubectl get deploy "${ORG_PROVISIONING_DEPLOYMENT}" -n "${ORG_PROVISIONING_NAMESPACE}" >/dev/null 2>&1; then
               echo "[catalyst-api-env-patch] #5527 Phase 3d: CATALYST_LOCAL_REGISTRY_URL=${LOCAL_OCI_BASE} -> deploy/${ORG_PROVISIONING_DEPLOYMENT} -n ${ORG_PROVISIONING_NAMESPACE}"
               kubectl set env "deploy/${ORG_PROVISIONING_DEPLOYMENT}" \
                 -n "${ORG_PROVISIONING_NAMESPACE}" \
                 "CATALYST_LOCAL_REGISTRY_URL=${LOCAL_OCI_BASE}"
-              # Read-back assert — live template value, not intention.
+              {{- /* Read-back assert — live template value, not intention. */}}
               LIVE=$(kubectl get deploy "${ORG_PROVISIONING_DEPLOYMENT}" \
                 -n "${ORG_PROVISIONING_NAMESPACE}" \
                 -o jsonpath="{.spec.template.spec.containers[0].env[?(@.name=='CATALYST_LOCAL_REGISTRY_URL')].value}" 2>/dev/null || echo "")
@@ -981,38 +1079,40 @@ data:
               echo "[catalyst-api-env-patch] #5527 Phase 3d SKIP: deploy/${ORG_PROVISIONING_DEPLOYMENT} not found in ${ORG_PROVISIONING_NAMESPACE} (no marketplace tier — no per-Org generator to pivot)"
             fi
 
-            # ---- Phase 3e (#5439): pivot the per-Org IMAGE registry host ----
-            # Phase 3d pivots the CHART base the per-Org generators emit. The
-            # IMAGE registry host they emit is a SECOND field and was never
-            # pivoted by any step: the three generators (org-controller,
-            # provisioning, catalyst-api) all default to `harbor.openova.io`
-            # — the MOTHERSHIP Harbor — and the bp-catalyst-platform chart
-            # ALWAYS stamps that literal onto the first two Deployments, so it
-            # is the live value on every Sovereign from birth.
-            #
-            # Live on hw292, cutoverComplete=true since 2026-08-03T08:12:04Z:
-            #   kubectl -n uatco get hr vcluster -o json | jq -r .spec.values
-            #     "image":{"registry":"harbor.openova.io"
-            #     "statefulSet":{"image":{"registry":"harbor.openova.io"
-            #     "coredns":{...:"harbor.openova.io/proxy-dockerhub/coredns/..."}
-            # Every Organization reconcile re-wrote that into the Flux-owned
-            # per-Org tree AFTER the cutover had reported success — the #5439
-            # re-tether, one field over from the #5527 one.
-            #
-            # WHY A NEW ENV NAME rather than `kubectl set env
-            # CATALYST_VCLUSTER_IMAGE_REGISTRY`: that var IS templated by
-            # products/catalyst/chart/templates/{controllers/organization-
-            # controller-deployment,org-services/provisioning}.yaml, so the
-            # next Flux-driven helm upgrade reverts a set-env on it within
-            # minutes. CATALYST_LOCAL_IMAGE_REGISTRY_HOST appears in NO chart
-            # manifest, so a strategic-merge preserves it — the same durability
-            # argument Phase 3d stakes on CATALYST_LOCAL_REGISTRY_URL.
-            #
-            # The value is byte-identical to step-10's target_host
-            # (harbor.${SOVEREIGN_FQDN}), so the generated source and the
-            # objects step-10 pivots agree and Flux has nothing to
-            # drift-correct. Deployment-absent is a SKIP; present-but-unstamped
-            # is FATAL (fail-open here IS the defect).
+            {{- /*
+             ---- Phase 3e (#5439): pivot the per-Org IMAGE registry host ----
+             Phase 3d pivots the CHART base the per-Org generators emit. The
+             IMAGE registry host they emit is a SECOND field and was never
+             pivoted by any step: the three generators (org-controller,
+             provisioning, catalyst-api) all default to `harbor.openova.io`
+             — the MOTHERSHIP Harbor — and the bp-catalyst-platform chart
+             ALWAYS stamps that literal onto the first two Deployments, so it
+             is the live value on every Sovereign from birth.
+
+             Live on hw292, cutoverComplete=true since 2026-08-03T08:12:04Z:
+               kubectl -n uatco get hr vcluster -o json | jq -r .spec.values
+                 "image":{"registry":"harbor.openova.io"
+                 "statefulSet":{"image":{"registry":"harbor.openova.io"
+                 "coredns":{...:"harbor.openova.io/proxy-dockerhub/coredns/..."}
+             Every Organization reconcile re-wrote that into the Flux-owned
+             per-Org tree AFTER the cutover had reported success — the #5439
+             re-tether, one field over from the #5527 one.
+
+             WHY A NEW ENV NAME rather than `kubectl set env
+             CATALYST_VCLUSTER_IMAGE_REGISTRY`: that var IS templated by
+             products/catalyst/chart/templates/{controllers/organization-
+             controller-deployment,org-services/provisioning}.yaml, so the
+             next Flux-driven helm upgrade reverts a set-env on it within
+             minutes. CATALYST_LOCAL_IMAGE_REGISTRY_HOST appears in NO chart
+             manifest, so a strategic-merge preserves it — the same durability
+             argument Phase 3d stakes on CATALYST_LOCAL_REGISTRY_URL.
+
+             The value is byte-identical to step-10's target_host
+             (harbor.${SOVEREIGN_FQDN}), so the generated source and the
+             objects step-10 pivots agree and Flux has nothing to
+             drift-correct. Deployment-absent is a SKIP; present-but-unstamped
+             is FATAL (fail-open here IS the defect).
+            */}}
             if [ -z "${SOVEREIGN_FQDN}" ] || [ "${SOVEREIGN_FQDN}" = "example.local" ]; then
               echo "[catalyst-api-env-patch] #5439 FATAL Phase 3e: sovereign.fqdn not overlaid (got '${SOVEREIGN_FQDN}') — cannot derive the local image-registry host" >&2
               exit 1
@@ -1031,7 +1131,7 @@ data:
               echo "[catalyst-api-env-patch] #5439 Phase 3e: CATALYST_LOCAL_IMAGE_REGISTRY_HOST=${LOCAL_IMAGE_HOST} -> deploy/${_d} -n ${_n}"
               kubectl set env "deploy/${_d}" -n "${_n}" \
                 "CATALYST_LOCAL_IMAGE_REGISTRY_HOST=${LOCAL_IMAGE_HOST}"
-              # Read-back assert — live template value, not intention.
+              {{- /* Read-back assert — live template value, not intention. */}}
               _live=$(kubectl get deploy "${_d}" -n "${_n}" \
                 -o jsonpath="{.spec.template.spec.containers[0].env[?(@.name=='CATALYST_LOCAL_IMAGE_REGISTRY_HOST')].value}" 2>/dev/null || echo "")
               if [ "${_live}" != "${LOCAL_IMAGE_HOST}" ]; then
@@ -1043,17 +1143,19 @@ data:
                 || echo "[catalyst-api-env-patch] #5439 WARN Phase 3e: deploy/${_d} rollout slow (best-effort — the fact is in the pod template; step-08's roll-set covers the live roll)"
             done
 
-            # ---- Phase 4 (#4973 #4975 #4961): comprehensive pod-spec image sweep ----
-            # The HR global.imageRegistry pivots above (Phases 1-2 + the additionalHRs
-            # loop) only reach images a chart renders THROUGH global.imageRegistry.
-            # Images pinned by full ref OUTSIDE that value stay tethered to a non-local
-            # host and would wedge step-08's roll-set: evs-csi CSI sidecars (#4973),
-            # continuum's prerequisite-check initContainer (#4975), flow-emitter (#4961).
-            # This sweep normalises EVERY container + initContainer of every
-            # external-registry workload to registry.<fqdn> so no pod-spec carries a
-            # non-local ref into the deny-egress hold. Fail-open (a tooling gap never
-            # wedges the cutover worse than the pre-sweep state; step-04's containerd
-            # rewrite is the durable steady-state safety net).
+            {{- /*
+             ---- Phase 4 (#4973 #4975 #4961): comprehensive pod-spec image sweep ----
+             The HR global.imageRegistry pivots above (Phases 1-2 + the additionalHRs
+             loop) only reach images a chart renders THROUGH global.imageRegistry.
+             Images pinned by full ref OUTSIDE that value stay tethered to a non-local
+             host and would wedge step-08's roll-set: evs-csi CSI sidecars (#4973),
+             continuum's prerequisite-check initContainer (#4975), flow-emitter (#4961).
+             This sweep normalises EVERY container + initContainer of every
+             external-registry workload to registry.<fqdn> so no pod-spec carries a
+             non-local ref into the deny-egress hold. Fail-open (a tooling gap never
+             wedges the cutover worse than the pre-sweep state; step-04's containerd
+             rewrite is the durable steady-state safety net).
+            */}}
             sweep_workload_podspec_images || echo "[catalyst-api-env-patch] #4973/#4975/#4961 WARN pod-spec image sweep incomplete (best-effort; step-04 containerd rewrite still covers pulls)"
 
             echo "[catalyst-api-env-patch] done (Phases 1-4 complete)"
@@ -1067,19 +1169,23 @@ data:
           readOnlyRootFilesystem: true
           capabilities:
             drop: ["ALL"]
-        # G63 (#2613, 2026-05-30): writable /tmp for G62 git clone +
-        # working dir. readOnlyRootFilesystem: true blocks any write
-        # to /tmp unless explicitly mounted emptyDir. Without this
-        # mount, G62's git clone fails with "Read-only file system"
-        # (verified live hw70 14:38Z). Same emptyDir pattern as
-        # Step 06's tmp mount.
+        {{- /*
+         G63 (#2613, 2026-05-30): writable /tmp for G62 git clone +
+         working dir. readOnlyRootFilesystem: true blocks any write
+         to /tmp unless explicitly mounted emptyDir. Without this
+         mount, G62's git clone fails with "Read-only file system"
+         (verified live hw70 14:38Z). Same emptyDir pattern as
+         Step 06's tmp mount.
+        */}}
         volumeMounts:
           - name: tmp
             mountPath: /tmp
-          # #4973 #4975 #4961 — the shared offline-mirror resolver (same file
-          # step-03/step-08 source), so the pod-spec sweep maps each image to the
-          # EXACT local Harbor path step-03 Phase A3 pushed it to (never a forked
-          # mapping that could target a path the mirror never held).
+          {{- /*
+           #4973 #4975 #4961 — the shared offline-mirror resolver (same file
+           step-03/step-08 source), so the pod-spec sweep maps each image to the
+           EXACT local Harbor path step-03 Phase A3 pushed it to (never a forked
+           mapping that could target a path the mirror never held).
+          */}}
           - name: offline-mirror-resolver
             mountPath: /resolver
             readOnly: true

--- a/platform/self-sovereign-cutover/chart/templates/08-egress-block-test-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/08-egress-block-test-job.yaml
@@ -38,23 +38,27 @@ metadata:
     bp.openova.io/cutover-mode: "job"
 data:
   stepName: egress-block-test
-  # Cilium 1.16 doesn't support FQDN matching in `egressDeny` (only in
-  # `egress`/allow). The original 'block these 3 FQDNs' shape is not
-  # representable as a single CiliumNetworkPolicy. Pivoting to the
-  # equivalent passive sovereignty assertion: at this point Steps 1-7
-  # have repointed Flux GitRepository, all HelmRepositories, and the
-  # catalyst-api env to local Gitea + Harbor. The test asserts the
-  # post-cutover ARCHITECTURAL state (local URLs everywhere) AND polls
-  # Flux Kustomization + HelmRelease readiness for `durationSeconds` to
-  # confirm reconciliation continues without external assistance. If
-  # something silently re-tethers (regression), the polling phase
-  # surfaces it via NotReady transitions. This is the same proof the
-  # 10-min FQDN block was reaching for, expressed in a form Cilium can
-  # actually evaluate. Caught live on otech103 2026-05-04.
+  {{- /*
+   Cilium 1.16 doesn't support FQDN matching in `egressDeny` (only in
+   `egress`/allow). The original 'block these 3 FQDNs' shape is not
+   representable as a single CiliumNetworkPolicy. Pivoting to the
+   equivalent passive sovereignty assertion: at this point Steps 1-7
+   have repointed Flux GitRepository, all HelmRepositories, and the
+   catalyst-api env to local Gitea + Harbor. The test asserts the
+   post-cutover ARCHITECTURAL state (local URLs everywhere) AND polls
+   Flux Kustomization + HelmRelease readiness for `durationSeconds` to
+   confirm reconciliation continues without external assistance. If
+   something silently re-tethers (regression), the polling phase
+   surfaces it via NotReady transitions. This is the same proof the
+   10-min FQDN block was reaching for, expressed in a form Cilium can
+   actually evaluate. Caught live on otech103 2026-05-04.
+  */}}
   cilium-policy.yaml: |
-    # No-op placeholder — kept as a ConfigMap entry so the volume mount
-    # in the podSpec still resolves. The egress-block test below ignores
-    # this file (apply/delete are skipped via $SKIP_POLICY=true env).
+    {{- /*
+     No-op placeholder — kept as a ConfigMap entry so the volume mount
+     in the podSpec still resolves. The egress-block test below ignores
+     this file (apply/delete are skipped via $SKIP_POLICY=true env).
+    */}}
     apiVersion: v1
     kind: ConfigMap
     metadata:
@@ -73,97 +77,117 @@ data:
             value: {{ .Values.egressTest.durationSeconds | quote }}
           - name: NAMESPACE
             value: {{ .Release.Namespace | quote }}
-          # #2940 — real egress-block enforcement. OFF by default: a
-          # false-positive (a mis-resolved upstream CIDR that overlaps a
-          # dependency) would FAIL Step-08 → cutover engine aborts →
-          # half-pivoted unrecoverable prov. So this stays opt-in until
-          # validated on a cutover walk, after which the default flips.
-          # When ON, the script resolves UPSTREAM_HOSTS → IPs and applies
-          # a scoped CiliumNetworkPolicy egressDeny toCIDR for the
-          # survival window, so ANY hidden runtime tether (not just the
-          # declarative HelmRepository/GitRepository surfaces) fails the
-          # proof. eq-toString guards the Sprig-bool pitfall.
+          {{- /*
+           #2940 — real egress-block enforcement. OFF by default: a
+           false-positive (a mis-resolved upstream CIDR that overlaps a
+           dependency) would FAIL Step-08 → cutover engine aborts →
+           half-pivoted unrecoverable prov. So this stays opt-in until
+           validated on a cutover walk, after which the default flips.
+           When ON, the script resolves UPSTREAM_HOSTS → IPs and applies
+           a scoped CiliumNetworkPolicy egressDeny toCIDR for the
+           survival window, so ANY hidden runtime tether (not just the
+           declarative HelmRepository/GitRepository surfaces) fails the
+           proof. eq-toString guards the Sprig-bool pitfall.
+          */}}
           - name: ENFORCE_CIDR_BLOCK
             value: {{ eq (toString .Values.egressTest.enforceCIDRBlock) "true" | quote }}
           - name: UPSTREAM_HOSTS
             value: {{ .Values.egressTest.blockedDomains | default (list "github.com" "ghcr.io" "harbor.openova.io") | join " " | quote }}
-          # #3678 — TRUE deny-egress. DEFAULT_DENY_EGRESS=true emits a
-          # default-deny CCNP with an explicit intra-cluster allow-list
-          # (ALLOW_CIDRS) so EVERYTHING public is denied, not just the 4
-          # enumerated tether CIDRs. The apiserver-strand (#3640) is avoided
-          # by the allow-list (10.96/12 covers 10.96.0.1), not by
-          # enableDefaultDeny.egress:false.
+          {{- /*
+           #3678 — TRUE deny-egress. DEFAULT_DENY_EGRESS=true emits a
+           default-deny CCNP with an explicit intra-cluster allow-list
+           (ALLOW_CIDRS) so EVERYTHING public is denied, not just the 4
+           enumerated tether CIDRs. The apiserver-strand (#3640) is avoided
+           by the allow-list (10.96/12 covers 10.96.0.1), not by
+           enableDefaultDeny.egress:false.
+          */}}
           - name: DEFAULT_DENY_EGRESS
             value: {{ eq (toString .Values.egressTest.defaultDenyEgress) "true" | quote }}
           - name: ALLOW_CIDRS
             value: {{ .Values.egressTest.allowIntraClusterCIDRs | default (list "10.42.0.0/16" "10.43.0.0/16" "10.96.0.0/12") | join " " | quote }}
-          # #4596 — IaaS PROVIDER control-plane API CIDR allow-list. The deny-egress
-          # hold must black-hole the MOTHERSHIP but NOT the cloud the Sovereign runs
-          # ON: the CSI driver needs the provider API (Huawei ECS/EVS, Hetzner API)
-          # to attach volumes for any pod that (re)schedules DURING the hold (the
-          # catalyst-api-env-patch restart). Empty by default (no-op on providers
-          # whose CSI/control-plane is reachable via the cluster/host paths);
-          # cloud-init sets it per region (Huawei kom4dc: "212.72.2.0/24" — the API
-          # /24, which EXCLUDES the bastion .24.x + the GitHub/mothership ranges).
+          {{- /*
+           #4596 — IaaS PROVIDER control-plane API CIDR allow-list. The deny-egress
+           hold must black-hole the MOTHERSHIP but NOT the cloud the Sovereign runs
+           ON: the CSI driver needs the provider API (Huawei ECS/EVS, Hetzner API)
+           to attach volumes for any pod that (re)schedules DURING the hold (the
+           catalyst-api-env-patch restart). Empty by default (no-op on providers
+           whose CSI/control-plane is reachable via the cluster/host paths);
+           cloud-init sets it per region (Huawei kom4dc: "212.72.2.0/24" — the API
+           /24, which EXCLUDES the bastion .24.x + the GitHub/mothership ranges).
+          */}}
           - name: PROVIDER_API_CIDRS
             value: {{ .Values.egressTest.allowProviderCIDRs | default (list) | join " " | quote }}
-          # #5359 — SECONDARY-REGION deny-egress legs. The sovereignty hold is
-          # applied to EVERY region's cluster (kubeconfigs from the optional
-          # /secondary-kubeconfigs mount) and every region must stay green
-          # through the window — a region-A-only hold proved nothing about
-          # region-B (hw288 false-positive cc=true). The secondary manifest
-          # is the region-A manifest (ALLOW_CIDRS + PROVIDER_API_CIDRS
-          # carve-outs inherited verbatim — the #4596/#5020-5025 CSI-freeze
-          # trap catalog applies per-region) PLUS: a mesh-wide toEndpoints
-          # allow (cross-cluster pod dials carry a ClusterMesh identity that
-          # toCIDR NEVER matches — the ipBlock/remote-identity lesson), the
-          # auto-resolved public IPs of the Sovereign's OWN
-          # registry.<fqdn>/gitea.<fqdn> gateway door, and these extra CIDRs.
+          {{- /*
+           #5359 — SECONDARY-REGION deny-egress legs. The sovereignty hold is
+           applied to EVERY region's cluster (kubeconfigs from the optional
+           /secondary-kubeconfigs mount) and every region must stay green
+           through the window — a region-A-only hold proved nothing about
+           region-B (hw288 false-positive cc=true). The secondary manifest
+           is the region-A manifest (ALLOW_CIDRS + PROVIDER_API_CIDRS
+           carve-outs inherited verbatim — the #4596/#5020-5025 CSI-freeze
+           trap catalog applies per-region) PLUS: a mesh-wide toEndpoints
+           allow (cross-cluster pod dials carry a ClusterMesh identity that
+           toCIDR NEVER matches — the ipBlock/remote-identity lesson), the
+           auto-resolved public IPs of the Sovereign's OWN
+           registry.<fqdn>/gitea.<fqdn> gateway door, and these extra CIDRs.
+          */}}
           - name: SECONDARY_EXTRA_ALLOW_CIDRS
             value: {{ .Values.secondaryRegions.extraEgressAllowCIDRs | default (list) | join " " | quote }}
           - name: SOVEREIGN_FQDN
             value: {{ .Values.sovereign.fqdn | quote }}
           - name: STATUS_CONFIGMAP
             value: {{ .Values.status.configMapName | quote }}
-          # #5359 — the per-region lint driver stamps
-          # step.egress-block-test.region.<key>.fluxSourceLint on the status
-          # ConfigMap, which lives in the cutover release namespace.
+          {{- /*
+           #5359 — the per-region lint driver stamps
+           step.egress-block-test.region.<key>.fluxSourceLint on the status
+           ConfigMap, which lives in the cutover release namespace.
+          */}}
           - name: CUTOVER_NAMESPACE
             value: {{ .Release.Namespace | quote }}
-          # #3678 — active call-home assertion knobs. During the hold, curl
-          # each CALL_HOME_HOSTS entry FROM this pod (under the policy); any
-          # that connects fails the proof.
+          {{- /*
+           #3678 — active call-home assertion knobs. During the hold, curl
+           each CALL_HOME_HOSTS entry FROM this pod (under the policy); any
+           that connects fails the proof.
+          */}}
           - name: CALL_HOME_ENABLED
             value: {{ eq (toString .Values.egressTest.callHomeAssertion.enabled) "true" | quote }}
           - name: CALL_HOME_TIMEOUT
             value: {{ .Values.egressTest.callHomeAssertion.timeoutSeconds | default 5 | quote }}
           - name: CALL_HOME_HOSTS
             value: {{ .Values.egressTest.callHomeAssertion.hosts | default (list "https://console.openova.io/healthz") | join " " | quote }}
-          # #3695 — host GitOps loop gate. The root bootstrap-kit Kustomization
-          # (+ sovereign-tls + org-tenants) MUST be Ready=True at the
-          # post-cutover revision or the proof fails BEFORE the window.
+          {{- /*
+           #3695 — host GitOps loop gate. The root bootstrap-kit Kustomization
+           (+ sovereign-tls + org-tenants) MUST be Ready=True at the
+           post-cutover revision or the proof fails BEFORE the window.
+          */}}
           - name: HOST_KS_GATE_ENABLED
             value: {{ eq (toString .Values.egressTest.hostKustomizationGate.enabled) "true" | quote }}
           - name: HOST_KS_NAMESPACE
             value: {{ .Values.egressTest.hostKustomizationGate.namespace | default "flux-system" | quote }}
           - name: HOST_KS_NAMES
             value: {{ .Values.egressTest.hostKustomizationGate.names | default (list "bootstrap-kit") | join " " | quote }}
-          # #3695 — roll EVERY external-registry workload under deny-egress,
-          # not one hand-picked openova-io Deployment.
+          {{- /*
+           #3695 — roll EVERY external-registry workload under deny-egress,
+           not one hand-picked openova-io Deployment.
+          */}}
           - name: ROLL_ALL_EXTERNAL
             value: {{ eq (toString .Values.egressTest.rollAllExternalRegistryWorkloads) "true" | quote }}
-          # #4975 (Refs #3379 #3695) — the local registry substr that
-          # classifies the roll-set. DERIVED from sovereign.harborPublicURL's
-          # host (registry.<fqdn>) unless the operator overrides
-          # egressTest.localRegistryHostSubstr. The FULL host is used (not
-          # "harbor." nor a bare "registry.") so it excludes ONLY the local
-          # registry — not the mothership harbor.openova.io tether (which MUST
-          # be rolled) and not registry.k8s.io (an external upstream).
+          {{- /*
+           #4975 (Refs #3379 #3695) — the local registry substr that
+           classifies the roll-set. DERIVED from sovereign.harborPublicURL's
+           host (registry.<fqdn>) unless the operator overrides
+           egressTest.localRegistryHostSubstr. The FULL host is used (not
+           "harbor." nor a bare "registry.") so it excludes ONLY the local
+           registry — not the mothership harbor.openova.io tether (which MUST
+           be rolled) and not registry.k8s.io (an external upstream).
+          */}}
           - name: LOCAL_REGISTRY_SUBSTR
             value: {{ .Values.egressTest.localRegistryHostSubstr | default (include "bp-self-sovereign-cutover.localRegistryHost" .) | quote }}
-          # #4975 — the offline-mirror coverage map + hosts, for the pre-hold
-          # completeness gate (HEAD every workload image against local Harbor)
-          # and the roll-set exclusions. Same env step-03/step-04 read.
+          {{- /*
+           #4975 — the offline-mirror coverage map + hosts, for the pre-hold
+           completeness gate (HEAD every workload image against local Harbor)
+           and the roll-set exclusions. Same env step-03/step-04 read.
+          */}}
           - name: HOST_PROJECT_MAP
             value: {{ include "bp-self-sovereign-cutover.hostProjectMapInline" . | quote }}
           - name: EXCLUDED_HOSTS
@@ -174,15 +198,17 @@ data:
             value: {{ include "bp-self-sovereign-cutover.localRegistryHost" . | quote }}
           - name: MIRROR_COMPLETENESS_GATE
             value: {{ eq (toString .Values.offlineMirror.enabled) "true" | quote }}
-          # #5194 (Refs #4975 #5191) — PRE-HOLD completeness SELF-HEAL. On a
-          # missing-manifest MISS the gate below auto-warms the image into
-          # local Harbor (reusing step-03 harbor-prewarm's exact skopeo
-          # proxy-copy mechanism) instead of failing immediately — closes the
-          # gap where a funnel Org provisioned MID-CUTOVER (after step-03
-          # already enumerated the workload set) is never mirrored. The
-          # remaining env below mirrors step-03's skopeo-copy env VERBATIM
-          # (same Secret refs, same prewarm.* knobs) so both consumers derive
-          # identical credentials + retry/backoff behavior from one source.
+          {{- /*
+           #5194 (Refs #4975 #5191) — PRE-HOLD completeness SELF-HEAL. On a
+           missing-manifest MISS the gate below auto-warms the image into
+           local Harbor (reusing step-03 harbor-prewarm's exact skopeo
+           proxy-copy mechanism) instead of failing immediately — closes the
+           gap where a funnel Org provisioned MID-CUTOVER (after step-03
+           already enumerated the workload set) is never mirrored. The
+           remaining env below mirrors step-03's skopeo-copy env VERBATIM
+           (same Secret refs, same prewarm.* knobs) so both consumers derive
+           identical credentials + retry/backoff behavior from one source.
+          */}}
           - name: MIRROR_SELF_HEAL_ENABLED
             value: {{ eq (toString .Values.offlineMirror.selfHeal.enabled) "true" | quote }}
           - name: MOTHERSHIP_HOST
@@ -203,40 +229,46 @@ data:
             value: {{ .Values.prewarm.proxyCopyAttempts | default 6 | quote }}
           - name: PREWARM_PROXY_BACKOFF_BASE_SECONDS
             value: {{ .Values.prewarm.proxyBackoffBaseSeconds | default 30 | quote }}
-          # #5026 — pre-hold ref-host lint toggle (treadmill-breaker).
+          {{- /* #5026 — pre-hold ref-host lint toggle (treadmill-breaker). */}}
           - name: PODSPEC_REFHOST_LINT
             value: {{ eq (toString .Values.egressTest.podspecRefHostLint.enabled) "true" | quote }}
-          # #5650 — pre-hold Flux SOURCE host lint. The deny-egress hold below
-          # proves nothing external is REACHABLE for 600s; it cannot prove
-          # nothing external is DEPENDED UPON, because the policy is torn down
-          # when the hold ends and a source whose reconcile interval straddles
-          # the window never dials during it. Live hw292: vcluster-system/loft
-          # (charts.loft.sh, interval 15m) sat Ready through a passing hold and
-          # re-fetched from the public internet ~10h after cutoverComplete=true.
-          # This lint is the timing-independent half of the proof.
+          {{- /*
+           #5650 — pre-hold Flux SOURCE host lint. The deny-egress hold below
+           proves nothing external is REACHABLE for 600s; it cannot prove
+           nothing external is DEPENDED UPON, because the policy is torn down
+           when the hold ends and a source whose reconcile interval straddles
+           the window never dials during it. Live hw292: vcluster-system/loft
+           (charts.loft.sh, interval 15m) sat Ready through a passing hold and
+           re-fetched from the public internet ~10h after cutoverComplete=true.
+           This lint is the timing-independent half of the proof.
+          */}}
           - name: FLUX_SOURCE_HOST_LINT
             value: {{ eq (toString .Values.egressTest.fluxSourceHostLint.enabled) "true" | quote }}
           - name: FLUX_SOURCE_HOST_ALLOW
             value: {{ .Values.egressTest.fluxSourceHostLint.allowHosts | default (list) | join " " | quote }}
-          # #5359 — pre-hold Flux SOURCE HEALTH lint. The host lint reads
-          # spec.url; this reads whether the controller ever converged on it.
-          # hw292 region-b carried a Sovereign-local GitRepository URL that
-          # source-controller had never once fetched (generation=2,
-          # observedGeneration=1, Ready=False), so it kept serving the
-          # pre-cutover github.com artifact and reverted all 64 pivoted
-          # HelmRepositories every 5m. A host-only lint passes over that.
+          {{- /*
+           #5359 — pre-hold Flux SOURCE HEALTH lint. The host lint reads
+           spec.url; this reads whether the controller ever converged on it.
+           hw292 region-b carried a Sovereign-local GitRepository URL that
+           source-controller had never once fetched (generation=2,
+           observedGeneration=1, Ready=False), so it kept serving the
+           pre-cutover github.com artifact and reverted all 64 pivoted
+           HelmRepositories every 5m. A host-only lint passes over that.
+          */}}
           - name: FLUX_SOURCE_HEALTH_LINT
             value: {{ eq (toString .Values.egressTest.fluxSourceHealthLint.enabled) "true" | quote }}
-          # #5650 — pre-hold Crossplane Provider PACKAGE host lint. Same class
-          # as FLUX_SOURCE_HOST_LINT, different controller: Crossplane's
-          # package manager fetches `Provider.spec.package` directly from the
-          # crossplane-system Pod (never through containerd, never through
-          # Flux source-controller), on its own reconcile loop, so it is
-          # invisible to BOTH the podspec ref-host lint (#5026, which only
-          # walks Deployment/DaemonSet/StatefulSet pod specs) and the Flux
-          # source lint above (which only walks HelmRepository/GitRepository/
-          # OCIRepository). Step-11 (crossplane-provider-pivot) durably
-          # rewrites spec.package; this proves the rewrite HELD.
+          {{- /*
+           #5650 — pre-hold Crossplane Provider PACKAGE host lint. Same class
+           as FLUX_SOURCE_HOST_LINT, different controller: Crossplane's
+           package manager fetches `Provider.spec.package` directly from the
+           crossplane-system Pod (never through containerd, never through
+           Flux source-controller), on its own reconcile loop, so it is
+           invisible to BOTH the podspec ref-host lint (#5026, which only
+           walks Deployment/DaemonSet/StatefulSet pod specs) and the Flux
+           source lint above (which only walks HelmRepository/GitRepository/
+           OCIRepository). Step-11 (crossplane-provider-pivot) durably
+           rewrites spec.package; this proves the rewrite HELD.
+          */}}
           - name: PROVIDER_PACKAGE_HOST_LINT
             value: {{ eq (toString .Values.egressTest.providerPackageHostLint.enabled) "true" | quote }}
           - name: PROVIDER_PACKAGE_HOST_ALLOW
@@ -255,9 +287,11 @@ data:
                 name: {{ .Values.harbor.adminSecretRef.name }}
                 key: {{ .Values.harbor.adminSecretRef.passwordKey }}
                 optional: true
-          # #3647 — fresh-pull-under-deny-egress proof knobs. See the
-          # FRESH-PULL phase in the script below + values.yaml egressTest.
-          # freshPullProof for the full rationale.
+          {{- /*
+           #3647 — fresh-pull-under-deny-egress proof knobs. See the
+           FRESH-PULL phase in the script below + values.yaml egressTest.
+           freshPullProof for the full rationale.
+          */}}
           - name: FRESH_PULL_PROOF
             value: {{ eq (toString .Values.egressTest.freshPullProof.enabled) "true" | quote }}
           - name: FRESH_PULL_NAMESPACE
@@ -268,19 +302,25 @@ data:
             value: {{ .Values.egressTest.freshPullProof.excludeDeploymentSubstring | quote }}
           - name: FRESH_PULL_TIMEOUT
             value: {{ .Values.egressTest.freshPullProof.timeoutSeconds | quote }}
-          # #5022 — DaemonSet rollouts are per-node sequential under
-          # RollingUpdate(maxUnavailable:1); budget scales with node count.
+          {{- /*
+           #5022 — DaemonSet rollouts are per-node sequential under
+           RollingUpdate(maxUnavailable:1); budget scales with node count.
+          */}}
           - name: FRESH_PULL_DS_PER_NODE
             value: {{ .Values.egressTest.freshPullProof.dsPerNodeSeconds | default 120 | quote }}
-          # #5022 — "<ns>/<name>" pairs never rolled by the sweep (the
-          # registry-pivot DS is the pivot mechanism itself — recursive).
+          {{- /*
+           #5022 — "<ns>/<name>" pairs never rolled by the sweep (the
+           registry-pivot DS is the pivot mechanism itself — recursive).
+          */}}
           - name: FRESH_PULL_EXCLUDE_WORKLOADS
             value: {{ .Values.egressTest.freshPullProof.excludeWorkloads | default (list "catalyst/registry-pivot") | join " " | quote }}
-          # #5074/#5065/#5059 — principled roll-set. "minimal" (default) rolls
-          # a representative sample of ORDINARY APP workloads and excludes
-          # infra by RULE (namespaces + DaemonSets-in-infra-ns) instead of the
-          # name-by-name whack-a-mole; "full" keeps the legacy roll-everything
-          # sweep. See values.yaml egressTest.freshPullProof.rollSetMode.
+          {{- /*
+           #5074/#5065/#5059 — principled roll-set. "minimal" (default) rolls
+           a representative sample of ORDINARY APP workloads and excludes
+           infra by RULE (namespaces + DaemonSets-in-infra-ns) instead of the
+           name-by-name whack-a-mole; "full" keeps the legacy roll-everything
+           sweep. See values.yaml egressTest.freshPullProof.rollSetMode.
+          */}}
           - name: FRESH_PULL_ROLL_SET_MODE
             value: {{ .Values.egressTest.freshPullProof.rollSetMode | default "minimal" | quote }}
           - name: FRESH_PULL_INFRA_NAMESPACES
@@ -291,22 +331,24 @@ data:
             value: {{ .Values.egressTest.freshPullProof.minRepresentativesPerRegion | default 12 | quote }}
           - name: FRESH_PULL_REPRESENTATIVE_NAMESPACES
             value: {{ .Values.egressTest.freshPullProof.representativeNamespaces | default (list "flux-system" "gitea" "harbor" "keycloak" "grafana") | join " " | quote }}
-          # #5091 — MINIMAL-mode rule c: NEVER force-roll a stateful RWO-EVS
-          # singleton (gitea, keycloak-postgresql, harbor-database/redis, cnpg,
-          # …). Its image locality is ALREADY proven by the #4975 pre-hold
-          # completeness HEAD gate + the #5026 ref-host lint (both prove locality
-          # WITHOUT rolling); the synthetic roll adds NO image-proof value and
-          # triggers the UNRECOVERABLE CSI NodeStage/VolumeAttachment desync — a
-          # Recreate roll's NodeUnstage removes the CSI globalmount, the
-          # VolumeAttachment persists unchanged, so NodeStage never re-fires and
-          # NodePublish then fails on the missing globalmount → the replacement
-          # pod hangs Init:0/3 past the roll budget → ROLL_FAIL → step-08 fails
-          # forever (proven live hw253 gitea, #5091). Detection = an RWO PVC whose
-          # storageClass is in rwoEvsExclusion.storageClasses OR whose bound-PV
-          # CSI driver is in rwoEvsExclusion.csiDrivers. This ONLY narrows the
-          # ROLL set — rule a/b, the #4975 completeness gate, the #5026 ref-host
-          # lint, the 600s deny-egress hold + the curl call-home proof are all
-          # untouched.
+          {{- /*
+           #5091 — MINIMAL-mode rule c: NEVER force-roll a stateful RWO-EVS
+           singleton (gitea, keycloak-postgresql, harbor-database/redis, cnpg,
+           …). Its image locality is ALREADY proven by the #4975 pre-hold
+           completeness HEAD gate + the #5026 ref-host lint (both prove locality
+           WITHOUT rolling); the synthetic roll adds NO image-proof value and
+           triggers the UNRECOVERABLE CSI NodeStage/VolumeAttachment desync — a
+           Recreate roll's NodeUnstage removes the CSI globalmount, the
+           VolumeAttachment persists unchanged, so NodeStage never re-fires and
+           NodePublish then fails on the missing globalmount → the replacement
+           pod hangs Init:0/3 past the roll budget → ROLL_FAIL → step-08 fails
+           forever (proven live hw253 gitea, #5091). Detection = an RWO PVC whose
+           storageClass is in rwoEvsExclusion.storageClasses OR whose bound-PV
+           CSI driver is in rwoEvsExclusion.csiDrivers. This ONLY narrows the
+           ROLL set — rule a/b, the #4975 completeness gate, the #5026 ref-host
+           lint, the 600s deny-egress hold + the curl call-home proof are all
+           untouched.
+          */}}
           - name: FRESH_PULL_RWO_EVS_EXCLUDE
             value: {{ eq (toString .Values.egressTest.freshPullProof.rwoEvsExclusion.enabled) "true" | quote }}
           - name: FRESH_PULL_RWO_EVS_STORAGECLASSES
@@ -314,25 +356,31 @@ data:
           - name: FRESH_PULL_RWO_EVS_CSIDRIVERS
             value: {{ .Values.egressTest.freshPullProof.rwoEvsExclusion.csiDrivers | default (list "evs.csi.huaweicloud.com") | join " " | quote }}
         volumeMounts:
-          # #3379 (hw139, 2026-06-15): WRITABLE emptyDir at /work. The
-          # container runs readOnlyRootFilesystem:true (securityContext
-          # below), so the egressDeny CCNP manifest the enforce path emits
-          # can NOT be written to /tmp (root FS) — the prior `>/tmp/egress-
-          # deny.yaml` redirect failed with "Read-only file system", the
-          # `kubectl apply` never ran, the cutover-egress-block CCNP was
-          # never created, and the 600s window passed as an assertion-only
-          # hold (NOT the witnessed deny-egress proof ADR-0002 demands).
-          # /work is the one writable path; the manifest is written there.
+          {{- /*
+           #3379 (hw139, 2026-06-15): WRITABLE emptyDir at /work. The
+           container runs readOnlyRootFilesystem:true (securityContext
+           below), so the egressDeny CCNP manifest the enforce path emits
+           can NOT be written to /tmp (root FS) — the prior `>/tmp/egress-
+           deny.yaml` redirect failed with "Read-only file system", the
+           `kubectl apply` never ran, the cutover-egress-block CCNP was
+           never created, and the 600s window passed as an assertion-only
+           hold (NOT the witnessed deny-egress proof ADR-0002 demands).
+           /work is the one writable path; the manifest is written there.
+          */}}
           - name: work
             mountPath: /work
-          # #4975 — the shared offline-mirror resolver (same file step-03
-          # sources), so the pre-hold completeness gate maps each workload
-          # image to the local Harbor path step-03 pushed it to.
+          {{- /*
+           #4975 — the shared offline-mirror resolver (same file step-03
+           sources), so the pre-hold completeness gate maps each workload
+           image to the local Harbor path step-03 pushed it to.
+          */}}
           - name: offline-mirror-resolver
             mountPath: /resolver
             readOnly: true
-          # #5359 — optional secondary-region kubeconfigs (empty on a
-          # single-region Sovereign; the secondary hold legs no-op).
+          {{- /*
+           #5359 — optional secondary-region kubeconfigs (empty on a
+           single-region Sovereign; the secondary hold legs no-op).
+          */}}
           - name: secondary-kubeconfigs
             mountPath: /secondary-kubeconfigs
             readOnly: true
@@ -342,13 +390,15 @@ data:
             set -eu
             : "${HARBOR_USERNAME:=admin}"
 
-            # #4975 — the offline-mirror image→local-path resolver (shared with
-            # step-03). Defines offlinemirror_local_paths over the SAME
-            # HOST_PROJECT_MAP / EXCLUDED_* / LOCAL_REGISTRY_HOST env, so the
-            # pre-hold completeness gate below HEADs the EXACT path step-03
-            # pushed each image to. Guard the source in case the resolver
-            # ConfigMap ever fails to mount (degrade to survival-poll, never
-            # wedge the cutover on a tooling gap).
+            {{- /*
+             #4975 — the offline-mirror image→local-path resolver (shared with
+             step-03). Defines offlinemirror_local_paths over the SAME
+             HOST_PROJECT_MAP / EXCLUDED_* / LOCAL_REGISTRY_HOST env, so the
+             pre-hold completeness gate below HEADs the EXACT path step-03
+             pushed each image to. Guard the source in case the resolver
+             ConfigMap ever fails to mount (degrade to survival-poll, never
+             wedge the cutover on a tooling gap).
+            */}}
             if [ -r /resolver/resolver.sh ]; then
               . /resolver/resolver.sh
             else
@@ -356,9 +406,11 @@ data:
               MIRROR_COMPLETENESS_GATE="false"
             fi
 
-            # Architectural assertion phase — verifies the data-plane
-            # pivots from Steps 5/6/7 are actually live BEFORE we begin
-            # the survival window.
+            {{- /*
+             Architectural assertion phase — verifies the data-plane
+             pivots from Steps 5/6/7 are actually live BEFORE we begin
+             the survival window.
+            */}}
             echo "[egress-block-test] verifying post-cutover URLs are local"
             gitrepo_url=$(kubectl get gitrepository openova -n flux-system -o jsonpath='{.spec.url}')
             echo "  gitrepository.openova.url=${gitrepo_url}"
@@ -366,45 +418,49 @@ data:
               *gitea-http*|*gitea.*) : ;;
               *) echo "  FAIL — GitRepository still upstream"; exit 1 ;;
             esac
-            # Slot-managed self-reference HelmRepositories (declared in
-            # clusters/_template/bootstrap-kit/) are re-applied by Flux
-            # Kustomization on every reconcile, so Step-6's patch is
-            # transient for them. They're whitelisted here because the
-            # data-plane impact is null — the chart they point at is
-            # already installed and isn't pulled again until next
-            # cutover cycle, which would re-apply the patch first. The
-            # bulk of HelmRepositories ARE patched durably because
-            # Step-06 also git-pushes the rewritten bootstrap-kit YAML.
-            #
-            # #3526 — the pivot assertion MUST tolerate the async-git-push
-            # window. Step-06 (cutover-order 6) does TWO things to pivot
-            # the HelmRepository URLs:
-            #   (a) live `kubectl patch` of the listed HRs (immediate,
-            #       in-memory) — but Flux's bootstrap-kit Kustomization
-            #       re-applies the ORIGINAL ghcr.io manifests from Gitea
-            #       on its next 5-min reconcile, REVERTING those patches;
-            #   (b) a git-push of the sed-rewritten
-            #       clusters/_template/bootstrap-kit/*.yaml to local Gitea
-            #       — the DURABLE rewrite, which only takes effect once
-            #       the `openova` GitRepository pulls the new commit AND
-            #       the bootstrap-kit Kustomization re-applies it.
-            # Step-08 (cutover-order 8) runs ~3 min after Step-06, which
-            # on hw136 (#3379 walk) landed inside the revert window of (a)
-            # BEFORE (b) had reconciled — so a single-shot assertion saw
-            # 59 HRs back at ghcr.io and FAIL-FAST'd (exit 1, ~74s) before
-            # the 600s deny-egress hold ever ran (cutover-egress-block CCNP
-            # never applied, cutoverComplete stayed false).
-            #
-            # Fix: FORCE-RECONCILE the GitRepository + bootstrap-kit
-            # Kustomization so Step-06's durable git commit is pulled and
-            # re-applied NOW, then POLL the pivot to convergence with a
-            # bounded timeout. Only FAIL if the offenders persist after
-            # the full wait — by then the revert window has closed and a
-            # surviving ghcr.io URL is a real un-pivoted HelmRepository,
-            # not the transient Flux-revert race.
+            {{- /*
+             Slot-managed self-reference HelmRepositories (declared in
+             clusters/_template/bootstrap-kit/) are re-applied by Flux
+             Kustomization on every reconcile, so Step-6's patch is
+             transient for them. They're whitelisted here because the
+             data-plane impact is null — the chart they point at is
+             already installed and isn't pulled again until next
+             cutover cycle, which would re-apply the patch first. The
+             bulk of HelmRepositories ARE patched durably because
+             Step-06 also git-pushes the rewritten bootstrap-kit YAML.
+
+             #3526 — the pivot assertion MUST tolerate the async-git-push
+             window. Step-06 (cutover-order 6) does TWO things to pivot
+             the HelmRepository URLs:
+               (a) live `kubectl patch` of the listed HRs (immediate,
+                   in-memory) — but Flux's bootstrap-kit Kustomization
+                   re-applies the ORIGINAL ghcr.io manifests from Gitea
+                   on its next 5-min reconcile, REVERTING those patches;
+               (b) a git-push of the sed-rewritten
+                   clusters/_template/bootstrap-kit/*.yaml to local Gitea
+                   — the DURABLE rewrite, which only takes effect once
+                   the `openova` GitRepository pulls the new commit AND
+                   the bootstrap-kit Kustomization re-applies it.
+             Step-08 (cutover-order 8) runs ~3 min after Step-06, which
+             on hw136 (#3379 walk) landed inside the revert window of (a)
+             BEFORE (b) had reconciled — so a single-shot assertion saw
+             59 HRs back at ghcr.io and FAIL-FAST'd (exit 1, ~74s) before
+             the 600s deny-egress hold ever ran (cutover-egress-block CCNP
+             never applied, cutoverComplete stayed false).
+
+             Fix: FORCE-RECONCILE the GitRepository + bootstrap-kit
+             Kustomization so Step-06's durable git commit is pulled and
+             re-applied NOW, then POLL the pivot to convergence with a
+             bounded timeout. Only FAIL if the offenders persist after
+             the full wait — by then the revert window has closed and a
+             surviving ghcr.io URL is a real un-pivoted HelmRepository,
+             not the transient Flux-revert race.
+            */}}
             count_offenders() {
-              # Echoes the current external (non-slot-self-ref) ghcr.io
-              # HelmRepositories, one per line; caller derives the count.
+              {{- /*
+               Echoes the current external (non-slot-self-ref) ghcr.io
+               HelmRepositories, one per line; caller derives the count.
+              */}}
               kubectl get helmrepositories.source.toolkit.fluxcd.io -A \
                 -o jsonpath='{range .items[*]}{.metadata.namespace}/{.metadata.name}={.spec.url}{"\n"}{end}' \
                 | grep -E '=oci://ghcr\.io/openova-io' \
@@ -413,29 +469,35 @@ data:
 
             echo "[egress-block-test] #3526: force-reconciling Step-06's durable git-push before asserting HelmRepository pivot"
             now_ts=$(date +%s)
-            # GitRepository pull (SA has gitrepositories patch). This pulls
-            # Step-06 phase-2's local-Gitea commit immediately rather than
-            # waiting for the 1-min GitRepository interval.
+            {{- /*
+             GitRepository pull (SA has gitrepositories patch). This pulls
+             Step-06 phase-2's local-Gitea commit immediately rather than
+             waiting for the 1-min GitRepository interval.
+            */}}
             kubectl annotate --overwrite gitrepository openova -n flux-system \
               "reconcile.fluxcd.io/requestedAt=${now_ts}" >/dev/null 2>&1 \
               && echo "  reconcile requested: gitrepository/openova" \
               || echo "  WARN — could not annotate gitrepository/openova (continuing; the 1-min interval still converges)"
-            # bootstrap-kit Kustomization re-apply (SA has kustomizations
-            # patch as of chart 0.1.58 #3526). This re-applies the pulled
-            # commit's rewritten HelmRepository manifests immediately
-            # rather than waiting for the 5-min Kustomization interval —
-            # the long interval is exactly what made the revert window wide
-            # enough to catch Step-08 on hw136.
+            {{- /*
+             bootstrap-kit Kustomization re-apply (SA has kustomizations
+             patch as of chart 0.1.58 #3526). This re-applies the pulled
+             commit's rewritten HelmRepository manifests immediately
+             rather than waiting for the 5-min Kustomization interval —
+             the long interval is exactly what made the revert window wide
+             enough to catch Step-08 on hw136.
+            */}}
             kubectl annotate --overwrite kustomization bootstrap-kit -n flux-system \
               "reconcile.fluxcd.io/requestedAt=${now_ts}" >/dev/null 2>&1 \
               && echo "  reconcile requested: kustomization/bootstrap-kit" \
               || echo "  WARN — could not annotate kustomization/bootstrap-kit (continuing; the 5-min interval still converges)"
 
-            # Bounded poll to convergence. Up to ~5 min, re-checking every
-            # 15s, so a slow source-controller pull + helm/kustomize
-            # re-apply has time to land the durable local URLs before we
-            # judge. Re-annotate the GitRepository + Kustomization each
-            # cycle so a missed reconcile-request doesn't strand the poll.
+            {{- /*
+             Bounded poll to convergence. Up to ~5 min, re-checking every
+             15s, so a slow source-controller pull + helm/kustomize
+             re-apply has time to land the durable local URLs before we
+             judge. Re-annotate the GitRepository + Kustomization each
+             cycle so a missed reconcile-request doesn't strand the poll.
+            */}}
             pivot_deadline=$(( $(date +%s) + 300 ))
             ext_offenders="$(count_offenders)"
             ext_count=$(printf '%s' "${ext_offenders}" | grep -c '=' || true)
@@ -465,33 +527,35 @@ data:
               *gitea-http*|*gitea.*) : ;;
               *) echo "  FAIL — catalyst-api env still upstream"; exit 1 ;;
             esac
-            # #2940 — real egress-block enforcement (opt-in). Resolve the
-            # upstream hosts to public IPs and deny egress to those /32s
-            # for the survival window so a HIDDEN runtime tether (a Go
-            # constant hitting harbor.openova.io, an image pull not via a
-            # HelmRepository) surfaces as NotReady — the declarative-only
-            # assertion above can't catch those. Private/loopback IPs are
-            # skipped so intra-cluster traffic is never blocked. Fail-safe:
-            # any resolve/apply error falls back to assertion-only and
-            # NEVER wedges the cutover on a tooling failure.
-            # ── #5194 (Refs #4975 #5191) PRE-HOLD COMPLETENESS SELF-HEAL ──
-            # A funnel Org provisioned MID-CUTOVER (after step-03 harbor-
-            # prewarm already enumerated the workload set) is never mirrored
-            # — its pods are Running (they pulled fine pre-hold) but the
-            # completeness gate below 404s on the missing NATIVE local
-            # manifest (live hw269: harbor.openova.io/proxy-dockerhub/
-            # mariadb:11 + wordpress:6-apache, org `hw269uatwalk`). Egress is
-            # still OPEN at this point (the deny-egress hold hasn't started),
-            # so the gap is recoverable: reuse the EXACT step-03 skopeo
-            # proxy-copy mechanism (HOST_PROJECT_MAP host->project mapping,
-            # the ghcr.io PAT + mothership-proxy direct-source fallback,
-            # PREWARM_PROXY_COPY_ATTEMPTS/backoff) to push the missing
-            # manifest into local Harbor, then re-HEAD. Only a warm that
-            # itself fails (or a still-missing manifest afterward) fails the
-            # gate — every app provisioned at ANY time now survives the
-            # sovereignty proof. Lazy: skopeo is installed + creds parsed
-            # ONLY on the first actual miss, so a complete mirror (the common
-            # case) pays zero extra cost.
+            {{- /*
+             #2940 — real egress-block enforcement (opt-in). Resolve the
+             upstream hosts to public IPs and deny egress to those /32s
+             for the survival window so a HIDDEN runtime tether (a Go
+             constant hitting harbor.openova.io, an image pull not via a
+             HelmRepository) surfaces as NotReady — the declarative-only
+             assertion above can't catch those. Private/loopback IPs are
+             skipped so intra-cluster traffic is never blocked. Fail-safe:
+             any resolve/apply error falls back to assertion-only and
+             NEVER wedges the cutover on a tooling failure.
+             ── #5194 (Refs #4975 #5191) PRE-HOLD COMPLETENESS SELF-HEAL ──
+             A funnel Org provisioned MID-CUTOVER (after step-03 harbor-
+             prewarm already enumerated the workload set) is never mirrored
+             — its pods are Running (they pulled fine pre-hold) but the
+             completeness gate below 404s on the missing NATIVE local
+             manifest (live hw269: harbor.openova.io/proxy-dockerhub/
+             mariadb:11 + wordpress:6-apache, org `hw269uatwalk`). Egress is
+             still OPEN at this point (the deny-egress hold hasn't started),
+             so the gap is recoverable: reuse the EXACT step-03 skopeo
+             proxy-copy mechanism (HOST_PROJECT_MAP host->project mapping,
+             the ghcr.io PAT + mothership-proxy direct-source fallback,
+             PREWARM_PROXY_COPY_ATTEMPTS/backoff) to push the missing
+             manifest into local Harbor, then re-HEAD. Only a warm that
+             itself fails (or a still-missing manifest afterward) fails the
+             gate — every app provisioned at ANY time now survives the
+             sovereignty proof. Lazy: skopeo is installed + creds parsed
+             ONLY on the first actual miss, so a complete mirror (the common
+             case) pays zero extra cost.
+            */}}
             _selfheal_skopeo_ready=0
             _selfheal_creds_loaded=0
             _selfheal_ghcr_user=""; _selfheal_ghcr_pat=""
@@ -524,12 +588,14 @@ data:
               return 1
             }
 
-            # Parses the SAME flux-system/ghcr-pull dockerconfigjson step-03
-            # reads, extracting the ghcr.io PAT + any mothership-Harbor auth
-            # entry. Optional: an absent/empty GHCR_DOCKERCONFIG degrades to
-            # anonymous-only warm (public proxy-* upstreams still warm fine;
-            # a private ghcr.io/openova-io image would still fail the warm —
-            # falling through to the pre-#5194 FAIL, never a regression).
+            {{- /*
+             Parses the SAME flux-system/ghcr-pull dockerconfigjson step-03
+             reads, extracting the ghcr.io PAT + any mothership-Harbor auth
+             entry. Optional: an absent/empty GHCR_DOCKERCONFIG degrades to
+             anonymous-only warm (public proxy-* upstreams still warm fine;
+             a private ghcr.io/openova-io image would still fail the warm —
+             falling through to the pre-#5194 FAIL, never a regression).
+            */}}
             self_heal_load_creds() {
               [ "${_selfheal_creds_loaded}" = "1" ] && return 0
               _selfheal_creds_loaded=1
@@ -562,10 +628,12 @@ data:
               esac
             }
 
-            # self_heal_warm_image UPSTREAM_REF LOCAL_PATH -> 0 warmed, 1 not.
-            # UPSTREAM_REF is the ORIGINAL pod-spec image (the enumerated
-            # ${_img}); LOCAL_PATH is the exact resolver-derived destination
-            # (${_lp} — the SAME path the completeness HEAD just missed on).
+            {{- /*
+             self_heal_warm_image UPSTREAM_REF LOCAL_PATH -> 0 warmed, 1 not.
+             UPSTREAM_REF is the ORIGINAL pod-spec image (the enumerated
+             ${_img}); LOCAL_PATH is the exact resolver-derived destination
+             (${_lp} — the SAME path the completeness HEAD just missed on).
+            */}}
             self_heal_warm_image() {
               _wi_up=$(offlinemirror_normalize_ref "$1")
               _wi_lp="$2"
@@ -577,9 +645,11 @@ data:
               _wi_srchost="${_wi_up%%/*}"
               case "${_wi_srchost}" in *.*|*:*|localhost) : ;; *) _wi_srchost="docker.io" ;; esac
               _wi_sc=$(self_heal_src_creds_for "${_wi_srchost}")
-              # Mothership-proxy direct-source fallback — the SAME inverse
-              # HOST_PROJECT_MAP derivation step-03's copy_one uses (#5095):
-              # harbor.openova.io/proxy-dockerhub/<path> -> docker.io/<path>.
+              {{- /*
+               Mothership-proxy direct-source fallback — the SAME inverse
+               HOST_PROJECT_MAP derivation step-03's copy_one uses (#5095):
+               harbor.openova.io/proxy-dockerhub/<path> -> docker.io/<path>.
+              */}}
               _wi_fb_up=""; _wi_fb_sc=""
               if [ -n "${MOTHERSHIP_HOST:-}" ] && [ "${_wi_srchost}" = "${MOTHERSHIP_HOST}" ]; then
                 _wi_rest="${_wi_up#*/}"
@@ -635,17 +705,19 @@ data:
               return 1
             }
 
-            # ── #4975 PRE-HOLD OFFLINE-MIRROR COMPLETENESS GATE ───────────
-            # BEFORE the deny-egress hold (egress still OPEN), HEAD every
-            # workload image against the LOCAL Harbor at the exact path the
-            # shared resolver maps it to. A missing manifest = an image that
-            # would ImagePullBackOff the moment its pod is rolled under the
-            # hold. #5194: a miss is no longer immediately FATAL — it is
-            # first auto-warmed (see self_heal_warm_image above) and
-            # re-HEADed; only a still-missing manifest after the warm NAMES
-            # the offender(s) — the systemic end of the per-prov
-            # whack-a-mole (an opaque mid-hold ImagePullBackOff becomes a
-            # clear "step-03 Phase A3 did not mirror <image>").
+            {{- /*
+             ── #4975 PRE-HOLD OFFLINE-MIRROR COMPLETENESS GATE ───────────
+             BEFORE the deny-egress hold (egress still OPEN), HEAD every
+             workload image against the LOCAL Harbor at the exact path the
+             shared resolver maps it to. A missing manifest = an image that
+             would ImagePullBackOff the moment its pod is rolled under the
+             hold. #5194: a miss is no longer immediately FATAL — it is
+             first auto-warmed (see self_heal_warm_image above) and
+             re-HEADed; only a still-missing manifest after the warm NAMES
+             the offender(s) — the systemic end of the per-prov
+             whack-a-mole (an opaque mid-hold ImagePullBackOff becomes a
+             clear "step-03 Phase A3 did not mirror <image>").
+            */}}
             run_offline_mirror_completeness() {
               echo "[egress-block-test] #4975: PRE-HOLD completeness — HEAD every workload image against local Harbor ${HARBOR_PUBLIC_URL}"
               _base="${HARBOR_PUBLIC_URL}/v2"
@@ -667,14 +739,16 @@ data:
                   "") continue ;;   # excluded by design — not mirrored
                 esac
                 for _lp in ${_paths}; do
-                  # Split "<repo>[:tag|@digest]" into repo + manifest ref.
+                  {{- /* Split "<repo>[:tag|@digest]" into repo + manifest ref. */}}
                   _repo="${_lp}"; _ref="latest"
                   case "${_lp}" in
                     *@*) _ref="${_lp##*@}"; _repo="${_lp%@*}"; case "${_repo##*/}" in *:*) _repo="${_repo%:*}" ;; esac ;;
                     *) case "${_lp##*/}" in *:*) _ref="${_lp##*:}"; _repo="${_lp%:*}" ;; esac ;;
                   esac
-                  # 3 attempts to absorb a transient Harbor blip (a genuine
-                  # 404/absent still FATALs — that is the whole point).
+                  {{- /*
+                   3 attempts to absorb a transient Harbor blip (a genuine
+                   404/absent still FATALs — that is the whole point).
+                  */}}
                   _code=000
                   _try=1
                   while [ "${_try}" -le 3 ]; do
@@ -689,10 +763,12 @@ data:
                   case "${_code}" in
                     200|301|302) : ;;
                     *)
-                      # #5194 — self-heal BEFORE recording a miss: egress is
-                      # still open here, so warm the exact missing manifest
-                      # into local Harbor and re-HEAD once. Only a warm
-                      # failure or a still-missing manifest afterward counts.
+                      {{- /*
+                       #5194 — self-heal BEFORE recording a miss: egress is
+                       still open here, so warm the exact missing manifest
+                       into local Harbor and re-HEAD once. Only a warm
+                       failure or a still-missing manifest afterward counts.
+                      */}}
                       if [ "${MIRROR_SELF_HEAL_ENABLED:-true}" = "true" ] && self_heal_warm_image "${_img}" "${_lp}"; then
                         _code=$(curl -sk -o /dev/null -w '%{http_code}' \
                           -u "${HARBOR_USERNAME}:${HARBOR_PASSWORD}" \
@@ -726,35 +802,37 @@ data:
               fi
             fi
 
-            # #5026 — PRE-HOLD REF-HOST LINT (treadmill-breaker). Complements the
-            # content-completeness gate above: that proves the IMAGE is in local
-            # Harbor; this proves the pod-spec REF RESOLVES to local Harbor. A ref
-            # on a host that is NEITHER the local registry NOR a step-04 redirect-
-            # covered host is a genuine deny-egress tether (a raw github.com/… ref
-            # with NO containerd redirect) → latent ImagePullBackOff under the hold.
-            # This lists EVERY such offender at once and fails BEFORE the hold so
-            # the whole un-covered set surfaces in a single prov.
-            #
-            # #5036 (Refs #5026 #5027 #4975 — hw246) — REDIRECT-AWARE. The premise
-            # is NOT "the ref host must be registry.<fqdn>". Step-04 (04-registry-
-            # pivot-daemonset.yaml, which PASSED before this step) writes a
-            # containerd certs.d/<host>/hosts.toml redirect to registry.<fqdn> for
-            # EVERY host in HOST_PROJECT_MAP — the mothership harbor.openova.io
-            # host-swap AND ghcr.io/docker.io/quay.io/registry.k8s.io/… (proxy-cache
-            # pull-through). So a pod-spec ref like harbor.openova.io/proxy-<x>/PATH
-            # pulls from the LOCAL Harbor via that redirect and NEVER dials the
-            # mothership — it is already sovereign (verified live hw246:
-            # certs.d/harbor.openova.io/hosts.toml → server="https://harbor.openova.io",
-            # host."https://registry.<fqdn>"). Requiring step-07 to TEXTUALLY rewrite
-            # those ~40 chart-default refs (Option B, deferred backlog) is
-            # belt-and-suspenders, not a sovereignty requirement. This lint therefore
-            # exempts a host if it is the local registry OR appears in HOST_PROJECT_MAP
-            # (the SAME single-source env step-04 reads — no fresh hardcoded literal).
-            # SOUNDNESS: the deny-egress hold below is the authoritative proof; a
-            # redirect-covered ref that could NOT actually pull locally would still
-            # ImagePullBackOff during the hold and fail the proof, so exempting it
-            # here removes only a false positive on an already-local ref, never a
-            # real tether. The completeness gate above independently proves content.
+            {{- /*
+             #5026 — PRE-HOLD REF-HOST LINT (treadmill-breaker). Complements the
+             content-completeness gate above: that proves the IMAGE is in local
+             Harbor; this proves the pod-spec REF RESOLVES to local Harbor. A ref
+             on a host that is NEITHER the local registry NOR a step-04 redirect-
+             covered host is a genuine deny-egress tether (a raw github.com/… ref
+             with NO containerd redirect) → latent ImagePullBackOff under the hold.
+             This lists EVERY such offender at once and fails BEFORE the hold so
+             the whole un-covered set surfaces in a single prov.
+
+             #5036 (Refs #5026 #5027 #4975 — hw246) — REDIRECT-AWARE. The premise
+             is NOT "the ref host must be registry.<fqdn>". Step-04 (04-registry-
+             pivot-daemonset.yaml, which PASSED before this step) writes a
+             containerd certs.d/<host>/hosts.toml redirect to registry.<fqdn> for
+             EVERY host in HOST_PROJECT_MAP — the mothership harbor.openova.io
+             host-swap AND ghcr.io/docker.io/quay.io/registry.k8s.io/… (proxy-cache
+             pull-through). So a pod-spec ref like harbor.openova.io/proxy-<x>/PATH
+             pulls from the LOCAL Harbor via that redirect and NEVER dials the
+             mothership — it is already sovereign (verified live hw246:
+             certs.d/harbor.openova.io/hosts.toml → server="https://harbor.openova.io",
+             host."https://registry.<fqdn>"). Requiring step-07 to TEXTUALLY rewrite
+             those ~40 chart-default refs (Option B, deferred backlog) is
+             belt-and-suspenders, not a sovereignty requirement. This lint therefore
+             exempts a host if it is the local registry OR appears in HOST_PROJECT_MAP
+             (the SAME single-source env step-04 reads — no fresh hardcoded literal).
+             SOUNDNESS: the deny-egress hold below is the authoritative proof; a
+             redirect-covered ref that could NOT actually pull locally would still
+             ImagePullBackOff during the hold and fail the proof, so exempting it
+             here removes only a false positive on an already-local ref, never a
+             real tether. The completeness gate above independently proves content.
+            */}}
             run_podspec_refhost_lint() {
               echo "[egress-block-test] #5026/#5036: PRE-HOLD ref-host lint — every rolled workload pod-spec image host must be ${LOCAL_REGISTRY_HOST} OR a step-04 redirect-covered host (HOST_PROJECT_MAP: harbor.openova.io/ghcr.io/…); genuine offenders are hosts with NO containerd redirect that deny-egress would block"
               _lint_off="/work/refhost-offenders.$$"; : > "${_lint_off}"
@@ -763,7 +841,7 @@ data:
                   -o jsonpath='{range .items[*]}{.metadata.namespace}{" "}{.metadata.name}{"\n"}{end}' 2>/dev/null \
                 | while IFS=' ' read -r _lns _lname; do
                     [ -n "${_lns}" ] && [ -n "${_lname}" ] || continue
-                    # roll-set workload exclusions (registry-pivot etc.) — never linted.
+                    {{- /* roll-set workload exclusions (registry-pivot etc.) — never linted. */}}
                     _lex=0
                     for _lw in ${FRESH_PULL_EXCLUDE_WORKLOADS}; do
                       [ "${_lns}/${_lname}" = "${_lw}" ] && { _lex=1; break; }
@@ -773,16 +851,18 @@ data:
                       -o jsonpath='{range .spec.template.spec.containers[*]}{.name}{"="}{.image}{"\n"}{end}{range .spec.template.spec.initContainers[*]}{.name}{"="}{.image}{"\n"}{end}' 2>/dev/null \
                     | while IFS='=' read -r _lcn _limg; do
                         [ -n "${_limg}" ] || continue
-                        # Excluded image substrings (rancher/k3s, loft-sh/vcluster) → not an offender.
+                        {{- /* Excluded image substrings (rancher/k3s, loft-sh/vcluster) → not an offender. */}}
                         _sk=0
                         for _es in ${EXCLUDED_SUBSTRINGS}; do
                           case "${_limg}" in *"${_es}"*) _sk=1; break ;; esac
                         done
                         [ "${_sk}" = "1" ] && continue
-                        # Host classification — mirrors step-08's roll-set + the sweep's
-                        # podspec_pivot_ref EXACTLY: a bare `name[:tag]` or an implicit
-                        # docker.io `ns/name` (first segment has NO dot/:port) is NOT a
-                        # tether (containerd default mirror covers it) → skip.
+                        {{- /*
+                         Host classification — mirrors step-08's roll-set + the sweep's
+                         podspec_pivot_ref EXACTLY: a bare `name[:tag]` or an implicit
+                         docker.io `ns/name` (first segment has NO dot/:port) is NOT a
+                         tether (containerd default mirror covers it) → skip.
+                        */}}
                         case "${_limg}" in
                           */*)
                             _lh="${_limg%%/*}"
@@ -792,20 +872,22 @@ data:
                             esac ;;
                           *) continue ;;
                         esac
-                        # Excluded hosts (xpkg.upbound.io — step-11 owns it) → skip.
+                        {{- /* Excluded hosts (xpkg.upbound.io — step-11 owns it) → skip. */}}
                         for _eh in ${EXCLUDED_HOSTS}; do
                           [ "${_lh}" = "${_eh}" ] && { _sk=1; break; }
                         done
                         [ "${_sk}" = "1" ] && continue
-                        # The local registry host is sovereign.
+                        {{- /* The local registry host is sovereign. */}}
                         [ "${_lh}" = "${LOCAL_REGISTRY_HOST}" ] && continue
-                        # #5036 — a host that step-04's containerd registries redirect
-                        # maps to the local registry is ALSO sovereign. HOST_PROJECT_MAP
-                        # is the SAME space-separated `host:project` env step-04 loops
-                        # over to write each certs.d/<host>/hosts.toml redirect to
-                        # registry.<fqdn> (harbor.openova.io host-swap + ghcr.io/docker.io/
-                        # … proxy-cache), so a ref on any of those hosts pulls locally via
-                        # the redirect and never dials the mothership → not an offender.
+                        {{- /*
+                         #5036 — a host that step-04's containerd registries redirect
+                         maps to the local registry is ALSO sovereign. HOST_PROJECT_MAP
+                         is the SAME space-separated `host:project` env step-04 loops
+                         over to write each certs.d/<host>/hosts.toml redirect to
+                         registry.<fqdn> (harbor.openova.io host-swap + ghcr.io/docker.io/
+                         … proxy-cache), so a ref on any of those hosts pulls locally via
+                         the redirect and never dials the mothership → not an offender.
+                        */}}
                         _redir=0
                         for _rp in ${HOST_PROJECT_MAP:-}; do
                           [ "${_lh}" = "${_rp%%:*}" ] && { _redir=1; break; }
@@ -832,59 +914,63 @@ data:
               fi
             fi
 
-            # ── #5650 FLUX SOURCE HOST LINT ────────────────────────────────
-            # WHY this exists as a SEPARATE assertion from the hold. The hold
-            # applies a cluster-wide default-deny egress CCNP, runs for
-            # ${DURATION}s, and is then TORN DOWN. It therefore proves exactly
-            # one thing: nothing external was REACHABLE during that window. It
-            # cannot prove the Sovereign has no external DEPENDENCY, and those
-            # are different claims — Pillar 5 / ADR-0002 assert the second.
-            #
-            # The concrete miss (hw292, dep 1c56518035a83e03): HelmRepository
-            # vcluster-system/loft -> https://charts.loft.sh, spec.interval 15m,
-            # not suspended, referenced by a live HelmRelease. A 15m interval can
-            # straddle a 600s hold entirely, so the tether need never fire while
-            # the policy is up; its artifact was then re-fetched from the public
-            # internet at 18:36:28Z, ~10h AFTER cutoverComplete=true was set.
-            # The hold passed and was correct to pass. The gap is that nothing
-            # asserted over the object graph.
-            #
-            # SCOPE NOTE — why the step-04 redirect exemption does NOT apply
-            # here. run_podspec_refhost_lint exempts HOST_PROJECT_MAP hosts
-            # because containerd rewrites IMAGE pulls via certs.d/<host>/
-            # hosts.toml. Flux's source-controller fetches HelmRepository /
-            # GitRepository / OCIRepository URLs itself over HTTPS and never
-            # traverses containerd, so a certs.d redirect cannot cover it. The
-            # exemption set here is therefore strictly the Sovereign's OWN
-            # hosts plus in-cluster DNS — anything else is a live tether.
-            # #5359 (hw292, dep 1c56518035a83e03) — the lint MUST run PER REGION.
-            # It shipped in 0.1.162 measuring ONE cluster, which is the same
-            # shape as the defect it exists to catch: on hw292 region-a held 69
-            # HelmRepositories on the local Harbor and 0 on ghcr, while region-b
-            # held 0 local and 64 on ghcr, and cutoverComplete=true was set from
-            # the region-a measurement alone. A fleet property asserted from a
-            # single-region sample is not asserted at all.
-            #
-            # ARGS: $1 = region label (for the operator-facing message), $2 =
-            # kubeconfig path ("" = this Job's own in-cluster context = the
-            # primary). The `_fs_kubectl` shim is written on ONE line on purpose:
-            # chart/tests/flux-source-host-lint.sh extracts this function out of
-            # the RENDER with an awk range that terminates on the first bare `}`
-            # line, so a nested multi-line function definition would silently
-            # truncate the function under test and leave the suite validating a
-            # fragment (the #5646 drift shape).
+            {{- /*
+             ── #5650 FLUX SOURCE HOST LINT ────────────────────────────────
+             WHY this exists as a SEPARATE assertion from the hold. The hold
+             applies a cluster-wide default-deny egress CCNP, runs for
+             ${DURATION}s, and is then TORN DOWN. It therefore proves exactly
+             one thing: nothing external was REACHABLE during that window. It
+             cannot prove the Sovereign has no external DEPENDENCY, and those
+             are different claims — Pillar 5 / ADR-0002 assert the second.
+
+             The concrete miss (hw292, dep 1c56518035a83e03): HelmRepository
+             vcluster-system/loft -> https://charts.loft.sh, spec.interval 15m,
+             not suspended, referenced by a live HelmRelease. A 15m interval can
+             straddle a 600s hold entirely, so the tether need never fire while
+             the policy is up; its artifact was then re-fetched from the public
+             internet at 18:36:28Z, ~10h AFTER cutoverComplete=true was set.
+             The hold passed and was correct to pass. The gap is that nothing
+             asserted over the object graph.
+
+             SCOPE NOTE — why the step-04 redirect exemption does NOT apply
+             here. run_podspec_refhost_lint exempts HOST_PROJECT_MAP hosts
+             because containerd rewrites IMAGE pulls via certs.d/<host>/
+             hosts.toml. Flux's source-controller fetches HelmRepository /
+             GitRepository / OCIRepository URLs itself over HTTPS and never
+             traverses containerd, so a certs.d redirect cannot cover it. The
+             exemption set here is therefore strictly the Sovereign's OWN
+             hosts plus in-cluster DNS — anything else is a live tether.
+             #5359 (hw292, dep 1c56518035a83e03) — the lint MUST run PER REGION.
+             It shipped in 0.1.162 measuring ONE cluster, which is the same
+             shape as the defect it exists to catch: on hw292 region-a held 69
+             HelmRepositories on the local Harbor and 0 on ghcr, while region-b
+             held 0 local and 64 on ghcr, and cutoverComplete=true was set from
+             the region-a measurement alone. A fleet property asserted from a
+             single-region sample is not asserted at all.
+
+             ARGS: $1 = region label (for the operator-facing message), $2 =
+             kubeconfig path ("" = this Job's own in-cluster context = the
+             primary). The `_fs_kubectl` shim is written on ONE line on purpose:
+             chart/tests/flux-source-host-lint.sh extracts this function out of
+             the RENDER with an awk range that terminates on the first bare `}`
+             line, so a nested multi-line function definition would silently
+             truncate the function under test and leave the suite validating a
+             fragment (the #5646 drift shape).
+            */}}
             run_flux_source_host_lint() {
               _fs_region="${1:-primary}"
               _FS_KUBECONFIG="${2:-}"
               _fs_kubectl() { if [ -n "${_FS_KUBECONFIG:-}" ]; then kubectl --kubeconfig="${_FS_KUBECONFIG}" "$@"; else kubectl "$@"; fi; }
               echo "[egress-block-test] #5650/#5359: PRE-HOLD Flux source-host lint [region=${_fs_region}] — every HelmRepository/GitRepository/OCIRepository URL must resolve to a Sovereign-local host (registry./gitea./harbor.${SOVEREIGN_FQDN}, in-cluster DNS, or an explicit FLUX_SOURCE_HOST_ALLOW entry). containerd redirects do NOT cover these: source-controller dials them directly."
-              # WORK_DIR defaults to the Job's /work emptyDir; overridable so the
-              # function is drivable from chart/tests/flux-source-host-lint.sh.
-              # The `: >` MUST be checked: if the scratch file cannot be created
-              # (missing or read-only mount) every later append silently no-ops,
-              # `-s` is false, and the lint returns PASS having examined nothing.
-              # That is a fail-OPEN guard — the exact shape this lint exists to
-              # eliminate — and the test suite caught it here before it shipped.
+              {{- /*
+               WORK_DIR defaults to the Job's /work emptyDir; overridable so the
+               function is drivable from chart/tests/flux-source-host-lint.sh.
+               The `: >` MUST be checked: if the scratch file cannot be created
+               (missing or read-only mount) every later append silently no-ops,
+               `-s` is false, and the lint returns PASS having examined nothing.
+               That is a fail-OPEN guard — the exact shape this lint exists to
+               eliminate — and the test suite caught it here before it shipped.
+              */}}
               _fs_off="${WORK_DIR:-/work}/fluxsrc-offenders.$$"
               if ! : > "${_fs_off}" 2>/dev/null; then
                 echo "  FAIL — cannot create ${_fs_off}; refusing to report PASS from a lint that cannot record an offender (fail-closed)"
@@ -893,20 +979,24 @@ data:
               _fs_raw="${WORK_DIR:-/work}/fluxsrc-raw.$$"
               _fs_err="${WORK_DIR:-/work}/fluxsrc-err.$$"
               for _fk in helmrepositories gitrepositories ocirepositories; do
-                # #5359 FAIL-CLOSED ENUMERATION. This used to be a bare
-                # `kubectl … 2>/dev/null` piped into the reader: when the get
-                # FAILED (unreadable secondary kubeconfig, unreachable API,
-                # expired cert) the pipe carried zero rows, no offender was
-                # recorded, and the lint returned PASS for a region it had never
-                # measured. Against a secondary cluster that is not a hypothetical
-                # — it is the single most likely failure mode, and it would
-                # re-mint exactly the false positive this issue is about.
+                {{- /*
+                 #5359 FAIL-CLOSED ENUMERATION. This used to be a bare
+                 `kubectl … 2>/dev/null` piped into the reader: when the get
+                 FAILED (unreadable secondary kubeconfig, unreachable API,
+                 expired cert) the pipe carried zero rows, no offender was
+                 recorded, and the lint returned PASS for a region it had never
+                 measured. Against a secondary cluster that is not a hypothetical
+                 — it is the single most likely failure mode, and it would
+                 re-mint exactly the false positive this issue is about.
+                */}}
                 if ! _fs_kubectl get "${_fk}" -A \
                   -o jsonpath='{range .items[*]}{.metadata.namespace}{" "}{.metadata.name}{" "}{.spec.url}{" "}{.spec.suspend}{"\n"}{end}' >"${_fs_raw}" 2>"${_fs_err}"; then
-                  # A kind that is not INSTALLED is zero rows, not a tether: a
-                  # Sovereign with no OCIRepository CRD legitimately has none.
-                  # Anything else (auth, TLS, connection) means the region could
-                  # not be measured and the verdict must be FAIL.
+                  {{- /*
+                   A kind that is not INSTALLED is zero rows, not a tether: a
+                   Sovereign with no OCIRepository CRD legitimately has none.
+                   Anything else (auth, TLS, connection) means the region could
+                   not be measured and the verdict must be FAIL.
+                  */}}
                   if grep -qiE "server doesn't have a resource type|could not find the requested resource|no matches for kind|the server could not find the requested resource" "${_fs_err}" 2>/dev/null; then
                     : > "${_fs_raw}"
                   else
@@ -917,27 +1007,33 @@ data:
                 fi
                 while IFS=' ' read -r _fns _fname _furl _fsusp; do
                     [ -n "${_fns}" ] && [ -n "${_furl}" ] || continue
-                    # Strip scheme, then any path/port, leaving the bare host.
+                    {{- /* Strip scheme, then any path/port, leaving the bare host. */}}
                     _fh="${_furl#*://}"; _fh="${_fh%%/*}"; _fh="${_fh%%:*}"
                     [ -n "${_fh}" ] || continue
-                    # Sovereign-local: the local registry, the local Gitea, the
-                    # local Harbor, any *.<SOVEREIGN_FQDN>, in-cluster service
-                    # DNS, and loopback.
+                    {{- /*
+                     Sovereign-local: the local registry, the local Gitea, the
+                     local Harbor, any *.<SOVEREIGN_FQDN>, in-cluster service
+                     DNS, and loopback.
+                    */}}
                     case "${_fh}" in
                       "${LOCAL_REGISTRY_HOST}"|"gitea.${SOVEREIGN_FQDN}"|"harbor.${SOVEREIGN_FQDN}"|*".${SOVEREIGN_FQDN}") continue ;;
                       *.svc|*.svc.cluster.local|localhost|127.0.0.1) continue ;;
                     esac
-                    # Explicit operator-declared exceptions (default EMPTY, so
-                    # this lint fails closed: a host is a tether until someone
-                    # states otherwise in values, in Git, under review).
+                    {{- /*
+                     Explicit operator-declared exceptions (default EMPTY, so
+                     this lint fails closed: a host is a tether until someone
+                     states otherwise in values, in Git, under review).
+                    */}}
                     _fex=0
                     for _fa in ${FLUX_SOURCE_HOST_ALLOW:-}; do
                       [ "${_fh}" = "${_fa}" ] && { _fex=1; break; }
                     done
                     [ "${_fex}" = "1" ] && continue
-                    # A suspended source cannot reconcile, so it is reported
-                    # distinctly — still a declared dependency worth seeing, but
-                    # not a live fetch. It does NOT fail the lint.
+                    {{- /*
+                     A suspended source cannot reconcile, so it is reported
+                     distinctly — still a declared dependency worth seeing, but
+                     not a live fetch. It does NOT fail the lint.
+                    */}}
                     if [ "${_fsusp}" = "true" ]; then
                       echo "    SUSPENDED (not failing) ${_fns}/${_fname} [${_fk}] ${_furl} (host:${_fh})"
                       continue
@@ -956,34 +1052,36 @@ data:
               echo "  PASS — region ${_fs_region}: every non-suspended Flux source resolves to a Sovereign-local host; no external dependency remains in the object graph (#5650)"
               return 0
             }
-            # ── #5359 FLUX SOURCE HEALTH LINT ──────────────────────────────
-            # The host lint above reads spec.url. A URL is a DECLARATION, and
-            # hw292 proved a declaration can be cosmetic: step-05's secondary leg
-            # patched region-b's GitRepository url to the local Gitea and reported
-            # success, but source-controller never once fetched from it —
-            # generation=2, observedGeneration=1, Ready=False
-            # ("pkt-line 3: EOF") from 07:39:48Z onward. source-controller
-            # therefore kept SERVING the last artifact it had, which was
-            # main@sha1:4cc85ad9…, fetched from PUBLIC github.com at 07:31:11Z
-            # before the pivot. region-b's kustomize-controller then re-applied
-            # that pre-cutover GitHub content every 5m, reverting all 64
-            # HelmRepositories the step-06 leg had just patched.
-            #
-            # So a host-only lint can pass over a region whose real source of
-            # truth is still the public internet. What discriminates the two is
-            # not the URL but whether the controller has CONVERGED on it:
-            # observedGeneration == generation AND Ready=True.
-            #
-            # SCOPE — why `type: oci` HelmRepositories are exempt, measured not
-            # assumed. source-controller does not reconcile them (they are static
-            # config consumed by helm-controller), so they carry `status: {}` with
-            # no conditions and no observedGeneration at all. Live on hw292 that
-            # is 70/70 HelmRepositories in region-a and 65/65 in region-b —
-            # asserting health over them would fail every region of every
-            # Sovereign and wedge the flow this guard protects (#5505 shape).
-            # Restricted to the kinds a controller actually drives, the live
-            # blast radius on hw292 is exactly ONE object: region-b's
-            # flux-system/openova GitRepository — the defect itself.
+            {{- /*
+             ── #5359 FLUX SOURCE HEALTH LINT ──────────────────────────────
+             The host lint above reads spec.url. A URL is a DECLARATION, and
+             hw292 proved a declaration can be cosmetic: step-05's secondary leg
+             patched region-b's GitRepository url to the local Gitea and reported
+             success, but source-controller never once fetched from it —
+             generation=2, observedGeneration=1, Ready=False
+             ("pkt-line 3: EOF") from 07:39:48Z onward. source-controller
+             therefore kept SERVING the last artifact it had, which was
+             main@sha1:4cc85ad9…, fetched from PUBLIC github.com at 07:31:11Z
+             before the pivot. region-b's kustomize-controller then re-applied
+             that pre-cutover GitHub content every 5m, reverting all 64
+             HelmRepositories the step-06 leg had just patched.
+
+             So a host-only lint can pass over a region whose real source of
+             truth is still the public internet. What discriminates the two is
+             not the URL but whether the controller has CONVERGED on it:
+             observedGeneration == generation AND Ready=True.
+
+             SCOPE — why `type: oci` HelmRepositories are exempt, measured not
+             assumed. source-controller does not reconcile them (they are static
+             config consumed by helm-controller), so they carry `status: {}` with
+             no conditions and no observedGeneration at all. Live on hw292 that
+             is 70/70 HelmRepositories in region-a and 65/65 in region-b —
+             asserting health over them would fail every region of every
+             Sovereign and wedge the flow this guard protects (#5505 shape).
+             Restricted to the kinds a controller actually drives, the live
+             blast radius on hw292 is exactly ONE object: region-b's
+             flux-system/openova GitRepository — the defect itself.
+            */}}
             run_flux_source_health_lint() {
               _fh_region="${1:-primary}"
               _FS_KUBECONFIG="${2:-}"
@@ -1007,11 +1105,13 @@ data:
                     return 1
                   fi
                 fi
-                # `|`-separated on purpose: observedGeneration and the Ready
-                # condition are ABSENT on an unreconciled object, and with a
-                # space separator an empty middle field collapses and every later
-                # field shifts left — the reader would then compare the wrong two
-                # values and pass. The separator is load-bearing.
+                {{- /*
+                 `|`-separated on purpose: observedGeneration and the Ready
+                 condition are ABSENT on an unreconciled object, and with a
+                 space separator an empty middle field collapses and every later
+                 field shifts left — the reader would then compare the wrong two
+                 values and pass. The separator is load-bearing.
+                */}}
                 while IFS='|' read -r _hns _hname _hsusp _hgen _hobs _hready _hmsg; do
                   [ -n "${_hns}" ] && [ -n "${_hname}" ] || continue
                   [ "${_hsusp}" = "true" ] && continue
@@ -1033,26 +1133,28 @@ data:
               echo "  PASS — region ${_fh_region}: every non-suspended reconciled Flux source has converged on its declared Sovereign-local URL (#5359)"
               return 0
             }
-            # ── #5650 PROVIDER PACKAGE HOST LINT ────────────────────────────
-            # WHY this is a SEPARATE object graph from the Flux source lint
-            # above, and not something FLUX_SOURCE_HOST_LINT already covers.
-            # `pkg.crossplane.io/v1.Provider.spec.package` is the SAME shape
-            # of defect this issue is about, on a DIFFERENT controller:
-            # Crossplane's package manager fetches spec.package with its own
-            # `remote.Image()` call straight from the crossplane-system
-            # controller Pod (see step-11's header) — never through containerd
-            # (so a step-04 HOST_PROJECT_MAP redirect cannot cover it, exactly
-            # like a Flux source), and never through source-controller (so
-            # FLUX_SOURCE_HOST_LINT's `helmrepositories`/`gitrepositories`/
-            # `ocirepositories` enumeration cannot see it either — a Provider
-            # is not any of those three kinds). Step-11 pivots spec.package
-            # AND git-pushes the durable overlay rewrite, but nothing short of
-            # this lint proves the pivot HELD: a Provider installed after
-            # step-11 ran (an operator's own `kubectl apply`, or a bootstrap-
-            # kit change that lands a new Provider CR) reverts to
-            # xpkg.upbound.io silently, on the package manager's own
-            # reconcile loop, invisible to a torn-down 600s hold in exactly
-            # the way vcluster-system/loft was.
+            {{- /*
+             ── #5650 PROVIDER PACKAGE HOST LINT ────────────────────────────
+             WHY this is a SEPARATE object graph from the Flux source lint
+             above, and not something FLUX_SOURCE_HOST_LINT already covers.
+             `pkg.crossplane.io/v1.Provider.spec.package` is the SAME shape
+             of defect this issue is about, on a DIFFERENT controller:
+             Crossplane's package manager fetches spec.package with its own
+             `remote.Image()` call straight from the crossplane-system
+             controller Pod (see step-11's header) — never through containerd
+             (so a step-04 HOST_PROJECT_MAP redirect cannot cover it, exactly
+             like a Flux source), and never through source-controller (so
+             FLUX_SOURCE_HOST_LINT's `helmrepositories`/`gitrepositories`/
+             `ocirepositories` enumeration cannot see it either — a Provider
+             is not any of those three kinds). Step-11 pivots spec.package
+             AND git-pushes the durable overlay rewrite, but nothing short of
+             this lint proves the pivot HELD: a Provider installed after
+             step-11 ran (an operator's own `kubectl apply`, or a bootstrap-
+             kit change that lands a new Provider CR) reverts to
+             xpkg.upbound.io silently, on the package manager's own
+             reconcile loop, invisible to a torn-down 600s hold in exactly
+             the way vcluster-system/loft was.
+            */}}
             run_provider_package_host_lint() {
               _pp_region="${1:-primary}"
               _PP_KUBECONFIG="${2:-}"
@@ -1065,12 +1167,16 @@ data:
               fi
               _pp_raw="${WORK_DIR:-/work}/pkgsrc-raw.$$"
               _pp_err="${WORK_DIR:-/work}/pkgsrc-err.$$"
-              # Provider is CLUSTER-SCOPED (no `-A`, no namespace column) —
-              # unlike the three Flux source kinds above.
+              {{- /*
+               Provider is CLUSTER-SCOPED (no `-A`, no namespace column) —
+               unlike the three Flux source kinds above.
+              */}}
               if ! _pp_kubectl get providers.pkg.crossplane.io \
                 -o jsonpath='{range .items[*]}{.metadata.name}{" "}{.spec.package}{"\n"}{end}' >"${_pp_raw}" 2>"${_pp_err}"; then
-                # A CRD that is not INSTALLED is zero rows, not a tether: a
-                # Sovereign without Crossplane installed legitimately has none.
+                {{- /*
+                 A CRD that is not INSTALLED is zero rows, not a tether: a
+                 Sovereign without Crossplane installed legitimately has none.
+                */}}
                 if grep -qiE "server doesn't have a resource type|could not find the requested resource|no matches for kind|the server could not find the requested resource" "${_pp_err}" 2>/dev/null; then
                   : > "${_pp_raw}"
                 else
@@ -1081,18 +1187,20 @@ data:
               fi
               while IFS=' ' read -r _pname _ppkg; do
                   [ -n "${_pname}" ] && [ -n "${_ppkg}" ] || continue
-                  # spec.package is an IMAGE ref (host[:port]/path[:tag|@digest]),
-                  # never a URL with a scheme. UNLIKE run_podspec_refhost_lint,
-                  # a ref with NO explicit host segment is NOT skipped here: the
-                  # podspec lint may treat an implicit "docker.io" ref as covered
-                  # because the kubelet's containerd default-registry mirror
-                  # redirects it, but step-11's own header states Crossplane's
-                  # package manager pulls with its own remote.Image() call that
-                  # NEVER traverses containerd — so there is no redirect to save
-                  # a bare "org/name:tag" ref, and it resolves to the real
-                  # implicit default (docker.io) exactly as dialled. Reporting
-                  # it as an offender (rather than silently passing it, the way
-                  # an allowlist-shaped check would) is the point of this lint.
+                  {{- /*
+                   spec.package is an IMAGE ref (host[:port]/path[:tag|@digest]),
+                   never a URL with a scheme. UNLIKE run_podspec_refhost_lint,
+                   a ref with NO explicit host segment is NOT skipped here: the
+                   podspec lint may treat an implicit "docker.io" ref as covered
+                   because the kubelet's containerd default-registry mirror
+                   redirects it, but step-11's own header states Crossplane's
+                   package manager pulls with its own remote.Image() call that
+                   NEVER traverses containerd — so there is no redirect to save
+                   a bare "org/name:tag" ref, and it resolves to the real
+                   implicit default (docker.io) exactly as dialled. Reporting
+                   it as an offender (rather than silently passing it, the way
+                   an allowlist-shaped check would) is the point of this lint.
+                  */}}
                   case "${_ppkg}" in
                     */*)
                       _ph="${_ppkg%%/*}"
@@ -1124,13 +1232,15 @@ data:
               echo "  PASS — region ${_pp_region}: every Crossplane Provider.spec.package resolves to a Sovereign-local host; no external package dependency remains in the object graph (#5650)"
               return 0
             }
-            # ── #5359 PER-REGION DRIVER ────────────────────────────────────
-            # Every region is evaluated — no short-circuit — so one run names
-            # every offender in the fleet instead of stopping at the first. The
-            # verdict is an AND across regions, and an unreadable region is a
-            # FAIL, not a skip: `cutoverComplete=true` must be structurally
-            # unable to be set while ANY region has an off-Sovereign or
-            # unconverged Flux source.
+            {{- /*
+             ── #5359 PER-REGION DRIVER ────────────────────────────────────
+             Every region is evaluated — no short-circuit — so one run names
+             every offender in the fleet instead of stopping at the first. The
+             verdict is an AND across regions, and an unreadable region is a
+             FAIL, not a skip: `cutoverComplete=true` must be structurally
+             unable to be set while ANY region has an off-Sovereign or
+             unconverged Flux source.
+            */}}
             if [ "${FLUX_SOURCE_HOST_LINT}" = "true" ] || [ "${FLUX_SOURCE_HEALTH_LINT}" = "true" ] || [ "${PROVIDER_PACKAGE_HOST_LINT}" = "true" ]; then
               _fs_verdict=0
               for _fs_target in "primary=" $(for _k in /secondary-kubeconfigs/*.yaml; do [ -e "${_k}" ] && printf '%s=%s ' "$(basename "${_k}" .yaml)" "${_k}"; done); do
@@ -1174,24 +1284,26 @@ data:
               if [ -z "${block_ips}" ] && [ "${DEFAULT_DENY_EGRESS}" != "true" ]; then
                 echo "  WARN — zero public upstream IPs resolved; assertion-only fallback (fail-safe)"
               elif [ "${DEFAULT_DENY_EGRESS}" = "true" ]; then
-                # ── #3678 TRUE DEFAULT-DENY EGRESS ────────────────────────
-                # The PROOF the founder demands: block EVERY mothership
-                # tether, not 4 hand-picked CIDRs. We emit a cluster-wide
-                # default-deny egress policy (enableDefaultDeny.egress:true —
-                # NOT the #3640 retreat to false) with an explicit allow-list
-                # of the Sovereign's OWN intra-cluster ranges. Result: pods
-                # can reach the apiserver (10.96.0.1, inside 10.96/12), CoreDNS,
-                # each other (10.42/16) and node-local services, but EVERY
-                # public destination — console.openova.io, ghcr.io,
-                # harbor.openova.io, and any host nobody enumerated — is
-                # black-holed. The #3640 apiserver-strand is avoided by the
-                # allow-list, not by making the policy subtractive.
-                #
-                # Cilium semantics: a CCNP with endpointSelector:{} and ANY
-                # egress: rule sets enableDefaultDeny.egress=true implicitly,
-                # so listing only the allow `egress:` toCIDR/toEntities rules
-                # denies everything else. We set it explicitly for clarity and
-                # to be robust against future Cilium default changes.
+                {{- /*
+                 ── #3678 TRUE DEFAULT-DENY EGRESS ────────────────────────
+                 The PROOF the founder demands: block EVERY mothership
+                 tether, not 4 hand-picked CIDRs. We emit a cluster-wide
+                 default-deny egress policy (enableDefaultDeny.egress:true —
+                 NOT the #3640 retreat to false) with an explicit allow-list
+                 of the Sovereign's OWN intra-cluster ranges. Result: pods
+                 can reach the apiserver (10.96.0.1, inside 10.96/12), CoreDNS,
+                 each other (10.42/16) and node-local services, but EVERY
+                 public destination — console.openova.io, ghcr.io,
+                 harbor.openova.io, and any host nobody enumerated — is
+                 black-holed. The #3640 apiserver-strand is avoided by the
+                 allow-list, not by making the policy subtractive.
+
+                 Cilium semantics: a CCNP with endpointSelector:{} and ANY
+                 egress: rule sets enableDefaultDeny.egress=true implicitly,
+                 so listing only the allow `egress:` toCIDR/toEntities rules
+                 denies everything else. We set it explicitly for clarity and
+                 to be robust against future Cilium default changes.
+                */}}
                 {
                   echo "apiVersion: cilium.io/v2"
                   echo "kind: CiliumClusterwideNetworkPolicy"
@@ -1202,42 +1314,50 @@ data:
                   echo "  enableDefaultDeny:"
                   echo "    egress: true"
                   echo "  egress:"
-                  # Allow the Sovereign's own intra-cluster CIDRs (pods,
-                  # services incl. apiserver ClusterIP, node ranges).
+                  {{- /*
+                   Allow the Sovereign's own intra-cluster CIDRs (pods,
+                   services incl. apiserver ClusterIP, node ranges).
+                  */}}
                   echo "    - toCIDR:"
                   for cidr in ${ALLOW_CIDRS}; do
                     echo "        - ${cidr}"
                   done
-                  # #4596 — allow the IaaS PROVIDER control-plane API (Huawei
-                  # ECS/EVS, Hetzner API, …) so the CSI driver can attach volumes
-                  # for any pod that (re)schedules DURING the hold — notably the
-                  # catalyst-api-env-patch restart that runs just before this step.
-                  # The hold must black-hole the MOTHERSHIP (github.com / ghcr.io /
-                  # harbor.openova.io), NOT the underlying IaaS the Sovereign runs
-                  # ON. Denying the cloud CSI API wedged the cutover engine's own
-                  # catalyst-api (live on 5150f96: FailedAttachVolume x5000 →
-                  # ContainerCreating → engine down → cutoverComplete never set).
-                  # These are the provider API ranges ONLY; the mothership + bastion
-                  # live in DIFFERENT ranges and stay denied. Provider sets them via
-                  # .Values.egressTest.allowProviderCIDRs (cloud-init populates per
-                  # region, e.g. Huawei kom4dc "212.72.2.0/24").
+                  {{- /*
+                   #4596 — allow the IaaS PROVIDER control-plane API (Huawei
+                   ECS/EVS, Hetzner API, …) so the CSI driver can attach volumes
+                   for any pod that (re)schedules DURING the hold — notably the
+                   catalyst-api-env-patch restart that runs just before this step.
+                   The hold must black-hole the MOTHERSHIP (github.com / ghcr.io /
+                   harbor.openova.io), NOT the underlying IaaS the Sovereign runs
+                   ON. Denying the cloud CSI API wedged the cutover engine's own
+                   catalyst-api (live on 5150f96: FailedAttachVolume x5000 →
+                   ContainerCreating → engine down → cutoverComplete never set).
+                   These are the provider API ranges ONLY; the mothership + bastion
+                   live in DIFFERENT ranges and stay denied. Provider sets them via
+                   .Values.egressTest.allowProviderCIDRs (cloud-init populates per
+                   region, e.g. Huawei kom4dc "212.72.2.0/24").
+                  */}}
                   for cidr in ${PROVIDER_API_CIDRS}; do
                     echo "        - ${cidr}"
                   done
-                  # Allow control-plane + DNS + node entities so the apiserver
-                  # (also reachable as the `kube-apiserver` entity when it has a
-                  # non-ClusterIP address), CoreDNS, host and remote-node paths
-                  # stay up. `cluster` covers all in-cluster endpoints; `host`
-                  # + `remote-node` cover node-local + other-node kubelet/proxy.
+                  {{- /*
+                   Allow control-plane + DNS + node entities so the apiserver
+                   (also reachable as the `kube-apiserver` entity when it has a
+                   non-ClusterIP address), CoreDNS, host and remote-node paths
+                   stay up. `cluster` covers all in-cluster endpoints; `host`
+                   + `remote-node` cover node-local + other-node kubelet/proxy.
+                  */}}
                   echo "    - toEntities:"
                   echo "        - kube-apiserver"
                   echo "        - host"
                   echo "        - remote-node"
                   echo "        - cluster"
-                  # Allow DNS explicitly (CoreDNS ClusterIP is inside 10.96/12,
-                  # but make the intent first-class and tolerate non-default
-                  # DNS service CIDRs): UDP/TCP 53 to world, rules-restricted to
-                  # the DNS ports so this is not a general egress hole.
+                  {{- /*
+                   Allow DNS explicitly (CoreDNS ClusterIP is inside 10.96/12,
+                   but make the intent first-class and tolerate non-default
+                   DNS service CIDRs): UDP/TCP 53 to world, rules-restricted to
+                   the DNS ports so this is not a general egress hole.
+                  */}}
                   echo "    - toPorts:"
                   echo "        - ports:"
                   echo "            - port: \"53\""
@@ -1247,12 +1367,14 @@ data:
                 } >/work/egress-deny.yaml
               else
                 {
-                  # Legacy SUBTRACTIVE fallback (DEFAULT_DENY_EGRESS=false) —
-                  # kept only for environments that explicitly opt out of the
-                  # true default-deny. Deny ONLY the resolved tether CIDRs.
-                  # NOTE: this shape leaves console.openova.io + any
-                  # un-enumerated mothership host reachable — it is NOT the
-                  # ADR-0002 proof; #3678 makes default-deny the default.
+                  {{- /*
+                   Legacy SUBTRACTIVE fallback (DEFAULT_DENY_EGRESS=false) —
+                   kept only for environments that explicitly opt out of the
+                   true default-deny. Deny ONLY the resolved tether CIDRs.
+                   NOTE: this shape leaves console.openova.io + any
+                   un-enumerated mothership host reachable — it is NOT the
+                   ADR-0002 proof; #3678 makes default-deny the default.
+                  */}}
                   echo "apiVersion: cilium.io/v2"
                   echo "kind: CiliumClusterwideNetworkPolicy"
                   echo "metadata:"
@@ -1267,30 +1389,36 @@ data:
                     echo "        - cidr: ${ip}/32"
                   done
                 } >/work/egress-deny.yaml
-                # /work is a writable emptyDir (readOnlyRootFilesystem:true
-                # makes /tmp unwritable). The subtractive manifest is written
-                # here; the SHARED apply below (outside this if/elif/else)
-                # applies whichever branch emitted it.
+                {{- /*
+                 /work is a writable emptyDir (readOnlyRootFilesystem:true
+                 makes /tmp unwritable). The subtractive manifest is written
+                 here; the SHARED apply below (outside this if/elif/else)
+                 applies whichever branch emitted it.
+                */}}
               fi
-              # ── #3379 (omantel.biz, 2026-06-24): SHARED apply path. The
-              # `kubectl apply` + POLICY_APPLIED + teardown trap PREVIOUSLY
-              # lived ONLY in the legacy subtractive `else` branch above, so
-              # under the shipped `defaultDenyEgress: true` (#3678) the
-              # default-deny CCNP was WRITTEN to /work/egress-deny.yaml but
-              # NEVER applied: POLICY_APPLIED stayed empty, the #3678 call-home
-              # and #3647 fresh-pull proofs (both gated on POLICY_APPLIED=yes)
-              # were skipped, and the 600s survival window degenerated to an
-              # assertion-only hold. cutoverComplete=true could then be earned
-              # WITHOUT a witnessed deny-egress — the exact opposite of the
-              # ADR-0002 proof. Applying whichever manifest the branch above
-              # emitted (default-deny OR legacy subtractive), once, fixes both.
+              {{- /*
+               ── #3379 (omantel.biz, 2026-06-24): SHARED apply path. The
+               `kubectl apply` + POLICY_APPLIED + teardown trap PREVIOUSLY
+               lived ONLY in the legacy subtractive `else` branch above, so
+               under the shipped `defaultDenyEgress: true` (#3678) the
+               default-deny CCNP was WRITTEN to /work/egress-deny.yaml but
+               NEVER applied: POLICY_APPLIED stayed empty, the #3678 call-home
+               and #3647 fresh-pull proofs (both gated on POLICY_APPLIED=yes)
+               were skipped, and the 600s survival window degenerated to an
+               assertion-only hold. cutoverComplete=true could then be earned
+               WITHOUT a witnessed deny-egress — the exact opposite of the
+               ADR-0002 proof. Applying whichever manifest the branch above
+               emitted (default-deny OR legacy subtractive), once, fixes both.
+              */}}
               if [ -f /work/egress-deny.yaml ]; then
                 if kubectl apply -f /work/egress-deny.yaml; then
                   POLICY_APPLIED="yes"
-                  # Trap teardown so an abnormal exit (activeDeadline SIGTERM,
-                  # eviction) can't strand a cluster-wide egressDeny on the
-                  # Sovereign (reviewer PR #3072 — SIGKILL/OOM is the only
-                  # uncovered path).
+                  {{- /*
+                   Trap teardown so an abnormal exit (activeDeadline SIGTERM,
+                   eviction) can't strand a cluster-wide egressDeny on the
+                   Sovereign (reviewer PR #3072 — SIGKILL/OOM is the only
+                   uncovered path).
+                  */}}
                   trap 'kubectl delete ciliumclusterwidenetworkpolicy cutover-egress-block --ignore-not-found=true 2>/dev/null || true' TERM EXIT
                   echo "[egress-block-test] egressDeny applied (default-deny=${DEFAULT_DENY_EGRESS}) — hidden runtime tethers will now surface as NotReady"
                 else
@@ -1301,30 +1429,32 @@ data:
               echo "[egress-block-test] enforce mode OFF (default) — assertion + survival-poll only (#2940: flip egressTest.enforceCIDRBlock=true after a validated cutover walk)"
             fi
 
-            # ── #3647 FRESH-PULL-UNDER-DENY-EGRESS PROOF ──────────────────
-            # The legacy survival-window below only proves ALREADY-RUNNING
-            # pods stay green — it never exercises a NEW image pull, the one
-            # path that breaks post-cutover (hw149: a rolled pod went
-            # Init:ImagePullBackOff on ghcr.io because the registry-pivot
-            # mirror was inert for new pulls). Here, WHILE the egressDeny
-            # CCNP is applied (external tethers blocked, apiserver/DNS/
-            # intra-cluster reachable), we force-roll ONE openova-io-imaged
-            # Pod and require its replacement to reach Running by pulling
-            # from local Harbor. A fresh pull that succeeds with egress
-            # denied is the actual ADR-0002 sovereignty proof.
-            #
-            # Fail-safe: only runs when the egressDeny policy is actually up
-            # (POLICY_APPLIED=yes) — with no deny there's nothing to prove,
-            # so we skip rather than bounce a pod for nothing. If no suitable
-            # Deployment is found we log and continue (never wedge on a
-            # tooling gap). A NEW Pod that lands in ImagePull{BackOff,Err} or
-            # never reaches Running within FRESH_PULL_TIMEOUT FAILS the proof
-            # → the policy is torn down → exit 1 → cutoverComplete stays false.
+            {{- /*
+             ── #3647 FRESH-PULL-UNDER-DENY-EGRESS PROOF ──────────────────
+             The legacy survival-window below only proves ALREADY-RUNNING
+             pods stay green — it never exercises a NEW image pull, the one
+             path that breaks post-cutover (hw149: a rolled pod went
+             Init:ImagePullBackOff on ghcr.io because the registry-pivot
+             mirror was inert for new pulls). Here, WHILE the egressDeny
+             CCNP is applied (external tethers blocked, apiserver/DNS/
+             intra-cluster reachable), we force-roll ONE openova-io-imaged
+             Pod and require its replacement to reach Running by pulling
+             from local Harbor. A fresh pull that succeeds with egress
+             denied is the actual ADR-0002 sovereignty proof.
+
+             Fail-safe: only runs when the egressDeny policy is actually up
+             (POLICY_APPLIED=yes) — with no deny there's nothing to prove,
+             so we skip rather than bounce a pod for nothing. If no suitable
+             Deployment is found we log and continue (never wedge on a
+             tooling gap). A NEW Pod that lands in ImagePull{BackOff,Err} or
+             never reaches Running within FRESH_PULL_TIMEOUT FAILS the proof
+             → the policy is torn down → exit 1 → cutoverComplete stays false.
+            */}}
             run_fresh_pull_proof() {
               echo "[egress-block-test] #3647: FRESH-PULL proof — rolling one openova-io workload under deny-egress"
               ns="${FRESH_PULL_NAMESPACE}"
               dep="${FRESH_PULL_DEPLOYMENT}"
-              # Auto-discover an openova-io-imaged Deployment when not pinned.
+              {{- /* Auto-discover an openova-io-imaged Deployment when not pinned. */}}
               if [ -z "${dep}" ]; then
                 discovered=$(kubectl get deployments -A \
                   -o jsonpath='{range .items[*]}{.metadata.namespace}/{.metadata.name}={.spec.template.spec.containers[*].image}{"\n"}{end}' 2>/dev/null \
@@ -1340,10 +1470,12 @@ data:
               fi
               echo "  target Deployment: ${ns}/${dep}"
 
-              # Build a label selector "k1=v1,k2=v2" from the Deployment's
-              # spec.selector.matchLabels so we can enumerate its Pods (the
-              # alpine/k8s image ships jq). Record the pre-delete Pod set so
-              # we can detect the brand-new replacement.
+              {{- /*
+               Build a label selector "k1=v1,k2=v2" from the Deployment's
+               spec.selector.matchLabels so we can enumerate its Pods (the
+               alpine/k8s image ships jq). Record the pre-delete Pod set so
+               we can detect the brand-new replacement.
+              */}}
               label_sel=$(kubectl get deployment "${dep}" -n "${ns}" -o json 2>/dev/null \
                 | jq -r '.spec.selector.matchLabels | to_entries | map("\(.key)=\(.value)") | join(",")' 2>/dev/null || true)
               if [ -z "${label_sel}" ]; then
@@ -1360,26 +1492,30 @@ data:
               echo "  deleting Pod ${ns}/${victim} (ReplicaSet will recreate it → forces a fresh image pull)"
               kubectl delete pod "${victim}" -n "${ns}" --wait=false >/dev/null 2>&1 || true
 
-              # Wait for a NEW Pod (name not in before_pods) of this
-              # Deployment to reach Running with all containers ready. Treat
-              # ImagePullBackOff / ErrImagePull on the new Pod as a hard
-              # FAIL — that is exactly the mirror-inert failure mode.
+              {{- /*
+               Wait for a NEW Pod (name not in before_pods) of this
+               Deployment to reach Running with all containers ready. Treat
+               ImagePullBackOff / ErrImagePull on the new Pod as a hard
+               FAIL — that is exactly the mirror-inert failure mode.
+              */}}
               fp_start=$(date +%s)
               fp_deadline=$(( fp_start + ${FRESH_PULL_TIMEOUT} ))
               while [ "$(date +%s)" -lt "${fp_deadline}" ]; do
                 now_pods=$(kubectl get pods -n "${ns}" -l "${label_sel}" \
                   -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null | sort -u || true)
-                # New = current Pod names absent from the pre-delete set.
-                # POSIX `grep -vxF -f` (no bash process substitution — this
-                # container's /bin/sh is busybox ash, which parse-errors on
-                # `<(...)`; the #3634 lesson applies here too). before_pods is
-                # written to a file so grep can use it as the pattern set.
+                {{- /*
+                 New = current Pod names absent from the pre-delete set.
+                 POSIX `grep -vxF -f` (no bash process substitution — this
+                 container's /bin/sh is busybox ash, which parse-errors on
+                 `<(...)`; the #3634 lesson applies here too). before_pods is
+                 written to a file so grep can use it as the pattern set.
+                */}}
                 printf '%s\n' "${before_pods}" > /work/fp_before.txt
                 printf '%s\n' "${now_pods}" > /work/fp_now.txt
                 new_pod=$(grep -vxF -f /work/fp_before.txt /work/fp_now.txt 2>/dev/null | head -1 || true)
                 if [ -n "${new_pod}" ]; then
                   phase=$(kubectl get pod "${new_pod}" -n "${ns}" -o jsonpath='{.status.phase}' 2>/dev/null || echo "")
-                  # Any container waiting with an image-pull error = inert mirror = FAIL.
+                  {{- /* Any container waiting with an image-pull error = inert mirror = FAIL. */}}
                   waiting_reasons=$(kubectl get pod "${new_pod}" -n "${ns}" \
                     -o jsonpath='{range .status.containerStatuses[*]}{.state.waiting.reason}{" "}{end}{range .status.initContainerStatuses[*]}{.state.waiting.reason}{" "}{end}' 2>/dev/null || echo "")
                   case "${waiting_reasons}" in
@@ -1403,22 +1539,26 @@ data:
               return 1
             }
 
-            # ── #3695/#3379 §7 GENERALIZED FRESH-PULL ─────────────────────
-            # Roll EVERY workload (Deployment/DaemonSet/StatefulSet, any ns)
-            # whose image host is NOT the local registry, under deny-egress —
-            # not one hand-picked openova-io Deployment. Any that ImagePull-
-            # BackOffs FAILS the proof. This is the cross-cutting guarantee:
-            # the gate is generic across ALL workloads/HRs, so leaving ANY one
-            # on harbor.openova.io / ghcr.io/openova-io fails the proof. We
-            # roll via `kubectl rollout restart` then `rollout status` with a
-            # bounded timeout, and explicitly scan the new Pods for image-pull
-            # errors (rollout status alone would just time out on a BackOff).
+            {{- /*
+             ── #3695/#3379 §7 GENERALIZED FRESH-PULL ─────────────────────
+             Roll EVERY workload (Deployment/DaemonSet/StatefulSet, any ns)
+             whose image host is NOT the local registry, under deny-egress —
+             not one hand-picked openova-io Deployment. Any that ImagePull-
+             BackOffs FAILS the proof. This is the cross-cutting guarantee:
+             the gate is generic across ALL workloads/HRs, so leaving ANY one
+             on harbor.openova.io / ghcr.io/openova-io fails the proof. We
+             roll via `kubectl rollout restart` then `rollout status` with a
+             bounded timeout, and explicitly scan the new Pods for image-pull
+             errors (rollout status alone would just time out on a BackOff).
+            */}}
             roll_and_check_workload() {
               kind="$1"; ns="$2"; name="$3"
-              # #5022 — a multi-node DaemonSet rolls per-node SEQUENTIALLY
-              # under RollingUpdate(maxUnavailable:1): scale the budget with
-              # the node count (hw242 run 3: 6-node registry-pivot + falco
-              # blew the flat budget spuriously).
+              {{- /*
+               #5022 — a multi-node DaemonSet rolls per-node SEQUENTIALLY
+               under RollingUpdate(maxUnavailable:1): scale the budget with
+               the node count (hw242 run 3: 6-node registry-pivot + falco
+               blew the flat budget spuriously).
+              */}}
               roll_timeout="${FRESH_PULL_TIMEOUT}"
               if [ "${kind}" = "daemonset" ]; then
                 ds_nodes=$(kubectl get daemonset "${name}" -n "${ns}" -o jsonpath='{.status.desiredNumberScheduled}' 2>/dev/null || echo 1)
@@ -1427,13 +1567,15 @@ data:
               fi
               echo "  rolling ${kind}/${name} -n ${ns} (forces fresh pull from local registry; budget ${roll_timeout}s)"
               kubectl rollout restart "${kind}/${name}" -n "${ns}" >/dev/null 2>&1 || true
-              # Bounded wait; rollout status returns non-zero on timeout.
+              {{- /* Bounded wait; rollout status returns non-zero on timeout. */}}
               if kubectl rollout status "${kind}/${name}" -n "${ns}" --timeout="${roll_timeout}s" >/dev/null 2>&1; then
                 echo "    PASS — ${kind}/${name} rolled out (images pulled from local registry under deny-egress)"
                 return 0
               fi
-              # Timed out — surface WHY. An image-pull error on any Pod of this
-              # workload is the inert-mirror / residual-tether failure (#3695).
+              {{- /*
+               Timed out — surface WHY. An image-pull error on any Pod of this
+               workload is the inert-mirror / residual-tether failure (#3695).
+              */}}
               sel=$(kubectl get "${kind}" "${name}" -n "${ns}" -o json 2>/dev/null \
                 | jq -r '.spec.selector.matchLabels | to_entries | map("\(.key)=\(.value)") | join(",")' 2>/dev/null || true)
               reasons=""
@@ -1446,48 +1588,52 @@ data:
                   echo "    FAIL — ${kind}/${name} has a Pod in image-pull error under deny-egress (${reasons}); residual external-registry tether or inert mirror (#3695)"
                   return 1 ;;
               esac
-              # #4674 — rollout status timed out but NO image-pull error (checked
-              # above). The ACTUAL sovereignty proof is "pulled a fresh image from
-              # the LOCAL registry under deny-egress", NOT "rollout fully completed".
-              # A LEADER-ELECTED SINGLETON (Flux source-controller) whose readiness
-              # probe is gated on acquiring the leader lease, under maxUnavailable=0,
-              # DEADLOCKS a rollout-restart: the new Pod pulls its image from the
-              # local registry (no tether) but can't pass readiness until the old
-              # Pod releases the lease, and the old Pod won't terminate until the new
-              # one is Ready. That is a rollout artifact, NOT an egress failure. If
-              # the new-template Pod exists (updatedReplicas>=1) and the workload is
-              # still serving (readyReplicas>=1) with no pull error, the fresh-pull
-              # proof PASSED. (updatedReplicas/readyReplicas are empty on a DaemonSet
-              # → falls through to the strict FAIL, unchanged for those.)
+              {{- /*
+               #4674 — rollout status timed out but NO image-pull error (checked
+               above). The ACTUAL sovereignty proof is "pulled a fresh image from
+               the LOCAL registry under deny-egress", NOT "rollout fully completed".
+               A LEADER-ELECTED SINGLETON (Flux source-controller) whose readiness
+               probe is gated on acquiring the leader lease, under maxUnavailable=0,
+               DEADLOCKS a rollout-restart: the new Pod pulls its image from the
+               local registry (no tether) but can't pass readiness until the old
+               Pod releases the lease, and the old Pod won't terminate until the new
+               one is Ready. That is a rollout artifact, NOT an egress failure. If
+               the new-template Pod exists (updatedReplicas>=1) and the workload is
+               still serving (readyReplicas>=1) with no pull error, the fresh-pull
+               proof PASSED. (updatedReplicas/readyReplicas are empty on a DaemonSet
+               → falls through to the strict FAIL, unchanged for those.)
+              */}}
               updated=$(kubectl get "${kind}" "${name}" -n "${ns}" -o jsonpath='{.status.updatedReplicas}' 2>/dev/null || echo 0)
               ready=$(kubectl get "${kind}" "${name}" -n "${ns}" -o jsonpath='{.status.readyReplicas}' 2>/dev/null || echo 0)
               if [ "${updated:-0}" -ge 1 ] && [ "${ready:-0}" -ge 1 ]; then
                 echo "    PASS — ${kind}/${name} pulled a fresh image from the local registry under deny-egress (rollout status incomplete = leader-election readiness artifact under maxUnavailable=0; workload still serving) (#4674)"
                 return 0
               fi
-              # #4975 (Refs #3379 #3695) — a Recreate-strategy single-replica
-              # stateful workload (bp-gitea sets strategy.type=Recreate for
-              # RWO-PVC/LevelDB-lock safety, #3188) tears its OLD Pod down FIRST,
-              # so during a roll readyReplicas is transiently 0 — the #4674
-              # serving-check above CANNOT fire (no old Pod is left serving) — and
-              # the new Pod sits PodInitializing while its embedded init /
-              # DB-migration runs (live hw238: `gitea did not roll out within 240s
-              # (PodInitializing x4)`). That is NOT a mothership tether: the image
-              # ALREADY pulled from the local registry — any pull failure would
-              # have surfaced as ImagePullBackOff/ErrImagePull and been caught by
-              # the strict-FAIL image-pull check ABOVE (untouched, still the hard
-              # security gate). The fresh-pull proof's job is narrowly "did this
-              # workload pull its image from the LOCAL registry under deny-egress";
-              # a slow readiness (init/migration) is judged by the survival-window
-              # HR-readiness poll below, not this roll. So when a NEW-revision Pod
-              # (updatedReplicas>=1) has POSITIVELY pulled + STARTED at least one
-              # container (an init or main container in running/terminated state),
-              # the local-registry pull is PROVEN and the proof PASSES. A Pod that
-              # is stuck Pending / never started a container (nothing pulled) has
-              # NO started-container evidence and still falls through to the strict
-              # FAIL below. DaemonSets expose numberReady/updatedNumberScheduled
-              # (not updatedReplicas) so `updated` is empty → this carve-out never
-              # fires for them; they keep the strict FAIL, unchanged.
+              {{- /*
+               #4975 (Refs #3379 #3695) — a Recreate-strategy single-replica
+               stateful workload (bp-gitea sets strategy.type=Recreate for
+               RWO-PVC/LevelDB-lock safety, #3188) tears its OLD Pod down FIRST,
+               so during a roll readyReplicas is transiently 0 — the #4674
+               serving-check above CANNOT fire (no old Pod is left serving) — and
+               the new Pod sits PodInitializing while its embedded init /
+               DB-migration runs (live hw238: `gitea did not roll out within 240s
+               (PodInitializing x4)`). That is NOT a mothership tether: the image
+               ALREADY pulled from the local registry — any pull failure would
+               have surfaced as ImagePullBackOff/ErrImagePull and been caught by
+               the strict-FAIL image-pull check ABOVE (untouched, still the hard
+               security gate). The fresh-pull proof's job is narrowly "did this
+               workload pull its image from the LOCAL registry under deny-egress";
+               a slow readiness (init/migration) is judged by the survival-window
+               HR-readiness poll below, not this roll. So when a NEW-revision Pod
+               (updatedReplicas>=1) has POSITIVELY pulled + STARTED at least one
+               container (an init or main container in running/terminated state),
+               the local-registry pull is PROVEN and the proof PASSES. A Pod that
+               is stuck Pending / never started a container (nothing pulled) has
+               NO started-container evidence and still falls through to the strict
+               FAIL below. DaemonSets expose numberReady/updatedNumberScheduled
+               (not updatedReplicas) so `updated` is empty → this carve-out never
+               fires for them; they keep the strict FAIL, unchanged.
+              */}}
               started_evidence=""
               if [ -n "${sel}" ]; then
                 started_evidence=$(kubectl get pods -n "${ns}" -l "${sel}" \
@@ -1501,19 +1647,21 @@ data:
               return 1
             }
 
-            # ── #5091 rule-c detection: is a workload a stateful RWO-EVS singleton? ─
-            # Echoes a human reason "<claim> sc=<sc> driver=<driver> modes=<modes>"
-            # for the FIRST pod-template volume whose PVC is ReadWriteOnce AND
-            # backed by EVS (storageClass in FRESH_PULL_RWO_EVS_STORAGECLASSES OR
-            # the BOUND-PV CSI driver in FRESH_PULL_RWO_EVS_CSIDRIVERS); empty
-            # output = NOT an RWO-EVS stateful singleton → safe to roll. Only
-            # single-writer (RWO) volumes hit the NodeStage/VolumeAttachment desync
-            # (#5091) — a RWX shared-fs volume has no per-node globalmount hand-off
-            # to lose, so it is never matched. FAIL-OPEN: any kubectl/jq gap yields
-            # empty (the workload STAYS a roll candidate — its image locality is
-            # still HARD-proven by the #4975 completeness HEAD gate either way, so a
-            # missing RBAC/tooling read can never silently weaken the sovereignty
-            # proof, only over-roll).
+            {{- /*
+             ── #5091 rule-c detection: is a workload a stateful RWO-EVS singleton? ─
+             Echoes a human reason "<claim> sc=<sc> driver=<driver> modes=<modes>"
+             for the FIRST pod-template volume whose PVC is ReadWriteOnce AND
+             backed by EVS (storageClass in FRESH_PULL_RWO_EVS_STORAGECLASSES OR
+             the BOUND-PV CSI driver in FRESH_PULL_RWO_EVS_CSIDRIVERS); empty
+             output = NOT an RWO-EVS stateful singleton → safe to roll. Only
+             single-writer (RWO) volumes hit the NodeStage/VolumeAttachment desync
+             (#5091) — a RWX shared-fs volume has no per-node globalmount hand-off
+             to lose, so it is never matched. FAIL-OPEN: any kubectl/jq gap yields
+             empty (the workload STAYS a roll candidate — its image locality is
+             still HARD-proven by the #4975 completeness HEAD gate either way, so a
+             missing RBAC/tooling read can never silently weaken the sovereignty
+             proof, only over-roll).
+            */}}
             workload_rwo_evs_reason() {
               _wek="$1"; _wens="$2"; _wenm="$3"
               _we_scs="${FRESH_PULL_RWO_EVS_STORAGECLASSES:-evs-ssd}"
@@ -1553,11 +1701,13 @@ data:
 
             run_fresh_pull_all() {
               echo "[egress-block-test] #3695: fresh-pull roll under deny-egress (roll-set mode: ${FRESH_PULL_ROLL_SET_MODE:-minimal})"
-              # Enumerate Deployments/DaemonSets/StatefulSets whose container
-              # images reference a dotted registry host. We also exclude the
-              # cutover runner's own catalyst-api (FRESH_PULL_EXCLUDE) so the
-              # engine is never bounced mid-hold. Rows look like
-              # "kind ns name=img1,img2".
+              {{- /*
+               Enumerate Deployments/DaemonSets/StatefulSets whose container
+               images reference a dotted registry host. We also exclude the
+               cutover runner's own catalyst-api (FRESH_PULL_EXCLUDE) so the
+               engine is never bounced mid-hold. Rows look like
+               "kind ns name=img1,img2".
+              */}}
               workloads=$(
                 for kind in deployments daemonsets statefulsets; do
                   kubectl get "${kind}" -A \
@@ -1565,70 +1715,80 @@ data:
                 done
               )
               if [ "${FRESH_PULL_ROLL_SET_MODE:-minimal}" = "full" ]; then
-                # LEGACY full mode — unchanged behaviour: keep rows whose image
-                # list contains a NON-local registry host. A bare image
-                # (docker-library short form) or a localhost/local Harbor ref is
-                # NOT a tether. We treat any image containing a dotted host
-                # (registry) that does NOT include LOCAL_REGISTRY_SUBSTR as
-                # external, and roll ALL of them.
+                {{- /*
+                 LEGACY full mode — unchanged behaviour: keep rows whose image
+                 list contains a NON-local registry host. A bare image
+                 (docker-library short form) or a localhost/local Harbor ref is
+                 NOT a tether. We treat any image containing a dotted host
+                 (registry) that does NOT include LOCAL_REGISTRY_SUBSTR as
+                 external, and roll ALL of them.
+                */}}
                 targets=$(printf '%s\n' "${workloads}" \
                   | grep -E '=[^ ]*[a-z0-9.-]+\.[a-z]+/' \
                   | grep -vE "[=, ]${LOCAL_REGISTRY_SUBSTR}" \
                   | { [ -n "${FRESH_PULL_EXCLUDE}" ] && grep -vE " ${FRESH_PULL_EXCLUDE}[^ ]*=" || cat; } \
                   || true)
               else
-                # #5074/#5065/#5059 MINIMAL mode (default) — candidates are ALL
-                # image-registry-dependent workloads (dotted-host refs), local-
-                # registry refs INCLUDED: post-step-07 the ordinary-app refs are
-                # pivoted to registry.<fqdn> and rolling THOSE is exactly the
-                # fresh-pull-from-local-Harbor witness; redirect-covered external
-                # refs stay candidates too (they pull locally via the step-04
-                # containerd redirect). Rule-based infra exclusion + the
-                # representative sampling below then cut this to the minimal set.
+                {{- /*
+                 #5074/#5065/#5059 MINIMAL mode (default) — candidates are ALL
+                 image-registry-dependent workloads (dotted-host refs), local-
+                 registry refs INCLUDED: post-step-07 the ordinary-app refs are
+                 pivoted to registry.<fqdn> and rolling THOSE is exactly the
+                 fresh-pull-from-local-Harbor witness; redirect-covered external
+                 refs stay candidates too (they pull locally via the step-04
+                 containerd redirect). Rule-based infra exclusion + the
+                 representative sampling below then cut this to the minimal set.
+                */}}
                 targets=$(printf '%s\n' "${workloads}" \
                   | grep -E '=[^ ]*[a-z0-9.-]+\.[a-z]+/' \
                   | { [ -n "${FRESH_PULL_EXCLUDE}" ] && grep -vE " ${FRESH_PULL_EXCLUDE}[^ ]*=" || cat; } \
                   || true)
               fi
-              # #4975 — never roll a workload the offline mirror deliberately
-              # does NOT cover: xpkg.upbound.io (step-11 crossplane), rancher/k3s
-              # (per-Org vcluster distro), loft-sh/vcluster (step-10). Rolling
-              # them under deny-egress would ImagePullBackOff on an image the
-              # mirror was never meant to hold and FAIL the proof spuriously.
+              {{- /*
+               #4975 — never roll a workload the offline mirror deliberately
+               does NOT cover: xpkg.upbound.io (step-11 crossplane), rancher/k3s
+               (per-Org vcluster distro), loft-sh/vcluster (step-10). Rolling
+               them under deny-egress would ImagePullBackOff on an image the
+               mirror was never meant to hold and FAIL the proof spuriously.
+              */}}
               for _x in ${EXCLUDED_HOSTS} ${EXCLUDED_SUBSTRINGS}; do
                 [ -z "${_x}" ] && continue
                 targets=$(printf '%s\n' "${targets}" | grep -vF "${_x}" || true)
               done
-              # #5022 — name-scoped exclusions ("<ns>/<name>"): the registry-
-              # pivot DS is the certs.d/hosts pivot mechanism every OTHER
-              # fresh pull depends on; rolling it mid-hold is recursive and
-              # its health is already asserted by the step-04 daemonset-wait
-              # + per-node v2 ACKs. Rows are "kind ns name=imgs".
+              {{- /*
+               #5022 — name-scoped exclusions ("<ns>/<name>"): the registry-
+               pivot DS is the certs.d/hosts pivot mechanism every OTHER
+               fresh pull depends on; rolling it mid-hold is recursive and
+               its health is already asserted by the step-04 daemonset-wait
+               + per-node v2 ACKs. Rows are "kind ns name=imgs".
+              */}}
               for _w in ${FRESH_PULL_EXCLUDE_WORKLOADS}; do
                 [ -z "${_w}" ] && continue
                 _wns="${_w%%/*}"; _wname="${_w##*/}"
                 targets=$(printf '%s\n' "${targets}" | grep -vE "^[a-z]+ ${_wns} ${_wname}=" || true)
               done
-              # ── #5074/#5065/#5059 MINIMAL ROLL-SET SELECTION ────────────
-              # Excludes infra by RULE instead of the per-workload
-              # excludeWorkloads whack-a-mole (each prov surfaced ONE more
-              # infra workload broken by the forced roll: oauth2-proxy #5059,
-              # falco #5065, the EVS CSI driver #5074):
-              #   (a) any workload in FRESH_PULL_INFRA_NAMESPACES is skipped
-              #       unless "<ns>/<name>" is in FRESH_PULL_INFRA_ALLOWLIST;
-              #   (b) a DaemonSet in an infra namespace is NEVER rolled —
-              #       even an allowlist entry cannot re-include one (its
-              #       restart risks the hold's own machinery: CSI mounts,
-              #       CNI, the registry pivot).
-              # Then a REPRESENTATIVE SAMPLE rolls instead of all ~130
-              # workloads: every candidate in the representative namespaces
-              # (stateful-PVC/gitops/auth/registry/observability classes) plus
-              # a top-up of other candidate Deployments to at least
-              # FRESH_PULL_MIN_REPS_PER_REGION x <node-region-count>. Image
-              # locality for everything NOT rolled remains HARD-gated by the
-              # #4975 pre-hold completeness HEAD gate + the #5026 ref-host
-              # lint (both ran above, both prove locality without rolling);
-              # the deny-egress call-home proof is untouched.
+              {{- /*
+               ── #5074/#5065/#5059 MINIMAL ROLL-SET SELECTION ────────────
+               Excludes infra by RULE instead of the per-workload
+               excludeWorkloads whack-a-mole (each prov surfaced ONE more
+               infra workload broken by the forced roll: oauth2-proxy #5059,
+               falco #5065, the EVS CSI driver #5074):
+                 (a) any workload in FRESH_PULL_INFRA_NAMESPACES is skipped
+                     unless "<ns>/<name>" is in FRESH_PULL_INFRA_ALLOWLIST;
+                 (b) a DaemonSet in an infra namespace is NEVER rolled —
+                     even an allowlist entry cannot re-include one (its
+                     restart risks the hold's own machinery: CSI mounts,
+                     CNI, the registry pivot).
+               Then a REPRESENTATIVE SAMPLE rolls instead of all ~130
+               workloads: every candidate in the representative namespaces
+               (stateful-PVC/gitops/auth/registry/observability classes) plus
+               a top-up of other candidate Deployments to at least
+               FRESH_PULL_MIN_REPS_PER_REGION x <node-region-count>. Image
+               locality for everything NOT rolled remains HARD-gated by the
+               #4975 pre-hold completeness HEAD gate + the #5026 ref-host
+               lint (both ran above, both prove locality without rolling);
+               the deny-egress call-home proof is untouched.
+              */}}
               if [ "${FRESH_PULL_ROLL_SET_MODE:-minimal}" != "full" ]; then
                 : > /work/rollset_candidates.txt
                 printf '%s\n' "${targets}" | while IFS= read -r _row; do
@@ -1654,20 +1814,22 @@ data:
                       continue
                     fi
                   fi
-                  # ── #5091 rule c: skip stateful RWO-EVS singletons ──────────
-                  # A Deployment/StatefulSet whose pod template mounts an RWO PVC
-                  # backed by EVS is a stateful singleton whose forced roll under
-                  # the deny-egress hold triggers the UNRECOVERABLE NodeStage/
-                  # VolumeAttachment desync (globalmount removed on NodeUnstage,
-                  # the VA persists, NodeStage never re-fires → NodePublish fails
-                  # on the missing globalmount → the replacement pod hangs
-                  # Init:0/3 → ROLL_FAIL → step-08 fails forever; live hw253
-                  # gitea, #5091). Its image locality is ALREADY HEAD-proven by
-                  # the #4975 pre-hold completeness gate, so the synthetic roll
-                  # adds NO image-proof value — the fresh-pull ROLL proof rolls
-                  # STATELESS representative workloads only. Applied to
-                  # deployment/statefulset (a DaemonSet cannot mount an RWO PVC
-                  # across nodes; rule b already covers infra-ns DaemonSets).
+                  {{- /*
+                   ── #5091 rule c: skip stateful RWO-EVS singletons ──────────
+                   A Deployment/StatefulSet whose pod template mounts an RWO PVC
+                   backed by EVS is a stateful singleton whose forced roll under
+                   the deny-egress hold triggers the UNRECOVERABLE NodeStage/
+                   VolumeAttachment desync (globalmount removed on NodeUnstage,
+                   the VA persists, NodeStage never re-fires → NodePublish fails
+                   on the missing globalmount → the replacement pod hangs
+                   Init:0/3 → ROLL_FAIL → step-08 fails forever; live hw253
+                   gitea, #5091). Its image locality is ALREADY HEAD-proven by
+                   the #4975 pre-hold completeness gate, so the synthetic roll
+                   adds NO image-proof value — the fresh-pull ROLL proof rolls
+                   STATELESS representative workloads only. Applied to
+                   deployment/statefulset (a DaemonSet cannot mount an RWO PVC
+                   across nodes; rule b already covers infra-ns DaemonSets).
+                  */}}
                   if [ "${FRESH_PULL_RWO_EVS_EXCLUDE:-true}" = "true" ] \
                      && { [ "${_rkind}" = "deployment" ] || [ "${_rkind}" = "statefulset" ]; }; then
                     _rwo_reason=$(workload_rwo_evs_reason "${_rkind}" "${_rns}" "${_rname}")
@@ -1678,25 +1840,29 @@ data:
                   fi
                   printf '%s\n' "${_row}" >> /work/rollset_candidates.txt
                 done
-                # Region-aware sample floor: N per region (node
-                # topology.kubernetes.io/region labels; 1 when unlabeled).
+                {{- /*
+                 Region-aware sample floor: N per region (node
+                 topology.kubernetes.io/region labels; 1 when unlabeled).
+                */}}
                 _regions=$(kubectl get nodes \
                   -o jsonpath='{range .items[*]}{.metadata.labels.topology\.kubernetes\.io/region}{"\n"}{end}' 2>/dev/null \
                   | sort -u | grep -c . || true)
                 [ "${_regions:-0}" -ge 1 ] || _regions=1
                 _min_total=$(( ${FRESH_PULL_MIN_REPS_PER_REGION:-12} * _regions ))
-                # Every candidate in the representative namespaces rolls.
+                {{- /* Every candidate in the representative namespaces rolls. */}}
                 : > /work/rollset.txt
                 for _rns in ${FRESH_PULL_REPRESENTATIVE_NAMESPACES}; do
                   awk -v ns="${_rns}" '$2 == ns' /work/rollset_candidates.txt >> /work/rollset.txt
                 done
                 _picked=$(grep -c . /work/rollset.txt || true)
                 if [ "${_picked}" -lt "${_min_total}" ]; then
-                  # Top up with other (non-representative-ns) candidate
-                  # Deployments, stable-sorted, to the floor. An empty
-                  # rollset.txt pattern file makes grep -v pass ALL candidate
-                  # rows (documented busybox/GNU behaviour used by the #3634
-                  # baseline diff above).
+                  {{- /*
+                   Top up with other (non-representative-ns) candidate
+                   Deployments, stable-sorted, to the floor. An empty
+                   rollset.txt pattern file makes grep -v pass ALL candidate
+                   rows (documented busybox/GNU behaviour used by the #3634
+                   baseline diff above).
+                  */}}
                   grep -vxF -f /work/rollset.txt /work/rollset_candidates.txt 2>/dev/null \
                     | awk '$1 == "deployment"' | sort \
                     | head -n $(( _min_total - _picked )) >> /work/rollset.txt || true
@@ -1715,8 +1881,10 @@ data:
               echo "  workloads to roll:"
               printf '%s\n' "${targets}" | sed 's/^/    /'
               rc=0
-              # Roll each; collect the first failure but attempt all so the log
-              # lists every offender.
+              {{- /*
+               Roll each; collect the first failure but attempt all so the log
+               lists every offender.
+              */}}
               printf '%s\n' "${targets}" | while IFS= read -r row; do
                 [ -z "${row}" ] && continue
                 kind=$(printf '%s' "${row}" | awk '{print $1}')
@@ -1734,37 +1902,41 @@ data:
               return "${rc}"
             }
 
-            # ── #3678 ACTIVE CALL-HOME ASSERTION ──────────────────────────
-            # The survival poll only proves ALREADY-RUNNING HRs stay Ready —
-            # it never makes an outbound call, so a catalyst-api still issuing
-            # tokens with iss=console.openova.io kept every HR green and the
-            # 4-CIDR block left console.openova.io wide open. Here we ACTIVELY
-            # curl each mothership host FROM this pod (which is under the
-            # default-deny CCNP). Under a TRUE default-deny, EVERY one must
-            # FAIL to connect; if ANY connects, the deny-egress is leaky and
-            # the sovereignty proof FAILS. This is what makes the proof catch
-            # an ARBITRARY mothership tether, not the 4 enumerated hosts.
+            {{- /*
+             ── #3678 ACTIVE CALL-HOME ASSERTION ──────────────────────────
+             The survival poll only proves ALREADY-RUNNING HRs stay Ready —
+             it never makes an outbound call, so a catalyst-api still issuing
+             tokens with iss=console.openova.io kept every HR green and the
+             4-CIDR block left console.openova.io wide open. Here we ACTIVELY
+             curl each mothership host FROM this pod (which is under the
+             default-deny CCNP). Under a TRUE default-deny, EVERY one must
+             FAIL to connect; if ANY connects, the deny-egress is leaky and
+             the sovereignty proof FAILS. This is what makes the proof catch
+             an ARBITRARY mothership tether, not the 4 enumerated hosts.
+            */}}
             run_call_home_assertion() {
               echo "[egress-block-test] #3678: active call-home — asserting every mothership host is UNREACHABLE under the hold"
               leaked=""
               for url in ${CALL_HOME_HOSTS}; do
-                # --max-time bounds each probe; -o /dev/null -s -w "%{http_code}"
-                # yields the HTTP status (000 on connect failure/timeout, which
-                # is the EXPECTED, PASSING outcome under deny-egress). A genuine
-                # 2xx/3xx/4xx/5xx means the TCP+TLS handshake SUCCEEDED → the
-                # host is reachable → LEAK.
-                #
-                # #4557: when curl FAILS to connect (the desired deny-egress
-                # outcome) `curl -w '%{http_code}'` ALREADY prints `000` to
-                # stdout AND exits non-zero — so the `|| echo "000"` fallback
-                # DOUBLE-appends → code="000000" (or "000" repeated per probe),
-                # and the old exact `[ "${code}" = "000" ]` test then mis-flagged
-                # a correctly-blocked host as a LEAK → the sovereignty proof
-                # failed on a PASSING egress block (live c39f0cd4455b7a46:
-                # http_code=000000 reported LEAK while every host was in fact
-                # black-holed). Drop the double-echo and treat ANY all-zeros /
-                # empty code (000, 000000, "") as unreachable; only a code with
-                # a non-zero digit is a real HTTP response = a genuine LEAK.
+                {{- /*
+                 --max-time bounds each probe; -o /dev/null -s -w "%{http_code}"
+                 yields the HTTP status (000 on connect failure/timeout, which
+                 is the EXPECTED, PASSING outcome under deny-egress). A genuine
+                 2xx/3xx/4xx/5xx means the TCP+TLS handshake SUCCEEDED → the
+                 host is reachable → LEAK.
+
+                 #4557: when curl FAILS to connect (the desired deny-egress
+                 outcome) `curl -w '%{http_code}'` ALREADY prints `000` to
+                 stdout AND exits non-zero — so the `|| echo "000"` fallback
+                 DOUBLE-appends → code="000000" (or "000" repeated per probe),
+                 and the old exact `[ "${code}" = "000" ]` test then mis-flagged
+                 a correctly-blocked host as a LEAK → the sovereignty proof
+                 failed on a PASSING egress block (live c39f0cd4455b7a46:
+                 http_code=000000 reported LEAK while every host was in fact
+                 black-holed). Drop the double-echo and treat ANY all-zeros /
+                 empty code (000, 000000, "") as unreachable; only a code with
+                 a non-zero digit is a real HTTP response = a genuine LEAK.
+                */}}
                 code=$(curl -ksS -o /dev/null -w '%{http_code}' --max-time "${CALL_HOME_TIMEOUT}" "${url}" 2>/dev/null)
                 case "${code}" in
                   *[1-9]*)
@@ -1772,7 +1944,7 @@ data:
                     leaked="${leaked} ${url}"
                     ;;
                   *)
-                    # "", "000", "000000" … — no successful handshake.
+                    {{- /* "", "000", "000000" … — no successful handshake. */}}
                     echo "  OK — ${url} unreachable (curl exit/timeout, http_code=${code:-000}) — denied as required"
                     ;;
                 esac
@@ -1803,8 +1975,10 @@ data:
                 fresh_pull_fn=run_fresh_pull_proof
               fi
               if ! ${fresh_pull_fn}; then
-                # Tear the deny policy down before failing so we never leave
-                # a cluster-wide egressDeny lingering on the Sovereign.
+                {{- /*
+                 Tear the deny policy down before failing so we never leave
+                 a cluster-wide egressDeny lingering on the Sovereign.
+                */}}
                 kubectl delete ciliumclusterwidenetworkpolicy cutover-egress-block --ignore-not-found=true || true
                 echo "[egress-block-test] FRESH-PULL proof FAILED — sovereignty proof FAILED (cutoverComplete stays false)"
                 exit 1
@@ -1813,21 +1987,23 @@ data:
               echo "[egress-block-test] #3647: FRESH-PULL proof requested but egressDeny not applied (enforce off / fail-safe fallback) — skipping the fresh pull, survival-poll only"
             fi
 
-            # ── #3376 (Refs #3689): org-tenants MUST be Ready BEFORE the hold ─
-            # The customer-onboarding Flux Kustomization `flux-system/
-            # org-tenants` reconciles the per-tenant overlay tree. On hw150 it
-            # was NotReady ("kustomization path not found") and the baseline
-            # capture below silently EXCLUDED it from the regression check —
-            # declaring sovereignty GREEN while the customer journey was dead
-            # (PRINCIPLES A1/A2: a green gate that excludes a broken component
-            # is theater at journey scale). The chart now seeds an empty parent
-            # index so the path exists from first convergence
-            # (gitea-tenants-repo-bootstrap-job.yaml Step 5); here we ASSERT it
-            # is actually Ready, loudly, before the proof — never as "baseline
-            # noise". Bounded poll (the GitRepository may still be pulling the
-            # freshly-seeded index when step-08 starts). Operator-gated so a
-            # non-marketplace Sovereign (no org-tenants Kustomization) is not
-            # forced to grow one: SKIP when the Kustomization is absent.
+            {{- /*
+             ── #3376 (Refs #3689): org-tenants MUST be Ready BEFORE the hold ─
+             The customer-onboarding Flux Kustomization `flux-system/
+             org-tenants` reconciles the per-tenant overlay tree. On hw150 it
+             was NotReady ("kustomization path not found") and the baseline
+             capture below silently EXCLUDED it from the regression check —
+             declaring sovereignty GREEN while the customer journey was dead
+             (PRINCIPLES A1/A2: a green gate that excludes a broken component
+             is theater at journey scale). The chart now seeds an empty parent
+             index so the path exists from first convergence
+             (gitea-tenants-repo-bootstrap-job.yaml Step 5); here we ASSERT it
+             is actually Ready, loudly, before the proof — never as "baseline
+             noise". Bounded poll (the GitRepository may still be pulling the
+             freshly-seeded index when step-08 starts). Operator-gated so a
+             non-marketplace Sovereign (no org-tenants Kustomization) is not
+             forced to grow one: SKIP when the Kustomization is absent.
+            */}}
             org_tenants_ks="${ORG_TENANTS_KUSTOMIZATION:-org-tenants}"
             org_tenants_ns="${ORG_TENANTS_KUSTOMIZATION_NAMESPACE:-flux-system}"
             if kubectl -n "${org_tenants_ns}" get kustomization "${org_tenants_ks}" >/dev/null 2>&1; then
@@ -1859,15 +2035,17 @@ data:
               echo "[egress-block-test] #3376: ${org_tenants_ns}/${org_tenants_ks} absent (non-marketplace Sovereign) — skipping the customer-path readiness assertion"
             fi
 
-            # ── #3695 HOST GITOPS LOOP GATE ───────────────────────────────
-            # HARD gate, NOT subject to the baseline-exclude below. The root
-            # bootstrap-kit Kustomization owns all 63 bp-* HRs with prune=true
-            # — if it cannot build (e.g. step-10's awk injector duplicated a
-            # `values:` key on 13b-bp-sso-bridge.yaml, hw150), the Sovereign
-            # can no longer apply ANY git change and is not operable as a
-            # GitOps cluster, even though every already-running pod stays up
-            # and the survival poll would pass. Assert each host Kustomization
-            # is Ready=True NOW; any NotReady fails the proof before the window.
+            {{- /*
+             ── #3695 HOST GITOPS LOOP GATE ───────────────────────────────
+             HARD gate, NOT subject to the baseline-exclude below. The root
+             bootstrap-kit Kustomization owns all 63 bp-* HRs with prune=true
+             — if it cannot build (e.g. step-10's awk injector duplicated a
+             `values:` key on 13b-bp-sso-bridge.yaml, hw150), the Sovereign
+             can no longer apply ANY git change and is not operable as a
+             GitOps cluster, even though every already-running pod stays up
+             and the survival poll would pass. Assert each host Kustomization
+             is Ready=True NOW; any NotReady fails the proof before the window.
+            */}}
             if [ "${HOST_KS_GATE_ENABLED}" = "true" ]; then
               echo "[egress-block-test] #3695: asserting host GitOps Kustomizations are Ready (the loop that reconciles local git)"
               host_ks_bad=""
@@ -1886,7 +2064,7 @@ data:
                 fi
               done
               if [ -n "${host_ks_bad}" ]; then
-                # Tear down any applied policy before failing.
+                {{- /* Tear down any applied policy before failing. */}}
                 [ -n "${POLICY_APPLIED}" ] && kubectl delete ciliumclusterwidenetworkpolicy cutover-egress-block --ignore-not-found=true || true
                 echo "[egress-block-test] #3695 FAIL — host GitOps loop not reconciling (NotReady:${host_ks_bad}); the cutover corrupted its own git loop — sovereignty proof FAILED"
                 exit 1
@@ -1894,13 +2072,15 @@ data:
               echo "[egress-block-test] #3695: host GitOps loop healthy — bootstrap-kit reconciles local git"
             fi
 
-            # ── #5359: SECONDARY-REGION deny-egress legs ─────────────────
-            # Applied HERE — after every pre-hold gate cleared on region-A
-            # and immediately before the baseline capture — so the
-            # secondaries are denied for exactly the survival window (the
-            # long region-A pre-hold roll sweep never runs with region-B
-            # blind-folded). Empty /secondary-kubeconfigs (single-region)
-            # renders this whole block inert.
+            {{- /*
+             ── #5359: SECONDARY-REGION deny-egress legs ─────────────────
+             Applied HERE — after every pre-hold gate cleared on region-A
+             and immediately before the baseline capture — so the
+             secondaries are denied for exactly the survival window (the
+             long region-A pre-hold roll sweep never runs with region-B
+             blind-folded). Empty /secondary-kubeconfigs (single-region)
+             renders this whole block inert.
+            */}}
             secondary_policy_teardown() {
               for td_kc in /secondary-kubeconfigs/*.yaml; do
                 [ -e "${td_kc}" ] || continue
@@ -1918,21 +2098,25 @@ data:
               cp /work/egress-deny.yaml /work/egress-deny-secondary.yaml
               if [ "${DEFAULT_DENY_EGRESS}" = "true" ]; then
                 {
-                  # Cross-cluster (intra-Sovereign) pod dials: a ClusterMesh
-                  # remote endpoint carries a mesh identity that toCIDR NEVER
-                  # matches (reference_k8s_netpol_ipblock_never_matches_
-                  # clustermesh_remote_identity) — region-B's flux clones the
-                  # local Gitea over the mesh alias, so allow mesh endpoints
-                  # explicitly. Both clusters belong to THIS Sovereign; no
-                  # public destination is opened.
+                  {{- /*
+                   Cross-cluster (intra-Sovereign) pod dials: a ClusterMesh
+                   remote endpoint carries a mesh identity that toCIDR NEVER
+                   matches (reference_k8s_netpol_ipblock_never_matches_
+                   clustermesh_remote_identity) — region-B's flux clones the
+                   local Gitea over the mesh alias, so allow mesh endpoints
+                   explicitly. Both clusters belong to THIS Sovereign; no
+                   public destination is opened.
+                  */}}
                   echo "    - toEndpoints:"
                   echo "        - {}"
-                  # The Sovereign's OWN gateway door (registry.<fqdn> +
-                  # gitea.<fqdn>): region-B's helm-controller pulls pivoted
-                  # charts through it. Its EIP is the Sovereign's own
-                  # infrastructure — allowing it proves nothing less about
-                  # github/ghcr/mothership independence. Resolved here (same
-                  # getent discipline as the UPSTREAM_HOSTS block-list).
+                  {{- /*
+                   The Sovereign's OWN gateway door (registry.<fqdn> +
+                   gitea.<fqdn>): region-B's helm-controller pulls pivoted
+                   charts through it. Its EIP is the Sovereign's own
+                   infrastructure — allowing it proves nothing less about
+                   github/ghcr/mothership independence. Resolved here (same
+                   getent discipline as the UPSTREAM_HOSTS block-list).
+                  */}}
                   for sov_host in "${LOCAL_REGISTRY_HOST}" "gitea.${SOVEREIGN_FQDN}"; do
                     for sov_ip in $(getent ahostsv4 "${sov_host}" 2>/dev/null | awk '{print $1}' | sort -u); do
                       case "${sov_ip}" in
@@ -1952,8 +2136,10 @@ data:
               for sc_kc in /secondary-kubeconfigs/*.yaml; do
                 [ -e "${sc_kc}" ] || continue
                 sc_region=$(basename "${sc_kc}" .yaml)
-                # Delete-before-apply: clears a stale hold policy leaked by a
-                # SIGKILLed prior run (idempotent re-run self-heal).
+                {{- /*
+                 Delete-before-apply: clears a stale hold policy leaked by a
+                 SIGKILLed prior run (idempotent re-run self-heal).
+                */}}
                 kubectl --kubeconfig "${sc_kc}" delete ciliumclusterwidenetworkpolicy cutover-egress-block --ignore-not-found=true 2>/dev/null || true
                 if kubectl --kubeconfig "${sc_kc}" apply -f /work/egress-deny-secondary.yaml; then
                   SECONDARY_POLICY_APPLIED="${SECONDARY_POLICY_APPLIED} ${sc_region}"
@@ -1964,8 +2150,10 @@ data:
                   exit 1
                 fi
               done
-              # Re-arm the teardown trap to cover the secondaries too (the
-              # region-A-only trap was set at the region-A apply above).
+              {{- /*
+               Re-arm the teardown trap to cover the secondaries too (the
+               region-A-only trap was set at the region-A apply above).
+              */}}
               trap 'kubectl delete ciliumclusterwidenetworkpolicy cutover-egress-block --ignore-not-found=true 2>/dev/null || true; secondary_policy_teardown' TERM EXIT
             elif [ "${secondary_kubeconfig_count}" -gt 0 ]; then
               echo "[egress-block-test] #5359: ${secondary_kubeconfig_count} secondary region(s) present but no region-A egressDeny was applied (enforce off / fail-safe fallback) — secondary legs run assertion-only like region-A"
@@ -1985,24 +2173,28 @@ data:
             else
               echo "[egress-block-test] baseline clean — no pre-existing NotReady items"
             fi
-            # #3634 — persist the baseline sets to files on the writable /work
-            # emptyDir for the POSIX regression diff in the survival loop below.
-            # The previous diff used `comm -13 <(echo "${baseline_hr}") <(echo
-            # "${hr_not_ready}")` — bash PROCESS SUBSTITUTION. This container
-            # runs `command: ["/bin/sh", ...]` and on the alpine/k8s image
-            # `/bin/sh` is busybox ash, which does NOT support `<(...)`: it is a
-            # PARSE-time syntax error (`syntax error: unexpected "("`) that
-            # aborted the WHOLE step-08 Job before it ran anything — no egress
-            # CCNP applied, no survival window, no PASS, so cutoverComplete
-            # never flipped true. `comm -13 A B` (lines in B not in A) is
-            # exactly `grep -vxF -f A B`, which is POSIX (passes dash -n AND
-            # busybox ash -n) and needs the baseline as a file.
+            {{- /*
+             #3634 — persist the baseline sets to files on the writable /work
+             emptyDir for the POSIX regression diff in the survival loop below.
+             The previous diff used `comm -13 <(echo "${baseline_hr}") <(echo
+             "${hr_not_ready}")` — bash PROCESS SUBSTITUTION. This container
+             runs `command: ["/bin/sh", ...]` and on the alpine/k8s image
+             `/bin/sh` is busybox ash, which does NOT support `<(...)`: it is a
+             PARSE-time syntax error (`syntax error: unexpected "("`) that
+             aborted the WHOLE step-08 Job before it ran anything — no egress
+             CCNP applied, no survival window, no PASS, so cutoverComplete
+             never flipped true. `comm -13 A B` (lines in B not in A) is
+             exactly `grep -vxF -f A B`, which is POSIX (passes dash -n AND
+             busybox ash -n) and needs the baseline as a file.
+            */}}
             printf '%s\n' "${baseline_hr}" > /work/baseline_hr.txt
             printf '%s\n' "${baseline_ks}" > /work/baseline_ks.txt
 
-            # #5359 — per-secondary baselines (same only-NEW-regressions
-            # criterion as region-A; a secondary's pre-existing NotReady set
-            # is excluded, a NEW NotReady during the hold fails the proof).
+            {{- /*
+             #5359 — per-secondary baselines (same only-NEW-regressions
+             criterion as region-A; a secondary's pre-existing NotReady set
+             is excluded, a NEW NotReady during the hold fails the proof).
+            */}}
             for sb_kc in /secondary-kubeconfigs/*.yaml; do
               [ -e "${sb_kc}" ] || continue
               sb_region=$(basename "${sb_kc}" .yaml)
@@ -2017,9 +2209,11 @@ data:
                 sed "s/^/  baseline[${sb_region}] HR /" "/work/baseline_hr_${sb_region}.txt" || true
                 sed "s/^/  baseline[${sb_region}] KS /" "/work/baseline_ks_${sb_region}.txt" || true
               fi
-              # Normalize a 0-byte baseline to the single-newline shape the
-              # region-A files carry (printf '%s\n' "") so `grep -vxF -f`
-              # behaves identically across grep flavors.
+              {{- /*
+               Normalize a 0-byte baseline to the single-newline shape the
+               region-A files carry (printf '%s\n' "") so `grep -vxF -f`
+               behaves identically across grep flavors.
+              */}}
               [ -s "/work/baseline_hr_${sb_region}.txt" ] || printf '\n' > "/work/baseline_hr_${sb_region}.txt"
               [ -s "/work/baseline_ks_${sb_region}.txt" ] || printf '\n' > "/work/baseline_ks_${sb_region}.txt"
             done
@@ -2040,15 +2234,17 @@ data:
                 -o jsonpath='{range .items[*]}{.metadata.namespace}/{.metadata.name}={.status.conditions[?(@.type=="Ready")].status}{"\n"}{end}' \
                 | grep -E '=False$' | sort -u || true)
 
-              # Diff against baseline — only new entries count as a regression.
-              # POSIX-safe (#3634): `grep -vxF -f BASELINE CURRENT` emits the
-              # CURRENT lines absent from BASELINE — byte-identical to the old
-              # `comm -13 <(echo BASELINE) <(echo CURRENT)` but with no bash
-              # process substitution (busybox ash /bin/sh rejects `<(...)`).
-              # `-x` whole-line, `-F` fixed-string so `/` and `=` in the
-              # ns/name=False rows are literal. An empty baseline file makes
-              # grep match no patterns → `-v` returns ALL current lines (every
-              # not-ready item is new) — same as `comm -13` with an empty A.
+              {{- /*
+               Diff against baseline — only new entries count as a regression.
+               POSIX-safe (#3634): `grep -vxF -f BASELINE CURRENT` emits the
+               CURRENT lines absent from BASELINE — byte-identical to the old
+               `comm -13 <(echo BASELINE) <(echo CURRENT)` but with no bash
+               process substitution (busybox ash /bin/sh rejects `<(...)`).
+               `-x` whole-line, `-F` fixed-string so `/` and `=` in the
+               ns/name=False rows are literal. An empty baseline file makes
+               grep match no patterns → `-v` returns ALL current lines (every
+               not-ready item is new) — same as `comm -13` with an empty A.
+              */}}
               printf '%s\n' "${hr_not_ready}" > /work/hr_not_ready.txt
               printf '%s\n' "${ks_not_ready}" > /work/ks_not_ready.txt
               new_hr=$(grep -vxF -f /work/baseline_hr.txt /work/hr_not_ready.txt || true)
@@ -2061,10 +2257,12 @@ data:
                 new_failures=$((new_failures+1))
               fi
 
-              # #5359 — the same regression diff against every SECONDARY
-              # region: a NEW NotReady on region-B during the hold means
-              # region-B still NEEDS an external tether — the proof must
-              # fail for the whole Sovereign, not just region-A.
+              {{- /*
+               #5359 — the same regression diff against every SECONDARY
+               region: a NEW NotReady on region-B during the hold means
+               region-B still NEEDS an external tether — the proof must
+               fail for the whole Sovereign, not just region-A.
+              */}}
               for sp_kc in /secondary-kubeconfigs/*.yaml; do
                 [ -e "${sp_kc}" ] || continue
                 sp_region=$(basename "${sp_kc}" .yaml)
@@ -2089,19 +2287,21 @@ data:
             done
 
             echo "[egress-block-test] window complete; new-regression-cycles=${new_failures}"
-            # Remove the egress-block policy (if applied) BEFORE the verdict
-            # so it's torn down on both pass and fail paths — never leave a
-            # deny policy lingering on the sovereign cluster.
+            {{- /*
+             Remove the egress-block policy (if applied) BEFORE the verdict
+             so it's torn down on both pass and fail paths — never leave a
+             deny policy lingering on the sovereign cluster.
+            */}}
             if [ -n "${POLICY_APPLIED}" ]; then
               kubectl delete ciliumclusterwidenetworkpolicy cutover-egress-block --ignore-not-found=true || true
               echo "[egress-block-test] egressDeny removed"
             fi
-            # #5359 — remove the secondary holds on the same pass/fail paths.
+            {{- /* #5359 — remove the secondary holds on the same pass/fail paths. */}}
             if [ -n "${SECONDARY_POLICY_APPLIED}" ]; then
               secondary_policy_teardown
               echo "[egress-block-test] #5359 secondary egressDeny removed (${SECONDARY_POLICY_APPLIED} )"
             fi
-            # #5359 — per-region durable verdict on the status ConfigMap.
+            {{- /* #5359 — per-region durable verdict on the status ConfigMap. */}}
             for sv_kc in /secondary-kubeconfigs/*.yaml; do
               [ -e "${sv_kc}" ] || continue
               sv_region=$(basename "${sv_kc}" .yaml)
@@ -2129,12 +2329,14 @@ data:
           capabilities:
             drop: ["ALL"]
     volumes:
-      # #3379 (hw139): writable scratch for the egressDeny CCNP manifest the
-      # enforce path emits + applies. readOnlyRootFilesystem:true blocks
-      # writing it under /tmp, so a dedicated emptyDir is the only writable
-      # path. (The former read-only `cilium-policy` configMap mount carried
-      # only a no-op placeholder — the script never consumed it — so it is
-      # dropped: the actual CCNP is generated inline + written here.)
+      {{- /*
+       #3379 (hw139): writable scratch for the egressDeny CCNP manifest the
+       enforce path emits + applies. readOnlyRootFilesystem:true blocks
+       writing it under /tmp, so a dedicated emptyDir is the only writable
+       path. (The former read-only `cilium-policy` configMap mount carried
+       only a no-op placeholder — the script never consumed it — so it is
+       dropped: the actual CCNP is generated inline + written here.)
+      */}}
       - name: work
         emptyDir: {}
       - name: offline-mirror-resolver
@@ -2143,9 +2345,11 @@ data:
           items:
             - key: resolver.sh
               path: resolver.sh
-      # #5359 — materialised by catalyst-api (cutover.go runCutover) from its
-      # on-PVC secondary kubeconfig store at every run start; optional:true
-      # so a single-region Sovereign (no Secret) schedules unchanged.
+      {{- /*
+       #5359 — materialised by catalyst-api (cutover.go runCutover) from its
+       on-PVC secondary kubeconfig store at every run start; optional:true
+       so a single-region Sovereign (no Secret) schedules unchanged.
+      */}}
       - name: secondary-kubeconfigs
         secret:
           secretName: {{ .Values.secondaryRegions.kubeconfigSecretName }}

--- a/platform/self-sovereign-cutover/chart/templates/09-cutover-status-configmap.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/09-cutover-status-configmap.yaml
@@ -76,9 +76,11 @@ data:
   failedStep: ""
   lastError: ""
   registriesYamlActive: "v1"
-  # Per-step keys are populated lazily by catalyst-api as steps run.
-  # Initial empty placeholders included so a UI rendering this ConfigMap
-  # before /start has been called has something to bind to.
+  {{- /*
+   Per-step keys are populated lazily by catalyst-api as steps run.
+   Initial empty placeholders included so a UI rendering this ConfigMap
+   before /start has been called has something to bind to.
+  */}}
   step.gitea-mirror.startedAt: ""
   step.gitea-mirror.finishedAt: ""
   step.gitea-mirror.result: ""

--- a/platform/self-sovereign-cutover/chart/templates/09-gitea-token-mint-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/09-gitea-token-mint-job.yaml
@@ -85,9 +85,11 @@ data:
     serviceAccountName: {{ include "bp-self-sovereign-cutover.serviceAccountName" . }}
     restartPolicy: Never
     activeDeadlineSeconds: {{ .Values.stepTimeouts.giteaTokenMintSeconds | default 600 }}
-    # #5214 — re-assert gitea-admin-secret in the release namespace at step
-    # execution time (durable close of the #4557/#4558/#4661 recurrence class).
-    # See _helpers.tpl.
+    {{- /*
+     #5214 — re-assert gitea-admin-secret in the release namespace at step
+     execution time (durable close of the #4557/#4558/#4661 recurrence class).
+     See _helpers.tpl.
+    */}}
     initContainers:
       {{- include "bp-self-sovereign-cutover.giteaSecretSelfHealInitContainer" (dict "ctx" . "phase" "post") | nindent 6 }}
     containers:
@@ -110,12 +112,14 @@ data:
           - name: TOKEN_NAME
             value: {{ .Values.giteaTokenMint.tokenName | default "catalyst-platform-bootstrap" | quote }}
           - name: TOKEN_SCOPES
-            # Comma-separated Gitea API scope list. "all" is the
-            # broadest scope — provisioning needs to create repos +
-            # branches + commits + tags + webhooks under arbitrary org
-            # paths the tenant wizard generates. Narrowing post-pivot
-            # is a follow-up (#TBD-C18-narrow); shipping broad here so
-            # journey step 16 unblocks today.
+            {{- /*
+             Comma-separated Gitea API scope list. "all" is the
+             broadest scope — provisioning needs to create repos +
+             branches + commits + tags + webhooks under arbitrary org
+             paths the tenant wizard generates. Narrowing post-pivot
+             is a follow-up (#TBD-C18-narrow); shipping broad here so
+             journey step 16 unblocks today.
+            */}}
             value: {{ .Values.giteaTokenMint.tokenScopes | default "all" | quote }}
           - name: DEST_SECRET_NAMESPACE
             value: {{ .Values.giteaTokenMint.destSecretNamespace | default "org-services" | quote }}
@@ -135,10 +139,12 @@ data:
             echo "[gitea-token-mint] token name   = ${TOKEN_NAME}"
             echo "[gitea-token-mint] dest secret  = ${DEST_SECRET_NAMESPACE}/${DEST_SECRET_NAME}.${DEST_SECRET_KEY}"
 
-            # ── 1. DNS-readiness probe ─────────────────────────────────────
-            # Same pattern as step 01 (gitea-mirror). On a fresh
-            # Sovereign the gitea Pod may have just reached Ready and
-            # the headless Service DNS record may not have propagated.
+            {{- /*
+             ── 1. DNS-readiness probe ─────────────────────────────────────
+             Same pattern as step 01 (gitea-mirror). On a fresh
+             Sovereign the gitea Pod may have just reached Ready and
+             the headless Service DNS record may not have propagated.
+            */}}
             if [ -n "${gitea_host}" ]; then
               echo "[gitea-token-mint] waiting for DNS resolution of ${gitea_host}"
               dns_ready="false"
@@ -156,19 +162,21 @@ data:
               fi
             fi
 
-            # ── 2. Re-run no-op probe (#2938) ─────────────────────────────
-            # OLD behavior (idempotency VIOLATION, UAT Wave-2 ATTACK#7):
-            # delete-then-mint on every run. On a cutover replay the
-            # DELETE invalidated the token live workloads were using;
-            # between the Secret patch and the rollout-restart serving
-            # new Pods, every holder of the old token got hard 401s with
-            # NO recovery path (token gone server-side).
-            #
-            # NEW contract: if the destination Secret already holds a
-            # token Gitea still accepts, steady-state is correct — exit 0
-            # WITHOUT touching anything (no delete, no mint, no rollout).
-            # Probe = GET /api/v1/user authenticated WITH that token
-            # (valid for any live token; 401 → revoked/invalid).
+            {{- /*
+             ── 2. Re-run no-op probe (#2938) ─────────────────────────────
+             OLD behavior (idempotency VIOLATION, UAT Wave-2 ATTACK#7):
+             delete-then-mint on every run. On a cutover replay the
+             DELETE invalidated the token live workloads were using;
+             between the Secret patch and the rollout-restart serving
+             new Pods, every holder of the old token got hard 401s with
+             NO recovery path (token gone server-side).
+
+             NEW contract: if the destination Secret already holds a
+             token Gitea still accepts, steady-state is correct — exit 0
+             WITHOUT touching anything (no delete, no mint, no rollout).
+             Probe = GET /api/v1/user authenticated WITH that token
+             (valid for any live token; 401 → revoked/invalid).
+            */}}
             existing_token=$(kubectl -n "${DEST_SECRET_NAMESPACE}" get secret "${DEST_SECRET_NAME}" \
               -o jsonpath="{.data.${DEST_SECRET_KEY}}" 2>/dev/null | base64 -d 2>/dev/null || true)
             if [ -n "${existing_token}" ]; then
@@ -178,17 +186,19 @@ data:
                 "${api_url}/user" 2>/dev/null || echo "000")
               if [ "${probe_code}" = "200" ]; then
                 echo "[gitea-token-mint] existing token in ${DEST_SECRET_NAMESPACE}/${DEST_SECRET_NAME} is VALID — re-run is a no-op (#2938: re-runs must not break working state)"
-                # #3376 (Refs #3689): stamp the cutover annotations on the
-                # no-op path too, so the on-disk Secret never diverges from
-                # what a full mint would have produced. The init gate no
-                # longer reads this annotation (it now DATA-probes the token),
-                # but catalyst-api's provisioning-github-token.yaml
-                # $cutoverOwned preservation branch + an operator forensicking
-                # `kubectl describe secret` both still expect it. Idempotent —
-                # patches ONLY the annotations, never the token bytes (so the
-                # working token the probe just validated is untouched). A
-                # failure here is non-fatal: the token is already valid, which
-                # is what actually matters.
+                {{- /*
+                 #3376 (Refs #3689): stamp the cutover annotations on the
+                 no-op path too, so the on-disk Secret never diverges from
+                 what a full mint would have produced. The init gate no
+                 longer reads this annotation (it now DATA-probes the token),
+                 but catalyst-api's provisioning-github-token.yaml
+                 $cutoverOwned preservation branch + an operator forensicking
+                 `kubectl describe secret` both still expect it. Idempotent —
+                 patches ONLY the annotations, never the token bytes (so the
+                 working token the probe just validated is untouched). A
+                 failure here is non-fatal: the token is already valid, which
+                 is what actually matters.
+                */}}
                 ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
                 noop_annot_patch=$(printf '{"metadata":{"annotations":{"catalyst.openova.io/token-minted-at":"%s","catalyst.openova.io/token-source":"self-sovereign-cutover-step-09"}}}' "${ts}")
                 kubectl -n "${DEST_SECRET_NAMESPACE}" patch secret "${DEST_SECRET_NAME}" \
@@ -202,43 +212,49 @@ data:
               echo "[gitea-token-mint] no existing token in destination Secret — first run"
             fi
 
-            # ── 2b. Unique per-run token name (#2938 Option 2) ───────────
-            # Mint under base-name + epoch nonce instead of delete-then-
-            # reuse: old tokens are NEVER invalidated by a re-run, so any
-            # Pod still holding one keeps working until its own rollout
-            # completes. Orphaned old tokens are inert (rotated out of
-            # the Secret, unused); the shared base-name prefix keeps the
-            # Gitea token list auditable. This also removes the 422
-            # name-collision the old DELETE existed to clear.
+            {{- /*
+             ── 2b. Unique per-run token name (#2938 Option 2) ───────────
+             Mint under base-name + epoch nonce instead of delete-then-
+             reuse: old tokens are NEVER invalidated by a re-run, so any
+             Pod still holding one keeps working until its own rollout
+             completes. Orphaned old tokens are inert (rotated out of
+             the Secret, unused); the shared base-name prefix keeps the
+             Gitea token list auditable. This also removes the 422
+             name-collision the old DELETE existed to clear.
+            */}}
             TOKEN_NAME="${TOKEN_NAME}-$(date +%s)"
             echo "[gitea-token-mint] minting under unique name ${TOKEN_NAME}"
 
-            # ── 3. Mint a fresh token ────────────────────────────────────
-            # POST /api/v1/users/{username}/tokens body:
-            #   {"name":"<TOKEN_NAME>","scopes":["all"]}
-            # Returns:
-            #   {"id":N,"name":"...","sha1":"<RAW TOKEN>","token_last_eight":"...","scopes":["all"]}
-            # The `sha1` field is the ONLY place the raw token bytes
-            # ever appear — Gitea hashes it server-side and a later GET
-            # returns only the last 8 chars. We MUST capture it from
-            # this single response.
-            #
-            # Scope-list JSON encoding: Gitea expects a JSON array. We
-            # take a comma-separated env var (operator-friendly) and
-            # turn it into a JSON array via sed.
+            {{- /*
+             ── 3. Mint a fresh token ────────────────────────────────────
+             POST /api/v1/users/{username}/tokens body:
+               {"name":"<TOKEN_NAME>","scopes":["all"]}
+             Returns:
+               {"id":N,"name":"...","sha1":"<RAW TOKEN>","token_last_eight":"...","scopes":["all"]}
+             The `sha1` field is the ONLY place the raw token bytes
+             ever appear — Gitea hashes it server-side and a later GET
+             returns only the last 8 chars. We MUST capture it from
+             this single response.
+
+             Scope-list JSON encoding: Gitea expects a JSON array. We
+             take a comma-separated env var (operator-friendly) and
+             turn it into a JSON array via sed.
+            */}}
             scope_json_array="[\"$(printf '%s' "${TOKEN_SCOPES}" | sed 's/, */","/g')\"]"
             mint_body=$(printf '{"name":"%s","scopes":%s}' "${TOKEN_NAME}" "${scope_json_array}")
             echo "[gitea-token-mint] minting token (scopes=${TOKEN_SCOPES})"
 
-            # #3643 (Refs #3584): Gitea MANDATES BasicAuth for token creation (a
-            # token cannot mint a token — see the header note), so the #3584 PAT
-            # remedy cannot apply here. But Gitea's apiAuth consults the
-            # openova-sso OAuth2 source when validating a BasicAuth PASSWORD, which
-            # BLOCKS ~130s then 401s while Keycloak is still re-converging in the
-            # cutover window (step-07 just rolled catalyst-api + pivoted the
-            # issuer). Bound each attempt (--max-time 40, under the ~130s hang) and
-            # retry with backoff so the mint survives the transient slowness until
-            # the OAuth2 lookup is fast — ~6 attempts x (40s + 15s) ~= 5.5min.
+            {{- /*
+             #3643 (Refs #3584): Gitea MANDATES BasicAuth for token creation (a
+             token cannot mint a token — see the header note), so the #3584 PAT
+             remedy cannot apply here. But Gitea's apiAuth consults the
+             openova-sso OAuth2 source when validating a BasicAuth PASSWORD, which
+             BLOCKS ~130s then 401s while Keycloak is still re-converging in the
+             cutover window (step-07 just rolled catalyst-api + pivoted the
+             issuer). Bound each attempt (--max-time 40, under the ~130s hang) and
+             retry with backoff so the mint survives the transient slowness until
+             the OAuth2 lookup is fast — ~6 attempts x (40s + 15s) ~= 5.5min.
+            */}}
             mint_response=""; mint_ok=""
             for mint_attempt in 1 2 3 4 5 6; do
               if mint_response=$(curl -fsS --max-time 40 -u "${GITEA_USERNAME}:${GITEA_PASSWORD}" \
@@ -255,44 +271,50 @@ data:
             done
             if [ -z "${mint_ok}" ]; then
               echo "[gitea-token-mint] FATAL: mint POST failed after 6 attempts (~5.5min)" >&2
-              # Redact credential before surfacing the body.
+              {{- /* Redact credential before surfacing the body. */}}
               printf '%s\n' "${mint_response}" | sed -E "s,${GITEA_PASSWORD}+,REDACTED,g" >&2
               exit 1
             fi
 
-            # Extract the sha1 field WITHOUT printing it. Use grep
-            # because alpine/k8s has no jq guaranteed.
+            {{- /*
+             Extract the sha1 field WITHOUT printing it. Use grep
+             because alpine/k8s has no jq guaranteed.
+            */}}
             new_token=$(printf '%s' "${mint_response}" | grep -o '"sha1":"[^"]*"' | sed -E 's/"sha1":"([^"]*)"/\1/')
             if [ -z "${new_token}" ]; then
               echo "[gitea-token-mint] FATAL: mint response had no sha1 field" >&2
               printf '%s\n' "${mint_response}" | sed -E "s,${GITEA_PASSWORD}+,REDACTED,g" >&2
               exit 1
             fi
-            # #5467 — do NOT print any fragment of the minted token. The old
-            # `${new_token##???…???}` glob-stripped the first 35 characters and
-            # emitted the LAST 5 of a live Gitea API token — the credential the
-            # host GitOps loop authenticates with for the rest of the
-            # Sovereign's life. It is the same disclosure class as the step-03
-            # GHCR-PAT prefix, in a different spelling: no `:0:N`, no `cut -c`,
-            # so no grep for the step-03 idiom would ever have found it. The
-            # comment 8 lines up already says "WITHOUT printing it"; this line
-            # was quietly contradicting it on every cutover.
-            # Length + set/unset is the whole diagnostic: it distinguishes
-            # "mint returned a plausible sha1" from "mint returned junk".
+            {{- /*
+             #5467 — do NOT print any fragment of the minted token. The old
+             `${new_token##???…???}` glob-stripped the first 35 characters and
+             emitted the LAST 5 of a live Gitea API token — the credential the
+             host GitOps loop authenticates with for the rest of the
+             Sovereign's life. It is the same disclosure class as the step-03
+             GHCR-PAT prefix, in a different spelling: no `:0:N`, no `cut -c`,
+             so no grep for the step-03 idiom would ever have found it. The
+             comment 8 lines up already says "WITHOUT printing it"; this line
+             was quietly contradicting it on every cutover.
+             Length + set/unset is the whole diagnostic: it distinguishes
+             "mint returned a plausible sha1" from "mint returned junk".
+            */}}
             echo "[gitea-token-mint] minted token: set (len=${#new_token})"
 
-            # ── 4. Validate the token against Gitea ──────────────────────
-            # GET /api/v1/user with `Authorization: token <X>` returns
-            # the authenticated user's profile. A 401 here means we
-            # have NOT actually fixed the bug — abort before patching
-            # the Secret (otherwise we'd just rotate the broken state).
+            {{- /*
+             ── 4. Validate the token against Gitea ──────────────────────
+             GET /api/v1/user with `Authorization: token <X>` returns
+             the authenticated user's profile. A 401 here means we
+             have NOT actually fixed the bug — abort before patching
+             the Secret (otherwise we'd just rotate the broken state).
+            */}}
             echo "[gitea-token-mint] validating token via GET /api/v1/user"
             validate_response=$(curl -fsS \
               -H "Authorization: token ${new_token}" \
               -H "Accept: application/json" \
               "${api_url}/user" 2>&1) || {
               echo "[gitea-token-mint] FATAL: token validation failed (token does not authenticate)" >&2
-              # NEVER echo ${new_token} in error output.
+              {{- /* NEVER echo ${new_token} in error output. */}}
               printf '%s\n' "${validate_response}" | sed -E "s,${new_token}+,REDACTED_TOKEN,g; s,${GITEA_PASSWORD}+,REDACTED_PWD,g" >&2
               exit 1
             }
@@ -302,23 +324,27 @@ data:
             fi
             echo "[gitea-token-mint] token validates (GET /api/v1/user returned 200 + login)"
 
-            # ── 5. Patch the destination Secret ──────────────────────────
-            # Use kubectl patch with a strategic-merge-patch on the
-            # stringData field (kubectl base64-encodes for us). We use
-            # an env-fed -f stdin to avoid embedding the token in any
-            # process-listing visible to other namespaces.
-            #
-            # The Secret already exists (created by bp-catalyst-platform
-            # template provisioning-github-token.yaml, with helm.sh/
-            # resource-policy: keep). If it doesn't (degraded path
-            # where catalyst-platform was uninstalled then reinstalled
-            # mid-cutover), we create it from scratch.
+            {{- /*
+             ── 5. Patch the destination Secret ──────────────────────────
+             Use kubectl patch with a strategic-merge-patch on the
+             stringData field (kubectl base64-encodes for us). We use
+             an env-fed -f stdin to avoid embedding the token in any
+             process-listing visible to other namespaces.
+
+             The Secret already exists (created by bp-catalyst-platform
+             template provisioning-github-token.yaml, with helm.sh/
+             resource-policy: keep). If it doesn't (degraded path
+             where catalyst-platform was uninstalled then reinstalled
+             mid-cutover), we create it from scratch.
+            */}}
             echo "[gitea-token-mint] patching ${DEST_SECRET_NAMESPACE}/${DEST_SECRET_NAME}.${DEST_SECRET_KEY}"
             if kubectl -n "${DEST_SECRET_NAMESPACE}" get secret "${DEST_SECRET_NAME}" >/dev/null 2>&1; then
-              # Strategic-merge stringData — kubectl b64-encodes; we
-              # send the raw token via stdin under env to avoid leaking
-              # into argv. Annotate so an operator forensicking the
-              # Secret sees the bootstrap-time provenance.
+              {{- /*
+               Strategic-merge stringData — kubectl b64-encodes; we
+               send the raw token via stdin under env to avoid leaking
+               into argv. Annotate so an operator forensicking the
+               Secret sees the bootstrap-time provenance.
+              */}}
               ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
               patch_body=$(printf '{"metadata":{"annotations":{"catalyst.openova.io/token-minted-at":"%s","catalyst.openova.io/token-source":"self-sovereign-cutover-step-09"}},"stringData":{"%s":"%s"}}' \
                 "${ts}" "${DEST_SECRET_KEY}" "${new_token}")
@@ -336,17 +362,19 @@ data:
             fi
             echo "[gitea-token-mint] secret patched"
 
-            # ── 6. Trip a rolling restart of the provisioning Pod ────────
-            # The provisioning Deployment's pod env reads GITHUB_TOKEN
-            # via secretKeyRef at Pod start — a Secret patch alone does
-            # NOT restart Pods (this is K8s behaviour, not a chart
-            # choice). We must bounce the Pod so the new token takes
-            # effect immediately, rather than waiting for the next
-            # natural restart (which could be hours or days). The
-            # rollout is best-effort — provisioning may not exist yet
-            # (if marketplace is disabled in this Sovereign's overlay),
-            # in which case kubectl returns NotFound and we tolerate
-            # that.
+            {{- /*
+             ── 6. Trip a rolling restart of the provisioning Pod ────────
+             The provisioning Deployment's pod env reads GITHUB_TOKEN
+             via secretKeyRef at Pod start — a Secret patch alone does
+             NOT restart Pods (this is K8s behaviour, not a chart
+             choice). We must bounce the Pod so the new token takes
+             effect immediately, rather than waiting for the next
+             natural restart (which could be hours or days). The
+             rollout is best-effort — provisioning may not exist yet
+             (if marketplace is disabled in this Sovereign's overlay),
+             in which case kubectl returns NotFound and we tolerate
+             that.
+            */}}
             echo "[gitea-token-mint] rolling restart provisioning Deployment (best-effort)"
             if kubectl -n "${DEST_SECRET_NAMESPACE}" get deploy provisioning >/dev/null 2>&1; then
               kubectl -n "${DEST_SECRET_NAMESPACE}" rollout restart deploy/provisioning >/dev/null

--- a/platform/self-sovereign-cutover/chart/templates/10-auto-trigger-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/10-auto-trigger-job.yaml
@@ -151,39 +151,47 @@ spec:
             - |
               set -eu
 
-              # Optional pre-flight delay to let just-handed-over operators
-              # confirm the dashboard renders before the cutover hides the
-              # CTA. autoDelaySeconds=0 means "fire immediately".
+              {{- /*
+               Optional pre-flight delay to let just-handed-over operators
+               confirm the dashboard renders before the cutover hides the
+               CTA. autoDelaySeconds=0 means "fire immediately".
+              */}}
               if [ "${AUTO_DELAY_SECONDS}" -gt 0 ]; then
                 echo "[auto-trigger] sleeping ${AUTO_DELAY_SECONDS}s before firing cutover"
                 sleep "${AUTO_DELAY_SECONDS}"
               fi
 
               api="${CATALYST_API_URL%/}"
-              # Issue #957 — chart 0.1.18: poll the unauthenticated
-              # /healthz endpoint to test reachability. /api/v1/sovereign/
-              # cutover/status (used in 0.1.17) lives behind RequireSession
-              # middleware and returned 401 to every probe from this Pod
-              # because the in-cluster Job has no operator session cookie.
-              # The probe treated 401 as "API not ready" → loop never
-              # broke → trigger was never called → cutover never fired.
-              # /healthz exists for exactly this purpose (kubelet liveness
-              # + in-cluster reachability) and returns 200 unconditionally
-              # while the process is up.
+              {{- /*
+               Issue #957 — chart 0.1.18: poll the unauthenticated
+               /healthz endpoint to test reachability. /api/v1/sovereign/
+               cutover/status (used in 0.1.17) lives behind RequireSession
+               middleware and returned 401 to every probe from this Pod
+               because the in-cluster Job has no operator session cookie.
+               The probe treated 401 as "API not ready" → loop never
+               broke → trigger was never called → cutover never fired.
+               /healthz exists for exactly this purpose (kubelet liveness
+               + in-cluster reachability) and returns 200 unconditionally
+               while the process is up.
+              */}}
               healthz_url="${api}/healthz"
-              # Issue #935 Bug 2: hit the in-cluster /internal/cutover/trigger
-              # endpoint (lives outside RequireSession) with this Pod's
-              # ServiceAccount token. The previous /sovereign/cutover/start
-              # path required a human session cookie and 401'd forever.
+              {{- /*
+               Issue #935 Bug 2: hit the in-cluster /internal/cutover/trigger
+               endpoint (lives outside RequireSession) with this Pod's
+               ServiceAccount token. The previous /sovereign/cutover/start
+               path required a human session cookie and 401'd forever.
+              */}}
               trigger_url="${api}/api/v1/internal/cutover/trigger"
               sa_token_file="/var/run/secrets/kubernetes.io/serviceaccount/token"
 
-              # 1. Wait for catalyst-api to be reachable. In a fresh
-              #    Sovereign, the cutover chart and catalyst-platform
-              #    chart land on slightly different timelines via Flux.
-              #    We poll /healthz (an unauthenticated liveness endpoint)
-              #    up to WAIT_TIMEOUT_SECONDS so a transient unreachability
-              #    doesn't fail the hook.
+              {{- /*
+               1. Wait for catalyst-api to be reachable. In a fresh
+                  Sovereign, the cutover chart and catalyst-platform
+                  chart land on slightly different timelines via Flux.
+                  We poll /healthz (an unauthenticated liveness endpoint)
+                  up to WAIT_TIMEOUT_SECONDS so a transient unreachability
+                  doesn't fail the hook.
+              */}}
               echo "[auto-trigger] waiting for catalyst-api at ${api}"
               deadline=$(( $(date +%s) + WAIT_TIMEOUT_SECONDS ))
               api_ready="false"
@@ -203,61 +211,71 @@ spec:
                 exit 0
               fi
 
-              # 2. Skip the pre-flight cutoverComplete=true short-circuit
-              #    that 0.1.17 had: /internal/cutover/trigger is itself
-              #    idempotent — it returns 200 with the existing snapshot
-              #    when cutoverComplete=true (cutover_internal.go line
-              #    279). Removing the pre-read keeps us off the auth-gated
-              #    /sovereign/cutover/status endpoint entirely, which is
-              #    the whole point of the 0.1.18 change.
+              {{- /*
+               2. Skip the pre-flight cutoverComplete=true short-circuit
+                  that 0.1.17 had: /internal/cutover/trigger is itself
+                  idempotent — it returns 200 with the existing snapshot
+                  when cutoverComplete=true (cutover_internal.go line
+                  279). Removing the pre-read keeps us off the auth-gated
+                  /sovereign/cutover/status endpoint entirely, which is
+                  the whole point of the 0.1.18 change.
+              */}}
 
-              # 3. Confirm the SA token is mountable. Should always be
-              #    true when the Pod is running with our serviceAccount,
-              #    but a friendlier failure message helps operators
-              #    triage AutomountServiceAccountToken=false misconfig.
+              {{- /*
+               3. Confirm the SA token is mountable. Should always be
+                  true when the Pod is running with our serviceAccount,
+                  but a friendlier failure message helps operators
+                  triage AutomountServiceAccountToken=false misconfig.
+              */}}
               if [ ! -r "${sa_token_file}" ]; then
                 echo "[auto-trigger] ServiceAccount token not mounted at ${sa_token_file}; cannot authenticate"
                 echo "[auto-trigger] check that the Pod's serviceAccountName matches the chart's RBAC subject"
-                # Exit 0 so the operator can fire manually via CTA;
-                # failing the hook would block the chart install.
+                {{- /*
+                 Exit 0 so the operator can fire manually via CTA;
+                 failing the hook would block the chart install.
+                */}}
                 exit 0
               fi
 
-              # 4. POST /api/v1/internal/cutover/trigger with the SA
-              #    token, RETRYING on the handover-completion gate. catalyst-
-              #    api validates the token via TokenReview and runs the same
-              #    engine path as /sovereign/cutover/start.
-              #
-              #    Idempotency contract:
-              #    - cutoverComplete=true → 200 with the existing snapshot
-              #    - cutover already running on this Pod → 409 (benign)
-              #    - no steps found → 424 (chart not installed; impossible here)
-              #    - success → 200 with the freshly-seeded snapshot
-              #    - handover not yet sealed → 425 (FailedDependency)
-              #    - SA token rejected by apiserver → 502 (transient)
-              #    - SA mismatch → 403 (chart RBAC misconfig)
-              #
-              # THE 425-NO-RETRY RACE (#4632, verified live on dep 8fd457a8).
-              # This hook is a `post-install,post-upgrade` Job with
-              # hook-delete-policy `hook-succeeded`. On a FRESH prov it fires
-              # at slot-06a install time — BEFORE bp-catalyst-platform reaches
-              # Ready and the handover post-install hook seals
-              # secret/catalyst/tofu-phase0-archive — so catalyst-api correctly
-              # refuses with HTTP 425 ("handover not complete"). The previous
-              # 425 handler did a single `exit 0` and GAVE UP; the hook was then
-              # deleted, so NOTHING ever re-POSTed the trigger and the cutover
-              # NEVER auto-fired. Live proof: 8fd457a8's handover seal was
-              # written at 13:56:41 but the lone POST 425'd at 13:54:48 (~2 min
-              # too early) → cutover stuck progressPercent=0, cutoverStartedAt="".
-              # FIX: poll on 425 (and transient 000/502) until a non-425 result
-              # or a bounded handover-wait deadline. The retry runs INSIDE the
-              # Job's own lifetime, so the trigger is re-POSTed the moment the
-              # gate opens — no operator CTA click required (founder rule #933).
+              {{- /*
+               4. POST /api/v1/internal/cutover/trigger with the SA
+                  token, RETRYING on the handover-completion gate. catalyst-
+                  api validates the token via TokenReview and runs the same
+                  engine path as /sovereign/cutover/start.
+
+                  Idempotency contract:
+                  - cutoverComplete=true → 200 with the existing snapshot
+                  - cutover already running on this Pod → 409 (benign)
+                  - no steps found → 424 (chart not installed; impossible here)
+                  - success → 200 with the freshly-seeded snapshot
+                  - handover not yet sealed → 425 (FailedDependency)
+                  - SA token rejected by apiserver → 502 (transient)
+                  - SA mismatch → 403 (chart RBAC misconfig)
+
+               THE 425-NO-RETRY RACE (#4632, verified live on dep 8fd457a8).
+               This hook is a `post-install,post-upgrade` Job with
+               hook-delete-policy `hook-succeeded`. On a FRESH prov it fires
+               at slot-06a install time — BEFORE bp-catalyst-platform reaches
+               Ready and the handover post-install hook seals
+               secret/catalyst/tofu-phase0-archive — so catalyst-api correctly
+               refuses with HTTP 425 ("handover not complete"). The previous
+               425 handler did a single `exit 0` and GAVE UP; the hook was then
+               deleted, so NOTHING ever re-POSTed the trigger and the cutover
+               NEVER auto-fired. Live proof: 8fd457a8's handover seal was
+               written at 13:56:41 but the lone POST 425'd at 13:54:48 (~2 min
+               too early) → cutover stuck progressPercent=0, cutoverStartedAt="".
+               FIX: poll on 425 (and transient 000/502) until a non-425 result
+               or a bounded handover-wait deadline. The retry runs INSIDE the
+               Job's own lifetime, so the trigger is re-POSTed the moment the
+               gate opens — no operator CTA click required (founder rule #933).
+              */}}
               hdeadline=$(( $(date +%s) + HANDOVER_WAIT_SECONDS ))
               echo "[auto-trigger] POSTing ${trigger_url} (will retry on HTTP 425 until handover seals, up to ${HANDOVER_WAIT_SECONDS}s)"
               while : ; do
-                # Read the token at request time (not as an env var) so
-                # rotation during a long deadline still authenticates.
+                {{- /*
+                 Read the token at request time (not as an env var) so
+                 rotation during a long deadline still authenticates.
+                */}}
                 code=$(curl -s -o /tmp/trigger.json -w "%{http_code}" \
                   -X POST --connect-timeout 10 --max-time 60 \
                   -H "Authorization: Bearer $(cat ${sa_token_file})" \
@@ -283,21 +301,25 @@ spec:
                   401|403)
                     echo "[auto-trigger] catalyst-api rejected our SA token (HTTP ${code}); chart RBAC may be misconfigured"
                     cat /tmp/trigger.json 2>/dev/null || true
-                    # Exit 0 — operator-actionable, not a chart-install
-                    # failure. CTA still works via the operator session.
+                    {{- /*
+                     Exit 0 — operator-actionable, not a chart-install
+                     failure. CTA still works via the operator session.
+                    */}}
                     exit 0
                     ;;
                   425)
-                    # Handover-completion gate (catalyst-api
-                    # cutover_internal.go). On a FRESH prov this hook fires
-                    # at bootstrap — long before handover — and catalyst-api
-                    # correctly refuses to start the cutover engine until the
-                    # tofu-phase0-archive is sealed at handover. RETRY until the
-                    # gate opens (#4632) instead of giving up: a single exit 0
-                    # here means nothing ever re-POSTs and the cutover never
-                    # auto-fires (the registry half-pivot guard from hw93
-                    # 2026-06-04 stays intact — the engine only starts once the
-                    # archive is sealed, we just keep asking until it is).
+                    {{- /*
+                     Handover-completion gate (catalyst-api
+                     cutover_internal.go). On a FRESH prov this hook fires
+                     at bootstrap — long before handover — and catalyst-api
+                     correctly refuses to start the cutover engine until the
+                     tofu-phase0-archive is sealed at handover. RETRY until the
+                     gate opens (#4632) instead of giving up: a single exit 0
+                     here means nothing ever re-POSTs and the cutover never
+                     auto-fires (the registry half-pivot guard from hw93
+                     2026-06-04 stays intact — the engine only starts once the
+                     archive is sealed, we just keep asking until it is).
+                    */}}
                     if [ "$(date +%s)" -ge "${hdeadline}" ]; then
                       echo "[auto-trigger] cutover still deferred after ${HANDOVER_WAIT_SECONDS}s handover wait (HTTP 425) — exiting 0; operator can fire manually via CTA once handover completes."
                       cat /tmp/trigger.json 2>/dev/null || true
@@ -307,10 +329,12 @@ spec:
                     sleep 15
                     ;;
                   *)
-                    # Transient (000 connect failure, 502 TokenReview blip,
-                    # etc.). Retry within the same handover-wait budget rather
-                    # than giving up on a momentary hiccup, then exit 0 so a
-                    # genuinely-sick API never fails the chart install.
+                    {{- /*
+                     Transient (000 connect failure, 502 TokenReview blip,
+                     etc.). Retry within the same handover-wait budget rather
+                     than giving up on a momentary hiccup, then exit 0 so a
+                     genuinely-sick API never fails the chart install.
+                    */}}
                     echo "[auto-trigger] transient/unexpected status ${code}"
                     cat /tmp/trigger.json 2>/dev/null || true
                     if [ "$(date +%s)" -ge "${hdeadline}" ]; then

--- a/platform/self-sovereign-cutover/chart/templates/10-vcluster-registry-pivot-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/10-vcluster-registry-pivot-job.yaml
@@ -135,21 +135,25 @@ data:
     serviceAccountName: {{ include "bp-self-sovereign-cutover.serviceAccountName" . }}
     restartPolicy: Never
     activeDeadlineSeconds: {{ .Values.stepTimeouts.vclusterRegistryPivotSeconds }}
-    # #5262 — the #5214 gitea-admin-secret self-heal initContainer is GONE
-    # from this step: the Phase-2 git clone/push now authenticates with the
-    # step-09 minted `catalyst-gitea-token` PAT (read at runtime below), so
-    # this step no longer consumes gitea-admin-secret at all and must not
-    # keep a wedge-path on its presence (contract Case 63 asserts absence).
+    {{- /*
+     #5262 — the #5214 gitea-admin-secret self-heal initContainer is GONE
+     from this step: the Phase-2 git clone/push now authenticates with the
+     step-09 minted `catalyst-gitea-token` PAT (read at runtime below), so
+     this step no longer consumes gitea-admin-secret at all and must not
+     keep a wedge-path on its presence (contract Case 63 asserts absence).
+    */}}
     containers:
       - name: vcluster-registry-pivot
-        # alpine/k8s ships both kubectl AND git so we can patch live
-        # HelmReleases AND push the YAML edit to local Gitea (same image
-        # Step 06 uses for the same reason).
-        # Fix #163 (2026-05-11, MIRROR-EVERYTHING): explicit
-        # harbor.openova.io/proxy-dockerhub prefix per CLAUDE.md
-        # inviolable rule — pre-cutover containerd already routes this
-        # via the proxy, so the Job can pull its own image during the
-        # cutover sequence.
+        {{- /*
+         alpine/k8s ships both kubectl AND git so we can patch live
+         HelmReleases AND push the YAML edit to local Gitea (same image
+         Step 06 uses for the same reason).
+         Fix #163 (2026-05-11, MIRROR-EVERYTHING): explicit
+         harbor.openova.io/proxy-dockerhub prefix per CLAUDE.md
+         inviolable rule — pre-cutover containerd already routes this
+         via the proxy, so the Job can pull its own image during the
+         cutover sequence.
+        */}}
         image: harbor.openova.io/proxy-dockerhub/alpine/k8s:1.31.4
         imagePullPolicy: IfNotPresent
         env:
@@ -159,18 +163,20 @@ data:
             value: {{ .Values.sovereign.fqdn | quote }}
           - name: GITEA_INTERNAL_URL
             value: {{ .Values.sovereign.giteaInternalURL | quote }}
-          # #5262 (live hw277) — the Phase-2 git clone/push authenticates
-          # with the step-09 minted `catalyst-gitea-token` PAT, NOT the
-          # gitea admin password. On hw277 a mid-cutover bp-gitea re-render
-          # rotated gitea-admin-secret while Gitea's DB kept the
-          # install-time password → the clone here 401'd (git exit 128,
-          # ~1s) and the step wedged. A Gitea PAT is accepted as the HTTP
-          # git password under any existing username (step-01 #3584 + step-05
-          # #3536 precedent), is fresh-per-cutover by construction (step-09
-          # runs at order 9, directly before this step), and is a direct
-          # local sha1 lookup — immune to admin-password drift AND to the
-          # external openova-sso apiAuth hang. Username stays the admin
-          # login for commit auditability (gitRepositorySecretRef.username).
+          {{- /*
+           #5262 (live hw277) — the Phase-2 git clone/push authenticates
+           with the step-09 minted `catalyst-gitea-token` PAT, NOT the
+           gitea admin password. On hw277 a mid-cutover bp-gitea re-render
+           rotated gitea-admin-secret while Gitea's DB kept the
+           install-time password → the clone here 401'd (git exit 128,
+           ~1s) and the step wedged. A Gitea PAT is accepted as the HTTP
+           git password under any existing username (step-01 #3584 + step-05
+           #3536 precedent), is fresh-per-cutover by construction (step-09
+           runs at order 9, directly before this step), and is a direct
+           local sha1 lookup — immune to admin-password drift AND to the
+           external openova-sso apiAuth hang. Username stays the admin
+           login for commit auditability (gitRepositorySecretRef.username).
+          */}}
           - name: GITEA_USERNAME
             value: {{ .Values.gitRepositorySecretRef.username | quote }}
           - name: PAT_SOURCE_NAMESPACE
@@ -193,11 +199,13 @@ data:
           - |
             set -eu
 
-            # The Sovereign-local Harbor host. bp-*-vcluster charts'
-            # `image.repository` is HOST + PATH ("harbor.openova.io/
-            # proxy-ghcr/loft-sh/vcluster"), but the upstream loft-sh
-            # subchart splits it into `.image.registry` (HOST only) +
-            # `.image.repository` (PATH only). So we compute both.
+            {{- /*
+             The Sovereign-local Harbor host. bp-*-vcluster charts'
+             `image.repository` is HOST + PATH ("harbor.openova.io/
+             proxy-ghcr/loft-sh/vcluster"), but the upstream loft-sh
+             subchart splits it into `.image.registry` (HOST only) +
+             `.image.repository` (PATH only). So we compute both.
+            */}}
             target_host="harbor.${SOVEREIGN_FQDN}"
             wrapper_repo="${target_host}/proxy-ghcr/loft-sh/vcluster"
             sub_registry="${target_host}"
@@ -207,19 +215,21 @@ data:
             echo "[vcluster-registry-pivot] wrapper image.repository: ${wrapper_repo}"
             echo "[vcluster-registry-pivot] subchart image.registry: ${sub_registry} repository: ${sub_repo_path}"
 
-            # #3695 — a real YAML processor for the Phase-2b/2c git-persist
-            # merges (Principle #15). Line-oriented awk/sed on a multi-document
-            # YAML with an EVOLVING schema is the wrong tool: 13b-bp-sso-bridge.yaml
-            # GAINED a `spec.values` block (the #2940 global.registryMirror
-            # overlay), so the old awk injector's "append a fresh values: under
-            # spec:" produced a SECOND values: key → duplicate-mapping-key →
-            # bootstrap-kit BuildFailed → the root GitOps loop died while
-            # cutoverComplete flipped true. yq MERGES into the existing mapping
-            # and is idempotent against a file that already carries the key.
-            # The alpine/k8s image ships yq (mikefarah/Go yq); if a future image
-            # variant drops it we apk-add it (best-effort; proxied alpine repos),
-            # and fall back to a NO-OP-when-values-exists guard so we can NEVER
-            # re-introduce the duplicate-key corruption.
+            {{- /*
+             #3695 — a real YAML processor for the Phase-2b/2c git-persist
+             merges (Principle #15). Line-oriented awk/sed on a multi-document
+             YAML with an EVOLVING schema is the wrong tool: 13b-bp-sso-bridge.yaml
+             GAINED a `spec.values` block (the #2940 global.registryMirror
+             overlay), so the old awk injector's "append a fresh values: under
+             spec:" produced a SECOND values: key → duplicate-mapping-key →
+             bootstrap-kit BuildFailed → the root GitOps loop died while
+             cutoverComplete flipped true. yq MERGES into the existing mapping
+             and is idempotent against a file that already carries the key.
+             The alpine/k8s image ships yq (mikefarah/Go yq); if a future image
+             variant drops it we apk-add it (best-effort; proxied alpine repos),
+             and fall back to a NO-OP-when-values-exists guard so we can NEVER
+             re-introduce the duplicate-key corruption.
+            */}}
             HAVE_YQ=""
             if command -v yq >/dev/null 2>&1; then
               HAVE_YQ="yes"
@@ -233,35 +243,41 @@ data:
               echo "[vcluster-registry-pivot] WARN yq unavailable — Phase-2 image.repository merge will NO-OP when a values: block already exists (never injects a duplicate); the durable registry host pivot still rides global.registryMirror (Phase-2c)"
             fi
 
-            # ---- Phase 1: live K8s patch on each of the 3 bp-*-vcluster HelmReleases ----
-            #
-            # The bp-*-vcluster wrapper charts each expose:
-            #   spec.values.<role>Vcluster.image.repository   (umbrella)
-            #   spec.values.vcluster.controlPlane.statefulSet.image.{registry,repository}   (subchart)
-            # where <role> is one of {mgmt, rtz, dmz}. We merge-patch
-            # both knobs in a single kubectl invocation per HR so a
-            # partial-patch race can't leave one knob pivoted and the
-            # other not.
-            #
-            # Idempotency: kubectl patch --type=merge is a no-op when
-            # the requested value equals the current value, so re-runs
-            # don't churn the HR resourceVersion. We additionally read
-            # the current wrapper image.repository before patching and
-            # log a SKIP when it's already correct.
+            {{- /*
+             ---- Phase 1: live K8s patch on each of the 3 bp-*-vcluster HelmReleases ----
+
+             The bp-*-vcluster wrapper charts each expose:
+               spec.values.<role>Vcluster.image.repository   (umbrella)
+               spec.values.vcluster.controlPlane.statefulSet.image.{registry,repository}   (subchart)
+             where <role> is one of {mgmt, rtz, dmz}. We merge-patch
+             both knobs in a single kubectl invocation per HR so a
+             partial-patch race can't leave one knob pivoted and the
+             other not.
+
+             Idempotency: kubectl patch --type=merge is a no-op when
+             the requested value equals the current value, so re-runs
+             don't churn the HR resourceVersion. We additionally read
+             the current wrapper image.repository before patching and
+             log a SKIP when it's already correct.
+            */}}
             ok=0
             skip=0
             fail=0
 
             patch_hr() {
-              # $1 = HR name (bp-mgmt-vcluster | bp-rtz-vcluster | bp-dmz-vcluster)
-              # $2 = role key (mgmtVcluster | rtzVcluster | dmzVcluster)
+              {{- /*
+               $1 = HR name (bp-mgmt-vcluster | bp-rtz-vcluster | bp-dmz-vcluster)
+               $2 = role key (mgmtVcluster | rtzVcluster | dmzVcluster)
+              */}}
               hr_name="$1"
               role_key="$2"
 
-              # Skip-if-absent guard. On a primary region the MGMT and
-              # DMZ HRs exist; secondaries only have DMZ + RTZ. We
-              # don't want a missing HR to fail the cutover step on
-              # the wrong topology.
+              {{- /*
+               Skip-if-absent guard. On a primary region the MGMT and
+               DMZ HRs exist; secondaries only have DMZ + RTZ. We
+               don't want a missing HR to fail the cutover step on
+               the wrong topology.
+              */}}
               if ! kubectl get helmrelease "${hr_name}" -n "${HELMRELEASE_NAMESPACE}" >/dev/null 2>&1; then
                 echo "[vcluster-registry-pivot] SKIP ${hr_name} (not present in this region — topology-dependent, expected)"
                 skip=$((skip+1))
@@ -279,8 +295,10 @@ data:
                 return 0
               fi
 
-              # Build a single merge-patch that updates BOTH knobs.
-              # Using a heredoc + printf to keep the JSON readable.
+              {{- /*
+               Build a single merge-patch that updates BOTH knobs.
+               Using a heredoc + printf to keep the JSON readable.
+              */}}
               patch_json=$(printf '{
                 "spec": {
                   "values": {
@@ -307,9 +325,11 @@ data:
                   -n "${HELMRELEASE_NAMESPACE}" \
                   --type=merge --patch "${patch_json}" >/dev/null 2>&1; then
                 echo "[vcluster-registry-pivot] OK ${hr_name} -> wrapper=${wrapper_repo} sub-registry=${sub_registry}"
-                # Trigger immediate Flux reconcile so helm-controller
-                # re-renders the chart within seconds rather than
-                # waiting for the 15m HR interval.
+                {{- /*
+                 Trigger immediate Flux reconcile so helm-controller
+                 re-renders the chart within seconds rather than
+                 waiting for the 15m HR interval.
+                */}}
                 kubectl annotate --overwrite helmrelease "${hr_name}" \
                   -n "${HELMRELEASE_NAMESPACE}" \
                   "reconcile.fluxcd.io/requestedAt=$(date +%s)" >/dev/null 2>&1 || true
@@ -324,33 +344,37 @@ data:
             patch_hr "bp-rtz-vcluster"  "rtzVcluster"
             patch_hr "bp-dmz-vcluster"  "dmzVcluster"
 
-            # ---- Phase 1b: live K8s patch on the bp-sso-bridge HelmRelease (#2951) ----
-            #
-            # bp-sso-bridge's chart default
-            # `image.repository: harbor.openova.io/proxy-dockerhub/alpine/k8s`
-            # keeps the reconciler Pod pulling from mothership Harbor
-            # post-cutover (UAT Wave-2 ATTACK#9, #2940). The
-            # `13b-bp-sso-bridge.yaml` overlay has NO image override, so the
-            # chart default wins on every reconcile. We pivot only the HOST
-            # segment (`harbor.openova.io` → `harbor.${SOVEREIGN_FQDN}`) and
-            # preserve the rest of the path so the local Harbor proxy-
-            # dockerhub project serves the same upstream alpine/k8s image.
-            #
-            # Idempotency: read the current value first; SKIP when it no
-            # longer references harbor.openova.io (already pivoted, or an
-            # operator overlay set a custom host). We never assume a fixed
-            # suffix — we string-replace the literal mothership host so a
-            # future chart image-tag/path change is preserved automatically.
+            {{- /*
+             ---- Phase 1b: live K8s patch on the bp-sso-bridge HelmRelease (#2951) ----
+
+             bp-sso-bridge's chart default
+             `image.repository: harbor.openova.io/proxy-dockerhub/alpine/k8s`
+             keeps the reconciler Pod pulling from mothership Harbor
+             post-cutover (UAT Wave-2 ATTACK#9, #2940). The
+             `13b-bp-sso-bridge.yaml` overlay has NO image override, so the
+             chart default wins on every reconcile. We pivot only the HOST
+             segment (`harbor.openova.io` → `harbor.${SOVEREIGN_FQDN}`) and
+             preserve the rest of the path so the local Harbor proxy-
+             dockerhub project serves the same upstream alpine/k8s image.
+
+             Idempotency: read the current value first; SKIP when it no
+             longer references harbor.openova.io (already pivoted, or an
+             operator overlay set a custom host). We never assume a fixed
+             suffix — we string-replace the literal mothership host so a
+             future chart image-tag/path change is preserved automatically.
+            */}}
             sso_hr="bp-sso-bridge"
             if kubectl get helmrelease "${sso_hr}" -n "${HELMRELEASE_NAMESPACE}" >/dev/null 2>&1; then
               cur_sso=$(kubectl get helmrelease "${sso_hr}" -n "${HELMRELEASE_NAMESPACE}" \
                 -o jsonpath='{.spec.values.image.repository}' 2>/dev/null || echo "")
               if [ -z "${cur_sso}" ]; then
-                # The overlay carries no spec.values.image.repository
-                # override, so the live HR reflects the chart default. Read
-                # it off the chart default literal we know ships today; if
-                # that ever changes the SKIP-on-no-harbor.openova.io guard
-                # below still keeps this safe.
+                {{- /*
+                 The overlay carries no spec.values.image.repository
+                 override, so the live HR reflects the chart default. Read
+                 it off the chart default literal we know ships today; if
+                 that ever changes the SKIP-on-no-harbor.openova.io guard
+                 below still keeps this safe.
+                */}}
                 cur_sso="harbor.openova.io/proxy-dockerhub/alpine/k8s"
               fi
               case "${cur_sso}" in
@@ -380,32 +404,34 @@ data:
               skip=$((skip+1))
             fi
 
-            # ---- Phase 1d: live K8s patch of spec.values.global.registryMirror (#3379, hw139) ----
-            #
-            # The 3 bp-*-vcluster HRs AND bp-sso-bridge each carry a
-            # `spec.values.global.registryMirror` knob (single source of truth
-            # for the image HOST — see each chart's
-            # templates/_helpers.tpl `global.registryMirror | default
-            # "harbor.openova.io"`). The bootstrap-kit overlays set it to
-            # `${REGISTRY_MIRROR:=harbor.openova.io}`, which on a Sovereign
-            # (REGISTRY_MIRROR unset) envsubst-resolves to the LITERAL
-            # `harbor.openova.io`. The Phase-1/1b image.repository pivots above
-            # do NOT touch global.registryMirror, so it stays at mothership
-            # Harbor — and the Phase-1c residual-tether check below greps the
-            # WHOLE spec.values for `harbor.openova.io`, so a surviving
-            # registryMirror makes the check FATAL ("N HelmRelease(s) still
-            # tethered") → BackoffLimitExceeded → cutover wedged at step-10.
-            # That is exactly the hw139 #3379 catch (4 HRs flagged:
-            # bp-mgmt/rtz/dmz-vcluster + bp-sso-bridge).
-            #
-            # Fix: pivot the registryMirror HOST here too
-            # (harbor.openova.io → harbor.${SOVEREIGN_FQDN}) so the residual
-            # check passes AND the vCluster/sso-bridge image pulls actually
-            # resolve through the Sovereign-local Harbor mirror. Idempotent:
-            # SKIP when the live value no longer equals harbor.openova.io
-            # (already pivoted, or an operator overlay set a custom mirror).
+            {{- /*
+             ---- Phase 1d: live K8s patch of spec.values.global.registryMirror (#3379, hw139) ----
+
+             The 3 bp-*-vcluster HRs AND bp-sso-bridge each carry a
+             `spec.values.global.registryMirror` knob (single source of truth
+             for the image HOST — see each chart's
+             templates/_helpers.tpl `global.registryMirror | default
+             "harbor.openova.io"`). The bootstrap-kit overlays set it to
+             `${REGISTRY_MIRROR:=harbor.openova.io}`, which on a Sovereign
+             (REGISTRY_MIRROR unset) envsubst-resolves to the LITERAL
+             `harbor.openova.io`. The Phase-1/1b image.repository pivots above
+             do NOT touch global.registryMirror, so it stays at mothership
+             Harbor — and the Phase-1c residual-tether check below greps the
+             WHOLE spec.values for `harbor.openova.io`, so a surviving
+             registryMirror makes the check FATAL ("N HelmRelease(s) still
+             tethered") → BackoffLimitExceeded → cutover wedged at step-10.
+             That is exactly the hw139 #3379 catch (4 HRs flagged:
+             bp-mgmt/rtz/dmz-vcluster + bp-sso-bridge).
+
+             Fix: pivot the registryMirror HOST here too
+             (harbor.openova.io → harbor.${SOVEREIGN_FQDN}) so the residual
+             check passes AND the vCluster/sso-bridge image pulls actually
+             resolve through the Sovereign-local Harbor mirror. Idempotent:
+             SKIP when the live value no longer equals harbor.openova.io
+             (already pivoted, or an operator overlay set a custom mirror).
+            */}}
             patch_registry_mirror() {
-              # $1 = HR name
+              {{- /* $1 = HR name */}}
               rm_hr="$1"
               kubectl get helmrelease "${rm_hr}" -n "${HELMRELEASE_NAMESPACE}" >/dev/null 2>&1 || {
                 echo "[vcluster-registry-pivot] SKIP registryMirror ${rm_hr} (HR not present)"
@@ -449,25 +475,27 @@ data:
             echo "[vcluster-registry-pivot] live-K8s ok=${ok} skip=${skip} fail=${fail}"
             [ "${fail}" -eq 0 ] || exit 1
 
-            # ---- Phase 1c: residual-tether self-assertion (#2951 / #2940 ATTACK#9) ----
-            #
-            # The four image.repository pivots above (3 vClusters + sso-bridge)
-            # are the ONLY chart-default `harbor.openova.io` tethers this step
-            # owns. Assert directly against live HR state that none of them
-            # still resolves to mothership Harbor, so the cutover Job itself
-            # FAILS LOUDLY rather than leaving a manual post-hoc
-            # `kubectl get hr -A -o yaml | grep harbor.openova.io` as the only
-            # acceptance gate (the VERIFIED-PARTIAL finding on #2940: "the
-            # cutover automation does not assert the pivots actually landed").
-            #
-            # Scope note (Pillar 5 / ADR-0002): we ONLY assert the four image
-            # tethers. We deliberately do NOT flag:
-            #   * powerdns `api.host` — the `11-powerdns.yaml` overlay already
-            #     templates `pdns.${SOVEREIGN_FQDN}` (no live harbor ref).
-            #   * cert-manager-powerdns-webhook `powerdns.host` — an INTENTIONAL
-            #     out-of-cluster ACME DNS-01 tether to contabo's central
-            #     PowerDNS; rewriting it would break wildcard-cert issuance.
-            #   * ghcr.io/openova-io chart-fetch URLs — ADR-0002 cold-start path.
+            {{- /*
+             ---- Phase 1c: residual-tether self-assertion (#2951 / #2940 ATTACK#9) ----
+
+             The four image.repository pivots above (3 vClusters + sso-bridge)
+             are the ONLY chart-default `harbor.openova.io` tethers this step
+             owns. Assert directly against live HR state that none of them
+             still resolves to mothership Harbor, so the cutover Job itself
+             FAILS LOUDLY rather than leaving a manual post-hoc
+             `kubectl get hr -A -o yaml | grep harbor.openova.io` as the only
+             acceptance gate (the VERIFIED-PARTIAL finding on #2940: "the
+             cutover automation does not assert the pivots actually landed").
+
+             Scope note (Pillar 5 / ADR-0002): we ONLY assert the four image
+             tethers. We deliberately do NOT flag:
+               * powerdns `api.host` — the `11-powerdns.yaml` overlay already
+                 templates `pdns.${SOVEREIGN_FQDN}` (no live harbor ref).
+               * cert-manager-powerdns-webhook `powerdns.host` — an INTENTIONAL
+                 out-of-cluster ACME DNS-01 tether to contabo's central
+                 PowerDNS; rewriting it would break wildcard-cert issuance.
+               * ghcr.io/openova-io chart-fetch URLs — ADR-0002 cold-start path.
+            */}}
             residual=0
             for hr_name in bp-mgmt-vcluster bp-rtz-vcluster bp-dmz-vcluster bp-sso-bridge; do
               kubectl get helmrelease "${hr_name}" -n "${HELMRELEASE_NAMESPACE}" >/dev/null 2>&1 || continue
@@ -489,16 +517,18 @@ data:
             fi
             echo "[vcluster-registry-pivot] residual-tether assertion PASS (0 of 4 image HRs on harbor.openova.io)"
 
-            # ---- Phase 2: push YAML edit to local Gitea ----
-            #
-            # bootstrap-kit Kustomization reconciles HelmRelease YAML
-            # from local Gitea every ~1 min. Without this phase, Phase
-            # 1's live patch is silently reverted on the next reconcile
-            # because the YAML in Gitea still lacks the image.repository
-            # override under spec.values. We inject the override block
-            # (same shape used by other Sovereign-overlay knobs in
-            # those files like `nodeSelector` and the existing
-            # `${SOVEREIGN_REGION_CANONICAL_LABEL}` substitutions).
+            {{- /*
+             ---- Phase 2: push YAML edit to local Gitea ----
+
+             bootstrap-kit Kustomization reconciles HelmRelease YAML
+             from local Gitea every ~1 min. Without this phase, Phase
+             1's live patch is silently reverted on the next reconcile
+             because the YAML in Gitea still lacks the image.repository
+             override under spec.values. We inject the override block
+             (same shape used by other Sovereign-overlay knobs in
+             those files like `nodeSelector` and the existing
+             `${SOVEREIGN_REGION_CANONICAL_LABEL}` substitutions).
+            */}}
             export HOME=/tmp
             git config --global user.name "self-sovereign-cutover"
             git config --global user.email "cutover@${SOVEREIGN_FQDN}"
@@ -510,12 +540,14 @@ data:
               sleep 5
             done
 
-            # #5262 — read the step-09 minted `catalyst-gitea-token` PAT for
-            # the git clone/push. Credential hygiene: the PAT is never
-            # echoed; it flows only into the git remote URL (logged in the
-            # redacted form). Bounded wait: step-09 (gitea-token-mint) runs
-            # directly before this step, so a populated token byte is the
-            # steady state; the retry only covers apiserver flakes.
+            {{- /*
+             #5262 — read the step-09 minted `catalyst-gitea-token` PAT for
+             the git clone/push. Credential hygiene: the PAT is never
+             echoed; it flows only into the git remote URL (logged in the
+             redacted form). Bounded wait: step-09 (gitea-token-mint) runs
+             directly before this step, so a populated token byte is the
+             steady state; the retry only covers apiserver flakes.
+            */}}
             echo "[vcluster-registry-pivot] reading PAT ${PAT_SOURCE_NAMESPACE}/${PAT_SOURCE_SECRET_NAME}.${PAT_SOURCE_KEY}"
             GITEA_PAT=""
             for i in $(seq 1 30); do
@@ -548,8 +580,10 @@ data:
               exit 1
             fi
 
-            # The three vCluster HR YAMLs and their role keys.
-            # Format: filename:role_key
+            {{- /*
+             The three vCluster HR YAMLs and their role keys.
+             Format: filename:role_key
+            */}}
             edited=0
             for entry in \
               "54-bp-dmz-vcluster.yaml:dmzVcluster" \
@@ -565,15 +599,19 @@ data:
                 continue
               fi
 
-              # Has the override block already been injected (re-run)?
-              # We look for our sentinel comment + the wrapper-repo URL
-              # under the role_key block.
+              {{- /*
+               Has the override block already been injected (re-run)?
+               We look for our sentinel comment + the wrapper-repo URL
+               under the role_key block.
+              */}}
               if grep -q "# ─── vCluster image registry pivot (TBD-V24 MISS-1) ──" "${path}"; then
-                # Idempotency: rewrite the URL value in case the
-                # SOVEREIGN_FQDN changed between runs (rare but
-                # possible when the operator renames the Sovereign).
-                # We replace the line beginning with `        repository:`
-                # under the role_key block.
+                {{- /*
+                 Idempotency: rewrite the URL value in case the
+                 SOVEREIGN_FQDN changed between runs (rare but
+                 possible when the operator renames the Sovereign).
+                 We replace the line beginning with `        repository:`
+                 under the role_key block.
+                */}}
                 if sed -i -E "/^[[:space:]]{4}${role_key}:[[:space:]]*$/,/^[[:space:]]{0,4}[a-zA-Z]/{s,^([[:space:]]{8}repository:[[:space:]]*).*$,\1${wrapper_repo}," "${path}" 2>/dev/null; then
                   edited=$((edited+1))
                   echo "[vcluster-registry-pivot] rewrote existing image override in ${path}"
@@ -583,11 +621,13 @@ data:
                 continue
               fi
 
-              # No existing override — inject the block under the
-              # `values:` key. The role-key block exists at 4-space
-              # indent under spec.values (every chart >= 0.1.0 ships
-              # this shape; the role keys are `mgmtVcluster`,
-              # `rtzVcluster`, `dmzVcluster`).
+              {{- /*
+               No existing override — inject the block under the
+               `values:` key. The role-key block exists at 4-space
+               indent under spec.values (every chart >= 0.1.0 ships
+               this shape; the role keys are `mgmtVcluster`,
+               `rtzVcluster`, `dmzVcluster`).
+              */}}
               if grep -qE "^[[:space:]]{4}${role_key}:[[:space:]]*$" "${path}"; then
                 awk -v role="${role_key}" -v repo="${wrapper_repo}" -v reg="${sub_registry}" -v rpath="${sub_repo_path}" -v tag="${IMAGE_TAG}" '
                   $0 ~ "^[[:space:]]{4}"role":[[:space:]]*$" && !done {
@@ -616,24 +656,30 @@ data:
                 continue
               fi
 
-              # ALSO inject (or replace) the subchart image block —
-              # the loft-sh upstream image. The file already has a
-              # `vcluster:` block at 4-space indent (every HR YAML
-              # has it for nodeSelector pinning). We append the
-              # subchart image under controlPlane.statefulSet, OR if
-              # the block already exists, replace the registry value.
+              {{- /*
+               ALSO inject (or replace) the subchart image block —
+               the loft-sh upstream image. The file already has a
+               `vcluster:` block at 4-space indent (every HR YAML
+               has it for nodeSelector pinning). We append the
+               subchart image under controlPlane.statefulSet, OR if
+               the block already exists, replace the registry value.
+              */}}
               if grep -qE "^[[:space:]]{8}statefulSet:[[:space:]]*$" "${path}"; then
                 if grep -qE "^[[:space:]]{10}image:[[:space:]]*$" "${path}"; then
-                  # Existing image block under statefulSet — replace
-                  # registry + repository lines at 12-space indent
-                  # using a bounded sed range so we don't touch other
-                  # image: blocks in the same file.
+                  {{- /*
+                   Existing image block under statefulSet — replace
+                   registry + repository lines at 12-space indent
+                   using a bounded sed range so we don't touch other
+                   image: blocks in the same file.
+                  */}}
                   sed -i -E "/^[[:space:]]{10}image:[[:space:]]*$/,/^[[:space:]]{0,10}[a-zA-Z]/{s,^([[:space:]]{12}registry:[[:space:]]*).*$,\1${sub_registry},; s,^([[:space:]]{12}repository:[[:space:]]*).*$,\1${sub_repo_path},}" "${path}" 2>/dev/null || true
                   echo "[vcluster-registry-pivot] rewrote subchart image registry/repository in ${path}"
                 else
-                  # Inject a new image block under statefulSet at
-                  # 10-space indent. statefulSet appears once; we add
-                  # `image:` as a sibling of `scheduling:`.
+                  {{- /*
+                   Inject a new image block under statefulSet at
+                   10-space indent. statefulSet appears once; we add
+                   `image:` as a sibling of `scheduling:`.
+                  */}}
                   awk -v reg="${sub_registry}" -v rpath="${sub_repo_path}" -v tag="${IMAGE_TAG}" '
                     /^[[:space:]]{8}statefulSet:[[:space:]]*$/ && !done {
                       print
@@ -650,38 +696,42 @@ data:
               fi
             done
 
-            # ---- Phase 2b: persist sso-bridge image override to Gitea (#2951/#3695) ----
-            #
-            # 13b-bp-sso-bridge.yaml is a MULTI-DOCUMENT YAML: doc 1 is the
-            # HelmRepository (its `spec:` carries type/url/secretRef), doc 2 is
-            # the HelmRelease whose `spec.values` takes image.repository. Since
-            # #2940 the HelmRelease ALSO carries a `spec.values` block
-            # (global.registryMirror + sovereign.fqdn). The old awk injector
-            # appended a SECOND `values:` under the HelmRelease spec → duplicate
-            # mapping key → bootstrap-kit BuildFailed (hw150). We now MERGE
-            # `image.repository` INTO the existing values mapping with yq,
-            # anchored to the HelmRelease document only (select by kind), so the
-            # result always has exactly ONE `values:` key. Idempotent: yq
-            # assignment is a no-op when the value already matches.
-            #
-            # The repository is host-LESS (proxy-dockerhub/alpine/k8s): the
-            # sso-bridge chart's `bp-sso-bridge.image` helper prepends
-            # global.registryMirror (pivoted durably to harbor.<fqdn> by
-            # Phase-2c), so the registry host has exactly ONE source of truth.
-            # Writing a host-qualified repository here would FIGHT that single
-            # source — the helper honours a host-qualified repo verbatim and
-            # would ignore the pivoted mirror.
+            {{- /*
+             ---- Phase 2b: persist sso-bridge image override to Gitea (#2951/#3695) ----
+
+             13b-bp-sso-bridge.yaml is a MULTI-DOCUMENT YAML: doc 1 is the
+             HelmRepository (its `spec:` carries type/url/secretRef), doc 2 is
+             the HelmRelease whose `spec.values` takes image.repository. Since
+             #2940 the HelmRelease ALSO carries a `spec.values` block
+             (global.registryMirror + sovereign.fqdn). The old awk injector
+             appended a SECOND `values:` under the HelmRelease spec → duplicate
+             mapping key → bootstrap-kit BuildFailed (hw150). We now MERGE
+             `image.repository` INTO the existing values mapping with yq,
+             anchored to the HelmRelease document only (select by kind), so the
+             result always has exactly ONE `values:` key. Idempotent: yq
+             assignment is a no-op when the value already matches.
+
+             The repository is host-LESS (proxy-dockerhub/alpine/k8s): the
+             sso-bridge chart's `bp-sso-bridge.image` helper prepends
+             global.registryMirror (pivoted durably to harbor.<fqdn> by
+             Phase-2c), so the registry host has exactly ONE source of truth.
+             Writing a host-qualified repository here would FIGHT that single
+             source — the helper honours a host-qualified repo verbatim and
+             would ignore the pivoted mirror.
+            */}}
             sso_file="${target_dir}/13b-bp-sso-bridge.yaml"
             sso_repo="proxy-dockerhub/alpine/k8s"
             if [ -f "${sso_file}" ]; then
               if [ -n "${HAVE_YQ}" ]; then
-                # MERGE into the HelmRelease document's spec.values.image.repository.
-                # `(select(.kind=="HelmRelease") | .spec.values.image.repository) = $r`
-                # creates the image: child under the EXISTING values: mapping
-                # (or creates values: if somehow absent) WITHOUT ever emitting a
-                # second values: key. Other documents (HelmRepository) are
-                # untouched. yq preserves the ${REGISTRY_MIRROR:=...} envsubst
-                # placeholders verbatim (they are plain scalar strings to yq).
+                {{- /*
+                 MERGE into the HelmRelease document's spec.values.image.repository.
+                 `(select(.kind=="HelmRelease") | .spec.values.image.repository) = $r`
+                 creates the image: child under the EXISTING values: mapping
+                 (or creates values: if somehow absent) WITHOUT ever emitting a
+                 second values: key. Other documents (HelmRepository) are
+                 untouched. yq preserves the ${REGISTRY_MIRROR:=...} envsubst
+                 placeholders verbatim (they are plain scalar strings to yq).
+                */}}
                 if yq eval -i "(select(.kind == \"HelmRelease\") | .spec.values.image.repository) = \"${sso_repo}\"" "${sso_file}" 2>/dev/null; then
                   echo "[vcluster-registry-pivot] merged sso-bridge image.repository=${sso_repo} into existing values (yq, single values: key) — ${sso_file}"
                   edited=$((edited+1))
@@ -689,13 +739,15 @@ data:
                   echo "[vcluster-registry-pivot] WARN: yq merge of sso-bridge image.repository failed on ${sso_file}; the durable registry host still rides global.registryMirror (Phase-2c)"
                 fi
               elif grep -qE "^[[:space:]]+values:[[:space:]]*$" "${sso_file}"; then
-                # No yq AND a values: block already exists → the awk injector
-                # would duplicate the key. NO-OP rather than corrupt the file:
-                # the registry host pivot is fully covered by Phase-2c's
-                # global.registryMirror rewrite (the image host's single source
-                # of truth), so skipping the image.repository merge does NOT
-                # leave a mothership tether. (#3695: never re-introduce the
-                # duplicate-mapping-key BuildFailed.)
+                {{- /*
+                 No yq AND a values: block already exists → the awk injector
+                 would duplicate the key. NO-OP rather than corrupt the file:
+                 the registry host pivot is fully covered by Phase-2c's
+                 global.registryMirror rewrite (the image host's single source
+                 of truth), so skipping the image.repository merge does NOT
+                 leave a mothership tether. (#3695: never re-introduce the
+                 duplicate-mapping-key BuildFailed.)
+                */}}
                 echo "[vcluster-registry-pivot] NO-OP sso-bridge image.repository merge (no yq + existing values: block) — registry host pivot covered by Phase-2c global.registryMirror"
               else
                 echo "[vcluster-registry-pivot] SKIP sso-bridge image.repository merge (no yq + no values: block) — Phase-1b K8s patch remains durable for one upgrade cycle"
@@ -704,21 +756,23 @@ data:
               echo "[vcluster-registry-pivot] SKIP ${sso_file} (not present)"
             fi
 
-            # ---- Phase 2c: persist global.registryMirror pivot to Gitea (#3379, hw139) ----
-            #
-            # Phase-1d live-patched spec.values.global.registryMirror on the
-            # 4 HRs, but the bootstrap-kit Kustomization reconciles those HR
-            # YAMLs from local Gitea every ~1 min and would REVERT the patch
-            # back to the overlay literal `harbor.openova.io` — re-tethering
-            # the Sovereign + re-arming the Phase-1c residual FATAL on the
-            # NEXT cutover. So rewrite the registryMirror host durably in the
-            # 4 overlay files too. The cloud-init-rendered Gitea copy carries
-            # the post-envsubst literal `registryMirror: harbor.openova.io`
-            # (REGISTRY_MIRROR unset on a Sovereign), so a line-anchored sed
-            # off that literal is exact — registryMirror appears once per
-            # overlay (under global:). Idempotent: a re-run finds the value
-            # already at harbor.${SOVEREIGN_FQDN} and the sed is a no-op
-            # (git diff stays empty for that line).
+            {{- /*
+             ---- Phase 2c: persist global.registryMirror pivot to Gitea (#3379, hw139) ----
+
+             Phase-1d live-patched spec.values.global.registryMirror on the
+             4 HRs, but the bootstrap-kit Kustomization reconciles those HR
+             YAMLs from local Gitea every ~1 min and would REVERT the patch
+             back to the overlay literal `harbor.openova.io` — re-tethering
+             the Sovereign + re-arming the Phase-1c residual FATAL on the
+             NEXT cutover. So rewrite the registryMirror host durably in the
+             4 overlay files too. The cloud-init-rendered Gitea copy carries
+             the post-envsubst literal `registryMirror: harbor.openova.io`
+             (REGISTRY_MIRROR unset on a Sovereign), so a line-anchored sed
+             off that literal is exact — registryMirror appears once per
+             overlay (under global:). Idempotent: a re-run finds the value
+             already at harbor.${SOVEREIGN_FQDN} and the sed is a no-op
+             (git diff stays empty for that line).
+            */}}
             for rm_file in \
               "54-bp-dmz-vcluster.yaml" \
               "58-bp-mgmt-vcluster.yaml" \
@@ -730,14 +784,16 @@ data:
                 echo "[vcluster-registry-pivot] SKIP registryMirror persist ${rm_path} (not present)"
                 continue
               fi
-              # #3695: prefer yq for a structural assignment of the HelmRelease
-              # document's spec.values.global.registryMirror. This is robust to
-              # the overlay carrying the value as a ${REGISTRY_MIRROR:=...}
-              # placeholder OR the post-envsubst literal harbor.openova.io, and
-              # never touches a HelmRepository document in the same file. The
-              # sed fallback (value-replacement on the literal line — safe, it
-              # rewrites a scalar in place and never adds a key) covers a
-              # yq-less image. Idempotent either way.
+              {{- /*
+               #3695: prefer yq for a structural assignment of the HelmRelease
+               document's spec.values.global.registryMirror. This is robust to
+               the overlay carrying the value as a ${REGISTRY_MIRROR:=...}
+               placeholder OR the post-envsubst literal harbor.openova.io, and
+               never touches a HelmRepository document in the same file. The
+               sed fallback (value-replacement on the literal line — safe, it
+               rewrites a scalar in place and never adds a key) covers a
+               yq-less image. Idempotent either way.
+              */}}
               if [ -n "${HAVE_YQ}" ]; then
                 cur=$(yq eval 'select(.kind == "HelmRelease") | .spec.values.global.registryMirror' "${rm_path}" 2>/dev/null | head -1 || true)
                 case "${cur}" in
@@ -768,7 +824,7 @@ data:
             echo "[vcluster-registry-pivot] edited ${edited} files (yq merge / sed fallback)"
             if [ "${edited}" -eq 0 ]; then
               echo "[vcluster-registry-pivot] no edits required — already pivoted in Gitea or files absent"
-              # Phase 1 already succeeded; nothing to push.
+              {{- /* Phase 1 already succeeded; nothing to push. */}}
               exit 0
             fi
 
@@ -785,8 +841,10 @@ data:
             }
             echo "[vcluster-registry-pivot] pushed to ${redacted}"
 
-            # Trigger an immediate Flux reconciliation so the new YAML
-            # lands without waiting for the polling interval.
+            {{- /*
+             Trigger an immediate Flux reconciliation so the new YAML
+             lands without waiting for the polling interval.
+            */}}
             kubectl annotate --overwrite gitrepository openova \
               -n flux-system \
               "reconcile.fluxcd.io/requestedAt=$(date +%s)" >/dev/null || true

--- a/platform/self-sovereign-cutover/chart/templates/11-crossplane-provider-pivot-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/11-crossplane-provider-pivot-job.yaml
@@ -107,16 +107,20 @@ data:
     serviceAccountName: {{ include "bp-self-sovereign-cutover.serviceAccountName" . }}
     restartPolicy: Never
     activeDeadlineSeconds: {{ .Values.stepTimeouts.crossplaneProviderPivotSeconds }}
-    # #5262 — the #5214 gitea-admin-secret self-heal initContainer is GONE
-    # from this step: the Phase-2 git clone/push now authenticates with the
-    # step-09 minted `catalyst-gitea-token` PAT (read at runtime below), so
-    # this step no longer consumes gitea-admin-secret at all and must not
-    # keep a wedge-path on its presence (contract Case 63 asserts absence).
+    {{- /*
+     #5262 — the #5214 gitea-admin-secret self-heal initContainer is GONE
+     from this step: the Phase-2 git clone/push now authenticates with the
+     step-09 minted `catalyst-gitea-token` PAT (read at runtime below), so
+     this step no longer consumes gitea-admin-secret at all and must not
+     keep a wedge-path on its presence (contract Case 63 asserts absence).
+    */}}
     containers:
       - name: crossplane-provider-pivot
-        # alpine/k8s carries both kubectl AND git so we can patch live
-        # Provider CRs AND push the YAML edit to local Gitea (same
-        # image Steps 06/10 use for the same reason).
+        {{- /*
+         alpine/k8s carries both kubectl AND git so we can patch live
+         Provider CRs AND push the YAML edit to local Gitea (same
+         image Steps 06/10 use for the same reason).
+        */}}
         image: harbor.openova.io/proxy-dockerhub/alpine/k8s:1.31.4
         imagePullPolicy: IfNotPresent
         env:
@@ -124,13 +128,15 @@ data:
             value: {{ .Values.sovereign.fqdn | quote }}
           - name: GITEA_INTERNAL_URL
             value: {{ .Values.sovereign.giteaInternalURL | quote }}
-          # #5262 (live hw277) — the Phase-2 git clone/push authenticates
-          # with the step-09 minted `catalyst-gitea-token` PAT, NOT the
-          # gitea admin password (which can rotate out from under Gitea's
-          # DB on a mid-cutover bp-gitea re-render → clone 401, git exit
-          # 128, the hw277 wedge). Same rationale + wiring as step-10;
-          # username stays the admin login for commit auditability
-          # (gitRepositorySecretRef.username).
+          {{- /*
+           #5262 (live hw277) — the Phase-2 git clone/push authenticates
+           with the step-09 minted `catalyst-gitea-token` PAT, NOT the
+           gitea admin password (which can rotate out from under Gitea's
+           DB on a mid-cutover bp-gitea re-render → clone 401, git exit
+           128, the hw277 wedge). Same rationale + wiring as step-10;
+           username stays the admin login for commit auditability
+           (gitRepositorySecretRef.username).
+          */}}
           - name: GITEA_USERNAME
             value: {{ .Values.gitRepositorySecretRef.username | quote }}
           - name: PAT_SOURCE_NAMESPACE
@@ -147,24 +153,30 @@ data:
             value: {{ .Values.crossplaneProviderPivot.upstreamHost | quote }}
           - name: REGISTRY_PATH
             value: {{ .Values.crossplaneProviderPivot.registryPath | quote }}
-          # #4488 — the mothership proxy-xpkg prefix a Huawei fresh prov
-          # already carries in provider-opentofu's spec.package. Pivoted to
-          # harbor.<fqdn>/proxy-xpkg too so no harbor.openova.io tether
-          # survives the cutover (Principle #11).
+          {{- /*
+           #4488 — the mothership proxy-xpkg prefix a Huawei fresh prov
+           already carries in provider-opentofu's spec.package. Pivoted to
+           harbor.<fqdn>/proxy-xpkg too so no harbor.openova.io tether
+           survives the cutover (Principle #11).
+          */}}
           - name: MOTHERSHIP_PROXY_PREFIX
             value: {{ .Values.crossplaneProviderPivot.mothershipProxyPrefix | quote }}
-          # #5204 — package-pull AUTH for the Sovereign-local Harbor. The
-          # canonical public registry host (registry.<sov-fqdn>) is derived
-          # from HARBOR_PUBLIC_URL exactly the way step 03/06 do; the pivot
-          # host (harbor.<sov-fqdn>) is computed from SOVEREIGN_FQDN below.
-          # Both are covered by the pull Secret + ImageConfig so the Crossplane
-          # package manager authenticates against whichever alias a Provider's
-          # spec.package carries.
+          {{- /*
+           #5204 — package-pull AUTH for the Sovereign-local Harbor. The
+           canonical public registry host (registry.<sov-fqdn>) is derived
+           from HARBOR_PUBLIC_URL exactly the way step 03/06 do; the pivot
+           host (harbor.<sov-fqdn>) is computed from SOVEREIGN_FQDN below.
+           Both are covered by the pull Secret + ImageConfig so the Crossplane
+           package manager authenticates against whichever alias a Provider's
+           spec.package carries.
+          */}}
           - name: HARBOR_PUBLIC_URL
             value: {{ .Values.sovereign.harborPublicURL | quote }}
-          # #5204 verify-before-pivot — the in-cluster Harbor Service URL for
-          # the artifact-API durable-presence probe (#5036 direct-Service
-          # path; single-encode %2F) + the operator toggle.
+          {{- /*
+           #5204 verify-before-pivot — the in-cluster Harbor Service URL for
+           the artifact-API durable-presence probe (#5036 direct-Service
+           path; single-encode %2F) + the operator toggle.
+          */}}
           - name: HARBOR_INTERNAL_URL
             value: {{ .Values.sovereign.harborInternalURL | quote }}
           - name: VERIFY_LOCAL_ARTIFACT
@@ -188,16 +200,20 @@ data:
             value: {{ .Values.crossplaneProviderPivot.packagePullAuth.pullSecretName | quote }}
           - name: IMAGE_CONFIG_NAME
             value: {{ .Values.crossplaneProviderPivot.packagePullAuth.imageConfigName | quote }}
-          # #5232 (Refs #5226 #5204) — the tag->digest map step-03 Phase A4
-          # minted (Harbor proxy-cache never records TAGS for pulled-through
-          # xpkg artifacts, so every pivot ref below is digest-addressed).
-          # SAME values-driven ConfigMap name as step-03 — no drift.
+          {{- /*
+           #5232 (Refs #5226 #5204) — the tag->digest map step-03 Phase A4
+           minted (Harbor proxy-cache never records TAGS for pulled-through
+           xpkg artifacts, so every pivot ref below is digest-addressed).
+           SAME values-driven ConfigMap name as step-03 — no drift.
+          */}}
           - name: XPKG_DIGEST_CM
             value: {{ .Values.prewarm.xpkgPackages.digestMapConfigMapName | quote }}
           - name: RELEASE_NAMESPACE
             value: {{ .Release.Namespace | quote }}
-          # The cutover status ConfigMap — named in the DIGEST-MISS recovery
-          # message (clearing step.harbor-prewarm.result forces the re-warm).
+          {{- /*
+           The cutover status ConfigMap — named in the DIGEST-MISS recovery
+           message (clearing step.harbor-prewarm.result forces the re-warm).
+          */}}
           - name: STATUS_CM
             value: {{ .Values.status.configMapName | quote }}
         volumeMounts:
@@ -208,11 +224,13 @@ data:
           - |
             set -eu
 
-            # Compute the Sovereign-local target prefix. The Crossplane
-            # Provider's `spec.package` is HOST + PATH + ":" + TAG
-            # (e.g. xpkg.upbound.io/crossplane-contrib/provider-hcloud:
-            # v0.4.0). We rewrite ONLY the HOST + PATH-prefix segment
-            # so the upstream path + tag are preserved untouched.
+            {{- /*
+             Compute the Sovereign-local target prefix. The Crossplane
+             Provider's `spec.package` is HOST + PATH + ":" + TAG
+             (e.g. xpkg.upbound.io/crossplane-contrib/provider-hcloud:
+             v0.4.0). We rewrite ONLY the HOST + PATH-prefix segment
+             so the upstream path + tag are preserved untouched.
+            */}}
             target_host="harbor.${SOVEREIGN_FQDN}"
             target_prefix="${target_host}/${REGISTRY_PATH}"
             upstream_prefix="${UPSTREAM_HOST}"
@@ -221,42 +239,46 @@ data:
             echo "[crossplane-provider-pivot] upstream:      ${upstream_prefix}"
             echo "[crossplane-provider-pivot] target prefix: ${target_prefix}"
 
-            # ---- Phase 0: wire package-pull AUTH (ImageConfig + Secret) ----
-            #
-            # #5204 (Refs #3379). Pivoting spec.package to the local Harbor's
-            # `proxy-xpkg` project is NOT sufficient: `proxy-xpkg` is a Harbor
-            # PROXY-CACHE project, and Harbor requires an AUTHENTICATED pull
-            # from a proxy-cache project even when the project is public
-            # (unlike the push-mode offline-mirror projects step 02 creates
-            # public:true for anonymous pull). The Crossplane package manager
-            # (go-containerregistry remote.Image()) uses its OWN registry-auth
-            # path — NOT the node containerd certs.d (step 04) nor the
-            # flux-system/ghcr-pull dockerconfigjson (step 06, wired for Flux
-            # source-controller). With no credential wired it pulls anonymously
-            # and 401s (live hw270: provider-opentofu Installed=False,
-            # UnpackingPackage, 401 Unauthorized) — a latent Pillar-5 gap: the
-            # existing revision keeps running, but the Sovereign can never
-            # upgrade its own Crossplane providers post-severance.
-            #
-            # FIX (Crossplane 1.18 native): create a dockerconfigjson Secret in
-            # the Crossplane namespace carrying the SAME admin:<HARBOR password>
-            # credential step 02/03/06 use, and an ImageConfig
-            # (pkg.crossplane.io/v1beta1) whose matchImages prefixes cover the
-            # pivot host `harbor.<fqdn>/proxy-xpkg` AND the canonical
-            # `registry.<fqdn>/proxy-xpkg` alias, with
-            # spec.registry.authentication.pullSecretRef -> that Secret. The
-            # package manager then authenticates every package pull against the
-            # local Harbor. Runs BEFORE Phase 1 so the spec.package patch's
-            # immediate re-pull already has auth. Idempotent (kubectl apply).
+            {{- /*
+             ---- Phase 0: wire package-pull AUTH (ImageConfig + Secret) ----
+
+             #5204 (Refs #3379). Pivoting spec.package to the local Harbor's
+             `proxy-xpkg` project is NOT sufficient: `proxy-xpkg` is a Harbor
+             PROXY-CACHE project, and Harbor requires an AUTHENTICATED pull
+             from a proxy-cache project even when the project is public
+             (unlike the push-mode offline-mirror projects step 02 creates
+             public:true for anonymous pull). The Crossplane package manager
+             (go-containerregistry remote.Image()) uses its OWN registry-auth
+             path — NOT the node containerd certs.d (step 04) nor the
+             flux-system/ghcr-pull dockerconfigjson (step 06, wired for Flux
+             source-controller). With no credential wired it pulls anonymously
+             and 401s (live hw270: provider-opentofu Installed=False,
+             UnpackingPackage, 401 Unauthorized) — a latent Pillar-5 gap: the
+             existing revision keeps running, but the Sovereign can never
+             upgrade its own Crossplane providers post-severance.
+
+             FIX (Crossplane 1.18 native): create a dockerconfigjson Secret in
+             the Crossplane namespace carrying the SAME admin:<HARBOR password>
+             credential step 02/03/06 use, and an ImageConfig
+             (pkg.crossplane.io/v1beta1) whose matchImages prefixes cover the
+             pivot host `harbor.<fqdn>/proxy-xpkg` AND the canonical
+             `registry.<fqdn>/proxy-xpkg` alias, with
+             spec.registry.authentication.pullSecretRef -> that Secret. The
+             package manager then authenticates every package pull against the
+             local Harbor. Runs BEFORE Phase 1 so the spec.package patch's
+             immediate re-pull already has auth. Idempotent (kubectl apply).
+            */}}
             registry_host="$(printf '%s' "${HARBOR_PUBLIC_URL}" | sed -E 's,^https?://,,; s,/.*$,,')"
 
             if [ "${PACKAGE_PULL_AUTH_ENABLED}" != "true" ]; then
               echo "[crossplane-provider-pivot] Phase 0 SKIP — packagePullAuth.enabled=false"
             elif ! kubectl get crd imageconfigs.pkg.crossplane.io >/dev/null 2>&1; then
-              # Same very-early-handover guard Phase 1 uses: bp-crossplane not
-              # installed yet (no ImageConfig CRD, no crossplane-system ns).
-              # Phase 2 still rewrites Gitea so the eventual install pulls the
-              # pivoted URL; a step re-run once crossplane lands wires the auth.
+              {{- /*
+               Same very-early-handover guard Phase 1 uses: bp-crossplane not
+               installed yet (no ImageConfig CRD, no crossplane-system ns).
+               Phase 2 still rewrites Gitea so the eventual install pulls the
+               pivoted URL; a step re-run once crossplane lands wires the auth.
+              */}}
               echo "[crossplane-provider-pivot] Phase 0 SKIP — imageconfigs.pkg.crossplane.io CRD not installed yet (bp-crossplane not landed); auth wired on a later step re-run"
             else
               if [ -z "${HARBOR_PASSWORD:-}" ]; then
@@ -267,9 +289,11 @@ data:
               echo "[crossplane-provider-pivot] Phase 0: wiring package-pull auth in ns ${CROSSPLANE_NAMESPACE} for ${target_host} + ${registry_host}"
 
               harbor_auth="$(printf '%s:%s' "${HARBOR_USERNAME}" "${HARBOR_PASSWORD}" | base64 | tr -d '\n')"
-              # Auth keyed on BOTH aliases (exact host[:port] match by
-              # go-containerregistry). --arg keeps the password a literal
-              # (never re-parsed by the shell).
+              {{- /*
+               Auth keyed on BOTH aliases (exact host[:port] match by
+               go-containerregistry). --arg keeps the password a literal
+               (never re-parsed by the shell).
+              */}}
               dockercfg="$(jq -cn \
                 --arg th "${target_host}" \
                 --arg rh "${registry_host}" \
@@ -278,11 +302,13 @@ data:
                 '{auths: {($th): {username: $user, auth: $auth}, ($rh): {username: $user, auth: $auth}}}')"
               dockercfg_b64="$(printf '%s' "${dockercfg}" | base64 | tr -d '\n')"
 
-              # dockerconfigjson pull Secret — kubectl apply is idempotent
-              # (re-run rotates the password bytes cleanly). Built with printf
-              # and piped: a plain heredoc terminator cannot sit at column 0
-              # inside this YAML block scalar, so printf is the robust idiom.
-              # Nothing is written to disk (readOnlyRootFilesystem honoured).
+              {{- /*
+               dockerconfigjson pull Secret — kubectl apply is idempotent
+               (re-run rotates the password bytes cleanly). Built with printf
+               and piped: a plain heredoc terminator cannot sit at column 0
+               inside this YAML block scalar, so printf is the robust idiom.
+               Nothing is written to disk (readOnlyRootFilesystem honoured).
+              */}}
               secret_manifest="$(printf 'apiVersion: v1\nkind: Secret\nmetadata:\n  name: %s\n  namespace: %s\n  labels:\n    app.kubernetes.io/managed-by: self-sovereign-cutover\n    bp.openova.io/cutover-step: crossplane-provider-pivot\ntype: kubernetes.io/dockerconfigjson\ndata:\n  .dockerconfigjson: %s\n' \
                 "${PULL_SECRET_NAME}" "${CROSSPLANE_NAMESPACE}" "${dockercfg_b64}")"
               if ! printf '%s' "${secret_manifest}" | kubectl apply -f - >/dev/null; then
@@ -291,9 +317,11 @@ data:
               fi
               echo "[crossplane-provider-pivot]   OK Secret ${CROSSPLANE_NAMESPACE}/${PULL_SECRET_NAME}"
 
-              # ImageConfig binds the matchImages prefixes to the pull Secret.
-              # pullSecretRef resolves in the Crossplane install namespace.
-              # Same printf-piped idiom (no column-0 heredoc terminator).
+              {{- /*
+               ImageConfig binds the matchImages prefixes to the pull Secret.
+               pullSecretRef resolves in the Crossplane install namespace.
+               Same printf-piped idiom (no column-0 heredoc terminator).
+              */}}
               imageconfig_manifest="$(printf 'apiVersion: pkg.crossplane.io/v1beta1\nkind: ImageConfig\nmetadata:\n  name: %s\n  labels:\n    app.kubernetes.io/managed-by: self-sovereign-cutover\n    bp.openova.io/cutover-step: crossplane-provider-pivot\nspec:\n  matchImages:\n    - prefix: %s/%s\n    - prefix: %s/%s\n  registry:\n    authentication:\n      pullSecretRef:\n        name: %s\n' \
                 "${IMAGE_CONFIG_NAME}" "${target_host}" "${REGISTRY_PATH}" "${registry_host}" "${REGISTRY_PATH}" "${PULL_SECRET_NAME}")"
               if ! printf '%s' "${imageconfig_manifest}" | kubectl apply -f - >/dev/null; then
@@ -303,30 +331,34 @@ data:
               echo "[crossplane-provider-pivot]   OK ImageConfig ${IMAGE_CONFIG_NAME} (matchImages: ${target_host}/${REGISTRY_PATH}, ${registry_host}/${REGISTRY_PATH})"
             fi
 
-            # ---- Phase 0.5 (#5204): local-artifact verify gate ----
-            #
-            # Rewrite a Provider's spec.package onto the local Harbor ONLY
-            # after the registry v2 manifest API confirms the package's digest
-            # is durably served locally (#5232 round 2, live hw274 — the
-            # multi-arch-aware durability signal; the Harbor artifact-
-            # management API records only the per-arch CHILD manifests for a
-            # multi-arch package and never exposes the top-level OCI index by
-            # its own digest, so a digest-addressed artifact-API probe 404s
-            # even when the index IS durable + servable via /v2, exactly
-            # containerd/Crossplane's pull path). Step-03 Phase A4 warms every
-            # Provider package through proxy-xpkg for exactly this; a miss here
-            # means the warm never ran / was skipped for this package (e.g. a
-            # Provider created mid-cutover after step-03 enumerated), and
-            # pivoting anyway would point spec.package at a ref the local
-            # registry cannot serve post-severance. FAIL-LOUD: the offender is
-            # named and the step exits 1 so the operator re-triggers the
-            # cutover (step-03 re-warms, idempotent) instead of shipping a
-            # silently-dangling pivot.
+            {{- /*
+             ---- Phase 0.5 (#5204): local-artifact verify gate ----
+
+             Rewrite a Provider's spec.package onto the local Harbor ONLY
+             after the registry v2 manifest API confirms the package's digest
+             is durably served locally (#5232 round 2, live hw274 — the
+             multi-arch-aware durability signal; the Harbor artifact-
+             management API records only the per-arch CHILD manifests for a
+             multi-arch package and never exposes the top-level OCI index by
+             its own digest, so a digest-addressed artifact-API probe 404s
+             even when the index IS durable + servable via /v2, exactly
+             containerd/Crossplane's pull path). Step-03 Phase A4 warms every
+             Provider package through proxy-xpkg for exactly this; a miss here
+             means the warm never ran / was skipped for this package (e.g. a
+             Provider created mid-cutover after step-03 enumerated), and
+             pivoting anyway would point spec.package at a ref the local
+             registry cannot serve post-severance. FAIL-LOUD: the offender is
+             named and the step exits 1 so the operator re-triggers the
+             cutover (step-03 re-warms, idempotent) instead of shipping a
+             silently-dangling pivot.
+            */}}
             verify_local_pkg_artifact() {
-              # $1 = local path project/repo@sha256:<digest> (step-11 always
-              # verifies BY DIGEST). 0 = the registry v2 API durably serves
-              # that digest (200) OR verification not applicable (disabled / no
-              # credential to probe with).
+              {{- /*
+               $1 = local path project/repo@sha256:<digest> (step-11 always
+               verifies BY DIGEST). 0 = the registry v2 API durably serves
+               that digest (200) OR verification not applicable (disabled / no
+               credential to probe with).
+              */}}
               case "${VERIFY_LOCAL_ARTIFACT:-true}" in
                 true|True|TRUE|1|yes) : ;;
                 *) return 0 ;;
@@ -349,52 +381,62 @@ data:
                 */*) : ;;
                 *)   return 1 ;;
               esac
-              # Registry v2 manifest API: LITERAL-slash repo path (no %2F
-              # encode — the /v2 API takes the nested repo name verbatim), the
-              # digest as the reference, must serve 200. Accept covers OCI
-              # index + docker manifest list + single manifest so a single-arch
-              # package (manifest.v2 digest, equally servable) needs no
-              # special-casing.
+              {{- /*
+               Registry v2 manifest API: LITERAL-slash repo path (no %2F
+               encode — the /v2 API takes the nested repo name verbatim), the
+               digest as the reference, must serve 200. Accept covers OCI
+               index + docker manifest list + single manifest so a single-arch
+               package (manifest.v2 digest, equally servable) needs no
+               special-casing.
+              */}}
               _vcode=$(curl -sk -o /dev/null -w '%{http_code}' --max-time 30 \
                 -u "${HARBOR_USERNAME}:${HARBOR_PASSWORD}" \
                 -H 'Accept: application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.v2+json' \
                 "${HARBOR_INTERNAL_URL}/v2/${_vp}/manifests/${_vref}" 2>/dev/null)
               [ "${_vcode}" = "200" ]
             }
-            # Sentinel: the Phase-1 while-loop runs in a pipeline subshell, so
-            # a verify miss records here and the parent FATALs after the loop.
+            {{- /*
+             Sentinel: the Phase-1 while-loop runs in a pipeline subshell, so
+             a verify miss records here and the parent FATALs after the loop.
+            */}}
             rm -f /tmp/xpkg-verify-failed
 
-            # ---- #5232: digest-addressed pivot refs ----
-            #
-            # Harbor proxy-cache NEVER records TAGS for pulled-through xpkg
-            # artifacts (live hw274 dep d51a69f885872a81: manual tag-create
-            # 401s on proxy projects; a fresh tag manifest GET serves the OCI
-            # index but still records no tag — deterministic), so a tag-form
-            # local ref genuinely 404s post-severance. Every spec.package
-            # pivot below is therefore DIGEST-addressed:
-            #   registry-path preserved, tag replaced by @sha256:<digest>.
-            # Crossplane's package manager accepts digest refs: spec.package
-            # is an unrestricted string (pkg.crossplane.io_providers.yaml CRD)
-            # parsed by go-containerregistry name.ParseReference (crossplane
-            # v1.18.0 internal/controller/pkg/manager/revisioner.go), and the
-            # xpkg naming layer treats ":@" as the identifier delimiter set
-            # (internal/xpkg/name.go) — digest identifiers are first-class.
-            # The ONLY digest mint is step-03 Phase A4's full pull-through +
-            # durable verify; there is NO live re-resolve here (a fresh tag
-            # GET through the proxy could record a manifest with COLD blobs).
+            {{- /*
+             ---- #5232: digest-addressed pivot refs ----
+
+             Harbor proxy-cache NEVER records TAGS for pulled-through xpkg
+             artifacts (live hw274 dep d51a69f885872a81: manual tag-create
+             401s on proxy projects; a fresh tag manifest GET serves the OCI
+             index but still records no tag — deterministic), so a tag-form
+             local ref genuinely 404s post-severance. Every spec.package
+             pivot below is therefore DIGEST-addressed:
+               registry-path preserved, tag replaced by @sha256:<digest>.
+             Crossplane's package manager accepts digest refs: spec.package
+             is an unrestricted string (pkg.crossplane.io_providers.yaml CRD)
+             parsed by go-containerregistry name.ParseReference (crossplane
+             v1.18.0 internal/controller/pkg/manager/revisioner.go), and the
+             xpkg naming layer treats ":@" as the identifier delimiter set
+             (internal/xpkg/name.go) — digest identifiers are first-class.
+             The ONLY digest mint is step-03 Phase A4's full pull-through +
+             durable verify; there is NO live re-resolve here (a fresh tag
+             GET through the proxy could record a manifest with COLD blobs).
+            */}}
             xpkg_digest_map_json=$(kubectl get configmap "${XPKG_DIGEST_CM}" -n "${RELEASE_NAMESPACE}" -o json 2>/dev/null) || xpkg_digest_map_json='{}'
             [ -n "${xpkg_digest_map_json}" ] || xpkg_digest_map_json='{}'
             lookup_pkg_digest() {
-              # $1 = local path project/repo[:tag]; echoes the sha256:<hex>
-              # step-03 Phase A4 minted for this exact ref, or empty on miss.
-              # SAME slug idiom as step-03 (tr -c 'A-Za-z0-9._-' '_').
+              {{- /*
+               $1 = local path project/repo[:tag]; echoes the sha256:<hex>
+               step-03 Phase A4 minted for this exact ref, or empty on miss.
+               SAME slug idiom as step-03 (tr -c 'A-Za-z0-9._-' '_').
+              */}}
               _ld_slug=$(printf '%s' "$1" | tr -c 'A-Za-z0-9._-' '_')
               printf '%s' "${xpkg_digest_map_json}" | jq -r --arg k "${_ld_slug}" '.data[$k] // empty' 2>/dev/null || true
             }
-            # split_pkg_ref REF -> sets _sp_repo (path with no ref) and
-            # _sp_digest (sha256:<hex> when REF carries one, else empty).
-            # Handles tag, digest, and the #4955 tag@digest shapes.
+            {{- /*
+             split_pkg_ref REF -> sets _sp_repo (path with no ref) and
+             _sp_digest (sha256:<hex> when REF carries one, else empty).
+             Handles tag, digest, and the #4955 tag@digest shapes.
+            */}}
             split_pkg_ref() {
               _sp_repo="$1"; _sp_digest=""
               case "${_sp_repo}" in
@@ -406,17 +448,19 @@ data:
               esac
             }
 
-            # ---- Phase 1: live K8s patch on every Provider CR ----
-            #
-            # `kubectl get providers.pkg.crossplane.io` is cluster-scoped
-            # (Provider is a non-namespaced CR). We iterate the list and
-            # patch any Provider whose .spec.package host == UPSTREAM_HOST.
-            # Skip-if-absent guard: if the CRD itself isn't installed
-            # (very early on a freshly-handed-over Sovereign before
-            # bp-crossplane lands), exit 0 cleanly — the bootstrap-kit
-            # will eventually install Crossplane + the Provider CR, and
-            # Phase-2 has already rewritten the YAML so the on-install
-            # spec.package will be the pivoted one.
+            {{- /*
+             ---- Phase 1: live K8s patch on every Provider CR ----
+
+             `kubectl get providers.pkg.crossplane.io` is cluster-scoped
+             (Provider is a non-namespaced CR). We iterate the list and
+             patch any Provider whose .spec.package host == UPSTREAM_HOST.
+             Skip-if-absent guard: if the CRD itself isn't installed
+             (very early on a freshly-handed-over Sovereign before
+             bp-crossplane lands), exit 0 cleanly — the bootstrap-kit
+             will eventually install Crossplane + the Provider CR, and
+             Phase-2 has already rewritten the YAML so the on-install
+             spec.package will be the pivoted one.
+            */}}
             if ! kubectl get crd providers.pkg.crossplane.io >/dev/null 2>&1; then
               echo "[crossplane-provider-pivot] SKIP Phase 1 — providers.pkg.crossplane.io CRD not installed yet"
               echo "[crossplane-provider-pivot] Phase 2 will still rewrite YAML in Gitea so the eventual install pulls from ${target_host}"
@@ -430,26 +474,30 @@ data:
             fail=0
 
             if [ "${phase1_skip}" -eq 0 ]; then
-              # List Provider CRs. JSONPath emits one line per Provider
-              # with `<name> <spec.package>` separated by tab so a
-              # while-read loop can parse without word-splitting on the
-              # package string (which can contain colons and slashes).
+              {{- /*
+               List Provider CRs. JSONPath emits one line per Provider
+               with `<name> <spec.package>` separated by tab so a
+               while-read loop can parse without word-splitting on the
+               package string (which can contain colons and slashes).
+              */}}
               providers_tsv=$(kubectl get providers.pkg.crossplane.io \
                 -o 'jsonpath={range .items[*]}{.metadata.name}{"\t"}{.spec.package}{"\n"}{end}' 2>/dev/null || echo "")
 
               if [ -z "${providers_tsv}" ]; then
                 echo "[crossplane-provider-pivot] no Provider CRs found in cluster (skip Phase 1)"
               else
-                # Use a heredoc + IFS=$'\t' to safely parse the TSV.
+                {{- /* Use a heredoc + IFS=$'\t' to safely parse the TSV. */}}
                 printf '%s\n' "${providers_tsv}" | while IFS="$(printf '\t')" read -r name pkg; do
                   if [ -z "${name}" ]; then continue; fi
 
-                  # #4488 — match EITHER the raw upstream host
-                  # (xpkg.upbound.io/..., Hetzner) OR the mothership
-                  # proxy-xpkg prefix (harbor.openova.io/proxy-xpkg/...,
-                  # the Huawei fresh-prov shape). Both rewrite to the
-                  # Sovereign-local target_prefix, preserving the path+tag
-                  # after the matched prefix.
+                  {{- /*
+                   #4488 — match EITHER the raw upstream host
+                   (xpkg.upbound.io/..., Hetzner) OR the mothership
+                   proxy-xpkg prefix (harbor.openova.io/proxy-xpkg/...,
+                   the Huawei fresh-prov shape). Both rewrite to the
+                   Sovereign-local target_prefix, preserving the path+tag
+                   after the matched prefix.
+                  */}}
                   matched_prefix=""
                   case "${pkg}" in
                     "${upstream_prefix}/"*)              matched_prefix="${upstream_prefix}" ;;
@@ -458,12 +506,14 @@ data:
 
                   case "${pkg}" in
                     "${upstream_prefix}/"* | "${MOTHERSHIP_PROXY_PREFIX}/"*)
-                      # Compute the DIGEST pivot ref (#5232): registry path
-                      # from the matched suffix + the digest step-03 minted
-                      # (or the digest the source ref itself carries, the
-                      # #4955 shape). A tag-form pivot ref is FORBIDDEN — it
-                      # 404s post-severance (Harbor records no tags on proxy
-                      # projects).
+                      {{- /*
+                       Compute the DIGEST pivot ref (#5232): registry path
+                       from the matched suffix + the digest step-03 minted
+                       (or the digest the source ref itself carries, the
+                       #4955 shape). A tag-form pivot ref is FORBIDDEN — it
+                       404s post-severance (Harbor records no tags on proxy
+                       projects).
+                      */}}
                       pkg_suffix="${pkg#${matched_prefix}/}"
                       split_pkg_ref "${pkg_suffix}"
                       pkg_repo="${_sp_repo}"
@@ -476,8 +526,10 @@ data:
                         touch /tmp/xpkg-verify-failed
                         continue
                       fi
-                      # #5204/#5232 verify-before-pivot BY DIGEST: the exact
-                      # artifact MUST be durably present BEFORE the rewrite.
+                      {{- /*
+                       #5204/#5232 verify-before-pivot BY DIGEST: the exact
+                       artifact MUST be durably present BEFORE the rewrite.
+                      */}}
                       if ! verify_local_pkg_artifact "${REGISTRY_PATH}/${pkg_repo}@${pkg_digest}"; then
                         echo "[crossplane-provider-pivot] VERIFY-FAIL ${name}: local Harbor does not durably serve ${REGISTRY_PATH}/${pkg_repo}@${pkg_digest} — refusing to pivot spec.package onto a ref the local registry cannot serve post-severance (#5204 #5232; step-03 Phase A4 should have warmed it)" >&2
                         touch /tmp/xpkg-verify-failed
@@ -485,25 +537,29 @@ data:
                       fi
                       new_pkg="${target_prefix}/${pkg_repo}@${pkg_digest}"
                       echo "[crossplane-provider-pivot] PATCH ${name} ${pkg} -> ${new_pkg}"
-                      # Merge-patch only spec.package — preserves every
-                      # other spec field (revisionActivationPolicy,
-                      # packagePullPolicy, controllerConfigRef, etc.).
+                      {{- /*
+                       Merge-patch only spec.package — preserves every
+                       other spec field (revisionActivationPolicy,
+                       packagePullPolicy, controllerConfigRef, etc.).
+                      */}}
                       patch_json=$(printf '{"spec":{"package":"%s"}}' "${new_pkg}")
                       if kubectl patch provider.pkg.crossplane.io "${name}" \
                           --type=merge --patch "${patch_json}" >/dev/null 2>&1; then
                         echo "[crossplane-provider-pivot]   OK ${name}"
                       else
-                        # #5436 (same class as step-06): this arm used to
-                        # print FAIL and nothing else — no counter, no
-                        # marker, no exit. The Provider stayed on
-                        # xpkg.upbound.io / the mothership proxy, the loop
-                        # ran in a `printf | while` SUBSHELL so a variable
-                        # could not carry the verdict out anyway, and the
-                        # step exited 0 with the tether intact. Record it on
-                        # the SAME marker file the #5204 verify misses use,
-                        # so the fail-loud check below (which already runs
-                        # BEFORE the durable Gitea rewrite) covers a failed
-                        # patch too.
+                        {{- /*
+                         #5436 (same class as step-06): this arm used to
+                         print FAIL and nothing else — no counter, no
+                         marker, no exit. The Provider stayed on
+                         xpkg.upbound.io / the mothership proxy, the loop
+                         ran in a `printf | while` SUBSHELL so a variable
+                         could not carry the verdict out anyway, and the
+                         step exited 0 with the tether intact. Record it on
+                         the SAME marker file the #5204 verify misses use,
+                         so the fail-loud check below (which already runs
+                         BEFORE the durable Gitea rewrite) covers a failed
+                         patch too.
+                        */}}
                         echo "[crossplane-provider-pivot]   FAIL ${name}: kubectl patch spec.package -> ${new_pkg} returned non-zero — the Provider is STILL on ${pkg} (#5436)" >&2
                         touch /tmp/xpkg-verify-failed
                       fi
@@ -514,9 +570,11 @@ data:
                       piv_repo="${_sp_repo}"
                       piv_digest="${_sp_digest}"
                       if [ -n "${piv_digest}" ]; then
-                        # #5204/#5232: an ALREADY digest-pivoted Provider must
-                        # ALSO durably resolve locally — the hw270 latent
-                        # shape (pivoted ref, cold cache). Verify BY DIGEST.
+                        {{- /*
+                         #5204/#5232: an ALREADY digest-pivoted Provider must
+                         ALSO durably resolve locally — the hw270 latent
+                         shape (pivoted ref, cold cache). Verify BY DIGEST.
+                        */}}
                         if ! verify_local_pkg_artifact "${REGISTRY_PATH}/${piv_repo}@${piv_digest}"; then
                           echo "[crossplane-provider-pivot] VERIFY-FAIL ${name}: already pivoted to ${pkg} but the local Harbor does not durably serve ${REGISTRY_PATH}/${piv_repo}@${piv_digest} (#5204 #5232; re-warm via step-03 Phase A4)" >&2
                           touch /tmp/xpkg-verify-failed
@@ -524,9 +582,11 @@ data:
                         fi
                         echo "[crossplane-provider-pivot] SKIP ${name} (already digest-pivoted: ${pkg})"
                       else
-                        # A TAG-form local pivot (the pre-#5232 0.1.142 shape)
-                        # genuinely 404s post-severance — UPGRADE it to the
-                        # digest form step-03 minted.
+                        {{- /*
+                         A TAG-form local pivot (the pre-#5232 0.1.142 shape)
+                         genuinely 404s post-severance — UPGRADE it to the
+                         digest form step-03 minted.
+                        */}}
                         piv_digest=$(lookup_pkg_digest "${REGISTRY_PATH}/${piv_suffix}")
                         if [ -z "${piv_digest}" ]; then
                           echo "[crossplane-provider-pivot] DIGEST-MISS ${name}: already pivoted to TAG-form ${pkg} but no recorded tag->digest for ${REGISTRY_PATH}/${piv_suffix} in ConfigMap ${RELEASE_NAMESPACE}/${XPKG_DIGEST_CM} (#5232). Force step-03 to re-warm+record: kubectl -n ${RELEASE_NAMESPACE} patch configmap ${STATUS_CM} --type merge -p '{\"data\":{\"step.harbor-prewarm.result\":\"\"}}' then re-trigger the cutover" >&2
@@ -545,9 +605,11 @@ data:
                             --type=merge --patch "${patch_json}" >/dev/null 2>&1; then
                           echo "[crossplane-provider-pivot]   OK ${name}"
                         else
-                          # #5436 — same un-wired verdict as the arm above;
-                          # a failed tag->digest upgrade leaves a TAG-form
-                          # local ref that 404s post-severance. Record it.
+                          {{- /*
+                           #5436 — same un-wired verdict as the arm above;
+                           a failed tag->digest upgrade leaves a TAG-form
+                           local ref that 404s post-severance. Record it.
+                          */}}
                           echo "[crossplane-provider-pivot]   FAIL ${name}: kubectl patch spec.package -> ${new_pkg} returned non-zero — the Provider is STILL on the TAG-form ${pkg} and will 404 post-severance (#5436 #5232)" >&2
                           touch /tmp/xpkg-verify-failed
                         fi
@@ -561,24 +623,30 @@ data:
               fi
             fi
 
-            # #5204 fail-loud: any verify miss recorded by the subshell loop
-            # fails the step BEFORE the durable Gitea rewrite, so nothing is
-            # half-pivoted onto a ref the local registry cannot serve. The
-            # live patches already applied are idempotent on the re-run.
+            {{- /*
+             #5204 fail-loud: any verify miss recorded by the subshell loop
+             fails the step BEFORE the durable Gitea rewrite, so nothing is
+             half-pivoted onto a ref the local registry cannot serve. The
+             live patches already applied are idempotent on the re-run.
+            */}}
             if [ -e /tmp/xpkg-verify-failed ]; then
               echo "[crossplane-provider-pivot] FATAL: one or more Provider packages are NOT durably served by the local Harbor by digest (DIGEST-MISS / VERIFY-FAIL lines above) — nothing was durably rewritten. Recovery: clear the step-03 success marker so the re-trigger re-warms + re-records digests (kubectl -n ${RELEASE_NAMESPACE} patch configmap ${STATUS_CM} --type merge -p '{\"data\":{\"step.harbor-prewarm.result\":\"\"}}'), then re-trigger the cutover (#5204 #5232)" >&2
               exit 1
             fi
 
-            # ---- Phase 2: push YAML edit to local Gitea ----
-            #
-            # bootstrap-kit Kustomization reconciles provider-*.yaml from
-            # local Gitea every ~1 min. Without this phase, Phase 1's
-            # live patch is reverted on the next reconcile because the
-            # YAML in Gitea still carries the xpkg.upbound.io literal.
+            {{- /*
+             ---- Phase 2: push YAML edit to local Gitea ----
+
+             bootstrap-kit Kustomization reconciles provider-*.yaml from
+             local Gitea every ~1 min. Without this phase, Phase 1's
+             live patch is reverted on the next reconcile because the
+             YAML in Gitea still carries the xpkg.upbound.io literal.
+            */}}
             # We sed-in-place every clusters/*/infrastructure/provider-
-            # *.yaml that carries the upstream host literal in its
-            # `spec.package` line.
+            {{- /*
+             *.yaml that carries the upstream host literal in its
+             `spec.package` line.
+            */}}
             export HOME=/tmp
             git config --global user.name "self-sovereign-cutover"
             git config --global user.email "cutover@${SOVEREIGN_FQDN}"
@@ -590,12 +658,14 @@ data:
               sleep 5
             done
 
-            # #5262 — read the step-09 minted `catalyst-gitea-token` PAT for
-            # the git clone/push. Credential hygiene: the PAT is never
-            # echoed; it flows only into the git remote URL (logged in the
-            # redacted form). Bounded wait: step-09 (gitea-token-mint) runs
-            # at order 9, so a populated token byte is the steady state; the
-            # retry only covers apiserver flakes.
+            {{- /*
+             #5262 — read the step-09 minted `catalyst-gitea-token` PAT for
+             the git clone/push. Credential hygiene: the PAT is never
+             echoed; it flows only into the git remote URL (logged in the
+             redacted form). Bounded wait: step-09 (gitea-token-mint) runs
+             at order 9, so a populated token byte is the steady state; the
+             retry only covers apiserver flakes.
+            */}}
             echo "[crossplane-provider-pivot] reading PAT ${PAT_SOURCE_NAMESPACE}/${PAT_SOURCE_SECRET_NAME}.${PAT_SOURCE_KEY}"
             GITEA_PAT=""
             for i in $(seq 1 30); do
@@ -623,35 +693,41 @@ data:
             cd repo
 
             # Find every clusters/*/infrastructure/provider-*.yaml that
-            # references the upstream host literal in its package spec.
-            # `grep -l` returns only filenames; `find` ensures we don't
-            # pick up unrelated provider-* files elsewhere in the tree.
+            {{- /*
+             references the upstream host literal in its package spec.
+             `grep -l` returns only filenames; `find` ensures we don't
+             pick up unrelated provider-* files elsewhere in the tree.
+            */}}
             edited=0
-            # #4212 — the cloud-agnostic restructure moved the _template
-            # provider-hcloud into clusters/_template/infrastructure/hetzner/.
-            # Match provider-*.yaml at ANY depth under an infrastructure/
-            # dir (two globs: direct child + one level deep) so the pivot
-            # catches both the per-Sovereign overlay copies (direct child)
-            # and the _template/.../hetzner/ overlay.
+            {{- /*
+             #4212 — the cloud-agnostic restructure moved the _template
+             provider-hcloud into clusters/_template/infrastructure/hetzner/.
+             Match provider-*.yaml at ANY depth under an infrastructure/
+             dir (two globs: direct child + one level deep) so the pivot
+             catches both the per-Sovereign overlay copies (direct child)
+             and the _template/.../hetzner/ overlay.
+            */}}
             matches=$( { find clusters -type f -path '*/infrastructure/provider-*.yaml'; \
                          find clusters -type f -path '*/infrastructure/*/provider-*.yaml'; } 2>/dev/null | sort -u || true)
             if [ -z "${matches}" ]; then
               echo "[crossplane-provider-pivot] no clusters/*/infrastructure/**/provider-*.yaml present in mirror"
             else
-              # #5232 — rewrite each file's `package:` literal to the DIGEST
-              # form so the bootstrap-kit reconcile from local Gitea
-              # re-asserts the SAME digest ref Phase 1 patched live (a
-              # tag-form YAML would revert the live patch on the next
-              # reconcile AND 404 post-severance). Handles all three source
-              # shapes Phase 1 handles: the raw upstream host, the mothership
-              # proxy prefix (#4488 Huawei), and a pre-#5232 tag-form local
-              # pivot. A ref with NO minted digest (a foreign-Sovereign /
-              # _template overlay whose Provider never ran on THIS cluster,
-              # or the very-early-handover path where step-03 skipped on the
-              # absent CRD) keeps the pre-#5232 host-swap so no upstream-host
-              # literal survives; the eventual step re-run upgrades it to the
-              # digest form. `,` sed delimiter — the refs never contain
-              # commas; the OLD literal has its `.` escaped for -E.
+              {{- /*
+               #5232 — rewrite each file's `package:` literal to the DIGEST
+               form so the bootstrap-kit reconcile from local Gitea
+               re-asserts the SAME digest ref Phase 1 patched live (a
+               tag-form YAML would revert the live patch on the next
+               reconcile AND 404 post-severance). Handles all three source
+               shapes Phase 1 handles: the raw upstream host, the mothership
+               proxy prefix (#4488 Huawei), and a pre-#5232 tag-form local
+               pivot. A ref with NO minted digest (a foreign-Sovereign /
+               _template overlay whose Provider never ran on THIS cluster,
+               or the very-early-handover path where step-03 skipped on the
+               absent CRD) keeps the pre-#5232 host-swap so no upstream-host
+               literal survives; the eventual step re-run upgrades it to the
+               digest form. `,` sed delimiter — the refs never contain
+               commas; the OLD literal has its `.` escaped for -E.
+              */}}
               for file in ${matches}; do
                 _f_changed=0
                 _f_pkgs=$(sed -n -E 's/^[[:space:]]*package:[[:space:]]+//p' "${file}" | sort -u)
@@ -713,8 +789,10 @@ data:
             }
             echo "[crossplane-provider-pivot] pushed to ${redacted}"
 
-            # Trigger an immediate Flux reconciliation so the new YAML
-            # lands without waiting for the polling interval.
+            {{- /*
+             Trigger an immediate Flux reconciliation so the new YAML
+             lands without waiting for the polling interval.
+            */}}
             kubectl annotate --overwrite gitrepository openova \
               -n flux-system \
               "reconcile.fluxcd.io/requestedAt=$(date +%s)" >/dev/null || true

--- a/platform/self-sovereign-cutover/chart/templates/11-mirror-resync-cronjob.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/11-mirror-resync-cronjob.yaml
@@ -105,15 +105,19 @@ metadata:
 spec:
   schedule: {{ .Values.mirrorResync.schedule | quote }}
   suspend: {{ .Values.mirrorResync.suspended }}
-  # Concurrency = Forbid: a long-running clone (slow GitHub day) must
-  # NOT pile up parallel pushes against local Gitea. Skip-if-busy.
+  {{- /*
+   Concurrency = Forbid: a long-running clone (slow GitHub day) must
+   NOT pile up parallel pushes against local Gitea. Skip-if-busy.
+  */}}
   concurrencyPolicy: Forbid
-  # Keep a small audit trail: 3 completed + 1 failed.
+  {{- /* Keep a small audit trail: 3 completed + 1 failed. */}}
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 1
-  # If a Sovereign was suspended for hours and the kube-controller-
-  # manager comes back up, do NOT replay every missed slot — fire at
-  # most one. The next scheduled fire will pick up any drift.
+  {{- /*
+   If a Sovereign was suspended for hours and the kube-controller-
+   manager comes back up, do NOT replay every missed slot — fire at
+   most one. The next scheduled fire will pick up any drift.
+  */}}
   startingDeadlineSeconds: 60
   jobTemplate:
     metadata:
@@ -121,7 +125,7 @@ spec:
         {{- include "bp-self-sovereign-cutover.labels" . | nindent 8 }}
         app.kubernetes.io/component: mirror-resync
     spec:
-      # TTL after finished — 1 hour audit window then GC.
+      {{- /* TTL after finished — 1 hour audit window then GC. */}}
       ttlSecondsAfterFinished: 3600
       backoffLimit: 1
       activeDeadlineSeconds: {{ .Values.mirrorResync.jobTimeoutSeconds }}
@@ -133,10 +137,12 @@ spec:
         spec:
           serviceAccountName: {{ include "bp-self-sovereign-cutover.serviceAccountName" . }}
           restartPolicy: Never
-          # #5214 — re-assert gitea-admin-secret in the release namespace before
-          # each resync fire (durable close of the #4557/#4558/#4661 recurrence
-          # class; the secretKeyRef below resolves only in this Pod's namespace).
-          # See _helpers.tpl.
+          {{- /*
+           #5214 — re-assert gitea-admin-secret in the release namespace before
+           each resync fire (durable close of the #4557/#4558/#4661 recurrence
+           class; the secretKeyRef below resolves only in this Pod's namespace).
+           See _helpers.tpl.
+          */}}
           initContainers:
             {{- include "bp-self-sovereign-cutover.giteaSecretSelfHealInitContainer" (dict "ctx" . "phase" "pre") | nindent 12 }}
           containers:
@@ -168,20 +174,24 @@ spec:
               args:
                 - |
                   set -eu
-                  # Credential hygiene mirrors 01-gitea-mirror-job.yaml:
-                  # never echo $GITEA_PASSWORD on stdout. The BasicAuth
-                  # header is base64-encoded into a single env-local
-                  # variable; git push uses URL embedding only.
+                  {{- /*
+                   Credential hygiene mirrors 01-gitea-mirror-job.yaml:
+                   never echo $GITEA_PASSWORD on stdout. The BasicAuth
+                   header is base64-encoded into a single env-local
+                   variable; git push uses URL embedding only.
+                  */}}
                   redacted_url="${GITEA_INTERNAL_URL}/${GITEA_ORG}/${GITEA_REPO}.git"
                   echo "[mirror-resync] upstream=${UPSTREAM_REPO_URL} branch=${UPSTREAM_BRANCH}"
                   echo "[mirror-resync] target=${redacted_url}"
 
-                  # Idempotent pre-flight: the CronJob is created at
-                  # chart-install time, BEFORE Step-01 (gitea-mirror)
-                  # has run. If the local repo doesn't exist yet, exit
-                  # 0 (no-op) so we don't conflict with the in-flight
-                  # cutover. The very next fire after Step-01 finishes
-                  # will pick up the work.
+                  {{- /*
+                   Idempotent pre-flight: the CronJob is created at
+                   chart-install time, BEFORE Step-01 (gitea-mirror)
+                   has run. If the local repo doesn't exist yet, exit
+                   0 (no-op) so we don't conflict with the in-flight
+                   cutover. The very next fire after Step-01 finishes
+                   will pick up the work.
+                  */}}
                   gitea_host="$(printf '%s' "${GITEA_INTERNAL_URL}" | sed -E 's|^https?://||' | cut -d: -f1 | cut -d/ -f1)"
                   if [ -n "${gitea_host}" ]; then
                     if ! nslookup "${gitea_host}" >/dev/null 2>&1; then
@@ -193,9 +203,11 @@ spec:
                   basic_auth=$(printf '%s' "${GITEA_USERNAME}:${GITEA_PASSWORD}" | base64 -w0 2>/dev/null || printf '%s' "${GITEA_USERNAME}:${GITEA_PASSWORD}" | base64 | tr -d '\n')
                   api_url="${GITEA_INTERNAL_URL}/api/v1"
 
-                  # Confirm the local repo exists. If it doesn't, Step-
-                  # 01 hasn't run yet (or the operator hasn't triggered
-                  # cutover) — exit 0 (no-op).
+                  {{- /*
+                   Confirm the local repo exists. If it doesn't, Step-
+                   01 hasn't run yet (or the operator hasn't triggered
+                   cutover) — exit 0 (no-op).
+                  */}}
                   repo_check=$(wget -q -O - \
                     --header="Authorization: Basic ${basic_auth}" \
                     --header="Content-Type: application/json" \
@@ -205,9 +217,11 @@ spec:
                     exit 0
                   fi
 
-                  # Bare-clone upstream and push --mirror --force to the
-                  # local Gitea. Same semantics as Step-01 step (3),
-                  # without the create-org + create-repo phases.
+                  {{- /*
+                   Bare-clone upstream and push --mirror --force to the
+                   local Gitea. Same semantics as Step-01 step (3),
+                   without the create-org + create-repo phases.
+                  */}}
                   export HOME=/tmp
                   git config --global user.name "gitea-mirror-resync"
                   git config --global user.email "mirror-resync@${gitea_host}"

--- a/platform/self-sovereign-cutover/chart/templates/12-daytwo-harbor-pin-reconciler.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/12-daytwo-harbor-pin-reconciler.yaml
@@ -177,9 +177,11 @@ metadata:
     catalyst.openova.io/purpose: "post-cutover-daytwo-harbor-pin-reconcile"
 spec:
   replicas: 1
-  # Recreate (never two writers): a single loop pushes to local Harbor + writes
-  # the missing-manifest ConfigMap; a rolling overlap could double-push / race
-  # the CM. The loop is cheap, so no availability cost.
+  {{- /*
+   Recreate (never two writers): a single loop pushes to local Harbor + writes
+   the missing-manifest ConfigMap; a rolling overlap could double-push / race
+   the CM. The loop is cheap, so no availability cost.
+  */}}
   strategy:
     type: Recreate
   selector:
@@ -193,15 +195,17 @@ spec:
         app.kubernetes.io/component: daytwo-harbor-reconciler
     spec:
       serviceAccountName: {{ include "bp-self-sovereign-cutover.serviceAccountName" . }}
-      # Harbor admin secret + the ghcr-pull warm credential resolve via
-      # secretKeyRef in THIS Pod's namespace; the runner SA + release-namespace
-      # bridges (harbor-admin Reflector mirror, #935) already land them here.
+      {{- /*
+       Harbor admin secret + the ghcr-pull warm credential resolve via
+       secretKeyRef in THIS Pod's namespace; the runner SA + release-namespace
+       bridges (harbor-admin Reflector mirror, #935) already land them here.
+      */}}
       containers:
         - name: daytwo-harbor-reconciler
           image: {{ include "bp-self-sovereign-cutover.image" (dict "repository" .Values.images.kubectl.repository "tag" .Values.images.kubectl.tag "cutoverPhase" "pre" "Values" .Values) }}
           imagePullPolicy: IfNotPresent
           env:
-            # ── local Harbor (presence probe + warm push dest) ──
+            {{- /* ── local Harbor (presence probe + warm push dest) ── */}}
             - name: HARBOR_INTERNAL_URL
               value: {{ .Values.sovereign.harborInternalURL | quote }}
             - name: HARBOR_PUBLIC_URL
@@ -217,7 +221,7 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.harbor.adminSecretRef.name }}
                   key: {{ .Values.harbor.adminSecretRef.passwordKey }}
-            # ── local Gitea mirror (frozen bootstrap-kit pins) ──
+            {{- /* ── local Gitea mirror (frozen bootstrap-kit pins) ── */}}
             - name: GITEA_INTERNAL_URL
               value: {{ .Values.sovereign.giteaInternalURL | quote }}
             - name: GITEA_ORG
@@ -228,35 +232,43 @@ spec:
               value: {{ .Values.upstream.branch | quote }}
             - name: UPSTREAM_PREFIX
               value: {{ .Values.helmRepositories.upstreamPrefix | quote }}
-            # #5640 catalog leg — the upstream catalog the ONE-SHOT `CATALOG`
-            # request re-syncs into the local Gitea mirror. Read ONLY inside an
-            # open request that explicitly names CATALOG; never dialled otherwise.
+            {{- /*
+             #5640 catalog leg — the upstream catalog the ONE-SHOT `CATALOG`
+             request re-syncs into the local Gitea mirror. Read ONLY inside an
+             open request that explicitly names CATALOG; never dialled otherwise.
+            */}}
             - name: UPSTREAM_REPO_URL
               value: {{ .Values.upstream.repoURL | quote }}
-            # #3584 — the git-push username the catalog leg embeds alongside the
-            # PAT, exactly as step-01 does.
+            {{- /*
+             #3584 — the git-push username the catalog leg embeds alongside the
+             PAT, exactly as step-01 does.
+            */}}
             - name: GITEA_USERNAME
               value: {{ .Values.gitRepositorySecretRef.username | quote }}
-            # catalyst-gitea-token PAT — the SAME coordinates + auth path steps
-            # 01/05 read (a PAT is a direct local sha1 lookup, immune to the
-            # openova-sso apiAuth hang a BasicAuth password takes mid-converge).
+            {{- /*
+             catalyst-gitea-token PAT — the SAME coordinates + auth path steps
+             01/05 read (a PAT is a direct local sha1 lookup, immune to the
+             openova-sso apiAuth hang a BasicAuth password takes mid-converge).
+            */}}
             - name: PAT_SOURCE_NAMESPACE
               value: {{ .Values.gitRepositorySecretRef.patSourceNamespace | quote }}
             - name: PAT_SOURCE_SECRET_NAME
               value: {{ .Values.gitRepositorySecretRef.patSourceSecretName | quote }}
             - name: PAT_SOURCE_KEY
               value: {{ .Values.gitRepositorySecretRef.patSourceKey | quote }}
-            # ── loop policy ──
+            {{- /* ── loop policy ── */}}
             - name: RECONCILE_INTERVAL_SECONDS
               value: {{ .Values.daytwoReconciler.intervalSeconds | quote }}
-            # detect (zero egress) | request (default; zero egress until the
-            # operator files ONE scoped, audited, one-shot request) | warm
-            # (always-on upstream mirror)
+            {{- /*
+             detect (zero egress) | request (default; zero egress until the
+             operator files ONE scoped, audited, one-shot request) | warm
+             (always-on upstream mirror)
+            */}}
             - name: RECONCILE_MODE
               value: {{ .Values.daytwoReconciler.mode | quote }}
             - name: MISSING_MANIFEST_CM
               value: {{ .Values.daytwoReconciler.missingManifestConfigMapName | quote }}
-            # ── #5640 operator-gated delivery (mode=request) ──
+            {{- /* ── #5640 operator-gated delivery (mode=request) ── */}}
             - name: REQUEST_CM
               value: {{ .Values.daytwoReconciler.request.configMapName | quote }}
             - name: DELIVERY_AUDIT_CM
@@ -267,33 +279,39 @@ spec:
               value: {{ .Values.daytwoReconciler.request.auditMaxLines | quote }}
             - name: RELEASE_NAMESPACE
               value: {{ .Release.Namespace | quote }}
-            # #5759 — cutoverComplete read every cycle (never cached): gates
-            # the catalog leg's refuse-by-default AND the source-host drift
-            # lint below. Same ConfigMap + key step-08's egress-block-test Job
-            # and scripts/sovereign-daytwo-bootstrap.sh already read.
+            {{- /*
+             #5759 — cutoverComplete read every cycle (never cached): gates
+             the catalog leg's refuse-by-default AND the source-host drift
+             lint below. Same ConfigMap + key step-08's egress-block-test Job
+             and scripts/sovereign-daytwo-bootstrap.sh already read.
+            */}}
             - name: STATUS_CONFIGMAP
               value: {{ .Values.status.configMapName | quote }}
-            # #5759 — the source-host drift lint's Sovereign-local allowlist.
-            # SOVEREIGN_FQDN + the host-classification shape are byte-identical
-            # to step-08's egressTest.fluxSourceHostLint (08-egress-block-test-
-            # job.yaml, run_flux_source_host_lint) — single-source discipline:
-            # one allowlist, declared once, consumed by both the one-shot
-            # cutover proof and this standing post-cutover watcher.
+            {{- /*
+             #5759 — the source-host drift lint's Sovereign-local allowlist.
+             SOVEREIGN_FQDN + the host-classification shape are byte-identical
+             to step-08's egressTest.fluxSourceHostLint (08-egress-block-test-
+             job.yaml, run_flux_source_host_lint) — single-source discipline:
+             one allowlist, declared once, consumed by both the one-shot
+             cutover proof and this standing post-cutover watcher.
+            */}}
             - name: SOVEREIGN_FQDN
               value: {{ .Values.sovereign.fqdn | quote }}
             - name: SOURCE_HOST_LINT_ENABLED
               value: {{ eq (toString .Values.daytwoReconciler.sourceHostLint.enabled) "true" | quote }}
             - name: SOURCE_HOST_LINT_ALLOW
               value: {{ .Values.egressTest.fluxSourceHostLint.allowHosts | default (list) | join " " | quote }}
-            # Per-leg switches. Both default true; an operator debugging one
-            # half can silence the other without losing the loop.
+            {{- /*
+             Per-leg switches. Both default true; an operator debugging one
+             half can silence the other without losing the loop.
+            */}}
             - name: CHART_LEG_ENABLED
               value: {{ eq (toString .Values.daytwoReconciler.charts.enabled) "true" | quote }}
             - name: IMAGE_LEG_ENABLED
               value: {{ eq (toString .Values.daytwoReconciler.images.enabled) "true" | quote }}
             - name: CATALOG_LEG_ENABLED
               value: {{ eq (toString .Values.daytwoReconciler.catalog.enabled) "true" | quote }}
-            # ── warm-mode source (operator-supplied; only read when mode=warm) ──
+            {{- /* ── warm-mode source (operator-supplied; only read when mode=warm) ── */}}
             - name: WARM_UPSTREAM_OCI_PREFIX
               value: {{ .Values.daytwoReconciler.warm.upstreamOciPrefix | quote }}
             - name: WARM_REGISTRY_HOST
@@ -306,9 +324,11 @@ spec:
               value: {{ .Values.daytwoReconciler.warm.credentialSecret.usernameKey | quote }}
             - name: WARM_CRED_PASSWORD_KEY
               value: {{ .Values.daytwoReconciler.warm.credentialSecret.passwordKey | quote }}
-            # ── #5640 image leg: the SAME offline-mirror env step-03/04/08 read.
-            # The coverage map is the single declaration of host→local-project;
-            # forking it here would re-open the very drift #4975 closed.
+            {{- /*
+             ── #5640 image leg: the SAME offline-mirror env step-03/04/08 read.
+             The coverage map is the single declaration of host→local-project;
+             forking it here would re-open the very drift #4975 closed.
+            */}}
             - name: HOST_PROJECT_MAP
               value: {{ include "bp-self-sovereign-cutover.hostProjectMapInline" . | quote }}
             - name: EXCLUDED_HOSTS
@@ -319,9 +339,11 @@ spec:
               value: {{ include "bp-self-sovereign-cutover.localRegistryHost" . | quote }}
             - name: MOTHERSHIP_HOST
               value: {{ include "bp-self-sovereign-cutover.mothershipHost" . | quote }}
-            # Optional ghcr/mothership dockerconfigjson — present pre-cutover,
-            # stripped by step-06 post-cutover (by design). Absent => the warm
-            # leg is anonymous-only and private refs stay in the manifest.
+            {{- /*
+             Optional ghcr/mothership dockerconfigjson — present pre-cutover,
+             stripped by step-06 post-cutover (by design). Absent => the warm
+             leg is anonymous-only and private refs stay in the manifest.
+            */}}
             - name: GHCR_DOCKERCONFIG
               valueFrom:
                 secretKeyRef:
@@ -371,30 +393,36 @@ spec:
               : "${SOURCE_HOST_LINT_ALLOW:=}"
               WORK=/tmp/daytwo-work
               mkdir -p "${WORK}"
-              # #5640 FAIL-CLOSED readiness surface. The reconciler is READY iff
-              # its last completed cycle proved every pinned artifact is
-              # servable by the registry this Sovereign is allowed to use.
-              # Anything else — a missing pin, a leg that could not run, no
-              # cycle yet — is NOT-READY, which shows up as 0/1 on
-              # `kubectl get deploy` and in every dashboard already watching
-              # workload readiness. Before #5640 the identical condition was a
-              # log line and a ConfigMap nobody was watching: a SILENT freeze.
-              # Seeded NOT-READY so the pre-first-cycle state can never read as
-              # an all-clear.
+              {{- /*
+               #5640 FAIL-CLOSED readiness surface. The reconciler is READY iff
+               its last completed cycle proved every pinned artifact is
+               servable by the registry this Sovereign is allowed to use.
+               Anything else — a missing pin, a leg that could not run, no
+               cycle yet — is NOT-READY, which shows up as 0/1 on
+               `kubectl get deploy` and in every dashboard already watching
+               workload readiness. Before #5640 the identical condition was a
+               log line and a ConfigMap nobody was watching: a SILENT freeze.
+               Seeded NOT-READY so the pre-first-cycle state can never read as
+               an all-clear.
+              */}}
               HEALTH_FILE="${WORK}/health"
               echo "NOTREADY no-cycle-completed-yet" > "${HEALTH_FILE}"
 
-              # Bare host of the local Harbor (registry.<fqdn>) — the helm
-              # registry login + push target in warm mode. Post-cutover its
-              # wildcard cert is production LE (in the base ca-certificates),
-              # so the helm push over :443 is trusted with no extra trust store.
+              {{- /*
+               Bare host of the local Harbor (registry.<fqdn>) — the helm
+               registry login + push target in warm mode. Post-cutover its
+               wildcard cert is production LE (in the base ca-certificates),
+               so the helm push over :443 is trusted with no extra trust store.
+              */}}
               HARBOR_HOST=$(printf '%s' "${HARBOR_PUBLIC_URL}" | sed -e 's,^https\?://,,' -e 's,/$,,')
               gitea_host="$(printf '%s' "${GITEA_INTERNAL_URL}" | sed -E 's|^https?://||' | cut -d: -f1 | cut -d/ -f1)"
 
-              # Shared 03a resolver — the SAME image→local-path mapping
-              # function step-03 (push dest) and step-08 (completeness HEAD)
-              # source. Fail-LOUD if absent: silently skipping the image leg is
-              # exactly the invisible-strand shape #5640 is about.
+              {{- /*
+               Shared 03a resolver — the SAME image→local-path mapping
+               function step-03 (push dest) and step-08 (completeness HEAD)
+               source. Fail-LOUD if absent: silently skipping the image leg is
+               exactly the invisible-strand shape #5640 is about.
+              */}}
               RESOLVER_OK=0
               if [ -f /offline-mirror/resolver.sh ]; then
                 . /offline-mirror/resolver.sh
@@ -411,21 +439,25 @@ spec:
                 *)       echo "[daytwo] mode=detect — reaching ONLY the local Gitea mirror + local Harbor (zero external egress; skopeo is never downloaded); missing artifacts are reported to ConfigMap ${RELEASE_NAMESPACE}/${MISSING_MANIFEST_CM} as the offline-media manifest" ;;
               esac
 
-              # ── #5640 OPERATOR-GATED DELIVERY ────────────────────────────────
-              # The whole point: an explicitly operator-initiated, scope-bounded,
-              # credential-scoped, audited, ONE-SHOT pull is a different object
-              # from an always-on mirror. `warm` is the latter and re-tethers the
-              # Sovereign for as long as it is set. `request` opens the window
-              # only for the refs one named request lists, then closes it.
+              {{- /*
+               ── #5640 OPERATOR-GATED DELIVERY ────────────────────────────────
+               The whole point: an explicitly operator-initiated, scope-bounded,
+               credential-scoped, audited, ONE-SHOT pull is a different object
+               from an always-on mirror. `warm` is the latter and re-tethers the
+               Sovereign for as long as it is set. `request` opens the window
+               only for the refs one named request lists, then closes it.
+              */}}
               REQ_ID=""; REQ_BY=""; REQ_SCOPE_FILE="${WORK}/request-scope.txt"
               REQ_ACTIVE=0; REQ_DELIVERED=0; REQ_FAILED=0
               AUDIT_FILE="${WORK}/audit.log"
               : > "${AUDIT_FILE}"
 
-              # daytwo_audit LINE — append to the durable delivery audit trail
-              # AND the Pod log. Read-modify-write so history is preserved
-              # across cycles and Pod restarts; capped so the ConfigMap cannot
-              # grow past the apiserver's 1 MiB object limit.
+              {{- /*
+               daytwo_audit LINE — append to the durable delivery audit trail
+               AND the Pod log. Read-modify-write so history is preserved
+               across cycles and Pod restarts; capped so the ConfigMap cannot
+               grow past the apiserver's 1 MiB object limit.
+              */}}
               daytwo_audit() {
                 _au_line="$(date -u +%Y-%m-%dT%H:%M:%SZ)\t$*"
                 printf '%b\n' "${_au_line}" >> "${AUDIT_FILE}"
@@ -448,9 +480,11 @@ spec:
                 : > "${AUDIT_FILE}"
               }
 
-              # daytwo_load_request — read the operator's request, if any, and
-              # decide whether THIS cycle may deliver. Sets REQ_ACTIVE=1 only for
-              # a request whose requestId has never been consumed.
+              {{- /*
+               daytwo_load_request — read the operator's request, if any, and
+               decide whether THIS cycle may deliver. Sets REQ_ACTIVE=1 only for
+               a request whose requestId has never been consumed.
+              */}}
               LAST_CONSUMED_ID=""
               daytwo_load_request() {
                 REQ_ACTIVE=0; REQ_ID=""; REQ_BY=""; : > "${REQ_SCOPE_FILE}"
@@ -489,11 +523,13 @@ spec:
                 echo "[daytwo] mode=request: delivery window OPEN for requestId '${REQ_ID}' (requestedBy=${REQ_BY}, ${_lr_n} scope line(s)); it will be consumed at the end of this cycle"
               }
 
-              # daytwo_in_scope REF UPSTREAM_REF LOCAL_PATH -> 0 iff this artifact
-              # is inside the OPEN request's scope. Matches the enumerated ref,
-              # the inverse-mapped upstream, the bare local path AND the fully
-              # qualified local ref, so an operator can paste back whichever form
-              # the missing manifest showed them.
+              {{- /*
+               daytwo_in_scope REF UPSTREAM_REF LOCAL_PATH -> 0 iff this artifact
+               is inside the OPEN request's scope. Matches the enumerated ref,
+               the inverse-mapped upstream, the bare local path AND the fully
+               qualified local ref, so an operator can paste back whichever form
+               the missing manifest showed them.
+              */}}
               daytwo_in_scope() {
                 [ "${REQ_ACTIVE}" = "1" ] || return 1
                 grep -qx 'ALL_MISSING' "${REQ_SCOPE_FILE}" 2>/dev/null && return 0
@@ -504,12 +540,14 @@ spec:
                 return 1
               }
 
-              # daytwo_delivery_allowed REF UPSTREAM_REF LOCAL_PATH -> 0 iff this
-              # cycle may reach upstream for THIS artifact. THE single gate every
-              # egress-bearing call sits behind; detect can never pass it, and
-              # request passes it only inside an open, in-scope, unconsumed
-              # window. Every mode other than warm/request falls through to the
-              # closed default, so an unrecognised mode value fails CLOSED.
+              {{- /*
+               daytwo_delivery_allowed REF UPSTREAM_REF LOCAL_PATH -> 0 iff this
+               cycle may reach upstream for THIS artifact. THE single gate every
+               egress-bearing call sits behind; detect can never pass it, and
+               request passes it only inside an open, in-scope, unconsumed
+               window. Every mode other than warm/request falls through to the
+               closed default, so an unrecognised mode value fails CLOSED.
+              */}}
               daytwo_delivery_allowed() {
                 case "${RECONCILE_MODE}" in
                   warm) return 0 ;;
@@ -518,10 +556,12 @@ spec:
                 esac
               }
 
-              # daytwo_consume_request — close the window. Recording consumption
-              # in the AUDIT ConfigMap (not the request ConfigMap) means it
-              # survives a Pod restart and cannot be undone by re-applying the
-              # request unchanged; a new window needs a NEW requestId.
+              {{- /*
+               daytwo_consume_request — close the window. Recording consumption
+               in the AUDIT ConfigMap (not the request ConfigMap) means it
+               survives a Pod restart and cannot be undone by re-applying the
+               request unchanged; a new window needs a NEW requestId.
+              */}}
               daytwo_consume_request() {
                 [ "${REQ_ACTIVE}" = "1" ] || return 0
                 LAST_CONSUMED_ID="${REQ_ID}"
@@ -530,8 +570,10 @@ spec:
                 REQ_ACTIVE=0
               }
 
-              # Read the catalyst-gitea-token PAT (never echoed; sent only via
-              # the Authorization header). Bounded per-call so a rotation heals.
+              {{- /*
+               Read the catalyst-gitea-token PAT (never echoed; sent only via
+               the Authorization header). Bounded per-call so a rotation heals.
+              */}}
               read_pat() {
                 _rp=""
                 for _i in $(seq 1 6); do
@@ -543,9 +585,11 @@ spec:
                 printf '%s' "${_rp}"
               }
 
-              # Harbor artifact API (Harbor CORE against its DB — NEVER a
-              # pull-through; the #5030 durable-presence probe step-03/08 use).
-              # 200 => the chart OCI artifact is DURABLY present locally.
+              {{- /*
+               Harbor artifact API (Harbor CORE against its DB — NEVER a
+               pull-through; the #5030 durable-presence probe step-03/08 use).
+               200 => the chart OCI artifact is DURABLY present locally.
+              */}}
               harbor_has() {
                 _hc=$(curl -sk -o /dev/null -w '%{http_code}' --max-time 30 \
                   -u "${HARBOR_USERNAME}:${HARBOR_PASSWORD}" \
@@ -553,14 +597,16 @@ spec:
                 [ "${_hc}" = "200" ]
               }
 
-              # warm ONE missing chart: helm pull upstream (operator cred if
-              # supplied) -> helm push local. Fail-SOFT (returns non-zero, the
-              # caller keeps it in the missing manifest; never crashes the loop).
-              # #5640 — the upstream `helm registry login` is itself an EGRESS
-              # call, so it is LAZY: performed on the first allowed chart
-              # delivery, never at startup. detect (and request with no open
-              # window) therefore dials nothing at all, which is the property the
-              # zero-egress contract actually needs.
+              {{- /*
+               warm ONE missing chart: helm pull upstream (operator cred if
+               supplied) -> helm push local. Fail-SOFT (returns non-zero, the
+               caller keeps it in the missing manifest; never crashes the loop).
+               #5640 — the upstream `helm registry login` is itself an EGRESS
+               call, so it is LAZY: performed on the first allowed chart
+               delivery, never at startup. detect (and request with no open
+               window) therefore dials nothing at all, which is the property the
+               zero-egress contract actually needs.
+              */}}
               WARM_LOGIN_DONE=0
               daytwo_helm_login_once() {
                 [ "${WARM_LOGIN_DONE}" = "1" ] && return 0
@@ -603,11 +649,13 @@ spec:
                 return 0
               }
 
-              # ── #5640 IMAGE LEG ─────────────────────────────────────────────
-              # skopeo acquisition — the SAME pinned static build step-03
-              # harbor-prewarm and step-08's #5194 self-heal use. Downloaded
-              # LAZILY and ONLY in warm mode, so detect mode keeps its
-              # zero-external-egress contract literally (no github.com dial).
+              {{- /*
+               ── #5640 IMAGE LEG ─────────────────────────────────────────────
+               skopeo acquisition — the SAME pinned static build step-03
+               harbor-prewarm and step-08's #5194 self-heal use. Downloaded
+               LAZILY and ONLY in warm mode, so detect mode keeps its
+               zero-external-egress contract literally (no github.com dial).
+              */}}
               _skopeo_ready=0
               daytwo_ensure_skopeo() {
                 [ "${_skopeo_ready}" = "1" ] && return 0
@@ -635,8 +683,10 @@ spec:
                 return 1
               }
 
-              # Parses the SAME flux-system/ghcr-pull dockerconfigjson step-03
-              # and step-08 read. Absent/empty => anonymous-only warm.
+              {{- /*
+               Parses the SAME flux-system/ghcr-pull dockerconfigjson step-03
+               and step-08 read. Absent/empty => anonymous-only warm.
+              */}}
               _creds_loaded=0
               _ghcr_user=""; _ghcr_pat=""
               _moth_user=""; _moth_pat=""
@@ -662,14 +712,16 @@ spec:
                   _moth_user=$(printf '%s' "${_ma}" | base64 -d | awk -F: '{print $1}')
                   _moth_pat=$(printf '%s' "${_ma}" | base64 -d | cut -d: -f2-)
                 fi
-                # An operator-supplied credential OVERRIDES the (possibly
-                # stripped) cutover one for the upstream registry host.
-                # #5640: bound to WARM_REGISTRY_HOST, NOT hard-wired to ghcr.io.
-                # The previous `&& [ "${WARM_REGISTRY_HOST}" = "ghcr.io" ]` meant
-                # an operator who mirrors the catalog into their own registry —
-                # the posture values.yaml explicitly documents — had their
-                # credential silently ignored and every private ref fell back to
-                # anonymous, which reads as "the image is missing".
+                {{- /*
+                 An operator-supplied credential OVERRIDES the (possibly
+                 stripped) cutover one for the upstream registry host.
+                 #5640: bound to WARM_REGISTRY_HOST, NOT hard-wired to ghcr.io.
+                 The previous `&& [ "${WARM_REGISTRY_HOST}" = "ghcr.io" ]` meant
+                 an operator who mirrors the catalog into their own registry —
+                 the posture values.yaml explicitly documents — had their
+                 credential silently ignored and every private ref fell back to
+                 anonymous, which reads as "the image is missing".
+                */}}
                 if [ -n "${WARM_CRED_SECRET_NAME}" ]; then
                   _wu=$(kubectl -n "${WARM_CRED_SECRET_NAMESPACE}" get secret "${WARM_CRED_SECRET_NAME}" -o "jsonpath={.data.${WARM_CRED_USERNAME_KEY}}" 2>/dev/null | base64 -d 2>/dev/null || true)
                   _wp=$(kubectl -n "${WARM_CRED_SECRET_NAMESPACE}" get secret "${WARM_CRED_SECRET_NAME}" -o "jsonpath={.data.${WARM_CRED_PASSWORD_KEY}}" 2>/dev/null | base64 -d 2>/dev/null || true)
@@ -692,10 +744,12 @@ spec:
                 esac
               }
 
-              # daytwo_manifest_present LOCAL_PATH -> 0 present, 1 absent.
-              # The SAME local-Harbor /v2 manifest HEAD step-08's completeness
-              # gate performs (3 attempts absorb a Harbor blip; a genuine 404
-              # is the signal).
+              {{- /*
+               daytwo_manifest_present LOCAL_PATH -> 0 present, 1 absent.
+               The SAME local-Harbor /v2 manifest HEAD step-08's completeness
+               gate performs (3 attempts absorb a Harbor blip; a genuine 404
+               is the signal).
+              */}}
               daytwo_manifest_present() {
                 _mp_lp="$1"
                 _mp_repo="${_mp_lp}"; _mp_ref="latest"
@@ -717,28 +771,32 @@ spec:
                 return 1
               }
 
-              # daytwo_warm_image UPSTREAM_REF LOCAL_PATH -> 0 warmed, 1 not.
-              # Byte-for-byte the step-08 #5194 self-heal copy: the same skopeo
-              # flags, the same #5095 mothership-proxy -> DIRECT inverse-map
-              # fallback, plus the #5525 scarf.sh -> mothership-proxy forward-map
-              # fallback step-03 copy_one carries. Source selection ONLY — the
-              # DEST is the resolver-derived local path, never re-derived here.
+              {{- /*
+               daytwo_warm_image UPSTREAM_REF LOCAL_PATH -> 0 warmed, 1 not.
+               Byte-for-byte the step-08 #5194 self-heal copy: the same skopeo
+               flags, the same #5095 mothership-proxy -> DIRECT inverse-map
+               fallback, plus the #5525 scarf.sh -> mothership-proxy forward-map
+               fallback step-03 copy_one carries. Source selection ONLY — the
+               DEST is the resolver-derived local path, never re-derived here.
+              */}}
               daytwo_warm_image() {
                 _wi_up=$(offlinemirror_normalize_ref "$1")
                 _wi_lp="$2"
                 _wi_lref="${LOCAL_REGISTRY_HOST}/${_wi_lp}"
-                # ── #5640 SOURCE INVERSION ────────────────────────────────────
-                # Post-cutover, step-07's pod-spec sweep has ALREADY rewritten
-                # this workload's image to registry.<fqdn>/<local-path>, so the
-                # ref enumerated off the live cluster carries NO upstream host.
-                # Copying it as the SOURCE asks skopeo to copy the local registry
-                # to itself, for an artifact the local registry just 404'd — it
-                # can never deliver anything, and it would report "copy failed"
-                # rather than "I do not know where this came from". That is the
-                # hw292 class exactly: catalyst-ui was pinned to a tag published
-                # after cutover, and its live ref was the pivoted one. Invert the
-                # SHARED 03a map (offlinemirror_upstream_ref) to recover the true
-                # upstream before copying.
+                {{- /*
+                 ── #5640 SOURCE INVERSION ────────────────────────────────────
+                 Post-cutover, step-07's pod-spec sweep has ALREADY rewritten
+                 this workload's image to registry.<fqdn>/<local-path>, so the
+                 ref enumerated off the live cluster carries NO upstream host.
+                 Copying it as the SOURCE asks skopeo to copy the local registry
+                 to itself, for an artifact the local registry just 404'd — it
+                 can never deliver anything, and it would report "copy failed"
+                 rather than "I do not know where this came from". That is the
+                 hw292 class exactly: catalyst-ui was pinned to a tag published
+                 after cutover, and its live ref was the pivoted one. Invert the
+                 SHARED 03a map (offlinemirror_upstream_ref) to recover the true
+                 upstream before copying.
+                */}}
                 case "${_wi_up}" in
                   "${LOCAL_REGISTRY_HOST}"/*)
                     _wi_inv=$(offlinemirror_upstream_ref "${_wi_up}" 2>/dev/null || true)
@@ -750,8 +808,10 @@ spec:
                     _wi_up="${_wi_inv}"
                     ;;
                 esac
-                # FAIL-CLOSED belt-and-braces: whatever the inversion produced,
-                # never let source and destination be the same registry.
+                {{- /*
+                 FAIL-CLOSED belt-and-braces: whatever the inversion produced,
+                 never let source and destination be the same registry.
+                */}}
                 if [ "${_wi_up%%/*}" = "${LOCAL_REGISTRY_HOST}" ]; then
                   echo "[daytwo] image delivery REFUSED ${_wi_up} -> ${_wi_lref}: source and destination are the SAME registry — a self-copy can only ever fail, and reporting it as a copy failure would hide the real defect (#5640)"
                   return 1
@@ -763,8 +823,10 @@ spec:
                 _wi_sc=$(daytwo_src_creds_for "${_wi_srchost}")
                 _wi_fb_up=""; _wi_fb_sc=""
                 if [ -n "${MOTHERSHIP_HOST:-}" ] && [ "${_wi_srchost}" = "${MOTHERSHIP_HOST}" ]; then
-                  # #5095 — INVERSE coverage-map walk: harbor.openova.io/proxy-<x>/<path>
-                  # -> the FIRST mapped host whose project is <x>. No second hand-list.
+                  {{- /*
+                   #5095 — INVERSE coverage-map walk: harbor.openova.io/proxy-<x>/<path>
+                   -> the FIRST mapped host whose project is <x>. No second hand-list.
+                  */}}
                   _wi_rest="${_wi_up#*/}"
                   case "${_wi_rest}" in
                     */*)
@@ -781,9 +843,11 @@ spec:
                       ;;
                   esac
                 elif [ -n "${MOTHERSHIP_HOST:-}" ]; then
-                  # #5525 — a *.docker.scarf.sh redirector shares Docker Hub's
-                  # ANONYMOUS per-IP quota, so its secondary source is the
-                  # mothership proxy, derived by the FORWARD map lookup.
+                  {{- /*
+                   #5525 — a *.docker.scarf.sh redirector shares Docker Hub's
+                   ANONYMOUS per-IP quota, so its secondary source is the
+                   mothership proxy, derived by the FORWARD map lookup.
+                  */}}
                   case "${_wi_srchost}" in
                     *.docker.scarf.sh)
                       _wi_sp=""
@@ -836,9 +900,11 @@ spec:
                 return 1
               }
 
-              # reconcile_images_once — the #5640 leg. Enumerate what the
-              # Sovereign's OWN GitOps declares, map each ref through the shared
-              # resolver, and assert the local Harbor can serve it.
+              {{- /*
+               reconcile_images_once — the #5640 leg. Enumerate what the
+               Sovereign's OWN GitOps declares, map each ref through the shared
+               resolver, and assert the local Harbor can serve it.
+              */}}
               CHART_PINS=0; CHART_PRESENT=0; CHART_WARMED=0; CHART_MISS=0; CHART_STATUS="skipped"
               IMAGE_REFS=0; IMAGE_PRESENT=0; IMAGE_WARMED=0; IMAGE_MISS=0; IMAGE_STATUS="skipped"
               MISSING_CHARTS_FILE="${WORK}/missing-charts.tsv"
@@ -856,10 +922,12 @@ spec:
                   IMAGE_STATUS="no-coverage-map"
                   return 1
                 fi
-                # running Pods ∪ declared workload templates — the #3944
-                # completeness union. The declared half is load-bearing HERE:
-                # the hw292 offender was in ImagePullBackOff, i.e. it had NO
-                # running container to enumerate.
+                {{- /*
+                 running Pods ∪ declared workload templates — the #3944
+                 completeness union. The declared half is load-bearing HERE:
+                 the hw292 offender was in ImagePullBackOff, i.e. it had NO
+                 running container to enumerate.
+                */}}
                 _running=$(kubectl get pods -A -o json 2>/dev/null | \
                   jq -r '.items[].spec | (.containers // [])[].image, (.initContainers // [])[].image' 2>/dev/null || true)
                 _declared=$(kubectl get deployments,statefulsets,daemonsets -A -o json 2>/dev/null | \
@@ -871,10 +939,12 @@ spec:
                 _imgs=$(printf '%s\n%s\n%s\n%s\n' "${_running}" "${_declared}" "${_cron}" "${_jobs}" | \
                   grep -E '^[^[:space:]]+$' | grep -v '^null$' | sort -u || true)
                 _n=$(printf '%s\n' "${_imgs}" | grep -c . || true)
-                # VACUITY GUARD. A zero-ref parse is NEVER "all clear" — it is a
-                # broken enumeration (RBAC lost, jq missing, API unreachable).
-                # Reporting it as green is precisely the failure mode that let
-                # #5640 stay invisible, so it is a loud, distinct outcome.
+                {{- /*
+                 VACUITY GUARD. A zero-ref parse is NEVER "all clear" — it is a
+                 broken enumeration (RBAC lost, jq missing, API unreachable).
+                 Reporting it as green is precisely the failure mode that let
+                 #5640 stay invisible, so it is a loud, distinct outcome.
+                */}}
                 if [ "${_n}" -eq 0 ]; then
                   echo "[daytwo] image leg: enumeration returned ZERO image refs — that is a broken read (RBAC/jq/apiserver), NOT an all-clear; skipping this cycle"
                   IMAGE_STATUS="enumeration-empty"
@@ -903,9 +973,11 @@ spec:
                       continue
                     fi
                     _code="${DAYTWO_LAST_CODE:-000}"
-                    # The upstream this local path came from — needed BOTH for
-                    # scope matching (so an operator can name the artifact in
-                    # upstream form) and for the copy itself.
+                    {{- /*
+                     The upstream this local path came from — needed BOTH for
+                     scope matching (so an operator can name the artifact in
+                     upstream form) and for the copy itself.
+                    */}}
                     _upref=$(offlinemirror_upstream_ref "${_img}" 2>/dev/null || true)
                     if daytwo_delivery_allowed "${_img}" "${_upref}" "${_lp}"; then
                       if daytwo_warm_image "${_img}" "${_lp}" && daytwo_manifest_present "${_lp}"; then
@@ -928,52 +1000,58 @@ spec:
                 return 0
               }
 
-              # ── #5640 leg 0: the CATALOG (git) pin ────────────────────────
-              # THE HEAD OF THE CHAIN. The chart leg below enumerates its pin set
-              # from the LOCAL GITEA MIRROR (`bootstrapkit_pins` over
-              # clusters/_template/bootstrap-kit at ${UPSTREAM_BRANCH}). Post
-              # cutover that mirror is FROZEN: `mirrorResync.enabled: false` is
-              # the deliberate Principle-14 severance (#2622/#3606 — an
+              {{- /*
+               ── #5640 leg 0: the CATALOG (git) pin ────────────────────────
+               THE HEAD OF THE CHAIN. The chart leg below enumerates its pin set
+               from the LOCAL GITEA MIRROR (`bootstrapkit_pins` over
+               clusters/_template/bootstrap-kit at ${UPSTREAM_BRANCH}). Post
+               cutover that mirror is FROZEN: `mirrorResync.enabled: false` is
+               the deliberate Principle-14 severance (#2622/#3606 — an
+              */}}
               # unattended */5 CronJob is a standing tether AND breaches the
-              # step-08 600s deny-egress hold), and nothing else re-runs step-01.
-              #
-              # So on a steady-state cut-over Sovereign the chart+image legs are
-              # STRUCTURALLY a no-op: they can only ever deliver artifacts for
-              # pins that already exist in the frozen mirror, and the frozen
-              # mirror by definition never names a version published after
-              # cutover. Measured on hw292 (dep 1c56518035a83e03, cc=true,
-              # 2026-08-06): local Gitea main@7bcd1d59, bootstrap-kit slot 06a
-              # still pinning bp-self-sovereign-cutover 0.1.159 while upstream
-              # main had moved to 0.1.169 — ten chart versions, zero arrived,
-              # and the chart leg correctly reported ALL_PINS_PRESENT the whole
-              # time because every FROZEN pin genuinely was present. That is the
-              # exact shape of "#5640 is invisible from the repo side".
-              #
-              # This leg closes it inside the SAME operator-gated window the
-              # artifact legs already use: one-shot, scope-bounded, audited,
-              # zero-egress-by-default. It writes INTO the local Gitea mirror; it
-              # does NOT repoint any Flux source. After the window closes Flux
-              # still reconciles EXCLUSIVELY from local Gitea + local Harbor, so
-              # Principle #11 / ADR-0002 hold literally — what P11 forbids is
-              # "reconciling Flux from github.com/openova-io/openova", not the
-              # operator refreshing their own mirror on their own schedule
-              # (CLAUDE.md §Customer-Sync makes that refresh canon).
-              #
-              # Ordering is load-bearing: this runs FIRST in the cycle so the
-              # freshly-synced pins are what the chart leg enumerates in the SAME
-              # open window. Running it last would sync the pins and then consume
-              # the request, leaving the new chart undeliverable until someone
-              # filed a SECOND request — the bootstrapping trap all over again,
-              # one layer up.
+              {{- /*
+               step-08 600s deny-egress hold), and nothing else re-runs step-01.
+
+               So on a steady-state cut-over Sovereign the chart+image legs are
+               STRUCTURALLY a no-op: they can only ever deliver artifacts for
+               pins that already exist in the frozen mirror, and the frozen
+               mirror by definition never names a version published after
+               cutover. Measured on hw292 (dep 1c56518035a83e03, cc=true,
+               2026-08-06): local Gitea main@7bcd1d59, bootstrap-kit slot 06a
+               still pinning bp-self-sovereign-cutover 0.1.159 while upstream
+               main had moved to 0.1.169 — ten chart versions, zero arrived,
+               and the chart leg correctly reported ALL_PINS_PRESENT the whole
+               time because every FROZEN pin genuinely was present. That is the
+               exact shape of "#5640 is invisible from the repo side".
+
+               This leg closes it inside the SAME operator-gated window the
+               artifact legs already use: one-shot, scope-bounded, audited,
+               zero-egress-by-default. It writes INTO the local Gitea mirror; it
+               does NOT repoint any Flux source. After the window closes Flux
+               still reconciles EXCLUSIVELY from local Gitea + local Harbor, so
+               Principle #11 / ADR-0002 hold literally — what P11 forbids is
+               "reconciling Flux from github.com/openova-io/openova", not the
+               operator refreshing their own mirror on their own schedule
+               (CLAUDE.md §Customer-Sync makes that refresh canon).
+
+               Ordering is load-bearing: this runs FIRST in the cycle so the
+               freshly-synced pins are what the chart leg enumerates in the SAME
+               open window. Running it last would sync the pins and then consume
+               the request, leaving the new chart undeliverable until someone
+               filed a SECOND request — the bootstrapping trap all over again,
+               one layer up.
+              */}}
               CATALOG_STATUS="disabled"
               CATALOG_SYNCED=0
-              # `CATALOG` must be named EXPLICITLY: ALL_MISSING deliberately does
-              # NOT imply it. ALL_MISSING means "fetch the artifacts I am already
-              # missing" — a bounded, known set. A catalog re-sync MOVES THE PINS
-              # THEMSELVES and can therefore trigger chart upgrades across the
-              # whole Sovereign. Folding that into a wildcard would let an
-              # operator who wanted two images get an unrequested platform-wide
-              # upgrade. Different blast radius ⇒ different opt-in.
+              {{- /*
+               `CATALOG` must be named EXPLICITLY: ALL_MISSING deliberately does
+               NOT imply it. ALL_MISSING means "fetch the artifacts I am already
+               missing" — a bounded, known set. A catalog re-sync MOVES THE PINS
+               THEMSELVES and can therefore trigger chart upgrades across the
+               whole Sovereign. Folding that into a wildcard would let an
+               operator who wanted two images get an unrequested platform-wide
+               upgrade. Different blast radius ⇒ different opt-in.
+              */}}
               catalog_in_scope() {
                 [ "${REQ_ACTIVE}" = "1" ] || return 1
                 grep -qx 'CATALOG' "${REQ_SCOPE_FILE}" 2>/dev/null && return 0
@@ -982,10 +1060,12 @@ spec:
 
               reconcile_catalog_once() {
                 CATALOG_SYNCED=0
-                # Audit identity. In warm mode there is no request, so REQ_ID /
-                # REQ_BY are empty — and warm is precisely the mode whose syncs
-                # most need an attributable record (it is the standing tether).
-                # Label them rather than emitting blank audit fields.
+                {{- /*
+                 Audit identity. In warm mode there is no request, so REQ_ID /
+                 REQ_BY are empty — and warm is precisely the mode whose syncs
+                 most need an attributable record (it is the standing tether).
+                 Label them rather than emitting blank audit fields.
+                */}}
                 _cat_id="${REQ_ID:-warm-mode}"
                 _cat_by="${REQ_BY:-standing-warm-posture}"
                 case "${RECONCILE_MODE}" in
@@ -1000,33 +1080,35 @@ spec:
                         return 0 ;;
                 esac
 
-                # #5759 — REFUSE-BY-DEFAULT. Measured live on hw292 (dep
-                # 1c56518035a83e03, cutoverComplete=true) 2026-08-06: this exact
-                # push reverted 62 of 69 region-a HelmRepositories from the
-                # local Harbor back to oci://ghcr.io/openova-io, with the
-                # ghcr-pull credential already stripped by step-06 (severance
-                # working as designed) — 44/72 HelmReleases went not-Ready and
-                # the Sovereign could not self-heal in-cluster (the only
-                # in-cluster remedy would be restoring the stripped upstream
-                # credential, i.e. re-tethering — exactly what cutover exists
-                # to prevent). Root cause, read off the push two lines below:
-                # `git push --force` against a bare clone of UPSTREAM, using
-                # the same explicit-refspec shape template 01 (gitea-mirror)
-                # uses, is a raw ref overwrite, not a merge.
-                # Step-06's durable "cutover: pivot N HelmRepository URLs to
-                # local Harbor" commit lives ONLY on this Sovereign's local
-                # `${UPSTREAM_BRANCH}` and is never reachable from a fresh
-                # upstream clone, so the force-push does not mask that commit,
-                # it DISCARDS it. There is today no merge-preserving
-                # alternative shipped, so this leg cannot guarantee the
-                # re-render preserves the cutover pivot — the exact guarantee
-                # #5759 requires before it may run. Refuse rather than revert
-                # silently. Gated on the LITERAL string 'false' (not merely
-                # "not true"): an unreadable/empty status ConfigMap is treated
-                # as cutover-complete for this check, fail-closed, the same
-                # posture step-08's per-region lint takes on an unmeasurable
-                # region (#5359) — "could not confirm this is safe" is never
-                # "safe".
+                {{- /*
+                 #5759 — REFUSE-BY-DEFAULT. Measured live on hw292 (dep
+                 1c56518035a83e03, cutoverComplete=true) 2026-08-06: this exact
+                 push reverted 62 of 69 region-a HelmRepositories from the
+                 local Harbor back to oci://ghcr.io/openova-io, with the
+                 ghcr-pull credential already stripped by step-06 (severance
+                 working as designed) — 44/72 HelmReleases went not-Ready and
+                 the Sovereign could not self-heal in-cluster (the only
+                 in-cluster remedy would be restoring the stripped upstream
+                 credential, i.e. re-tethering — exactly what cutover exists
+                 to prevent). Root cause, read off the push two lines below:
+                 `git push --force` against a bare clone of UPSTREAM, using
+                 the same explicit-refspec shape template 01 (gitea-mirror)
+                 uses, is a raw ref overwrite, not a merge.
+                 Step-06's durable "cutover: pivot N HelmRepository URLs to
+                 local Harbor" commit lives ONLY on this Sovereign's local
+                 `${UPSTREAM_BRANCH}` and is never reachable from a fresh
+                 upstream clone, so the force-push does not mask that commit,
+                 it DISCARDS it. There is today no merge-preserving
+                 alternative shipped, so this leg cannot guarantee the
+                 re-render preserves the cutover pivot — the exact guarantee
+                 #5759 requires before it may run. Refuse rather than revert
+                 silently. Gated on the LITERAL string 'false' (not merely
+                 "not true"): an unreadable/empty status ConfigMap is treated
+                 as cutover-complete for this check, fail-closed, the same
+                 posture step-08's per-region lint takes on an unmeasurable
+                 region (#5359) — "could not confirm this is safe" is never
+                 "safe".
+                */}}
                 if [ "${CUTOVER_COMPLETE:-}" != "false" ]; then
                   CATALOG_STATUS="blocked-post-cutover"
                   echo "[daytwo] catalog leg: REFUSING (#5759) — cutoverComplete='${CUTOVER_COMPLETE:-unreadable}' (expected the literal 'false' to proceed). Force-pushing ${UPSTREAM_REPO_URL} onto this Sovereign's local Gitea mirror would overwrite ${UPSTREAM_BRANCH} wholesale and silently discard step-06's durable HelmRepository-pivot commit, re-tethering every chart Flux re-renders to ghcr.io with no credential left to reach it (step-06 already stripped ghcr-pull auth by design). The mirror is UNCHANGED and the Sovereign keeps running on its current pins. No override exists for this refusal — a real fix needs a merge-preserving mirror mechanism, not a flag."
@@ -1052,15 +1134,17 @@ spec:
                   "${_cat_api}/branches/${UPSTREAM_BRANCH}" 2>/dev/null \
                   | jq -r '.commit.id // ""' 2>/dev/null || true)
 
-                # The push shape is step-01's, deliberately and exactly:
-                # bare clone + EXPLICIT refspecs. NEVER `git push --mirror` and
-                # never Gitea pull-mirror mode — both PRUNE refs the upstream
-                # does not have, which would clobber the sovereign-local refs
-                # step-06 (HelmRepository pivots) and step-07 (catalyst-api env)
-                # pushed into this very repo. That clobber is the G62/#3606
-                # regression; re-introducing it here would silently un-pivot the
-                # Sovereign back onto ghcr — a Principle-11 violation delivered
-                # by the very mechanism meant to preserve it.
+                {{- /*
+                 The push shape is step-01's, deliberately and exactly:
+                 bare clone + EXPLICIT refspecs. NEVER `git push --mirror` and
+                 never Gitea pull-mirror mode — both PRUNE refs the upstream
+                 does not have, which would clobber the sovereign-local refs
+                 step-06 (HelmRepository pivots) and step-07 (catalyst-api env)
+                 pushed into this very repo. That clobber is the G62/#3606
+                 regression; re-introducing it here would silently un-pivot the
+                 Sovereign back onto ghcr — a Principle-11 violation delivered
+                 by the very mechanism meant to preserve it.
+                */}}
                 _cat_work="${WORK}/catalog-sync"
                 rm -rf "${_cat_work}"; mkdir -p "${_cat_work}"
                 _cat_local="${GITEA_INTERNAL_URL%/}/${GITEA_ORG}/${GITEA_REPO}.git"
@@ -1103,8 +1187,10 @@ spec:
               reconcile_charts_once() {
                 : > "${MISSING_CHARTS_FILE}"
                 CHART_PINS=0; CHART_PRESENT=0; CHART_WARMED=0; CHART_MISS=0
-                # Idempotent pre-flight: pre-cutover (or before step-01 mirrored)
-                # the local Gitea repo isn't present — skip this iteration.
+                {{- /*
+                 Idempotent pre-flight: pre-cutover (or before step-01 mirrored)
+                 the local Gitea repo isn't present — skip this iteration.
+                */}}
                 if [ -n "${gitea_host}" ] && ! nslookup "${gitea_host}" >/dev/null 2>&1; then
                   echo "[daytwo] ${gitea_host} not resolvable yet — local Gitea not up (pre-cutover?); skipping the chart leg this cycle"
                   CHART_STATUS="gitea-absent"
@@ -1117,16 +1203,18 @@ spec:
                   return 1
                 fi
                 _api="${GITEA_INTERNAL_URL%/}/api/v1/repos/${GITEA_ORG}/${GITEA_REPO}"
-                # Repo present? (Not yet mirrored => nothing to reconcile.)
+                {{- /* Repo present? (Not yet mirrored => nothing to reconcile.) */}}
                 if ! curl -fsS --max-time 30 -H "Authorization: token ${_pat}" "${_api}" 2>/dev/null | grep -q '"full_name"'; then
                   echo "[daytwo] local repo ${GITEA_ORG}/${GITEA_REPO} not present yet — step-01 gitea-mirror has not completed; skipping the chart leg this cycle"
                   CHART_STATUS="repo-absent"
                   return 0
                 fi
 
-                # Fetch the freshly-synced bootstrap-kit slot files (contents+raw
-                # API, ~70 small text fetches — far lighter than a full clone),
-                # exactly as step-03 Phase A2-pins does.
+                {{- /*
+                 Fetch the freshly-synced bootstrap-kit slot files (contents+raw
+                 API, ~70 small text fetches — far lighter than a full clone),
+                 exactly as step-03 Phase A2-pins does.
+                */}}
                 _dir=/tmp/daytwo-bk; rm -rf "${_dir}"; mkdir -p "${_dir}"
                 _bkpath="clusters/_template/bootstrap-kit"
                 _list=$(curl -fsS --retry 3 --retry-delay 5 -H "Authorization: token ${_pat}" \
@@ -1145,7 +1233,7 @@ spec:
                 done
                 [ "${_ff}" -gt 0 ] && echo "[daytwo] WARN: ${_ff} slot file(s) failed to fetch this cycle — the pin set may be partial; retrying next interval will re-fetch"
 
-                # Shared 03b extractor — the SAME parser step-03 + step-06 use.
+                {{- /* Shared 03b extractor — the SAME parser step-03 + step-06 use. */}}
                 . /pin-extractor/extract-pins.sh
                 _pins=/tmp/daytwo-pins.tsv
                 bootstrapkit_pins "${_dir}" "${UPSTREAM_PREFIX}" "oci://${HARBOR_HOST}/openova-io" > "${_pins}" 2>/dev/null || true
@@ -1156,15 +1244,17 @@ spec:
                   return 1
                 fi
 
-                # Diff every frozen chart pin against local Harbor.
+                {{- /* Diff every frozen chart pin against local Harbor. */}}
                 while IFS="$(printf '\t')" read -r _c _v; do
                   [ -z "${_c}" ] && continue
                   if harbor_has "${_c}" "${_v}"; then
                     CHART_PRESENT=$((CHART_PRESENT+1)); continue
                   fi
-                  # Missing. Only an ALLOWED delivery may reach upstream — warm
-                  # always, request only for a chart this open window names as
-                  # `<chart>:<version>`. Re-check after.
+                  {{- /*
+                   Missing. Only an ALLOWED delivery may reach upstream — warm
+                   always, request only for a chart this open window names as
+                   `<chart>:<version>`. Re-check after.
+                  */}}
                   if daytwo_delivery_allowed "${_c}:${_v}" "" "${_c}:${_v}"; then
                     if warm_chart "${_c}" "${_v}" && harbor_has "${_c}" "${_v}"; then
                       CHART_WARMED=$((CHART_WARMED+1))
@@ -1184,11 +1274,13 @@ spec:
                 return 0
               }
 
-              # Publish the missing set to a durable ConfigMap (the offline-media
-              # manifest for air-gapped Sovereigns; the actionable signal for
-              # everyone). ALWAYS written — an empty manifest is the all-clear,
-              # and a leg that could not run says so EXPLICITLY rather than
-              # silently contributing zero misses.
+              {{- /*
+               Publish the missing set to a durable ConfigMap (the offline-media
+               manifest for air-gapped Sovereigns; the actionable signal for
+               everyone). ALWAYS written — an empty manifest is the all-clear,
+               and a leg that could not run says so EXPLICITLY rather than
+               silently contributing zero misses.
+              */}}
               publish_manifest() {
                 _mf="${WORK}/manifest.txt"
                 _total=$((CHART_MISS + IMAGE_MISS))
@@ -1214,37 +1306,41 @@ spec:
                   || echo "[daytwo] WARN: could not update ConfigMap ${RELEASE_NAMESPACE}/${MISSING_MANIFEST_CM} (logs still carry the manifest)"
               }
 
-              # ── #5759 CONTINUOUS SOURCE-HOST DRIFT LINT ──────────────────────
-              # Same host-classification shape as step-08's egressTest.
-              # fluxSourceHostLint (08-egress-block-test-job.yaml,
-              # run_flux_source_host_lint) — reused, not forked (single-source
-              # discipline: one allowlist, egressTest.fluxSourceHostLint.
-              # allowHosts, feeds both). The difference is WHEN it runs. That
-              # lint fires ONCE, inside the 600s deny-egress hold, at the
-              # ORIGINAL cutover, and is torn down with the hold — proving
-              # nothing about a re-render minutes, days or months later. This
-              # reconciler is a standing Deployment (#5157: a CronJob's
-              # scheduler dies with its region on a region-kill, so this is a
-              # Deployment on purpose), so its own copy keeps watching for the
-              # Sovereign's entire post-cutover life — INTERVAL-INDEPENDENT,
-              # per #5759 item 2 — and catches a revert from ANY cause: this
-              # reconciler's own (now-refused) CATALOG leg, a sovereign-admin
-              # re-stamping an unfixed step-01 PodSpec ConfigMap by hand via
-              # scripts/sovereign-daytwo-bootstrap.sh (chart-embedded fixes
-              # only protect a Sovereign already upgraded past this release),
-              # or a cause nobody has written yet. Measured live on hw292 (dep
-              # 1c56518035a83e03) 2026-08-06: 69/69 local HelmRepositories fell
-              # to 7/69 (62 reverted to ghcr.io) with nothing standing watch.
+              {{- /*
+               ── #5759 CONTINUOUS SOURCE-HOST DRIFT LINT ──────────────────────
+               Same host-classification shape as step-08's egressTest.
+               fluxSourceHostLint (08-egress-block-test-job.yaml,
+               run_flux_source_host_lint) — reused, not forked (single-source
+               discipline: one allowlist, egressTest.fluxSourceHostLint.
+               allowHosts, feeds both). The difference is WHEN it runs. That
+               lint fires ONCE, inside the 600s deny-egress hold, at the
+               ORIGINAL cutover, and is torn down with the hold — proving
+               nothing about a re-render minutes, days or months later. This
+               reconciler is a standing Deployment (#5157: a CronJob's
+               scheduler dies with its region on a region-kill, so this is a
+               Deployment on purpose), so its own copy keeps watching for the
+               Sovereign's entire post-cutover life — INTERVAL-INDEPENDENT,
+               per #5759 item 2 — and catches a revert from ANY cause: this
+               reconciler's own (now-refused) CATALOG leg, a sovereign-admin
+               re-stamping an unfixed step-01 PodSpec ConfigMap by hand via
+               scripts/sovereign-daytwo-bootstrap.sh (chart-embedded fixes
+               only protect a Sovereign already upgraded past this release),
+               or a cause nobody has written yet. Measured live on hw292 (dep
+               1c56518035a83e03) 2026-08-06: 69/69 local HelmRepositories fell
+               to 7/69 (62 reverted to ghcr.io) with nothing standing watch.
+              */}}
               run_daytwo_source_host_lint() {
                 DRIFT_STATUS="skipped"; DRIFT_COUNT=0
                 [ "${SOURCE_HOST_LINT_ENABLED}" = "true" ] || return 0
-                # Pre-cutover, external hosts are the NORMAL, correct state
-                # (nothing has been pivoted yet) — only assert once this
-                # Sovereign claims cutoverComplete=true. Fail-closed the other
-                # way from the catalog-leg refuse above: an unreadable status
-                # here must NOT manufacture a false drift report on a Sovereign
-                # that may still be mid-cutover, so this leg requires the
-                # LITERAL 'true' rather than "not 'false'".
+                {{- /*
+                 Pre-cutover, external hosts are the NORMAL, correct state
+                 (nothing has been pivoted yet) — only assert once this
+                 Sovereign claims cutoverComplete=true. Fail-closed the other
+                 way from the catalog-leg refuse above: an unreadable status
+                 here must NOT manufacture a false drift report on a Sovereign
+                 that may still be mid-cutover, so this leg requires the
+                 LITERAL 'true' rather than "not 'false'".
+                */}}
                 if [ "${CUTOVER_COMPLETE:-}" != "true" ]; then
                   DRIFT_STATUS="not-cutover"
                   return 0
@@ -1300,23 +1396,27 @@ spec:
                 return 0
               }
 
-              # #5640 FAIL-CLOSED readiness verdict. Written from the MEASURED
-              # cycle outcome, never from a knob: READY requires every enabled
-              # leg to have completed (status=ok) AND zero missing artifacts. A
-              # leg that could not run is NOT-READY — "I could not check" must
-              # never present as "all clear", which is the exact laundering that
-              # kept #5640 invisible.
+              {{- /*
+               #5640 FAIL-CLOSED readiness verdict. Written from the MEASURED
+               cycle outcome, never from a knob: READY requires every enabled
+               leg to have completed (status=ok) AND zero missing artifacts. A
+               leg that could not run is NOT-READY — "I could not check" must
+               never present as "all clear", which is the exact laundering that
+               kept #5640 invisible.
+              */}}
               publish_health() {
-                # CATALOG_STATUS is deliberately NOT a readiness input. Readiness
-                # here means a durable STATE — "this Sovereign holds a pin its
-                # registry cannot serve". `not-requested` is the normal, correct,
-                # sovereign steady state (no operator has opened a window), and a
-                # failed one-shot catalog sync is an EVENT, not a state: the
-                # Sovereign keeps running correctly on its current pins. Folding
-                # either into readiness would make every healthy cut-over
-                # Sovereign report 0/1 forever, which is how a real signal gets
-                # muted. The catalog outcome is carried by the audit ConfigMap,
-                # the cycle log line, and REQ_FAILED instead.
+                {{- /*
+                 CATALOG_STATUS is deliberately NOT a readiness input. Readiness
+                 here means a durable STATE — "this Sovereign holds a pin its
+                 registry cannot serve". `not-requested` is the normal, correct,
+                 sovereign steady state (no operator has opened a window), and a
+                 failed one-shot catalog sync is an EVENT, not a state: the
+                 Sovereign keeps running correctly on its current pins. Folding
+                 either into readiness would make every healthy cut-over
+                 Sovereign report 0/1 forever, which is how a real signal gets
+                 muted. The catalog outcome is carried by the audit ConfigMap,
+                 the cycle log line, and REQ_FAILED instead.
+                */}}
                 _ph_reason=""
                 if [ "${CHART_LEG_ENABLED}" = "true" ] && [ "${CHART_STATUS}" != "ok" ]; then
                   _ph_reason="chart-leg-${CHART_STATUS}"
@@ -1327,12 +1427,14 @@ spec:
                 if [ "$((CHART_MISS + IMAGE_MISS))" -gt 0 ]; then
                   _ph_reason="${_ph_reason:+${_ph_reason},}unpullable-pins=$((CHART_MISS + IMAGE_MISS))"
                 fi
-                # #5759 — UNLIKE CATALOG_STATUS above, source-host drift IS a
-                # readiness input: it is a durable STATE ("this cluster's Flux
-                # sources have reverted to a registry we deliberately no longer
-                # hold credentials for"), not a one-off event, and it stays
-                # true every cycle until a human fixes it. That is exactly the
-                # shape publish_health() exists to surface.
+                {{- /*
+                 #5759 — UNLIKE CATALOG_STATUS above, source-host drift IS a
+                 readiness input: it is a durable STATE ("this cluster's Flux
+                 sources have reverted to a registry we deliberately no longer
+                 hold credentials for"), not a one-off event, and it stays
+                 true every cycle until a human fixes it. That is exactly the
+                 shape publish_health() exists to surface.
+                */}}
                 if [ "${DRIFT_STATUS:-}" = "drifted" ]; then
                   _ph_reason="${_ph_reason:+${_ph_reason},}source-host-drift=${DRIFT_COUNT}"
                 elif [ "${DRIFT_STATUS:-}" = "unmeasurable" ] || [ "${DRIFT_STATUS:-}" = "scratch-unwritable" ]; then
@@ -1354,18 +1456,22 @@ spec:
                 IMAGE_REFS=0; IMAGE_PRESENT=0; IMAGE_WARMED=0; IMAGE_MISS=0
                 CATALOG_SYNCED=0
                 REQ_DELIVERED=0; REQ_FAILED=0
-                # #5759 — read fresh every cycle (never cached across cycles):
-                # gates the catalog leg's refuse-by-default AND the
-                # source-host drift lint below. Same ConfigMap+key
-                # scripts/sovereign-daytwo-bootstrap.sh and step-08 read.
+                {{- /*
+                 #5759 — read fresh every cycle (never cached across cycles):
+                 gates the catalog leg's refuse-by-default AND the
+                 source-host drift lint below. Same ConfigMap+key
+                 scripts/sovereign-daytwo-bootstrap.sh and step-08 read.
+                */}}
                 CUTOVER_COMPLETE=$(kubectl -n "${RELEASE_NAMESPACE}" get configmap "${STATUS_CONFIGMAP}" \
                   -o jsonpath='{.data.cutoverComplete}' 2>/dev/null || true)
                 daytwo_load_request
-                # Leg 0 FIRST — see reconcile_catalog_once's header. A catalog
-                # sync that landed AFTER the chart leg would move the pins and
-                # then have the window consumed under it, so the newly-pinned
-                # chart would need a SECOND request to be delivered. Running it
-                # first means one request moves the whole chain.
+                {{- /*
+                 Leg 0 FIRST — see reconcile_catalog_once's header. A catalog
+                 sync that landed AFTER the chart leg would move the pins and
+                 then have the window consumed under it, so the newly-pinned
+                 chart would need a SECOND request to be delivered. Running it
+                 first means one request moves the whole chain.
+                */}}
                 if [ "${CATALOG_LEG_ENABLED}" = "true" ]; then
                   reconcile_catalog_once || _rc=1
                 fi
@@ -1375,10 +1481,12 @@ spec:
                 if [ "${IMAGE_LEG_ENABLED}" = "true" ]; then
                   reconcile_images_once || _rc=1
                 fi
-                # #5759 — runs every cycle regardless of which legs are
-                # enabled: it watches the CLUSTER's Flux sources, not this
-                # reconciler's own actions, so it must not go blind just
-                # because an operator silenced CHART_LEG_ENABLED/etc.
+                {{- /*
+                 #5759 — runs every cycle regardless of which legs are
+                 enabled: it watches the CLUSTER's Flux sources, not this
+                 reconciler's own actions, so it must not go blind just
+                 because an operator silenced CHART_LEG_ENABLED/etc.
+                */}}
                 run_daytwo_source_host_lint || _rc=1
                 daytwo_consume_request
                 daytwo_audit_flush
@@ -1388,22 +1496,31 @@ spec:
                 return "${_rc}"
               }
 
+              {{- /* The next line stays a `#` comment: it is the truncation
+              point chart/tests/{daytwo-catalog-leg,daytwo-image-leg}.sh awk on
+              to strip the endless loop before sourcing the script under test
+              (`/^[[:space:]]*# The Day-2 loop\./{exit}`). Removing it from the
+              render hangs both tests rather than failing them. */}}
               # The Day-2 loop. Never exit on a transient cycle failure — a wedge
-              # in one cycle must not stop the reconciler (region-kill canon: the
-              # loop is the durable surface).
+              {{- /*
+               in one cycle must not stop the reconciler (region-kill canon: the
+               loop is the durable surface).
+              */}}
               while : ; do
                 reconcile_once || echo "[daytwo] this cycle could not complete fully (transient); retrying next interval"
                 echo "[daytwo] sleeping ${RECONCILE_INTERVAL_SECONDS}s"
                 sleep "${RECONCILE_INTERVAL_SECONDS}"
               done
-          # #5640 FAIL-CLOSED SURFACE. The loop writes READY into the health file
-          # only when its last cycle MEASURED every pinned chart + image as
-          # servable by the registry this Sovereign is permitted to use. So
-          # `kubectl get deploy cutover-daytwo-harbor-reconciler` reading 0/1 IS
-          # the statement "this Sovereign holds a pin it cannot pull" — a normal,
-          # alertable, non-silent condition instead of a log line and a ConfigMap
-          # nobody was watching. There is deliberately NO livenessProbe: a
-          # Sovereign that is missing an image must go NOT-READY, not restart.
+          {{- /*
+           #5640 FAIL-CLOSED SURFACE. The loop writes READY into the health file
+           only when its last cycle MEASURED every pinned chart + image as
+           servable by the registry this Sovereign is permitted to use. So
+           `kubectl get deploy cutover-daytwo-harbor-reconciler` reading 0/1 IS
+           the statement "this Sovereign holds a pin it cannot pull" — a normal,
+           alertable, non-silent condition instead of a log line and a ConfigMap
+           nobody was watching. There is deliberately NO livenessProbe: a
+           Sovereign that is missing an image must go NOT-READY, not restart.
+          */}}
           readinessProbe:
             exec:
               command: ["/bin/sh", "-c", "grep -qx READY /tmp/daytwo-work/health"]

--- a/platform/self-sovereign-cutover/chart/templates/rbac.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/rbac.yaml
@@ -71,9 +71,11 @@ metadata:
   labels:
     {{- include "bp-self-sovereign-cutover.labels" . | nindent 4 }}
 rules:
-  # ───────────────────────────────────────────────────────────────
-  # CREATE verbs — MUST be in their own Rule WITHOUT resourceNames.
-  # ───────────────────────────────────────────────────────────────
+  {{- /*
+   ───────────────────────────────────────────────────────────────
+   CREATE verbs — MUST be in their own Rule WITHOUT resourceNames.
+   ───────────────────────────────────────────────────────────────
+  */}}
   - apiGroups: [""]
     resources: ["configmaps"]   # cutover-status ConfigMap is created+updated by every step
     verbs: ["create"]
@@ -96,9 +98,11 @@ rules:
     resources: ["imageconfigs"]   # step 11 (#5204) creates the ImageConfig that binds the pivoted matchImages prefixes to the local-Harbor package-pull Secret so the Crossplane package manager authenticates post-cutover
     verbs: ["create"]
 
-  # ───────────────────────────────────────────────────────────────
-  # READ verbs — namespace-spanning per the step inventory above.
-  # ───────────────────────────────────────────────────────────────
+  {{- /*
+   ───────────────────────────────────────────────────────────────
+   READ verbs — namespace-spanning per the step inventory above.
+   ───────────────────────────────────────────────────────────────
+  */}}
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get", "list", "watch"]
@@ -157,9 +161,11 @@ rules:
     resources: ["customresourcedefinitions"]   # step 11 probes for providers.pkg.crossplane.io CRD presence before patching
     verbs: ["get", "list", "watch"]
 
-  # ───────────────────────────────────────────────────────────────
-  # UPDATE / PATCH / DELETE — separate from create per RBAC rule.
-  # ───────────────────────────────────────────────────────────────
+  {{- /*
+   ───────────────────────────────────────────────────────────────
+   UPDATE / PATCH / DELETE — separate from create per RBAC rule.
+   ───────────────────────────────────────────────────────────────
+  */}}
   - apiGroups: [""]
     resources: ["configmaps"]
     verbs: ["update", "patch"]

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-10T10:48:53.140Z",
+  "generatedAt": "2026-08-10T15:41:24.823Z",
   "blueprints": [
     {
       "id": "bp-agenity",
@@ -4640,7 +4640,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "0.1.177",
+      "version": "0.1.179",
       "section": "pts-2-3-per-sovereign-supporting-services",
       "depends": [
         "bp-gitea",

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -4775,7 +4775,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "0.1.177",
+    "version": "0.1.179",
     "section": "pts-2-3-per-sovereign-supporting-services",
     "depends": [
       "bp-gitea",

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3764,7 +3764,7 @@ name: bp-catalyst-platform
 #   Sovereign would keep installing cutover 0.1.176 while the seed in git
 #   claimed 0.1.177 — check-umbrella-republish-gate.py (#5734). Lockstep w/
 #   slot-13 pin.
-version: 1.4.1332
+version: 1.4.1334
 # 1.4.1229 — #5389: catalog-seed bp-newapi declares its `ui` endpoint
 #   (newapi.<fqdn>, ssoEnabled, launchDefault, ssoInitPath "/") instead of
 #   `endpoints: []`. The empty list made userUIGatePasses fail closed, which
@@ -3919,7 +3919,7 @@ version: 1.4.1332
 # scripts/check-chart-version-forward.sh (#5743) fails unless the two match —
 # main was carrying a pre-existing 1.4.1330/1.4.1329 split, so this bump heals
 # it in the same commit, exactly as the documented self-heal contract does.
-appVersion: 1.4.1332
+appVersion: 1.4.1334
 # 1.4.239 — Wave 3 / Issue #2140 (2026-05-23): Huawei provider
 # implementation lands behind the Wave 2 CloudProvider interface.
 # Adds the OpenTofu module at infra/providers/huawei/ (VPC + Subnet +

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5115,7 +5115,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.1.177"
+  version: "0.1.179"
   visibility: unlisted
   card:
     title: "Self-Sovereignty Cutover"
@@ -5132,7 +5132,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-self-sovereign-cutover
-    version: "0.1.177"
+    version: "0.1.179"
   topology:
     supported:
       - singleton

--- a/scripts/check-helm-release-payload-size.py
+++ b/scripts/check-helm-release-payload-size.py
@@ -1,0 +1,421 @@
+#!/usr/bin/env python3
+"""Fail a chart whose Helm release Secret would exceed the Kubernetes object ceiling.
+
+WHY THIS EXISTS (#6004)
+-----------------------
+On hw293 the Phase-1 install of `bp-self-sovereign-cutover@0.1.177` failed 10
+times in 13 minutes with:
+
+    create: failed to create: Secret "sh.helm.release.v1.self-sovereign-cutover.v1"
+    is invalid: data: Too long: must have at most 1048576 bytes
+
+Helm stores each release as a Secret whose single `release` key is
+
+    base64( gzip( json(release) ) )
+
+and Kubernetes caps the summed length of a Secret's data values at 1 MiB.
+Nothing in CI measured that number, so the chart grew across ~7 releases until
+it crossed the ceiling — and the only place the crossing was observable was a
+fresh Sovereign's Phase 1, where it takes out Pillar 5 entirely.
+
+WHAT IT MEASURES
+----------------
+The same four payload components Helm stores, in Helm's own order:
+
+  * chart.templates[].data  — every file under templates/, base64 in the JSON
+  * chart.values            — values.yaml PARSED (comments are dropped here)
+  * chart.files[].data      — every other packaged file, base64 in the JSON
+  * release.manifest        — the rendered output
+
+Two consequences drive how you keep a chart under the ceiling:
+
+  1. A `#` comment in a template is paid for TWICE — once in the template
+     bytes, once again in the rendered manifest. A `{{/* … */}}` comment is
+     paid for once. Converting the former to the latter costs a reader of the
+     source nothing and removes the bytes from every release Secret.
+  2. Files that only CI needs (chart/tests/*.sh are executed against the
+     working tree, never from the package) belong in `.helmignore`. They are
+     pure payload otherwise.
+
+MODEL FIDELITY
+--------------
+This reproduces Go's encoder rather than calling it: keys sorted, `<`, `>`,
+`&` escaped as \\uXXXX the way encoding/json does, non-ASCII emitted raw,
+gzip level 9.
+
+It was cross-checked against helm.sh/helm/v3 v3.16.3's OWN
+storage/driver encoder (action.Install with ClientOnly, then the release
+struct through the driver's json→gzip→base64), on bp-self-sovereign-cutover
+with the slot-06a overlay, on both sides of the #6004 fix:
+
+    chart state          helm's encoder      this model      delta
+    0.1.177 (failing)         1233060          1216220      -1.37%
+    0.1.179 (fixed)            743780           732444      -1.52%
+
+The residual is Go's flate implementation against zlib's, and it goes the
+UNSAFE way — the model reads slightly low. MODEL_ALLOWANCE below scales the
+measurement up by more than the observed drift so the verdict stays
+conservative, and the default budget then leaves a further 20% of the ceiling
+unused. A chart that clears this gate has real headroom, not a rounding error.
+"""
+from __future__ import annotations
+
+import argparse
+import base64
+import glob
+import gzip
+import io
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
+
+K8S_SECRET_LIMIT = 1048576  # hard cap on the summed length of a Secret's data
+# Fail above 90% — a chart within 10% of the cliff is one comment block away
+# from an install that cannot succeed on any Sovereign, and the cliff is only
+# observable at install time. NOTICE_PCT is loud but non-fatal, so a chart's
+# approach shows up in CI output long before it blocks a publish.
+DEFAULT_BUDGET_PCT = 90.0
+NOTICE_PCT = 75.0
+# Scale the modelled payload up before judging it. The model reads ~1.5% below
+# helm's own encoder (see MODEL FIDELITY above) and the error goes the unsafe
+# way, so the verdict is taken on the scaled figure, never the raw one.
+MODEL_ALLOWANCE = 1.03
+
+
+class MeasureError(RuntimeError):
+    """A chart could not be measured — never silently treated as passing."""
+
+
+def _fatal(msg: str) -> None:
+    print(f"FATAL: {msg}", file=sys.stderr)
+    sys.exit(2)
+
+
+def go_json(obj) -> bytes:
+    """Serialize the way Go's encoding/json does.
+
+    Go sorts map keys, emits raw UTF-8, and HTML-escapes `<`, `>` and `&`.
+    Those three characters cannot appear outside a JSON string literal, so
+    escaping them after serialization is exact, not an approximation.
+    """
+    s = json.dumps(obj, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    s = s.replace("<", "\\u003c").replace(">", "\\u003e").replace("&", "\\u0026")
+    return s.encode("utf-8")
+
+
+def encode_release(release: dict) -> int:
+    """len(base64(gzip(json(release)))) — Helm storage/driver.encodeRelease."""
+    raw = go_json(release)
+    buf = io.BytesIO()
+    # mtime=0 so the measurement is reproducible run to run.
+    with gzip.GzipFile(fileobj=buf, mode="wb", compresslevel=9, mtime=0) as gz:
+        gz.write(raw)
+    return len(base64.b64encode(buf.getvalue()))
+
+
+def package_chart(chart_dir: str, workdir: str) -> str:
+    """helm package the chart so .helmignore is applied exactly as at release."""
+    out = subprocess.run(
+        ["helm", "package", chart_dir, "--destination", workdir],
+        capture_output=True, text=True,
+    )
+    if out.returncode != 0:
+        raise MeasureError(f"helm package failed for {chart_dir}:\n{out.stderr.strip()}")
+    tgz = [f for f in os.listdir(workdir) if f.endswith(".tgz")]
+    if len(tgz) != 1:
+        raise MeasureError(f"expected one packaged chart in {workdir}, found {tgz}")
+    return os.path.join(workdir, tgz[0])
+
+
+def read_package(tgz: str) -> tuple[dict, dict, list, list]:
+    """Split a packaged chart into (metadata, values, templates, files) as Helm's loader does."""
+    values: dict = {}
+    metadata: dict = {}
+    templates: list = []
+    files: list = []
+    with tarfile.open(tgz, "r:gz") as tf:
+        for member in sorted(tf.getmembers(), key=lambda m: m.name):
+            if not member.isfile():
+                continue
+            # Strip the leading "<chartname>/" the package adds.
+            rel = member.name.split("/", 1)[1] if "/" in member.name else member.name
+            data = tf.extractfile(member).read()
+            if rel == "Chart.yaml":
+                # Stored as a PARSED Metadata struct, never as bytes — which is
+                # why Chart.yaml comments cost nothing in the release Secret
+                # while template comments cost twice.
+                metadata = load_yaml_bytes(data)
+                continue
+            if rel == "values.yaml":
+                values = load_yaml_bytes(data)
+                continue
+            entry = {"name": rel, "data": base64.b64encode(data).decode("ascii")}
+            if rel.startswith("templates/"):
+                templates.append(entry)
+            else:
+                files.append(entry)
+    return metadata, values, templates, files
+
+
+def load_yaml_bytes(data: bytes):
+    try:
+        import yaml  # type: ignore
+    except ImportError:
+        # PyYAML is not guaranteed on every runner. values.yaml contributes a
+        # low-single-digit-KB share of the payload, so fall back to counting it
+        # as its own raw bytes rather than skipping the measurement entirely.
+        return {"__unparsed_values__": data.decode("utf-8", "replace")}
+    return yaml.safe_load(data) or {}
+
+
+def render(tgz: str, values_files: list[str], release: str, namespace: str) -> str:
+    cmd = ["helm", "template", release, tgz, "--namespace", namespace]
+    for v in values_files:
+        cmd += ["-f", v]
+    out = subprocess.run(cmd, capture_output=True, text=True)
+    if out.returncode != 0:
+        raise MeasureError(f"helm template failed for {tgz}:\n{out.stderr.strip()}")
+    return out.stdout
+
+
+def measure(chart_dir: str, values_files: list[str], release: str, namespace: str) -> dict:
+    workdir = tempfile.mkdtemp(prefix="relpayload-")
+    try:
+        tgz = package_chart(chart_dir, workdir)
+        metadata, values, templates, files = read_package(tgz)
+        manifest = render(tgz, values_files, release, namespace)
+        user_values: dict = {}
+        for v in values_files:
+            with open(v, "rb") as fh:
+                merged = load_yaml_bytes(fh.read())
+            if isinstance(merged, dict):
+                user_values.update(merged)
+        rel = {
+            "name": release,
+            "info": {"status": "deployed", "description": "Install complete"},
+            "chart": {
+                "metadata": metadata,
+                "templates": templates,
+                "values": values,
+                "files": files,
+            },
+            "config": user_values,
+            "manifest": manifest,
+            "version": 1,
+            "namespace": namespace,
+        }
+        payload = encode_release(rel)
+        tpl_bytes = sum(len(base64.b64decode(t["data"])) for t in templates)
+        file_bytes = sum(len(base64.b64decode(f["data"])) for f in files)
+        return {
+            "payload": payload,
+            "manifest_bytes": len(manifest.encode("utf-8")),
+            "template_bytes": tpl_bytes,
+            "file_bytes": file_bytes,
+            "n_templates": len(templates),
+            "n_files": len(files),
+        }
+    finally:
+        shutil.rmtree(workdir, ignore_errors=True)
+
+
+def declares_dependencies(chart_dir: str) -> bool:
+    """True when Chart.yaml declares upstream subcharts.
+
+    Such a chart cannot be packaged without `helm dependency build` (which needs
+    registry credentials), so a plain repo sweep cannot measure it. It is still
+    gated — blueprint-release.yaml runs this same check after it builds the
+    dependencies and before it pushes, so nothing reaches GHCR unmeasured.
+    """
+    with open(os.path.join(chart_dir, "Chart.yaml"), encoding="utf-8") as fh:
+        for line in fh:
+            if re.match(r"^dependencies:\s*(#.*)?$", line):
+                return True
+    return False
+
+
+def discover_charts(root: str) -> list[str]:
+    found = []
+    for pattern in ("platform/*/chart", "products/*/chart", "products/*/charts/*"):
+        for d in sorted(glob.glob(os.path.join(root, pattern))):
+            if os.path.isfile(os.path.join(d, "Chart.yaml")):
+                found.append(os.path.relpath(d, root))
+    return found
+
+
+def sweep(root: str, budget_pct: float) -> int:
+    """Measure every chart that packages standalone; defer the rest, loudly."""
+    measured, deferred, over, broken = [], [], [], []
+    budget = int(K8S_SECRET_LIMIT * budget_pct / 100.0)
+    for chart in discover_charts(root):
+        full = os.path.join(root, chart)
+        if declares_dependencies(full):
+            deferred.append(chart)
+            continue
+        try:
+            m = measure(full, [], "release", "default")
+        except MeasureError as exc:
+            broken.append((chart, str(exc).splitlines()[0]))
+            continue
+        judged = int(m["payload"] * MODEL_ALLOWANCE)
+        measured.append((chart, judged))
+        if judged > budget:
+            over.append((chart, judged))
+
+    for chart, judged in sorted(measured, key=lambda kv: -kv[1]):
+        pct = 100.0 * judged / K8S_SECRET_LIMIT
+        flag = "OVER " if judged > budget else ("near " if pct >= NOTICE_PCT else "     ")
+        print(f"  {flag}{judged:>9} bytes {pct:>6.2f}%  {chart}")
+    print(f"\nmeasured {len(measured)} chart(s); "
+          f"{len(deferred)} deferred to blueprint-release (declare dependencies:)")
+
+    if broken:
+        for chart, why in broken:
+            print(f"::error title=Chart could not be measured::{chart}: {why}",
+                  file=sys.stderr)
+        print("A dependency-free chart that will not package is not a pass — fix it "
+              "or the payload ceiling goes unmeasured for that chart.", file=sys.stderr)
+        return 1
+    if over:
+        for chart, judged in over:
+            print(f"::error title=Helm release Secret too large::{chart} would store "
+                  f"~{judged} bytes, over the {budget_pct:g}% budget of the "
+                  f"{K8S_SECRET_LIMIT}-byte Secret ceiling (#6004).", file=sys.stderr)
+        return 1
+    return 0
+
+
+SELF_TEST_CHART_YAML = "apiVersion: v2\nname: payload-size-selftest\nversion: 0.0.1\n"
+
+
+def _write_selftest_chart(root: str, comment_lines: int) -> str:
+    """Build a chart whose only variable is how much `#` comment it renders."""
+    os.makedirs(os.path.join(root, "templates"), exist_ok=True)
+    with open(os.path.join(root, "Chart.yaml"), "w") as fh:
+        fh.write(SELF_TEST_CHART_YAML)
+    with open(os.path.join(root, "values.yaml"), "w") as fh:
+        fh.write("{}\n")
+    # Pseudo-random-ish but deterministic filler: repetitive text would gzip to
+    # nothing and the test would prove only that gzip works.
+    body = []
+    for i in range(comment_lines):
+        body.append("    # line %07d %s" % (i, hex(i * 2654435761 % (1 << 60))[2:]))
+    with open(os.path.join(root, "templates", "cm.yaml"), "w") as fh:
+        fh.write("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: selftest\n"
+                 "data:\n  payload.sh: |\n" + "\n".join(body) + "\n    exit 0\n")
+    return root
+
+
+def self_test() -> int:
+    """Prove the gate fails on an over-budget chart and passes on a small one.
+
+    A size check nobody has seen fail is not a check. This runs both directions
+    on every CI invocation, so the gate cannot rot into one that always passes.
+    """
+    ok = True
+    tmp = tempfile.mkdtemp(prefix="relpayload-selftest-")
+    try:
+        for name, lines, want in (("under", 200, 0), ("over", 60000, 1)):
+            root = _write_selftest_chart(os.path.join(tmp, name), lines)
+            m = measure(root, [], "selftest", "default")
+            judged = int(m["payload"] * MODEL_ALLOWANCE)
+            budget = int(K8S_SECRET_LIMIT * DEFAULT_BUDGET_PCT / 100.0)
+            got = 1 if judged > budget else 0
+            verdict = "PASS" if got == want else "FAIL"
+            if got != want:
+                ok = False
+            print(f"self-test {name:<6} {judged:>9} bytes vs budget {budget} "
+                  f"-> exit {got} (want {want}) {verdict}")
+        if not ok:
+            print("::error title=payload-size guard self-test failed::The gate did "
+                  "not return the expected verdict in both directions — it can no "
+                  "longer be trusted to catch an over-ceiling chart.", file=sys.stderr)
+            return 1
+        print("self-test OK — the gate fails over budget and passes under it.")
+        return 0
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("chart", nargs="?", help="path to a chart directory")
+    ap.add_argument("--self-test", action="store_true",
+                    help="prove the gate goes red over budget and green under it")
+    ap.add_argument("--all", metavar="REPO_ROOT", nargs="?", const=".",
+                    help="sweep every chart in the repo that packages standalone")
+    ap.add_argument("-f", "--values", action="append", default=[],
+                    help="extra values file (repeatable) — pass the per-Sovereign "
+                         "overlay to measure what a real install stores")
+    ap.add_argument("--release-name", default="release")
+    ap.add_argument("--namespace", default="default")
+    ap.add_argument("--budget-pct", type=float, default=DEFAULT_BUDGET_PCT,
+                    help=f"fail above this %% of the {K8S_SECRET_LIMIT}-byte "
+                         f"ceiling (default {DEFAULT_BUDGET_PCT})")
+    args = ap.parse_args()
+
+    if not shutil.which("helm"):
+        _fatal("helm not on PATH — this gate measures what helm itself would store")
+    if args.self_test:
+        return self_test()
+    if args.all:
+        return sweep(args.all, args.budget_pct)
+    if not args.chart:
+        _fatal("a chart directory is required (or pass --self-test / --all)")
+    if not os.path.isfile(os.path.join(args.chart, "Chart.yaml")):
+        _fatal(f"{args.chart} is not a chart directory (no Chart.yaml)")
+
+    m = measure(args.chart, args.values, args.release_name, args.namespace)
+    budget = int(K8S_SECRET_LIMIT * args.budget_pct / 100.0)
+    judged = int(m["payload"] * MODEL_ALLOWANCE)
+    pct = 100.0 * judged / K8S_SECRET_LIMIT
+
+    print(f"chart                     : {args.chart}")
+    print(f"  templates               : {m['n_templates']:>4} files, {m['template_bytes']:>9} bytes")
+    print(f"  packaged files          : {m['n_files']:>4} files, {m['file_bytes']:>9} bytes")
+    print(f"  rendered manifest       : {m['manifest_bytes']:>9} bytes")
+    print(f"  modelled payload        : {m['payload']:>9} bytes")
+    print(f"  judged (x{MODEL_ALLOWANCE:g} allowance) : {judged:>9} bytes  ({pct:.2f}% of {K8S_SECRET_LIMIT})")
+    print(f"  budget ({args.budget_pct:g}% of ceiling) : {budget:>9} bytes")
+
+    if judged > budget:
+        over = judged - budget
+        print()
+        print(f"::error title=Helm release Secret too large::{args.chart} would store "
+              f"~{judged} bytes in sh.helm.release.v1.* — {over} bytes over the "
+              f"{args.budget_pct:g}% budget of the {K8S_SECRET_LIMIT}-byte Kubernetes "
+              f"Secret ceiling. Above 100% every `helm install` of this chart fails with "
+              f"`data: Too long: must have at most {K8S_SECRET_LIMIT} bytes` (#6004).",
+              file=sys.stderr)
+        print("Cheapest reductions, in order, none of which delete reasoning:",
+              file=sys.stderr)
+        print("  1. Convert whole-line `#` comments in templates/ to `{{/* … */}}`. "
+              "A `#` comment is stored twice (template bytes + rendered manifest); a "
+              "`{{/* */}}` comment is stored once and still reads inline in the source.",
+              file=sys.stderr)
+        print("  2. Add build-time-only paths (chart/tests/*.sh, fixtures) to "
+              ".helmignore — CI runs them from the working tree, so packaging them "
+              "is pure payload.", file=sys.stderr)
+        print("  3. Split the chart if a single release genuinely needs this much "
+              "rendered output.", file=sys.stderr)
+        return 1
+
+    if pct >= NOTICE_PCT:
+        print(f"::notice title=Helm release Secret approaching the ceiling::"
+              f"{args.chart} is at {pct:.1f}% of the {K8S_SECRET_LIMIT}-byte "
+              f"Secret ceiling. It still publishes and installs, but it is the "
+              f"next chart in line for #6004. Reduce it before it reaches "
+              f"{args.budget_pct:g}%.")
+    print(f"OK — {budget - judged} bytes under budget, "
+          f"{K8S_SECRET_LIMIT - judged} bytes under the hard ceiling.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check-helm-release-payload-size.py
+++ b/scripts/check-helm-release-payload-size.py
@@ -50,7 +50,7 @@ with the slot-06a overlay, on both sides of the #6004 fix:
 
     chart state          helm's encoder      this model      delta
     0.1.177 (failing)         1233060          1216220      -1.37%
-    0.1.179 (fixed)            743780           732444      -1.52%
+    0.1.179 (fixed)            757264           745988      -1.49%
 
 The residual is Go's flate implementation against zlib's, and it goes the
 UNSAFE way — the model reads slightly low. MODEL_ALLOWANCE below scales the


### PR DESCRIPTION
## The defect

hw293's Phase 1 finished 66/67 installed. The one failure repeated **10 times** between 13:04:38Z and 13:17:56Z:

```
Helm install failed for release catalyst/self-sovereign-cutover with chart bp-self-sovereign-cutover@0.1.177:
create: failed to create: Secret "sh.helm.release.v1.self-sovereign-cutover.v1" is invalid:
data: Too long: must have at most 1048576 bytes
```

Helm stores a release as `base64(gzip(json(release)))` in that Secret; Kubernetes caps a Secret's data at 1048576 bytes. Measured with helm's own storage encoder, 0.1.177 produces **1,233,060 bytes — 117.59% of the ceiling**. Deterministic, not a race: the chart was uninstallable on every future prov, so Pillar 5 could not be proven at all.

## Where the bytes were — measured, not assumed

I reproduced helm's encoder offline (`action.Install` with `ClientOnly`, then the release struct through `storage/driver`'s json→gzip→base64) so the number could be measured on both sides of a change without touching a cluster.

The release stores the chart's **templates** (base64) *and* the **rendered manifest**. So:

* a `#` comment in a template is paid for **twice** — template bytes, then again in the manifest;
* a `{{/* … */}}` comment is stripped at render and paid for **once**.

384,279 bytes — **43% of the rendered manifest** — was `#` prose. Separately, the package shipped `chart/tests/*.sh`: **527,883 bytes** of CI-side test scripts that `blueprint-release.yaml` runs against the *working tree*, never from the package.

`Chart.yaml` (263,395 B) and `values.yaml` (189,798 B) turned out to be **innocent**. Helm stores `Metadata` and `Values` *parsed*, so the two largest files in the chart — almost entirely commentary — never cost a byte of the payload. Cutting them would have been loss with no gain, and the initial framing of this as "the chart is 57% comments" pointed at exactly those two files.

## What changed, and what did not

* **5,170 whole-line `#` comments across 21 templates → 718 `{{/* … */}}` block comments.** Nothing deleted. Every word still sits at the exact line a source reader is looking at; none of it reaches the release Secret.
* **`chart/tests/` left the package** via a new `.helmignore`, and stays in the repo where CI runs it.
* **Two sets of `#` comments stayed `#` on purpose**, each now saying why inline:
  * **Sixteen region anchors** the chart's own tests navigate the *render* by: `settled-roll-preflight BEGIN/END`, `Phase A4` / `Phase B`, `Phase 2c`, `Phase 0: ADD harbor`, the `Phase 3` strip header whose **line number** Case 17b compares against the executable `del(.auths[...])` to prove strip-after-pivot, the Day-2 loop truncation point, the `#5359` candidate chain, and the `#5215` CSI exclusion that Case 64 requires to be *auditable in the manifest* rather than merely absent.
  * **All of `04-registry-pivot-daemonset.yaml`.** `cutover_registry_pivot_mirror_test.go` slices shell functions out of that template **verbatim** and runs them under `/bin/sh` with no Helm rendering, so a Helm comment in a function body is `/bin/sh: Syntax error: "(" unexpected`, not a comment. CI found this on the first run of this PR — two registry-pivot tests died — and the file's header now names the test. It is the only cutover template any Go test reads.

## Proof the behaviour is unchanged

The rendered manifest, with `#` comment lines and blank lines removed and the `helm.sh/chart` version label normalised, is **byte-identical** to 0.1.177's — 507,299 bytes on both sides, zero differing lines:

```
$ cmp before-render.normalised after-render.normalised && echo IDENTICAL
IDENTICAL
```

All 16 `chart/tests/*.sh` pass, as they do on 0.1.177, and so do both registry-pivot Go tests. The tests earned their keep twice: the first pass of this conversion broke five shell tests by removing anchors (which is how the sixteen kept lines were found), and CI then broke two Go tests, which is how the `04` exception was found.

## Before / after

helm's own encoder (`helm.sh/helm/v3` v3.16.3 storage driver), with the slot-06a values a real Sovereign installs with:

| chart | release-Secret payload | % of 1048576 | headroom |
|---|---:|---:|---:|
| 0.1.177 | 1,233,060 | 117.59% | **−184,484** |
| 0.1.179 | 757,264 | **72.22%** | **+291,312** |

## The gate

`scripts/check-helm-release-payload-size.py` reproduces that encoding and fails a chart above **90%** of the ceiling.

**Shown to fail on the old content** — the exact 0.1.177 chart extracted from `origin/main`:

```
$ git archive origin/main platform/self-sovereign-cutover/chart | tar -x -C /tmp/old
$ python3 scripts/check-helm-release-payload-size.py /tmp/old/platform/self-sovereign-cutover/chart
  judged (x1.03 allowance) :   1252529 bytes  (119.45% of 1048576)
  budget (90% of ceiling) :    943718 bytes
::error title=Helm release Secret too large:: ... 308811 bytes over the 90% budget
exit 1
```

and to pass here (73.28% judged). Its `--self-test` builds one over-budget and one under-budget chart on **every** run and asserts the verdict in both directions, so it cannot rot into a check that always passes. The model reads ~1.5% below helm's encoder (Go flate vs zlib) — the docstring records the cross-check on both sides of this fix, and a 1.03 allowance scales the measurement up so the verdict stays conservative.

Wired in two places:

1. **`blueprint-release.yaml`**, after `helm dependency build` and **before `helm push`** — nothing reaches GHCR unmeasured.
2. **A PR sweep** (`--all`) over every chart that packages standalone. Charts declaring `dependencies:` cannot be packaged without registry credentials, so they are deferred *by name and count* to (1); a dependency-free chart that fails to package is an error, never a pass.

## The sweep found the next one

`products/catalyst/chart` is at **83.49%** of the ceiling. It installs today and is not touched here, but it is the same defect one release away — the gate now prints a notice on it on every run, and will block its publish at 90%.

## Lockstep

Chart 0.1.177 → **0.1.179** (0.1.178 is claimed by open PR #5959); umbrella 1.4.1332 → **1.4.1334** (1.4.1333 claimed by the same PR). All five sites moved: `Chart.yaml`, `blueprint.yaml`, the slot 06a pin, the catalog-seed card + delivery pin (`sync-catalog-seed-pin.py`), the regenerated catalog (`build-catalog.mjs`), the umbrella republish and its slot-13 pin. Green locally: `check-bootstrap-kit-pin-sync.sh`, `check-cutover-version-floor.py`, `check-catalog-seed-lockstep.sh`.

No step, value, RBAC rule or step-count change; still 11 steps. No live cluster was written to.

Refs #6004, #3379
