### PR TITLE
fix(catalyst): unresolved conflict markers on main froze the umbrella at 1.4.1332

### DIFF
--- a/.github/workflows/blueprint-release.yaml
+++ b/.github/workflows/blueprint-release.yaml
@@ -142,6 +142,25 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # ──────────────────────────────────────────────────────────────
+      # GATE — no unresolved merge-conflict markers (2026-08-10)
+      # ──────────────────────────────────────────────────────────────
+      # ad2d2e9ab committed a cherry-pick with its markers intact. Nine
+      # conflict blocks landed in three org-services templates and this
+      # job failed 12 steps later at "Run chart integration tests" with
+      #
+      #   YAML parse error on .../org-services/configmap.yaml:
+      #   yaml: line 22: could not find expected ':'
+      #
+      # — a line number in the RENDERED output, which points at a Helm
+      # comment in the source and names neither the cause nor the commit.
+      # bp-catalyst-platform then could not publish for a day, and because
+      # the umbrella carries the catalog-seed, no chart pin could reach any
+      # Sovereign. This runs first so the same defect costs one clear line
+      # instead of a day.
+      - name: "No unresolved merge-conflict markers"
+        run: bash scripts/check-no-conflict-markers.sh
+
       - name: Set up Helm
         uses: azure/setup-helm@v4
         with:

--- a/.github/workflows/check-no-banned-object-names.yaml
+++ b/.github/workflows/check-no-banned-object-names.yaml
@@ -1,0 +1,52 @@
+name: check — no banned entity-noun as a Kubernetes object name
+
+# scripts/check-no-banned-object-names.sh shipped on 2026-08-10 in
+# ad2d2e9ab and was never referenced by any workflow, so it had never run
+# once. It was also red against the very tree it landed in — the
+# one-release `tenant` deprecation-alias Service that #5974 kept on
+# purpose is now carried as a bidirectional TRACKED_EXCEPTIONS entry, so
+# deleting the alias next release fails this guard on the STALE entry and
+# forces the line back out.
+#
+# A guard nobody runs is documentation. This wires it.
+#
+# What it protects (UAT row 121 / #5435): a banned entity-noun used as a
+# Kubernetes OBJECT NAME reaches the sovereign-admin showback table at
+# /billing/orders through dashboard.go applicationKey (pod -> ReplicaSet
+# -> Deployment), which is why a source-side grep of the console tree
+# reported clean for months while the console rendered `tenant` verbatim.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'products/**/templates/**'
+      - 'platform/**/templates/**'
+      - 'core/**/templates/**'
+      - 'scripts/check-no-banned-object-names.sh'
+      - '.github/workflows/check-no-banned-object-names.yaml'
+  pull_request:
+    paths:
+      - 'products/**/templates/**'
+      - 'platform/**/templates/**'
+      - 'core/**/templates/**'
+      - 'scripts/check-no-banned-object-names.sh'
+      - '.github/workflows/check-no-banned-object-names.yaml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  no-banned-object-names:
+    name: Reject banned entity-nouns in object names
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Detector vacuity self-test
+        run: bash scripts/check-no-banned-object-names.sh --self-test-only
+
+      - name: Scan chart templates
+        run: bash scripts/check-no-banned-object-names.sh

--- a/.github/workflows/check-no-conflict-markers.yaml
+++ b/.github/workflows/check-no-conflict-markers.yaml
@@ -1,0 +1,46 @@
+name: check — no unresolved merge-conflict markers
+
+# Permanent guard that no tracked file carries an unresolved git
+# merge-conflict marker, for every future PR and every push to main.
+#
+# 2026-08-10 (ad2d2e9ab): a cherry-pick was committed with its markers
+# still in the file. Nine conflict blocks landed on main across three
+# bp-catalyst-platform templates and froze the umbrella at 1.4.1332 —
+# Blueprint Release died at "Run chart integration tests", so no chart pin
+# could reach any Sovereign (hw293's HelmRelease sat Ready=False
+# `:1.4.1334: not found`). See scripts/check-no-conflict-markers.sh for
+# why every gate that existed at the time was structurally blind to it:
+# the broken template is gated off by default, so the default-values smoke
+# render never touched it, and the error names a line in the RENDERED
+# output that corresponds to nothing in the source.
+#
+# NO path filter, deliberately. A marker in a Go file, a script, a doc or
+# an IaC module is the same defect; scoping this to charts would reproduce
+# exactly the blind spot it exists to close.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  no-conflict-markers:
+    name: Reject unresolved merge-conflict markers
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      # The guard runs its own vacuity self-test on every invocation and
+      # exits 2 if the detector has stopped detecting; this step surfaces
+      # that result on its own so a broken detector is never mistaken for
+      # a clean tree (#5512).
+      - name: Detector vacuity self-test
+        run: bash scripts/check-no-conflict-markers.sh --self-test-only
+
+      - name: Scan tracked files
+        run: bash scripts/check-no-conflict-markers.sh

