### PR TITLE
fix(catalyst-api): a Phase-1 component census must not decide whether two healthy apiservers mesh (Refs #6040)

### DIFF
--- a/.github/workflows/check-chart-version-bumped.yaml
+++ b/.github/workflows/check-chart-version-bumped.yaml
@@ -1,0 +1,62 @@
+name: Chart-version-bumped guard (pre-merge hollow-pin check)
+
+# Refs #6040. A Blueprint chart reaches a Sovereign by VERSION: the
+# bootstrap-kit slots pin `spec.chart.spec.version` and Flux resolves that pin
+# against the published OCI artifact. A merged edit to templates/ or values that
+# does NOT move `version:` in the chart's own Chart.yaml is therefore a HOLLOW
+# PIN — the code is on main, the cluster keeps pulling the old artifact, and
+# every reader who greps main concludes the defect is fixed.
+#
+# Motivating case: #6021 fixed platform/postgres/chart/templates/cluster.yaml
+# and left version at 0.2.18 — a version already published to ghcr and already
+# pinned by slots 16a/16c/16d. On hw293 (dep a0077ba47e3720e5) all three shared
+# CNPG instances stayed in CreateContainerConfigError under a live release
+# stamped bp-postgres-0.2.18, which is the very version carrying the fix.
+#
+# scripts/check-bootstrap-kit-pin-sync.sh cannot catch this: it asserts the pin
+# EQUALS the chart version, and 0.2.18 == 0.2.18 passed.
+#
+# Diff-scoped, so pre-existing debt in charts a PR does not touch never turns
+# this red. Event-driven only — no `schedule:` trigger.
+
+on:
+  pull_request:
+    paths:
+      - 'platform/*/chart/**'
+      - 'products/*/chart/**'
+      - 'products/*/charts/*/**'
+      - 'scripts/check-chart-version-bumped.sh'
+      - '.github/workflows/check-chart-version-bumped.yaml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Chart-version-bumped guard
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Full history: the guard diffs against the PR merge base and the
+          # --self-test replays a specific historical commit.
+          fetch-depth: 0
+
+      - name: Self-test — prove the guard can FAIL
+        # A guard that has never been observed rejecting the real defect is
+        # decorative. This replays #6021 (cc011ba1e) and requires rejection.
+        run: bash scripts/check-chart-version-bumped.sh --self-test
+
+      - name: Every touched chart must bump its version
+        run: |
+          set -euo pipefail
+          base_sha="${{ github.event.pull_request.base.sha }}"
+          head_sha="${{ github.event.pull_request.head.sha }}"
+          if [ -z "${base_sha}" ]; then
+            base_sha="origin/main"
+            head_sha="HEAD"
+          fi
+          bash scripts/check-chart-version-bumped.sh "$base_sha" "$head_sha"

--- a/products/catalyst/bootstrap/api/internal/handler/clustermesh.go
+++ b/products/catalyst/bootstrap/api/internal/handler/clustermesh.go
@@ -3822,8 +3822,32 @@ func (h *Handler) shouldStartupClusterMeshReconcile(dep *Deployment) bool {
 //
 // ready, OR failed-by-TIMEOUT (#3285/hw130): a timeout record's cluster keeps
 // converging under Flux — abandoning its mesh forever contradicted the
-// never-wipe-a-timeout doctrine. Hard failures (OutcomeFailed /
-// flux-not-reconciling) stay excluded.
+// never-wipe-a-timeout doctrine.
+//
+// #6040 also accepts failed+OutcomeFailed on a MULTI-REGION record — the
+// component-census signature (hw293, dep a0077ba47e3720e5). OutcomeFailed means
+// Phase 1 RAN and WATCHED components to a terminal census, which is only
+// possible when both regions' apiservers answered throughout; it is a statement
+// about HelmReleases, not about reachability. On hw293 exactly ONE of 67
+// components failed — self-sovereign-cutover, DORMANT by design, failed solely
+// because its Helm release Secret exceeded the 1 MiB object ceiling (#6004) —
+// and that single row excluded the deployment from every mesh path, so
+// `cilium-dbg troubleshoot clustermesh` reported "Found 0 cluster
+// configurations" in BOTH regions 4h after a fully-materialised 2-region prov.
+// The secondary's bp-catalyst-edge-routes Services select zero local Pods BY
+// DESIGN and reach region-a only through the mesh, so an unmeshed secondary
+// turns every gateway ELB member in region-b into a "no healthy upstream" 503:
+// 12 of 24 fresh TCP connections failed on every hostname measured. This is the
+// same correction #6015 made one branch up in markPhase1Done for the
+// secondary-kubeconfig producer — a HelmRelease census must not decide whether
+// a Sovereign is allowed to mesh its own peer region. The establish loop is
+// idempotent, so an already-meshed record's first attempt confirms + exits.
+//
+// Outcomes that genuinely mean the cluster is NOT usable stay excluded and are
+// pinned by the vacuity arms of TestClusterMeshReconcileStatusGate_
+// ComponentCensusFailure6040: OutcomeFluxNotReconciling, the kubeconfig-missing
+// and #3971 storage-downgrade reasons, and the EMPTY outcome of a record that
+// never reached Phase 1 at all (a tofu-stage failure has no clusters to mesh).
 //
 // #5253 also accepts failed+OutcomeReady — the pre-#5253 console-downgrade
 // signature (hw276): the PRIMARY fully converged (OutcomeReady is granted only
@@ -3850,10 +3874,42 @@ func (h *Handler) clusterMeshReconcileStatusGate(dep *Deployment) bool {
 	dep.mu.Unlock()
 	rescuableTimeout := status == "failed" && outcome == helmwatch.OutcomeTimeout
 	rescuableConsoleDowngrade := status == "failed" && outcome == helmwatch.OutcomeReady
-	if (status != "ready" && !rescuableTimeout && !rescuableConsoleDowngrade) || regionCount < 2 {
+	// #6040 — the component-census arm. See the doc comment above.
+	rescuableComponentCensus := status == "failed" && outcome == helmwatch.OutcomeFailed
+	if (status != "ready" && !rescuableTimeout && !rescuableConsoleDowngrade && !rescuableComponentCensus) || regionCount < 2 {
 		return false
 	}
 	return true
+}
+
+// clusterMeshLoopMayContinue reports whether the establish/heal goroutines may
+// keep running for a deployment in this lifecycle status (#6040).
+//
+// Widening clusterMeshReconcileStatusGate alone would have been a HALF-LANDED
+// fix. Three separate places re-read dep.Status and stop the work, and two of
+// them live INSIDE the loops rather than at the entry:
+//
+//	runAutoEstablishClusterMesh    stops the bounded retry loop  (phase1_watch.go)
+//	runClusterMeshSteadyStateHeal  stops the unbounded heal loop (phase1_watch.go)
+//
+// Both previously tested `status != "ready"`, so a record admitted by the
+// widened entry gate would still have abandoned the mesh after a single
+// attempt — converging zero times on the hw293 shape.
+//
+// What those checks EXIST for is the wipe: once a deployment is wiping/wiped
+// the kubeconfigs are gone or going, and hurling establish attempts at a
+// tearing-down cluster is pointless and noisy. That invariant is preserved
+// exactly — only the terminal Phase-1 statuses whose clusters are still
+// standing are admitted. Everything pre-terminal (queued / provisioning /
+// tofu-applying / phase1-watching) stays out too: the establish is a
+// post-Phase-1 producer and its own entry gates own that ordering.
+func clusterMeshLoopMayContinue(status string) bool {
+	switch status {
+	case "ready", "failed", "partial-failure":
+		return true
+	default:
+		return false
+	}
 }
 
 // retryStartupClusterMeshReconcile is the #4811 bounded self-heal for the

--- a/products/catalyst/bootstrap/api/internal/handler/clustermesh_component_census_6040_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/clustermesh_component_census_6040_test.go
@@ -1,0 +1,364 @@
+package handler
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/helmwatch"
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/provisioner"
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/store"
+)
+
+// #6040 — a Phase-1 COMPONENT CENSUS failure must not decide whether two
+// healthy apiservers get meshed.
+//
+// Live evidence (hw293, dep a0077ba47e3720e5, 2026-08-10/11): exactly ONE of
+// 67 components failed — self-sovereign-cutover, which is DORMANT by design
+// and failed only because its Helm release Secret exceeded the 1 MiB object
+// ceiling (#6004). That single row latched Phase1Outcome=failed, and every
+// ClusterMesh producer was gated shut behind it:
+//
+//	markPhase1Done          fired the establish only on OutcomeReady / OutcomeTimeout
+//	clusterMeshReconcileStatusGate  admitted only ready / failed+timeout / failed+ready
+//	runAutoEstablishClusterMesh     returned as soon as status != "ready"
+//	runClusterMeshSteadyStateHeal   returned as soon as status != "ready"
+//
+// so `cilium-dbg troubleshoot clustermesh` reported "Found 0 cluster
+// configurations" in BOTH regions 4h after a fully-materialised 2-region
+// prov. The secondary region's bp-catalyst-edge-routes stubs — Services that
+// select ZERO local Pods BY DESIGN and rely on the mesh to reach region-a —
+// were therefore permanent black holes, and the gateway ELB (6 region-a +
+// 6 region-b node members) 503'd exactly 12 of 24 fresh TCP connections on
+// every hostname whose backend lives in region-a.
+//
+// This is the same reasoning #6015 already applied to the secondary-kubeconfig
+// producer one branch above: a HelmRelease census is not a statement about
+// apiserver reachability. OutcomeFailed specifically means Phase 1 RAN and
+// WATCHED components — which requires both regions' apiservers to be up — so
+// it is precisely the shape that must keep meshing. Outcomes that mean the
+// cluster is NOT usable (OutcomeFluxNotReconciling, the kubeconfig-missing and
+// storage-downgrade reasons, and the empty outcome of a record that never
+// reached Phase 1) stay excluded; the vacuity sub-tests below pin that.
+func TestClusterMeshReconcileStatusGate_ComponentCensusFailure6040(t *testing.T) {
+	dir := t.TempDir()
+	h := &Handler{log: silentLogger(), kubeconfigsDir: dir}
+	kcPath := filepath.Join(dir, "census.yaml")
+	if err := os.WriteFile(kcPath, []byte("apiVersion: v1\nkind: Config\n"), 0o600); err != nil {
+		t.Fatalf("write kubeconfig: %v", err)
+	}
+	twoRegions := []provisioner.RegionSpec{
+		{Provider: "huawei", CloudRegion: "me-east-215-a"},
+		{Provider: "huawei", CloudRegion: "me-east-215-b"},
+	}
+
+	cases := []struct {
+		name    string
+		status  string
+		outcome string
+		regions []provisioner.RegionSpec
+		want    bool
+	}{
+		// The hw293 shape — the defect this test exists for.
+		{"failed-component-census-two-region", "failed", helmwatch.OutcomeFailed, twoRegions, true},
+
+		// Vacuity: the gate must still be capable of returning FALSE.
+		// Without these a fix that returns `true` unconditionally passes.
+		{"failed-component-census-single-region", "failed", helmwatch.OutcomeFailed, twoRegions[:1], false},
+		{"failed-flux-not-reconciling", "failed", helmwatch.OutcomeFluxNotReconciling, twoRegions, false},
+		{"failed-outcome-never-classified", "failed", "", twoRegions, false},
+		{"wiping", "wiping", helmwatch.OutcomeFailed, twoRegions, false},
+		{"provisioning", "provisioning", "", twoRegions, false},
+
+		// Pre-existing arms must not regress.
+		{"ready-two-region", "ready", helmwatch.OutcomeReady, twoRegions, true},
+		{"failed-timeout-3285", "failed", helmwatch.OutcomeTimeout, twoRegions, true},
+		{"failed-console-downgrade-5253", "failed", helmwatch.OutcomeReady, twoRegions, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dep := &Deployment{
+				ID:      "census-" + tc.name,
+				Status:  tc.status,
+				Request: provisioner.Request{Regions: tc.regions},
+				Result:  &provisioner.Result{KubeconfigPath: kcPath, Phase1Outcome: tc.outcome},
+			}
+			if got := h.clusterMeshReconcileStatusGate(dep); got != tc.want {
+				t.Errorf("clusterMeshReconcileStatusGate(status=%q, outcome=%q, regions=%d) = %v, want %v",
+					tc.status, tc.outcome, len(tc.regions), got, tc.want)
+			}
+		})
+	}
+}
+
+// TestClusterMeshLoopMayContinue6040 pins the SECOND and THIRD gates. The
+// status gate alone is not enough: even when the loop is kicked, both
+// runAutoEstablishClusterMesh's retry loop and runClusterMeshSteadyStateHeal
+// re-read dep.Status and bail on anything that is not "ready" — so a fix that
+// only widened the entry gate would have converged zero times on hw293 (the
+// half-landed shape). The wipe guard those checks exist for must survive.
+func TestClusterMeshLoopMayContinue6040(t *testing.T) {
+	cases := map[string]bool{
+		"ready":           true,
+		"failed":          true,
+		"partial-failure": true,
+		// A wipe in flight must still stop the loops — the kubeconfigs are
+		// gone or going. This is the invariant the `!= "ready"` checks were
+		// protecting, and it must not be lost by widening them.
+		"wiping":          false,
+		"wiped":           false,
+		"provisioning":    false,
+		"phase1-watching": false,
+		"queued":          false,
+	}
+	for status, want := range cases {
+		if got := clusterMeshLoopMayContinue(status); got != want {
+			t.Errorf("clusterMeshLoopMayContinue(%q) = %v, want %v", status, got, want)
+		}
+	}
+}
+
+// TestRunAutoEstablishClusterMesh_CensusFailedRecordSurvivesRetry6040 pins the
+// gate that the single-attempt end-to-end test structurally CANNOT reach.
+//
+// With fully-seeded fakes the establish converges on attempt 1 and emits the
+// success event BEFORE the loop ever re-reads dep.Status — so a test built on
+// that harness passes whether or not the loop's status check was widened, and
+// would have shipped gate 3 untested (verified by reverting
+// clusterMeshLoopMayContinue to ready-only: the single-attempt test still
+// passed). This variant starts region 0 with NO clustermesh-apiserver LB IP, so
+// attempt 1 MUST fail; the loop then hits the status check with status="failed"
+// and, pre-#6040, returned there and abandoned the mesh forever. The LB IP is
+// stamped only after the first retry event, exactly as LB-IPAM does in
+// production.
+//
+// The wipe invariant is exercised in the same run: watchAndStopSteadyStateOnConverged
+// flips the record to "wiped" at convergence, and the loop must then terminate —
+// so a fix that simply removed the status check would hang this test.
+func TestRunAutoEstablishClusterMesh_CensusFailedRecordSurvivesRetry6040(t *testing.T) {
+	fx := newTestFixture(t, []string{"", "203.0.113.20"})
+	restore := installClusterMeshClientFactory(fx.clients)
+	defer restore()
+	restoreDyn := installClusterMeshDynamicClientFactory(fx.dynClients)
+	defer restoreDyn()
+
+	// The hw293 record shape: Phase 1 ran, watched a terminal census, and one
+	// dormant component failed it.
+	fx.dep.mu.Lock()
+	fx.dep.Status = "failed"
+	fx.dep.Result.Phase1Outcome = helmwatch.OutcomeFailed
+	fx.dep.mu.Unlock()
+
+	setClusterMeshLBOverrides(t, 150*time.Millisecond, 25*time.Millisecond)
+	fx.handler.clusterMeshRetryInitialBackoff = 20 * time.Millisecond
+	fx.handler.clusterMeshRetryMaxBackoff = 60 * time.Millisecond
+	fx.handler.clusterMeshRetryBudget = 20 * time.Second
+	fx.handler.clusterMeshAttemptTimeout = 5 * time.Second
+	fx.handler.clusterMeshSteadyStateInterval = 20 * time.Millisecond
+
+	stopSteady := watchAndStopSteadyStateOnConvergedFrom6040(fx)
+	defer stopSteady()
+
+	flipDone := make(chan error, 1)
+	go func() {
+		deadline := time.Now().Add(15 * time.Second)
+		for time.Now().Before(deadline) {
+			if hasClusterMeshEvent(fx.dep, "warn", "retrying in") {
+				cs := fx.clients[fx.primaryKubeconfigPath]
+				svc, err := cs.CoreV1().Services(clusterMeshNamespace).Get(context.Background(), clusterMeshApiserverService, metav1.GetOptions{})
+				if err != nil {
+					flipDone <- err
+					return
+				}
+				svc.Status.LoadBalancer.Ingress = []corev1.LoadBalancerIngress{{IP: "203.0.113.10"}}
+				_, err = cs.CoreV1().Services(clusterMeshNamespace).Update(context.Background(), svc, metav1.UpdateOptions{})
+				flipDone <- err
+				return
+			}
+			time.Sleep(5 * time.Millisecond)
+		}
+		flipDone <- errNoRetryEvent6040
+	}()
+
+	loopDone := make(chan struct{})
+	go func() {
+		fx.handler.runAutoEstablishClusterMesh(fx.dep)
+		close(loopDone)
+	}()
+	select {
+	case <-loopDone:
+	case <-time.After(25 * time.Second):
+		t.Fatalf("reconcile loop did not terminate; events:\n%s", dumpClusterMeshEvents(fx.dep))
+	}
+	if err := <-flipDone; err != nil {
+		t.Fatalf("LB flip goroutine: %v", err)
+	}
+
+	// Attempt 1 failed and the loop RETRIED rather than abandoning the record.
+	if !hasClusterMeshEvent(fx.dep, "warn", "attempt 1 ended with", "retrying in") {
+		t.Fatalf("a census-failed record must keep retrying past attempt 1; events:\n%s", dumpClusterMeshEvents(fx.dep))
+	}
+	if !hasClusterMeshEvent(fx.dep, "info", "fully meshed (2/2 regions)", "reconcile loop complete") {
+		t.Fatalf("a census-failed record must reach full mesh; events:\n%s", dumpClusterMeshEvents(fx.dep))
+	}
+	// The wipe invariant held — the loop stopped once the record left the
+	// meshable statuses, rather than spinning against a tearing-down cluster.
+	fx.dep.mu.Lock()
+	finalStatus := fx.dep.Status
+	fx.dep.mu.Unlock()
+	if finalStatus != "wiped" {
+		t.Fatalf("harness should have flipped the record to wiped at convergence, got %q", finalStatus)
+	}
+}
+
+var errNoRetryEvent6040 = errors.New("never observed a retry progress event")
+
+// watchAndStopSteadyStateOnConvergedFrom6040 mirrors the existing
+// watchAndStopSteadyStateOnConverged helper but flips out of "failed" (this
+// record never was "ready"), so the steady-state heal phase releases the loop.
+func watchAndStopSteadyStateOnConvergedFrom6040(fx *testFixture) func() {
+	stop := make(chan struct{})
+	go func() {
+		ticker := time.NewTicker(5 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-stop:
+				return
+			case <-ticker.C:
+				if hasClusterMeshEvent(fx.dep, "info", "reconcile loop complete") {
+					fx.dep.mu.Lock()
+					if fx.dep.Status == "failed" {
+						fx.dep.Status = "wiped"
+					}
+					fx.dep.mu.Unlock()
+					return
+				}
+			}
+		}
+	}()
+	return func() { close(stop) }
+}
+
+// TestRestoreFromStore_KicksClusterMeshOnComponentCensusFailure6040 is the
+// END-TO-END guard: a rehydrated record carrying the exact hw293 shape
+// (status=failed, Phase1Outcome=failed, 2 materialised regions, primary
+// kubeconfig on the PVC) must reach FULL MESH on the startup reconcile.
+//
+// It exercises all three gates at once — the entry gate, the convergence
+// loop's status check, and the establish itself — and asserts the real
+// artifact (the cilium-clustermesh Secret written into BOTH fake regions),
+// not merely that a code path was entered.
+func TestRestoreFromStore_KicksClusterMeshOnComponentCensusFailure6040(t *testing.T) {
+	t.Setenv("SOVEREIGN_FQDN", "")
+	dir := t.TempDir()
+	caCert, caKey := genCAForTest(t, "test-mesh-ca-6040")
+
+	depID := "dep6040census"
+	regions := []provisioner.RegionSpec{
+		{Provider: "huawei", CloudRegion: "me-east-215-a"},
+		{Provider: "huawei", CloudRegion: "me-east-215-b"},
+	}
+	lbIPs := []string{"203.0.113.60", "203.0.113.70"}
+	clients := map[string]kubernetes.Interface{}
+	for i := range regions {
+		key := regionKeyFromSpec(regions[i], i)
+		kcPath := writeFakeKubeconfig(t, dir, depID, key)
+		cs := buildFakeClusterMeshCluster(t, lbIPs[i], caCert, caKey)
+		if i == 0 {
+			seedCNPGPairSourceSecrets(t, cs)
+		} else {
+			seedCNPGPairReplicaNamespace(t, cs)
+		}
+		clients[kcPath] = cs
+	}
+	primaryKubeconfigPath := filepath.Join(dir, depID+".yaml")
+	dynClients := map[string]dynamic.Interface{}
+	for i := range regions {
+		key := regionKeyFromSpec(regions[i], i)
+		kcPath := primaryKubeconfigPath
+		if i > 0 {
+			kcPath = filepath.Join(dir, depID+"-"+key+".yaml")
+		}
+		dynClients[kcPath] = newFakeKustomizationDynClient(t,
+			buildBootstrapKitKustomization(defaultBootstrapKitSubstitute()))
+	}
+	restore := installClusterMeshClientFactory(clients)
+	defer restore()
+	restoreDyn := installClusterMeshDynamicClientFactory(dynClients)
+	defer restoreDyn()
+
+	st, err := store.New(t.TempDir())
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	phase1Done := time.Now().Add(-1 * time.Hour).UTC()
+	rec := store.Record{
+		ID: depID,
+		// The hw293 record verbatim: ONE dormant component failed the
+		// census, so the whole deployment latched "failed".
+		Status: "failed",
+		Error:  "Phase 1 finished with 1 failed component(s); see ComponentStates for the per-component breakdown",
+		Request: store.Redact(provisioner.Request{
+			SovereignFQDN: "hw293.omantel.biz",
+			Regions:       regions,
+		}),
+		Result: &provisioner.Result{
+			SovereignFQDN:    "hw293.omantel.biz",
+			KubeconfigPath:   primaryKubeconfigPath,
+			Phase1Outcome:    helmwatch.OutcomeFailed,
+			Phase1FinishedAt: &phase1Done,
+			ComponentStates:  map[string]string{"self-sovereign-cutover": "failed"},
+		},
+		StartedAt:  time.Now().Add(-2 * time.Hour),
+		FinishedAt: time.Now().Add(-90 * time.Minute),
+	}
+	if err := st.Save(rec); err != nil {
+		t.Fatalf("store.Save: %v", err)
+	}
+
+	h := &Handler{log: silentLogger(), kubeconfigsDir: dir, store: st}
+	h.clusterMeshRetryInitialBackoff = 20 * time.Millisecond
+	h.clusterMeshRetryMaxBackoff = 60 * time.Millisecond
+	h.clusterMeshRetryBudget = 20 * time.Second
+	h.clusterMeshAttemptTimeout = 5 * time.Second
+	h.consumerHubSyncVerifyBackoff = 20 * time.Millisecond
+	h.consumerHubSyncVerifyAttempts = 3
+
+	h.restoreFromStore()
+
+	val, ok := h.deployments.Load(depID)
+	if !ok {
+		t.Fatalf("deployment %q not restored", depID)
+	}
+	dep := val.(*Deployment)
+
+	waitForClusterMeshEvent(t, dep, 10*time.Second, "info", "fully meshed (2/2 regions)", "reconcile loop complete")
+
+	for kcPath, client := range clients {
+		secret, err := client.CoreV1().Secrets(clusterMeshNamespace).Get(context.Background(), clusterMeshSecretName, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("Get cilium-clustermesh in %q: %v — a component-census failure must not leave the regions unmeshed", kcPath, err)
+		}
+		if len(secret.Data) != 4 {
+			t.Errorf("Secret in %q has %d entries, want 4 (keys %v)", kcPath, len(secret.Data), secretKeys(secret))
+		}
+	}
+	for kcPath, dyn := range dynClients {
+		ks := getBootstrapKitKustomization(t, dyn)
+		substitute, _, _ := unstructured.NestedStringMap(ks.Object, "spec", "postBuild", "substitute")
+		if got := substitute[clusterMeshCNPGPairSubstituteKey]; got != "true" {
+			t.Errorf("region %q: substitute[%s] = %q, want \"true\" — the cnpg-pair flip must land on a census-failed record too",
+				kcPath, clusterMeshCNPGPairSubstituteKey, got)
+		}
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/clustermesh_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/clustermesh_test.go
@@ -2381,8 +2381,16 @@ func TestShouldStartupClusterMeshReconcile_RescuesTimeoutRecords(t *testing.T) {
 	if !h.shouldStartupClusterMeshReconcile(mk("failed", helmwatch.OutcomeTimeout)) {
 		t.Errorf("failed+timeout record must be rescued (the hw130 abandonment)")
 	}
-	if h.shouldStartupClusterMeshReconcile(mk("failed", helmwatch.OutcomeFailed)) {
-		t.Errorf("failed+hard-failure record must stay excluded")
+	// #6040 INVERTED (was "must stay excluded"). OutcomeFailed means Phase 1
+	// ran and WATCHED components to a terminal census — only possible while
+	// both regions' apiservers answer — so it is a HelmRelease statement, not
+	// a reachability statement. hw293 proved the cost of treating it as the
+	// latter: one dormant chart over the #6004 1 MiB ceiling left BOTH regions
+	// at "Found 0 cluster configurations" and 503'd half of every fresh TCP
+	// connection through the gateway ELB. flux-not-reconciling stays excluded
+	// below — that one IS a reachability statement.
+	if !h.shouldStartupClusterMeshReconcile(mk("failed", helmwatch.OutcomeFailed)) {
+		t.Errorf("failed+component-census record must be rescued (the hw293 abandonment, #6040)")
 	}
 	if h.shouldStartupClusterMeshReconcile(mk("failed", "flux-not-reconciling")) {
 		t.Errorf("flux-not-reconciling record must stay excluded")
@@ -3978,7 +3986,10 @@ func TestClusterMeshReconcileStatusGate_ConsoleDowngradedRecord(t *testing.T) {
 		{"failed+timeout multi-region (#3317 arm intact)", "failed", helmwatch.OutcomeTimeout, 2, true},
 		{"failed+OutcomeReady multi-region (#5253 hw276 pre-fix shape)", "failed", helmwatch.OutcomeReady, 2, true},
 		{"failed+OutcomeReady single-region", "failed", helmwatch.OutcomeReady, 1, false},
-		{"failed+OutcomeFailed (genuine hard failure)", "failed", helmwatch.OutcomeFailed, 2, false},
+		// #6040: a component census is not a reachability statement — see
+		// clusterMeshReconcileStatusGate's doc comment and the hw293 evidence.
+		{"failed+OutcomeFailed multi-region (#6040 hw293 component-census shape)", "failed", helmwatch.OutcomeFailed, 2, true},
+		{"failed+OutcomeFailed single-region (#6040 vacuity)", "failed", helmwatch.OutcomeFailed, 1, false},
 		{"failed+flux-not-reconciling (genuine hard failure)", "failed", helmwatch.OutcomeFluxNotReconciling, 2, false},
 		{"failed+storage-downgrade (#3971 replaces the outcome)", "failed", provisioner.ReasonDefaultStorageClassEphemeral, 2, false},
 	}

--- a/products/catalyst/bootstrap/api/internal/handler/phase1_console_gate_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/phase1_console_gate_test.go
@@ -140,11 +140,18 @@ func TestMarkPhase1DoneConsoleGate(t *testing.T) {
 		if dep.Result.HandoverFiredAt != nil {
 			t.Fatalf("hard failure must NOT fire handover")
 		}
-		// failed + OutcomeFailed is excluded from the #5253 heal arms too —
-		// only the failed+OutcomeReady console-downgrade signature (records
-		// persisted by pre-#5253 builds) is rescuable.
-		if h.clusterMeshReconcileStatusGate(dep) {
-			t.Fatalf("failed+OutcomeFailed must NOT pass the mesh status gate")
+		// #6040 INVERTED. The LIFECYCLE stays failed (asserted above: no
+		// handover, no fire) — but the TOPOLOGY must keep converging. A
+		// component census is a statement about HelmReleases, never about
+		// apiserver reachability, and OutcomeFailed is only reachable when
+		// Phase 1 watched every component to a terminal state on both
+		// regions' live apiservers. hw293 (dep a0077ba47e3720e5) is the
+		// evidence: one DORMANT chart failing the census left both regions
+		// unmeshed, which turned the secondary's by-design endpoint-less
+		// edge-route stubs into "no healthy upstream" for half of every
+		// hostname's fresh TCP connections.
+		if !h.clusterMeshReconcileStatusGate(dep) {
+			t.Fatalf("failed+OutcomeFailed on a 2-region record must still pass the mesh status gate (#6040)")
 		}
 	})
 }

--- a/products/catalyst/bootstrap/api/internal/handler/phase1_watch.go
+++ b/products/catalyst/bootstrap/api/internal/handler/phase1_watch.go
@@ -1622,7 +1622,7 @@ func (h *Handler) markPhase1Done(dep *Deployment, finalStates map[string]string,
 		if consoleReachErr != nil {
 			h.spawnPostHandoverHook(func() { h.runConsoleReachabilityReprobe(dep) })
 		}
-	} else if outcome == helmwatch.OutcomeTimeout && len(dep.Request.Regions) >= 2 {
+	} else if (outcome == helmwatch.OutcomeTimeout || outcome == helmwatch.OutcomeFailed) && len(dep.Request.Regions) >= 2 {
 		// #3285/hw130 (2026-06-12): a Phase-1 TIMEOUT is the
 		// recoverable classification ("components observed, none
 		// hard-failed, not all converged") — Flux keeps reconciling
@@ -1637,6 +1637,22 @@ func (h *Handler) markPhase1Done(dep *Deployment, finalStates map[string]string,
 		// it converges exactly when the env does. Handover, the job
 		// sweep, and the policy flip stay ready-only — this rescues
 		// the TOPOLOGY, not the lifecycle.
+		//
+		// #6040 folds OutcomeFailed into the SAME arm. A component-census
+		// failure means Phase 1 ran and WATCHED every component to a terminal
+		// state — only possible while both regions' apiservers answer — so it
+		// is a statement about HelmReleases, not about reachability. On hw293
+		// (dep a0077ba47e3720e5) exactly ONE of 67 components failed: the
+		// DORMANT-by-design self-sovereign-cutover chart, over the #6004 1 MiB
+		// release-Secret ceiling. That single row left BOTH regions reporting
+		// "Found 0 cluster configurations" four hours into a fully-
+		// materialised 2-region prov. The secondary's bp-catalyst-edge-routes
+		// Services select ZERO local Pods by design and reach region-a only
+		// through the mesh, so an unmeshed secondary makes every region-b
+		// gateway ELB member answer "no healthy upstream" — 12 of 24 fresh TCP
+		// connections 503'd on every hostname measured. Identical correction
+		// to #6015's hoist above: a HelmRelease census must not decide whether
+		// a Sovereign may mesh its own peer region.
 		h.spawnPostHandoverHook(func() { h.runAutoEstablishClusterMesh(dep) })
 		// #3277 (founder, 2026-06-12): the secondary-region job rows
 		// freeze at their last-seen state forever on a timeout record
@@ -2068,14 +2084,18 @@ func (h *Handler) runAutoEstablishClusterMesh(dep *Deployment) {
 			)
 		}
 
-		// A deployment that left status=ready mid-loop (wipe, failure
-		// rewrite) must not keep getting establish attempts hurled at
-		// it for the rest of the budget.
+		// A deployment that entered a WIPE mid-loop must not keep getting
+		// establish attempts hurled at it for the rest of the budget — the
+		// kubeconfigs are gone or going. #6040 narrowed this from
+		// `status != "ready"` to the wipe/pre-terminal condition it was
+		// actually protecting: a Phase-1 component-census failure leaves both
+		// clusters standing and must keep meshing (see
+		// clusterMeshLoopMayContinue).
 		dep.mu.Lock()
 		status := dep.Status
 		dep.mu.Unlock()
-		if status != "ready" {
-			h.log.Info("clustermesh: reconcile loop stopped — deployment no longer ready",
+		if !clusterMeshLoopMayContinue(status) {
+			h.log.Info("clustermesh: reconcile loop stopped — deployment left the meshable lifecycle statuses",
 				"id", dep.ID,
 				"status", status,
 				"attempt", attempt,
@@ -2132,7 +2152,8 @@ func (h *Handler) runAutoEstablishClusterMesh(dep *Deployment) {
 // Lifecycle contract (do NOT widen):
 //   - Its own ctx is derived from context.Background(), NOT the retry
 //     budget — the budget bounds only the convergence phase; steady-state
-//     is unbounded in time and ends solely on status != "ready".
+//     is unbounded in time and ends solely when the deployment leaves the
+//     meshable lifecycle statuses (clusterMeshLoopMayContinue — #6040).
 //   - status is re-checked before AND after every pass (a wipe that lands
 //     mid-sleep or mid-pass exits the goroutine promptly — the kubeconfigs
 //     are gone or going, same rationale as the convergence loop's check).
@@ -2169,8 +2190,8 @@ func (h *Handler) runClusterMeshSteadyStateHeal(dep *Deployment) {
 		dep.mu.Lock()
 		status := dep.Status
 		dep.mu.Unlock()
-		if status != "ready" {
-			h.log.Info("clustermesh: steady-state heal phase stopped — deployment no longer ready",
+		if !clusterMeshLoopMayContinue(status) {
+			h.log.Info("clustermesh: steady-state heal phase stopped — deployment left the meshable lifecycle statuses",
 				"id", dep.ID,
 				"status", status,
 			)
@@ -2191,8 +2212,8 @@ func (h *Handler) runClusterMeshSteadyStateHeal(dep *Deployment) {
 		dep.mu.Lock()
 		status = dep.Status
 		dep.mu.Unlock()
-		if status != "ready" {
-			h.log.Info("clustermesh: steady-state heal phase stopped — deployment no longer ready",
+		if !clusterMeshLoopMayContinue(status) {
+			h.log.Info("clustermesh: steady-state heal phase stopped — deployment left the meshable lifecycle statuses",
 				"id", dep.ID,
 				"status", status,
 			)

--- a/scripts/check-chart-version-bumped.sh
+++ b/scripts/check-chart-version-bumped.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# check-chart-version-bumped.sh — Refs #6040
+#
+# WHY THIS EXISTS
+# ----------------
+# A Blueprint chart is delivered to a Sovereign by VERSION, not by commit. The
+# bootstrap-kit slots pin `spec.chart.spec.version: <semver>` and Flux resolves
+# that pin against the published OCI artifact. So a merged template edit that
+# does NOT move `version:` in the chart's own Chart.yaml is a HOLLOW PIN — the
+# code is on main, the artifact the cluster pulls is the old one, and every
+# reader who greps main concludes the defect is fixed.
+#
+# Live proof (2026-08-11, hw293 dep a0077ba47e3720e5, region me-east-215-b):
+# #6021 fixed platform/postgres/chart/templates/cluster.yaml so the replica side
+# stops naming a role Secret it never renders. It shipped 3 files — cluster.yaml,
+# a render test, and a new guard — and left Chart.yaml at `version: 0.2.18`.
+# 0.2.18 was ALREADY published to ghcr and already pinned by bootstrap-kit slots
+# 16a/16c/16d, so the Sovereign kept running the defective render: all three
+# shared CNPG instances sat in CreateContainerConfigError on
+#   secret "shared-pg-harbor" / "shared-pg-b-grafana" / "shared-pg-c-org" not found
+# under a live release stamped `helm.sh/chart: bp-postgres-0.2.18` — the exact
+# version that carries the fix on main. Region B held 14 Secrets in shared-data
+# against region A's 38, keycloak never got its database Secret, and 8 of 65
+# HelmReleases stayed blocked behind it.
+#
+# scripts/check-bootstrap-kit-pin-sync.sh cannot see this: it asserts the pin
+# EQUALS the chart's version, and 0.2.18 == 0.2.18 passed. Self-consistent is
+# not the same as delivered.
+#
+# WHAT IT CHECKS
+# ---------------
+# Diff-scoped, so it never turns red on pre-existing debt in charts this branch
+# does not touch. For every in-repo chart whose RENDERED SURFACE changed between
+# BASE and HEAD (templates/, values.yaml, values.schema.json, crds/), the
+# chart's own Chart.yaml `version:` MUST differ between BASE and HEAD.
+#
+# Usage:
+#   check-chart-version-bumped.sh [BASE_REF] [HEAD_REF]      # default origin/main HEAD
+#   check-chart-version-bumped.sh --self-test                # prove the guard CAN fail
+#
+# Exit 0: every touched chart bumped its version (or no chart surface changed).
+# Exit 1: at least one touched chart did not bump — each named with its version.
+# Exit 2: usage / repo error.
+
+set -uo pipefail
+
+RED=''; GRN=''; YEL=''; RST=''
+if [ -t 1 ]; then RED=$'\033[31m'; GRN=$'\033[32m'; YEL=$'\033[33m'; RST=$'\033[0m'; fi
+
+# chart_version <ref> <chart-dir> — prints the `version:` field, or empty if the
+# Chart.yaml does not exist at that ref (a brand-new chart).
+chart_version() {
+  git show "$1:$2/Chart.yaml" 2>/dev/null \
+    | sed -n 's/^version:[[:space:]]*["'"'"']\{0,1\}\([^"'"'"'[:space:]]*\).*/\1/p' \
+    | head -1
+}
+
+run_check() {
+  local base="$1" head="$2" label="${3:-}"
+  local merge_base
+  merge_base="$(git merge-base "$base" "$head" 2>/dev/null)" || merge_base="$base"
+
+  local changed
+  changed="$(git diff --name-only "$merge_base" "$head" -- \
+      'platform/*/chart/**' 'products/*/chart/**' 'products/*/charts/*/**' 2>/dev/null)"
+
+  # Reduce every changed path to the chart dir that OWNS it, keeping only paths
+  # that actually alter what Helm renders.
+  local charts
+  charts="$(printf '%s\n' "$changed" \
+    | grep -E '/(templates/|crds/|values\.yaml$|values\.schema\.json$)' \
+    | sed -E 's#/(templates|crds)/.*$##; s#/values(\.schema)?\.(yaml|json)$##' \
+    | sort -u)"
+
+  if [ -z "${charts//[[:space:]]/}" ]; then
+    echo "${GRN}PASS${RST}: ${label}no chart rendered-surface changes in ${merge_base:0:9}..${head} — nothing to bump."
+    return 0
+  fi
+
+  local fails=0 checked=0
+  local c old new
+  while IFS= read -r c; do
+    [ -n "$c" ] || continue
+    [ -f "$c/Chart.yaml" ] || continue
+    checked=$((checked + 1))
+    old="$(chart_version "$merge_base" "$c")"
+    new="$(chart_version "$head" "$c")"
+    if [ -z "$old" ]; then
+      echo "  ${GRN}OK  ${RST} $c: new chart (version=$new)"
+      continue
+    fi
+    if [ "$old" = "$new" ]; then
+      echo "  ${RED}FAIL${RST} $c: rendered surface changed but version stayed ${RED}$new${RST}"
+      echo "         a pinned Sovereign resolves that version to the ALREADY-PUBLISHED artifact,"
+      echo "         so this edit can never reach a cluster. Bump Chart.yaml version: and every"
+      echo "         bootstrap-kit slot that pins it (scripts/check-bootstrap-kit-pin-sync.sh)."
+      fails=$((fails + 1))
+    else
+      echo "  ${GRN}OK  ${RST} $c: $old -> $new"
+    fi
+  done <<< "$charts"
+
+  if [ "$fails" -gt 0 ]; then
+    echo "${RED}FAIL${RST}: ${label}${fails} of ${checked} touched chart(s) shipped a hollow pin."
+    return 1
+  fi
+  echo "${GRN}PASS${RST}: ${label}all ${checked} touched chart(s) bumped their version."
+  return 0
+}
+
+# --self-test — VACUITY CHECK. Replays the exact commit that motivated this
+# guard (#6021, cc011ba1e: cluster.yaml edited, Chart.yaml untouched) and
+# requires the guard to REJECT it. A guard that cannot fail is decorative, so
+# this must be run whenever the matcher above is edited.
+if [ "${1:-}" = "--self-test" ]; then
+  known_bad="cc011ba1ea90f0b221d4eb91d6ded797f85c1049"
+  if ! git cat-file -e "${known_bad}^{commit}" 2>/dev/null; then
+    echo "${YEL}SKIP${RST}: self-test commit $known_bad not in this clone (shallow?)."
+    exit 0
+  fi
+  echo "── self-test: the guard must REJECT ${known_bad:0:9} (#6021, hollow pin) ──"
+  if run_check "${known_bad}^" "$known_bad" "self-test: "; then
+    echo "${RED}FAIL${RST}: self-test PASSED the known-bad commit — the guard is vacuous."
+    exit 1
+  fi
+  echo "${GRN}PASS${RST}: self-test — the guard rejects the known-bad commit as required."
+  exit 0
+fi
+
+BASE_REF="${1:-origin/main}"
+HEAD_REF="${2:-HEAD}"
+git rev-parse --git-dir >/dev/null 2>&1 || { echo "not a git repo" >&2; exit 2; }
+run_check "$BASE_REF" "$HEAD_REF"


### PR DESCRIPTION
## What this fixes

Half of every fresh TCP connection to hw293 fails. Measured 2026-08-10T17:00Z, 24 fresh-TCP samples per host:

| host | region-B backend | result |
|---|---|---|
| `auth…/realms/master` | keycloak, **0 endpoints** | **12× 503** / 12× 200 |
| `mcp…` | openova-mcp, **0 endpoints** | **11× 503** |
| `hubble…` | hubble-ui-oauth2-proxy, **0 endpoints** | **11× 503** |
| `marketplace…` / `console…` | edge-route stubs, **0 endpoints** | **9/20 503** each |
| `bao…/v1/sys/health` | openbao, **1 endpoint** | **24× 200, zero failures** ← control |

Same ELB, same round-robin, same region-B envoy, same Gateway — `bao` never fails because it is the one route whose region-B Service has a local endpoint. The 503 body is envoy's `no healthy upstream`; the failing sample positions are identical across hosts. `terraform.tfstate` shows both gateway ELB pools carry 12 members — 6 region-A + 6 region-B node IPs at host ports 8080/8443 (no nodePorts). The fan-out is healthy; region B cannot serve.

## Root cause

```
#6004 cutover Helm release Secret > 1 MiB
  -> self-sovereign-cutover records failed (1 of 67 components; DORMANT by design)
    -> Phase1Outcome = "failed", dep.Status = "failed"
      -> markPhase1Done fires the establish only on OutcomeReady / OutcomeTimeout
      -> clusterMeshReconcileStatusGate admits only ready / failed+timeout / failed+ready
      -> runAutoEstablishClusterMesh returns on status != "ready"
      -> runClusterMeshSteadyStateHeal returns on status != "ready"
        -> ClusterMesh 0/0 in BOTH regions, zero phase=clustermesh events ever emitted
          -> bp-catalyst-edge-routes stubs (zero local Pods BY DESIGN) are black holes
```

All the tofu-level mesh plumbing the establish needs *was* built at 12:25–12:26 (VPC peering, `ingress_clustermesh_2379`, `ingress_clustermesh_proxy`, both `vpc_route` pairs). Only the catalyst-api producer never fired.

This is the correction #6015 already made one branch above for the secondary-kubeconfig producer: **a HelmRelease census is not a statement about apiserver reachability.** `OutcomeFailed` is only reachable when Phase 1 *watched* components to a terminal state, which requires both regions' apiservers to be answering.

## Changes

**`internal/handler/clustermesh.go`** — `clusterMeshReconcileStatusGate` gains the `rescuableComponentCensus` arm (`failed` + `OutcomeFailed`, multi-region only). Adds `clusterMeshLoopMayContinue`.

**`internal/handler/phase1_watch.go`** — `markPhase1Done` folds `OutcomeFailed` into the existing #3285 timeout arm. Both loop guards narrow from `status != "ready"` to `!clusterMeshLoopMayContinue(status)`.

**Three gates, not one.** Widening only the entry gate would have been half-landed — both loops re-read `dep.Status` and bail. The wipe invariant those checks existed for is preserved exactly: `wiping`/`wiped` and every pre-terminal status still stop the loops.

**The chart half is PR #6041, not this PR.** #6021 fixed `cluster.yaml`'s dangling replica-side `bootstrap.initdb.secret` reference and left `Chart.yaml` at 0.2.18 — already published to ghcr, already pinned — so Flux resolved the pin to the old artifact and hw293 kept running the defective render under a release stamped `bp-postgres-0.2.18`. I had bumped it here too; #6041 does it more completely (it also carries `blueprint.yaml`, the umbrella `Chart.yaml` and the catalog-seed pin), and the `no open PR claims the same chart version` gate correctly caught the collision on 0.2.19. Duplicate dropped; #6041 owns the release.

What stays here is the GUARD for that class. `check-bootstrap-kit-pin-sync.sh` structurally cannot catch a hollow pin: it asserts pin == chart version, and 0.2.18 == 0.2.18 passes.

**`scripts/check-chart-version-bumped.sh` + workflow** — diff-scoped, so pre-existing debt in untouched charts never turns it red.

## Guards, watched failing then passing

Pre-fix tree, exact readings:

```
ComponentCensusFailure/failed-component-census-two-region
    gate = false, want true          (the other 8 arms already passed -> not vacuous)
LoopMayContinue
    2 of 8 statuses wrong ("failed", "partial-failure")
CensusFailedRecordSurvivesRetry
    loop abandoned after attempt 1; never reached full mesh
RestoreFromStore_Kicks…
    "no info clustermesh-progress event … within 10s"  (zero events)
```

Post-fix: all 4 pass. Full `internal/handler` suite green (274s), `go vet` clean.

**Per-line vacuity.** Each fix reverted independently:
- remove the entry-gate arm → `ComponentCensusFailure` + `RestoreFromStore` fail
- `clusterMeshLoopMayContinue` back to ready-only → `CensusFailedRecordSurvivesRetry` fails

My first vacuity attempt was itself wrong and is worth recording: appending `&& false` to the gate's *exclusion* condition made it **more** permissive, so the test passed and looked like the fix was inert. Redone correctly. That re-run also exposed that the single-attempt end-to-end test **cannot** see the loop gate — with fully-seeded fakes the establish converges on attempt 1 and emits success before the loop re-reads status. `CensusFailedRecordSurvivesRetry` exists specifically for that: region 0 starts with no clustermesh-apiserver LB IP so attempt 1 must fail, and the same run asserts the wipe invariant still terminates the loop.

The chart guard carries `--self-test`, which replays `cc011ba1e` (#6021) and requires rejection; CI runs it before the diff check.

## Two superseded assertions inverted

`clustermesh_test.go` and `phase1_console_gate_test.go` each pinned "failed+OutcomeFailed must NOT pass the mesh status gate". Both now assert the opposite for the multi-region case, with the hw293 evidence in the comment. The **lifecycle** contract is untouched — a census-failed record still stays `failed`, still fires no handover, still runs no console probe; only the **topology** keeps converging. Single-region and `flux-not-reconciling` stay excluded and are pinned as vacuity arms.

## What this does NOT fix

The remaining half of #6016 — delivering region A's authoritative hub secrets into region B — is the catalyst-api cross-mesh hub-secret sync, which is downstream of the mesh and only becomes reachable once this lands. Region B's data tier stays blocked on `shared-pg-harbor` / `shared-pg-b-grafana` / `shared-pg-c-org` until then.

Both halves need a mothership catalyst-api roll to reach hw293; neither is verifiable on the live env from this PR alone.

## Note on the kubeconfig premise

While tracing this I re-measured the assumption that the mothership PVC holds one kubeconfig. It holds **two**, both working — the region-B one returns 6 Ready nodes. The **child Sovereign's** copy is the hollow one: 95 bytes, 5 lines, `server:` only, no `contexts`/`users`/CA. `catalyst/cutover-secondary-kubeconfigs` and `kube-system/cilium-clustermesh` are absent in both regions. Details in #6040.

Refs #6040 #6004 #6015 #6016 #6021

🤖 Generated with [Claude Code](https://claude.com/claude-code)