--- a/products/catalyst/chart/templates/org-services/configmap.yaml
+++ b/products/catalyst/chart/templates/org-services/configmap.yaml
@@ -189,7 +189,6 @@ data:
   # each other directly using these too.
   AUTH_URL: "http://auth.org-services.svc.cluster.local:8081"
   CATALOG_URL: "http://catalog.org-services.svc.cluster.local:8082"
-<<<<<<< HEAD
   # The env-var KEY stays TENANT_URL (every consumer's main.go reads that
   # name; renaming it here without renaming them would silently fall back
   # to each service's own hardcoded default). The VALUE moves to the
@@ -197,16 +196,6 @@ data:
   # `tenant` Service is kept one release as an annotated alias, so a pod
   # that has not rolled yet still resolves.
   TENANT_URL: "http://organizations.org-services.svc.cluster.local:8083"
-=======
-  # UAT row 121 / #3383 — the Service this points at is now named
-  # `organization` (organization.yaml). The KEY stays TENANT_URL because it
-  # is the env-var contract every consumer already reads
-  # (gateway/billing/domain/notification main.go); renaming the key without
-  # renaming those readers in the same commit would silently fall back to
-  # their compiled-in defaults, which is a worse failure than an unlovely
-  # key name. The VALUE is the part that has to track the object name.
-  TENANT_URL: "http://organization.org-services.svc.cluster.local:8083"
->>>>>>> cf1a2122d (fix(org-services): rename the `tenant` workload — UAT row 121)
   PROVISIONING_URL: "http://provisioning.org-services.svc.cluster.local:8084"
   BILLING_URL: "http://billing.org-services.svc.cluster.local:8085"
   DOMAIN_URL: "http://domain.org-services.svc.cluster.local:8086"

--- a/products/catalyst/chart/templates/org-services/notification.yaml
+++ b/products/catalyst/chart/templates/org-services/notification.yaml
@@ -54,6 +54,22 @@ spec:
                 configMapKeyRef:
                   name: org-services-config
                   key: NATS_URL
+            # TENANT_URL — the Organization service host the notification
+            # enricher (handlers/enrich.go) calls to resolve an org before
+            # it renders an email. notification was the ONLY consumer of
+            # this key that never wired it, so it fell through to the
+            # compiled-in default in core/services/notification/main.go.
+            # That default is not a safe fallback: UAT row 121 renamed the
+            # workload, and a compiled-in host cannot track a chart rename
+            # — it went stale the moment the object name moved and the
+            # enricher dialled NXDOMAIN. Read it from the ConfigMap like
+            # billing / domain / gateway already do, so the chart is the
+            # single source of truth for the host (Principle #4).
+            - name: TENANT_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: org-services-config
+                  key: TENANT_URL
             - name: JWT_SECRET
               valueFrom:
                 secretKeyRef:

--- a/products/catalyst/chart/templates/org-services/organization.yaml
+++ b/products/catalyst/chart/templates/org-services/organization.yaml
@@ -47,34 +47,20 @@ scripts/check-no-banned-object-names.sh is the guard that keeps it renamed.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-<<<<<<< HEAD
   name: organizations
-=======
-  name: organization
->>>>>>> cf1a2122d (fix(org-services): rename the `tenant` workload — UAT row 121)
   namespace: org-services
 spec:
   replicas: 1
   selector:
     matchLabels:
-<<<<<<< HEAD
       app: org-organizations
-=======
-      app: org-organization
->>>>>>> cf1a2122d (fix(org-services): rename the `tenant` workload — UAT row 121)
   template:
     metadata:
       labels:
         policy.cilium.io/enforced: "true"  # Wave 5.121 #2466
-<<<<<<< HEAD
         app: org-organizations
     spec:
       serviceAccountName: organizations
-=======
-        app: org-organization
-    spec:
-      serviceAccountName: organization
->>>>>>> cf1a2122d (fix(org-services): rename the `tenant` workload — UAT row 121)
       # TBD-D35a — must be true so the SandboxOrchestrator
       # (core/services/tenant/handlers/sandbox_consumer.go) can build an
       # in-cluster dynamic client and materialise Sandbox CRs in
@@ -89,13 +75,8 @@ spec:
       imagePullSecrets:
         - name: ghcr-pull
       containers:
-<<<<<<< HEAD
         - name: organizations
           image: "{{ if .Values.global.imageRegistry }}{{ .Values.global.imageRegistry }}{{ else }}{{ .Values.images.registry }}{{ end }}/{{ .Values.images.organization }}/services-tenant:{{ .Values.images.orgTag }}"
-=======
-        - name: organization
-          image:"{{ if .Values.global.imageRegistry }}{{ .Values.global.imageRegistry }}{{ else }}{{ .Values.images.registry }}{{ end }}/{{ .Values.images.organization }}/services-tenant:{{ .Values.images.orgTag }}"
->>>>>>> cf1a2122d (fix(org-services): rename the `tenant` workload — UAT row 121)
           imagePullPolicy: Always
           ports:
             - containerPort: 8083
@@ -176,7 +157,6 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-<<<<<<< HEAD
   name: organizations
   namespace: org-services
 spec:
@@ -205,13 +185,6 @@ metadata:
 spec:
   selector:
     app: org-organizations
-=======
-  name: organization
-  namespace: org-services
-spec:
-  selector:
-    app: org-organization
->>>>>>> cf1a2122d (fix(org-services): rename the `tenant` workload — UAT row 121)
   ports:
     - port: 8083
       targetPort: 8083

--- a/products/catalyst/chart/templates/org-services/serviceaccounts.yaml
+++ b/products/catalyst/chart/templates/org-services/serviceaccounts.yaml
@@ -39,7 +39,6 @@ metadata:
   namespace: org-services
 automountServiceAccountToken: false
 ---
-<<<<<<< HEAD
 # organizations SA (renamed from `tenant`, #5435 / UAT row 121 — the
 # workload identity is renamed in lockstep with the Deployment so a
 # `kubectl get sa -n org-services` read carries no banned entity-noun
@@ -47,12 +46,6 @@ automountServiceAccountToken: false
 # (core/services/tenant/handlers/sandbox_consumer.go) which materialises
 # Sandbox.sandbox.openova.io CRs in `catalyst-system` on every
 # `tenant.sandbox_requested` event. The orchestrator builds an in-cluster
-=======
-# organization SA — TBD-D35a: the organization service hosts the
-# SandboxOrchestrator (core/services/tenant/handlers/sandbox_consumer.go)
-# which materialises Sandbox.sandbox.openova.io CRs in `catalyst-system`
-# on every sandbox-requested event. The orchestrator builds an in-cluster
->>>>>>> cf1a2122d (fix(org-services): rename the `tenant` workload — UAT row 121)
 # dynamic client via rest.InClusterConfig() (main.go buildDynamicClient)
 # and silently disables itself with a WARN log when no SA token is
 # mounted — the exact symptom Wave 32 D35a verifier caught
@@ -70,11 +63,7 @@ automountServiceAccountToken: false
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-<<<<<<< HEAD
   name: organizations
-=======
-  name: organization
->>>>>>> cf1a2122d (fix(org-services): rename the `tenant` workload — UAT row 121)
   namespace: org-services
 automountServiceAccountToken: true
 ---
@@ -106,11 +95,7 @@ roleRef:
   name: organization-sandbox-orchestrator
 subjects:
   - kind: ServiceAccount
-<<<<<<< HEAD
     name: organizations
-=======
-    name: organization
->>>>>>> cf1a2122d (fix(org-services): rename the `tenant` workload — UAT row 121)
     namespace: org-services
 ---
 apiVersion: v1

--- a/scripts/check-no-banned-object-names.sh
+++ b/scripts/check-no-banned-object-names.sh
@@ -133,9 +133,20 @@ fi
 # cover. It also cannot absorb the class the row is about — a workload
 # `name:`/`serviceAccountName:`/`app:` value is not a Blueprint name and
 # has no entry here.
+#
+# The third entry is the one-release deprecation ALIAS Service that #5974
+# deliberately kept alongside the renamed `organizations` Service. It is a
+# Service, not a workload, so applicationKey never reaches it — the
+# showback table keys on the Deployment. It exists only so a consumer pod
+# that has not rolled yet (its TENANT_URL comes from a ConfigMap, and a
+# ConfigMap edit does not restart a Deployment) still resolves the old
+# host mid-upgrade. The bidirectional half below is what makes this safe
+# to write down: when the alias is deleted one release later, this guard
+# fails on the STALE entry and forces the line out of the list.
 TRACKED_EXCEPTIONS=(
   'products/catalyst/chart/templates/catalog-seed/blueprints.yaml:  name: bp-wordpress-tenant'
   'products/catalyst/chart/templates/catalog-seed/blueprints.yaml:  name: bp-stalwart-tenant'
+  'products/catalyst/chart/templates/org-services/organization.yaml:  name: tenant'
 )
 declare -A EXCEPTION_SEEN=()
 

--- a/scripts/check-no-conflict-markers.sh
+++ b/scripts/check-no-conflict-markers.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+# check-no-conflict-markers.sh — no tracked file may carry an unresolved
+# git merge-conflict marker.
+#
+# WHY THIS EXISTS
+# ---------------
+# 2026-08-10, commit ad2d2e9ab: a cherry-pick of cf1a2122d (an UNMERGED
+# branch that renamed the same objects a second, different way) was
+# committed WITH its conflict markers still in the file. Nine conflict
+# blocks landed on main across three chart templates:
+#
+#   products/catalyst/chart/templates/org-services/configmap.yaml       1
+#   products/catalyst/chart/templates/org-services/organization.yaml    5
+#   products/catalyst/chart/templates/org-services/serviceaccounts.yaml 3
+#
+# The cost was not cosmetic. `bp-catalyst-platform` stopped publishing:
+# Blueprint Release died at "Run chart integration tests" with
+#
+#   Error: YAML parse error on bp-catalyst-platform/templates/
+#   org-services/configmap.yaml: error converting YAML to JSON:
+#   yaml: line 22: could not find expected ':'
+#
+# The umbrella carries the catalog-seed, so with it stuck at 1.4.1332 NO
+# chart pin could reach any Sovereign — hw293's HelmRelease sat
+# Ready=False `:1.4.1334: not found`. One unresolved conflict froze the
+# whole release train.
+#
+# WHY NO EXISTING GATE CAUGHT IT
+#   * The chart's default-values smoke render PASSED: the whole
+#     org-services tree is gated on `.Values.ingress.marketplace.enabled`,
+#     which defaults to false, so the broken file was never rendered.
+#     Only a test that sets that value true reached it.
+#   * The failure surfaced as a line number in the RENDERED output, which
+#     points at nothing in the source file — source line 22 is inside a
+#     `{{- /* ... */ -}}` comment. The message actively misdirects.
+#   * A marker in a Go file, a script, or a doc would not have been caught
+#     at all. Nothing in this repo looked for them.
+#
+# This guard is therefore repo-wide and format-agnostic: it reads bytes,
+# not YAML, so it does not care whether a template is gated off, whether
+# the file renders, or what language it is in.
+#
+# DETECTION — deliberately strict, so a pass means something
+#   Flagged: a line that BEGINS a conflict (seven '<' then a space or EOL)
+#   or ENDS one (seven '>' then a space or EOL). git always writes both
+#   with a label, so the trailing-space form is the real shape.
+#   A bare seven-'=' line is flagged ONLY inside an open block. On its own
+#   it is a Setext heading underline, and this repo has four of them
+#   inside Helm comment blocks (platform/hcloud-csi, platform/keycloak,
+#   platform/huawei-evs-csi x2, all the "THE FIX\n=======" shape). Those
+#   are the control case in the self-test below: they share the suspect
+#   property — a line that IS the middle marker — and must not be flagged.
+#
+# Usage:
+#   scripts/check-no-conflict-markers.sh              # scan tracked files
+#   scripts/check-no-conflict-markers.sh --self-test-only
+#
+set -euo pipefail
+
+ROOT="${ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || echo .)}"
+
+# The markers are written with quantifiers, never as seven literal
+# characters, so this script does not match itself and can be scanned by
+# its own scan like every other tracked file.
+START_END_RE='^(<{7}|>{7})([[:space:]]|$)'
+ANY_MARKER_RE='^(<{7}|\|{7}|={7}|>{7})([[:space:]]|$)'
+
+# ─── Detector ─────────────────────────────────────────────────────────
+# Two phases. Phase 1 finds files that carry a START or END marker —
+# those are unambiguous. Phase 2 reports every marker line inside just
+# those files, which is what makes the bare '=' line reportable when it
+# is genuinely part of a conflict and invisible when it is a heading rule.
+# Prints "path:lineno:line" per hit; returns 1 when any hit was printed.
+detect() { # $1 = directory to scan
+  local dir="$1" candidates rc=0
+  candidates="$(grep -rIlE "${START_END_RE}" \
+    --exclude-dir=.git --exclude-dir=node_modules --exclude-dir=vendor \
+    "${dir}" 2>/dev/null || true)"
+  [[ -z "${candidates}" ]] && return 0
+  while IFS= read -r f; do
+    [[ -z "${f}" ]] && continue
+    while IFS= read -r hit; do
+      [[ -z "${hit}" ]] && continue
+      echo "${f#"${dir}"/}:${hit}"
+      rc=1
+    done < <(grep -nE "${ANY_MARKER_RE}" "${f}" || true)
+  done <<< "${candidates}"
+  return "${rc}"
+}
+
+# ─── Vacuity self-test ────────────────────────────────────────────────
+#
+# An absence-assertion reports "clean" both when the thing is absent AND
+# when the detector stopped working (#5512); scripts/check-no-nodeports.sh
+# has carried this protection since #4765 and every absence guard in this
+# repo owes it. POSITIVE fixtures must still be caught, NEGATIVE fixtures
+# must still be ignored, or this exits non-zero before scanning anything.
+#
+# The fixtures are BUILT from repeated characters rather than typed out,
+# for the same reason the regexes are: a literal marker in this file would
+# make the guard flag its own source.
+self_test() {
+  local t lt eq gt pipe out
+  lt="$(printf '<%.0s' 1 2 3 4 5 6 7)"
+  eq="$(printf '=%.0s' 1 2 3 4 5 6 7)"
+  gt="$(printf '>%.0s' 1 2 3 4 5 6 7)"
+  pipe="$(printf '|%.0s' 1 2 3 4 5 6 7)"
+  t="$(mktemp -d)"
+  trap 'rm -rf "${t}"' RETURN
+
+  # POSITIVE 1 — a plain merge conflict, the exact ad2d2e9ab shape.
+  mkdir -p "${t}/pos1"
+  printf '  KEY: a\n%s HEAD\n  KEY: b\n%s\n  KEY: c\n%s cf1a2122d (subject)\n' \
+    "${lt}" "${eq}" "${gt}" > "${t}/pos1/conflict.yaml"
+  # POSITIVE 2 — diff3 style, which adds a base section between the two.
+  mkdir -p "${t}/pos2"
+  printf '%s ours\nx\n%s base\ny\n%s\nz\n%s theirs\n' \
+    "${lt}" "${pipe}" "${eq}" "${gt}" > "${t}/pos2/conflict.go"
+  # NEGATIVE — the CONTROL. Shares the suspect property (a line that is
+  # exactly the seven-'=' middle marker) but is a Setext heading rule in a
+  # Helm comment, the shape four real charts in this repo use today.
+  mkdir -p "${t}/neg"
+  printf '{{- /*\nStorageClass hook.\n\nTHE FIX\n%s\nFlip the default class.\n*/ -}}\n' \
+    "${eq}" > "${t}/neg/heading.yaml"
+  printf 'Title\n%s\nbody\n' "$(printf '=%.0s' 1 2 3)" > "${t}/neg/short.md"
+
+  local fail=0
+  for p in pos1 pos2; do
+    if out="$(detect "${t}/${p}")"; then
+      echo "SELF-TEST FAIL: detector did not flag fixture ${p} — it has stopped working" >&2
+      fail=1
+    elif [[ -z "${out}" ]]; then
+      echo "SELF-TEST FAIL: detector returned nonzero but printed nothing for ${p}" >&2
+      fail=1
+    fi
+  done
+  if ! out="$(detect "${t}/neg")"; then
+    echo "SELF-TEST FAIL: detector flagged the heading-underline control:" >&2
+    echo "${out}" >&2
+    fail=1
+  fi
+  [[ ${fail} -ne 0 ]] && return 1
+  echo "self-test PASS: 2 conflict fixtures caught, heading-underline control not flagged"
+  return 0
+}
+
+self_test || exit 2
+[[ "${1:-}" == "--self-test-only" ]] && exit 0
+
+# ─── Scan ─────────────────────────────────────────────────────────────
+# Scans the checkout itself so the script works from an exported tree as
+# well as a clone; grep -I skips binaries and .git is excluded (MERGE_MSG
+# and rebase state are the one place markers legitimately live).
+if [[ ! -d "${ROOT}" ]]; then
+  echo "FAIL: ROOT '${ROOT}' is not a directory — a guard that looks at" >&2
+  echo "      nothing passes at nothing." >&2
+  exit 2
+fi
+
+if git -C "${ROOT}" rev-parse --git-dir >/dev/null 2>&1; then
+  file_count="$(git -C "${ROOT}" ls-files | wc -l | tr -d ' ')"
+else
+  file_count="$(find "${ROOT}" -type f -not -path '*/.git/*' | wc -l | tr -d ' ')"
+fi
+if [[ "${file_count}" -eq 0 ]]; then
+  echo "FAIL: found zero files to scan — the scan path is wrong." >&2
+  exit 2
+fi
+
+if hits="$(detect "${ROOT}")"; then
+  echo "OK: scanned ${file_count} files under ${ROOT} — no unresolved merge-conflict markers"
+  exit 0
+fi
+
+echo "${hits}" >&2
+cat >&2 <<'MSG'
+
+UNRESOLVED MERGE-CONFLICT MARKER above. A cherry-pick, rebase or merge was
+committed without resolving. Markers do not fail loudly where they land:
+a Helm template that is gated off still packages, and the render error you
+eventually get names a line in the OUTPUT that corresponds to nothing in
+the source. On 2026-08-10 nine such blocks froze bp-catalyst-platform at
+1.4.1332 and, with it, every chart pin bound for every Sovereign.
+
+Resolve the conflict — pick one side, delete both markers and the middle
+rule — then re-run:
+
+  scripts/check-no-conflict-markers.sh
+MSG
+exit 1


### PR DESCRIPTION
## What was actually wrong

`ad2d2e9ab` cherry-picked `cf1a2122d` — the tip of the **unmerged** branch `fix/uat-g7-121-19-w5-184`, a second parallel attempt at the UAT row 121 rename — and **committed the conflict markers unresolved**. Nine conflict blocks / 27 marker lines landed on `main` across three `org-services` templates.

`line 22` in the error is a line of the **rendered** document, not the source. Source line 22 sits inside a `{{- /* */ -}}` comment; rendered line 22 is the conflict start marker.

## Reproduction

Not intermittent, and not a moving dependency — `products/catalyst/chart/Chart.yaml` declares **no `dependencies:`**, so `helm dependency build` is a no-op and there is nothing to move. It is deterministic from `ad2d2e9ab` forward. The two runs that bracket it look non-deterministic only because `ad2d2e9ab` is a *docs*-titled commit that also touched `products/catalyst/chart/**`, which re-triggered `Blueprint Release` at the same unchanged chart version.

CI's exact invocation (helm **v3.18.4**, the runner's version), against unmodified `origin/main`:

```
$ git archive origin/main | tar -x -C $RED && cd $RED
$ for s in products/catalyst/chart/tests/*.sh; do bash "$s" products/catalyst/chart; done

api-single-writer-dr-contract.sh              PASS
baseline-cnp-allowlist.sh                     PASS
gitea-flux-auth-sync-rbac-order.sh            FAIL  -> Error: YAML parse error on bp-catalyst-platform/templates/org-services/configmap.yaml: error converting YAML to JSON: yaml: line 22: could not find expected ':'
nats-url-host-ns-contract.sh                  FAIL  -> (same)
oidc-broker-secret-reloader-contract.sh       PASS
org-services-smtp-autoroll-contract.sh        FAIL  -> (same)
qa-cnpg-region-fail-closed.sh                 PASS
sovereign-fqdn-lb-ip-contract.sh              PASS
```

3 of 8 fail; CI reports only the first because the step's loop runs under `set -e`. It also reproduces on helm v3.16.3, so the runner's helm version is not a factor.

## Why the earlier gates were blind

The default-values smoke render **passed** in the same job. The whole `org-services` tree is gated on `.Values.ingress.marketplace.enabled`, default `false`, so the broken file is never rendered by the default-values path. The three tests that fail are exactly the three that `--set ingress.marketplace.enabled=true`.

## Resolution — HEAD side, and why

`#5974` (`49511c96a`, merged 2026-08-10T11:34Z) renamed the workload to `organizations` and deliberately kept the `tenant` Service as an annotated one-release alias. The incoming side renamed to `organization`, dropped the alias, and carried a literal YAML defect — `image:"{{ ... }}"`, no space after the key.

Every non-conflicting change `ad2d2e9ab` brought is preserved. The residual diff against `abf935600` (the pre-conflict parent) is only that commit's legitimate content: the added doc comment, the comment corrections, and the `tenant-sandbox-orchestrator` -> `organization-sandbox-orchestrator` Role/RoleBinding rename. No object-name churn beyond deleting the markers and the losing side.

## Collateral fixed from the same commit

`ad2d2e9ab` also moved the compiled-in `TENANT_URL` fallback in four `core/services/*/main.go` to `http://organization...`. `notification` is the one consumer whose Deployment never wired `TENANT_URL` from the ConfigMap, so its enricher (`handlers/enrich.go`) falls through to that default — and the chart names the Service `organizations` plus a `tenant` alias, never `organization`. Before that commit the fallback resolved through the alias; after it, NXDOMAIN. `notification.yaml` now reads the key from `org-services-config` like `billing` / `domain` / `gateway` already do, which takes the compiled-in host out of the path entirely:

```
billing         TENANT_URL <- org-services-config/TENANT_URL
domain          TENANT_URL <- org-services-config/TENANT_URL
gateway         TENANT_URL <- org-services-config/TENANT_URL
notification    TENANT_URL <- org-services-config/TENANT_URL     <- new
ConfigMap value:  TENANT_URL: "http://organizations.org-services.svc.cluster.local:8083"
```

## Guard 1 — `scripts/check-no-conflict-markers.sh` (new)

Byte-level and repo-wide, so it does not care whether a template is gated off, whether the chart renders, or what language the file is in. Wired to its own workflow on every PR and every push to `main` with **no path filter**, plus a pre-gate step in `blueprint-release.yaml` so this class costs one named line instead of a parse error at step 13 of 25.

**Red — against unmodified `origin/main`:**

```
$ ROOT=$RED bash scripts/check-no-conflict-markers.sh ; echo exit=$?
products/catalyst/chart/templates/org-services/configmap.yaml:192:<<<<<<< HEAD
products/catalyst/chart/templates/org-services/configmap.yaml:200:=======
products/catalyst/chart/templates/org-services/configmap.yaml:209:>>>>>>> cf1a2122d (...)
... 24 more ...
exit=1

marker lines: 27      conflict blocks: 9      files: 3
  3  products/catalyst/chart/templates/org-services/configmap.yaml
 15  products/catalyst/chart/templates/org-services/organization.yaml
  9  products/catalyst/chart/templates/org-services/serviceaccounts.yaml
```

**Green — this branch:**

```
$ bash scripts/check-no-conflict-markers.sh ; echo exit=$?
self-test PASS: 2 conflict fixtures caught, heading-underline control not flagged
OK: scanned 7661 files — no unresolved merge-conflict markers
exit=0
```

**Control that shares the suspect property.** A bare seven-`=` line is the middle marker, and it is also a Setext heading rule. Four charts in this repo carry one today inside a Helm comment (`platform/hcloud-csi/chart/templates/default-class-hook.yaml`, `platform/keycloak/chart/templates/admin-credentials.yaml`, and two in `platform/huawei-evs-csi/`, all the `THE FIX\n=======` shape). The detector counts a bare `=======` **only inside an open block**, so on the red tree those four scored **0 hits** while the 27 real marker lines all landed. That is the difference between detecting conflicts and detecting the character `=`. The same four shapes are the NEGATIVE fixture in the built-in vacuity self-test, alongside POSITIVE fixtures for both plain and `diff3` conflicts; the self-test runs on every invocation and exits 2 if the detector has stopped detecting.

The script builds every marker from repeated characters instead of typing them, so it contains no literal marker and is scanned by its own scan like any other tracked file.

## Guard 2 — `scripts/check-no-banned-object-names.sh` was never wired

That guard shipped in `ad2d2e9ab` and is referenced by **no workflow** — `grep -rn check-no-banned-object-names .github/workflows/` returns nothing. It had never run once. It was also red against the tree it landed in:

```
$ git archive origin/main | tar -x -C $T && ROOT=$T bash scripts/check-no-banned-object-names.sh
BANNED OBJECT NAME: products/catalyst/chart/templates/org-services/organization.yaml:181:  name: tenant
exit=1
```

That hit is the `#5974` deprecation alias, kept on purpose — the guard came from the branch that deleted the alias, so it never had to account for one. It is now a bidirectional `TRACKED_EXCEPTIONS` entry, and the bidirectional half is what makes that safe to write down. Proof it self-cleans when the alias goes away next release:

```
$ # rename the alias in a scratch copy, then run the guard
STALE EXCEPTION: 'products/catalyst/chart/templates/org-services/organization.yaml:  name: tenant'
  is in TRACKED_EXCEPTIONS but no longer appears in the tree. Delete the entry — the rename landed.
exit=1
```

Green on this branch: `OK: scanned 705 chart template files`.

## Full publish path re-run locally, helm v3.18.4

```
8/8 chart tests                    PASS
helm package                       bp-catalyst-platform-1.4.1334.tgz
helm template (packaged tgz)       11236 lines
#6004 release-Secret payload gate  OK — 66439 bytes under budget
scripts/check-bootstrap-kit-pin-sync.sh   bp-catalyst-platform: chart=1.4.1334 pin=1.4.1334
```

## No version bump

`1.4.1334` is unpublished (ghcr's newest tag is `1.4.1332`, pushed 2026-08-10T12:12:25Z) and is exactly the version `clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml` and hw293's HelmRelease already ask for. Merging this publishes `1.4.1334` and the existing pin resolves with no further churn. `Chart.yaml` is untouched, so no version is claimed against any open PR.

## Not covered here

The four `core/services/*/main.go` compiled-in `TENANT_URL` fallbacks still read `http://organization...`, a host no chart creates. Every consumer now reads the ConfigMap, so no code path reaches them — but they are stale. Correcting them touches `core/services/**`, which fires `services-build.yaml` and its image + chart-version bump; running that concurrently with the umbrella's first publish in a day is the wrong order. Follow-up on #6043.

Refs #6043
