### PR TITLE
fix(deploy-bot): unbreak catalyst + services build — a 64 KiB pipe buffer stopped all chart publication for 4 days

### DIFF
--- a/.github/workflows/check-delivery-workflow-health.yaml
+++ b/.github/workflows/check-delivery-workflow-health.yaml
@@ -1,0 +1,85 @@
+name: Check — delivery workflow health
+
+# WHY THIS EXISTS (Refs #6049)
+#
+# `Build & Deploy Catalyst` failed on every push to main from 2026-08-06
+# 08:32Z onward — 54 consecutive red runs across four days — and nothing
+# anywhere went red about it. `services-build.yaml` was down the same four
+# days, on the identical line, for the identical reason. Neither is a required
+# check, so pull requests kept merging green while artifact publication had
+# stopped: catalyst-ui froze at tag b2294fd and the bp-catalyst-platform chart
+# version stopped advancing, which silently falsified every "merged, closes on
+# a roll" row in docs/ledger/.
+#
+# Every other check-*.yaml in this repo answers "is THIS commit good?".
+# None of them answered "is the pipeline still shipping?" — so a break that
+# lands AFTER merge, in a non-required workflow, was invisible by
+# construction. That is the gap this file closes.
+#
+# WHY A SCHEDULE HERE, when catalyst-build.yaml's own header says cron is
+# forbidden: that rule is about how the platform REACTS to change — Flux
+# dependsOn, NATS, SSE, push triggers — and catalyst-build.yaml correctly
+# stays event-driven. This workflow is not part of that datapath. It measures
+# the health of the build system itself, and "nobody pushed for 12 hours, so
+# nobody noticed the pipeline was dead" is precisely the condition it has to
+# detect. A push-triggered health check cannot observe its own absence. Ten
+# other workflows in this repo already carry `schedule:` for the same reason.
+
+on:
+  schedule:
+    # Every 6 hours. The budget in the script is 12h red, so two consecutive
+    # scheduled runs must agree something is wrong before it fires.
+    - cron: '17 */6 * * *'
+  workflow_dispatch:
+  # Runs at PR time too, but ONLY to exercise the guard's own test suite when
+  # the guard itself changes — see the `self-test` job.
+  pull_request:
+    paths:
+      - 'scripts/check-delivery-workflow-health.sh'
+      - 'scripts/tests/test-delivery-workflow-health.sh'
+      - '.github/workflows/check-delivery-workflow-health.yaml'
+  push:
+    branches: [main]
+    paths:
+      - 'scripts/check-delivery-workflow-health.sh'
+      - 'scripts/tests/test-delivery-workflow-health.sh'
+      - '.github/workflows/check-delivery-workflow-health.yaml'
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: delivery-workflow-health-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # The guard's own non-vacuity proof, driven by fixtures built from the real
+  # 2026-08-06 outage. Runs on every event including pull_request, needs no
+  # token and no network, and is what stops this canary quietly decaying into
+  # something that can only report "healthy".
+  self-test:
+    name: self-test (real-outage fixtures)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - name: test-delivery-workflow-health.sh
+        run: bash scripts/tests/test-delivery-workflow-health.sh
+
+  # The live check. Deliberately NOT run on pull_request: a PR from a fork has
+  # no useful token, and a PR author is not the right person to be told the
+  # main-branch pipeline is broken.
+  health:
+    name: live — are the delivery workflows still publishing?
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: self-test
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      REPO: ${{ github.repository }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: check-delivery-workflow-health.sh
+        run: bash scripts/check-delivery-workflow-health.sh

--- a/.github/workflows/test-ungated-trees.yaml
+++ b/.github/workflows/test-ungated-trees.yaml
@@ -258,6 +258,27 @@ jobs:
         working-directory: products/catalyst/bootstrap/ui
         run: npm ci
 
+      # TYPECHECK — the PR-time half of `npm run build` (= `tsc -b && vite
+      # build`). vitest below does NOT typecheck: vitest strips types via
+      # esbuild and never runs `tsc`, so a file can be fully green under
+      # vitest and still refuse to compile.
+      #
+      # That gap is not theoretical. 05d3f639c (#5979) removed the strongSwan
+      # profile rule from src/entities/deployment/model.ts and left its only
+      # input, `const hasAuditComp`, behind unread. Under this project's
+      # `noUnusedLocals` that is `error TS6133`, which fails `tsc -b` — so
+      # `npm run build` failed, so the catalyst-ui image stopped building, and
+      # catalyst-ui froze at tag b2294fd while catalyst-api kept advancing.
+      # Every PR-time check was green, because none of them ran `tsc`.
+      #
+      # `npm run typecheck` (= `tsc -b --noEmit`) is already defined in
+      # package.json and was already the right command; nothing was calling
+      # it. Verified red-then-green on the real defect: exit 2 with
+      # `model.ts(455,9): error TS6133` before the fix, exit 0 after.
+      - name: typecheck (tsc)
+        working-directory: products/catalyst/bootstrap/ui
+        run: npm run typecheck
+
       # Plain `npm test` (= `vitest run`). No `|| true`, no `|| echo WARN` —
       # the 2026-06-02 emergency unblock in catalyst-build.yaml used exactly
       # that shape and swallowed every failure for two months, which is how

--- a/products/catalyst/bootstrap/ui/src/entities/deployment/model.ts
+++ b/products/catalyst/bootstrap/ui/src/entities/deployment/model.ts
@@ -452,7 +452,12 @@ export function getProfileDefaults(
   const isTech       = /tech|software|saas|cloud|it services/.test(ind)
   const isRetail     = /retail|commerce|ecomm/.test(ind)
   const isLarge      = /10[,.]?000|50[,.]?000|100[,.]?000/.test(orgSize)
-  const hasAuditComp = comp.some(c => ['pci dss','hipaa','soc 2','iso 27001','gdpr'].some(r => c.includes(r)))
+  // NOTE: `hasAuditComp` (comp matches pci dss / hipaa / soc 2 / iso 27001 /
+  // gdpr) lived here until #5979 removed the strongSwan rule below — its only
+  // consumer. It was left behind unread, which is a `tsc` TS6133 error under
+  // this project's `noUnusedLocals`, and it broke `npm run build` (and so the
+  // catalyst-ui image) on every main push from 05d3f639c onward. Re-introduce
+  // it together with the rule that reads it, not before.
 
   const defaults: Record<string, string[]> = { ...DEFAULT_COMPONENT_GROUPS }
 

--- a/scripts/bump-chart-version.sh
+++ b/scripts/bump-chart-version.sh
@@ -76,9 +76,35 @@ fi
 
 git fetch --quiet origin main
 
-BASELINE="$(git show "origin/main:${CHART_YAML}")"
-BASE_VERSION="$(printf '%s\n' "${BASELINE}" | awk '/^version:/{print $2; exit}' | tr -d '"')"
-BASE_APPVERSION="$(printf '%s\n' "${BASELINE}" | awk '/^appVersion:/{print $2; exit}' | tr -d '"')"
+# Read the baseline through a TEMP FILE, never through a pipe.
+#
+# This line used to be:
+#   BASELINE="$(git show "origin/main:${CHART_YAML}")"
+#   BASE_VERSION="$(printf '%s\n' "${BASELINE}" | awk '/^version:/{print $2; exit}' | ...)"
+#
+# and it failed on 100% of its invocations from the moment it landed
+# (77a47f167, 2026-08-06) until this fix — 53 consecutive red runs of
+# `Build & Deploy Catalyst`, every one of them at this exact line.
+#
+# Mechanism: `awk … {exit}` stops reading as soon as it matches, which
+# CLOSES the pipe. products/catalyst/chart/Chart.yaml carries 88,958 bytes
+# AFTER its `version:` line — more than the 64 KiB (65,536 B) Linux pipe
+# buffer — so `printf` is still writing when the reader goes away, takes
+# EPIPE/SIGPIPE, and dies 141. `set -o pipefail` then fails the whole
+# pipeline and `set -e` aborts the script. The bug is invisible on a small
+# chart (everything fits in the buffer, printf finishes before awk exits),
+# which is why it survived review: it is a function of how many bytes
+# follow the matched line, not of anything about the version arithmetic.
+#
+# Reading from a file removes the pipe, so `exit` costs nothing and the
+# byte-size of the chart stops being load-bearing. Regression coverage:
+# scripts/tests/test-bump-chart-version.sh builds a chart with >64 KiB
+# after `version:` and asserts this script still exits 0.
+BASELINE_FILE="$(mktemp)"
+trap 'rm -f "${BASELINE_FILE}"' EXIT
+git show "origin/main:${CHART_YAML}" > "${BASELINE_FILE}"
+BASE_VERSION="$(awk '/^version:/{print $2; exit}' "${BASELINE_FILE}" | tr -d '"')"
+BASE_APPVERSION="$(awk '/^appVersion:/{print $2; exit}' "${BASELINE_FILE}" | tr -d '"')"
 
 if [ -z "${BASE_VERSION}" ]; then
   echo "::error title=bump-chart-version::No '^version:' line in origin/main's ${CHART_YAML}." >&2

--- a/scripts/check-delivery-workflow-health.sh
+++ b/scripts/check-delivery-workflow-health.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# check-delivery-workflow-health.sh — Refs #6049
+#
+# WHY THIS EXISTS
+# ---------------
+# `Build & Deploy Catalyst` failed on EVERY push to main from 2026-08-06
+# 08:32Z to 2026-08-10 17:37Z — 53 consecutive red runs, four days — and
+# nothing anywhere went red about it. It is not a required check, so PRs kept
+# merging green; its own job is the thing that publishes catalyst-ui and bumps
+# the chart, so image delivery just stopped while the ledger went on saying
+# "the fix is merged, it closes on a roll".
+#
+# The gap is structural, not a one-off: a workflow that is red on main blocks
+# nothing and notifies no one. Every per-check workflow in this repo answers
+# "is THIS commit good?". Nothing answered "is the delivery pipeline still
+# actually delivering?".
+#
+# WHAT IT CHECKS
+# --------------
+# For each watched workflow, on branch `main`:
+#   - the conclusion of the most recent COMPLETED run
+#   - how many consecutive runs have failed, newest-first
+#   - how many hours since the most recent SUCCESSFUL run
+#
+# It fails when a workflow has been red for longer than MAX_HOURS_RED
+# (default 12h) — i.e. sustained breakage, not a single flake — or when
+# consecutive failures reach MAX_CONSECUTIVE_FAILURES (default 5).
+#
+# ABSENT EVIDENCE IS A FAILURE, NEVER A PASS
+# ------------------------------------------
+# If the API returns no runs, or unparseable output, this script exits
+# non-zero. A health check that reports "healthy" because it could not see
+# anything is the exact defect class it exists to catch (docs/PRINCIPLES.md
+# A18 — a guard that cannot go red). There is no fail-open path here: every
+# `PASS` requires a positive, parsed observation.
+#
+# Usage:
+#   scripts/check-delivery-workflow-health.sh [workflow-file ...]
+#
+# Env:
+#   REPO                        owner/repo (default openova-io/openova)
+#   MAX_HOURS_RED               hours a workflow may sit red (default 12)
+#   MAX_CONSECUTIVE_FAILURES    consecutive red runs tolerated (default 5)
+#   FIXTURE_DIR                 read <workflow>.json from here instead of the
+#                               API — used by scripts/tests/ to drive this
+#                               guard red and green deterministically, with no
+#                               network and no token.
+#   HEALTH_NOW_EPOCH            override "now" (seconds since epoch) so
+#                               fixture-driven tests are not time-dependent.
+
+set -uo pipefail
+
+REPO="${REPO:-openova-io/openova}"
+MAX_HOURS_RED="${MAX_HOURS_RED:-12}"
+MAX_CONSECUTIVE_FAILURES="${MAX_CONSECUTIVE_FAILURES:-5}"
+FIXTURE_DIR="${FIXTURE_DIR:-}"
+NOW="${HEALTH_NOW_EPOCH:-$(date -u +%s)}"
+
+# The delivery-critical workflows. These are the ones whose redness means
+# artifacts stop being published, as opposed to a single commit being wrong.
+DEFAULT_WATCH=(
+  catalyst-build.yaml
+  services-build.yaml
+)
+
+WATCH=("$@")
+if [ "${#WATCH[@]}" -eq 0 ]; then
+  WATCH=("${DEFAULT_WATCH[@]}")
+fi
+
+FAILED=0
+fail() { echo "::error title=delivery-workflow-health::$*"; echo "FAIL: $*" >&2; FAILED=1; }
+pass() { echo "PASS: $*"; }
+
+fetch_runs() {
+  # Emits one `<conclusion> <created_at>` line per completed main run,
+  # newest first.
+  local wf="$1"
+  if [ -n "${FIXTURE_DIR}" ]; then
+    local f="${FIXTURE_DIR}/${wf}.json"
+    [ -r "${f}" ] || return 1
+    jq -r '.workflow_runs[] | "\(.conclusion) \(.created_at)"' < "${f}" 2>/dev/null
+    return $?
+  fi
+  gh api "/repos/${REPO}/actions/workflows/${wf}/runs?branch=main&status=completed&per_page=60" \
+    --jq '.workflow_runs[] | "\(.conclusion) \(.created_at)"' 2>/dev/null
+  return $?
+}
+
+for wf in "${WATCH[@]}"; do
+  echo "=========================================================="
+  echo "workflow: ${wf}  (branch main)"
+  echo "=========================================================="
+
+  RUNS="$(fetch_runs "${wf}")"
+  RC=$?
+
+  # ---- absent evidence => FAIL, never PASS -------------------------------
+  if [ "${RC}" -ne 0 ]; then
+    fail "${wf}: could not read run history (API/fixture error). This is an ACCESS failure, not a clean bill of health — refusing to report healthy from evidence I do not have."
+    continue
+  fi
+  if [ -z "${RUNS}" ]; then
+    fail "${wf}: run history came back EMPTY. Either the workflow file was renamed/deleted or the query is wrong; either way delivery health is unknown, which is reported as a failure by design."
+    continue
+  fi
+
+  TOTAL="$(printf '%s\n' "${RUNS}" | grep -c .)"
+
+  LATEST_CONCL="$(printf '%s\n' "${RUNS}" | head -1 | awk '{print $1}')"
+  LATEST_AT="$(printf '%s\n' "${RUNS}" | head -1 | awk '{print $2}')"
+
+  # Consecutive failures, newest-first.
+  CONSEC=0
+  while IFS=' ' read -r concl _at; do
+    [ -n "${concl}" ] || continue
+    if [ "${concl}" = "success" ]; then break; fi
+    CONSEC=$((CONSEC + 1))
+  done <<< "${RUNS}"
+
+  # Most recent success.
+  LAST_SUCCESS_AT="$(printf '%s\n' "${RUNS}" | awk '$1=="success"{print $2; exit}')"
+
+  if [ -n "${LAST_SUCCESS_AT}" ]; then
+    LAST_SUCCESS_EPOCH="$(date -u -d "${LAST_SUCCESS_AT}" +%s 2>/dev/null || echo "")"
+  else
+    LAST_SUCCESS_EPOCH=""
+  fi
+
+  if [ -n "${LAST_SUCCESS_EPOCH}" ]; then
+    HOURS_RED=$(( (NOW - LAST_SUCCESS_EPOCH) / 3600 ))
+  else
+    HOURS_RED=-1
+  fi
+
+  echo "  completed runs examined : ${TOTAL}"
+  echo "  latest run              : ${LATEST_CONCL} (${LATEST_AT})"
+  echo "  consecutive failures    : ${CONSEC}"
+  if [ -n "${LAST_SUCCESS_AT}" ]; then
+    echo "  last success            : ${LAST_SUCCESS_AT} (${HOURS_RED}h ago)"
+  else
+    echo "  last success            : NONE in the last ${TOTAL} runs"
+  fi
+
+  if [ "${LATEST_CONCL}" = "success" ]; then
+    pass "${wf}: latest main run is green."
+    continue
+  fi
+
+  # No success anywhere in the window is strictly worse than a long red
+  # streak — report it as such rather than letting HOURS_RED=-1 slip by.
+  if [ -z "${LAST_SUCCESS_AT}" ]; then
+    fail "${wf}: NO successful run in the last ${TOTAL} completed main runs. Artifact publication from this workflow has stopped entirely."
+    continue
+  fi
+
+  if [ "${HOURS_RED}" -gt "${MAX_HOURS_RED}" ]; then
+    fail "${wf}: red for ${HOURS_RED}h (last success ${LAST_SUCCESS_AT}, ${CONSEC} consecutive failures) — over the ${MAX_HOURS_RED}h budget. This workflow publishes delivery artifacts; while it is red, every 'merged, closes on a roll' claim downstream is false."
+    continue
+  fi
+
+  if [ "${CONSEC}" -ge "${MAX_CONSECUTIVE_FAILURES}" ]; then
+    fail "${wf}: ${CONSEC} consecutive failed main runs (>= ${MAX_CONSECUTIVE_FAILURES}) — a sustained break, not a flake. Last success ${LAST_SUCCESS_AT}."
+    continue
+  fi
+
+  pass "${wf}: latest run is ${LATEST_CONCL} but only ${CONSEC} consecutive failure(s) and ${HOURS_RED}h since the last success — inside the ${MAX_CONSECUTIVE_FAILURES}-run / ${MAX_HOURS_RED}h budget. Reported, not failed."
+done
+
+echo
+if [ "${FAILED}" -ne 0 ]; then
+  echo "OVERALL: FAIL — a delivery workflow has been red long enough to have stopped shipping artifacts."
+  exit 1
+fi
+echo "OVERALL: PASS — every watched delivery workflow is publishing."

--- a/scripts/tests/test-chart-version-forward.sh
+++ b/scripts/tests/test-chart-version-forward.sh
@@ -224,6 +224,99 @@ fi
 git -C "${CHECK}" log --oneline -5
 echo
 
+echo "=========================================================="
+echo "T6 — bump-chart-version.sh against a PRODUCTION-SIZED Chart.yaml"
+echo "     (>64 KiB of content after the 'version:' line)"
+echo "=========================================================="
+#
+# WHY THIS CASE EXISTS
+# --------------------
+# T5 above already drives bump-chart-version.sh end-to-end — and it passed
+# green on every run while the real `Build & Deploy Catalyst` workflow failed
+# 53 consecutive times on main (2026-08-06 → 2026-08-10) at that exact
+# script. T5 could not see it, because T5's fixture Chart.yaml is four lines
+# (~70 bytes) and the defect is a function of FILE SIZE, not of the version
+# arithmetic T5 asserts on:
+#
+#   BASE_VERSION="$(printf '%s\n' "${BASELINE}" | awk '/^version:/{print $2; exit}' …)"
+#
+# `awk … {exit}` closes the pipe on match. The real Chart.yaml carries 88,958
+# bytes AFTER its `version:` line — past the 64 KiB Linux pipe buffer — so
+# printf was still writing, took EPIPE, and died 141; pipefail + set -e then
+# aborted the bump. Under 64 KiB the write completes before awk exits and
+# nothing fails. T5's fixture made the production failure UNREACHABLE — a
+# guard exercising a surface that cannot fail (docs/PRINCIPLES.md A18).
+#
+# T6 restores the missing property: a chart shaped like the real one.
+BIGWORK="${WORK}/bigchart"
+mkdir -p "${BIGWORK}"
+BIG_UPSTREAM="${BIGWORK}/upstream.git"
+git init -b main --bare "${BIG_UPSTREAM}" >/dev/null
+BIG_CLONE="${BIGWORK}/clone"
+git clone "${BIG_UPSTREAM}" "${BIG_CLONE}" >/dev/null 2>&1
+mkdir -p "${BIG_CLONE}/products/catalyst/chart"
+BIG_CHART="${BIG_CLONE}/products/catalyst/chart/Chart.yaml"
+
+{
+  echo "apiVersion: v2"
+  echo "name: bp-catalyst-platform"
+  echo "version: 1.4.1400"
+  echo "appVersion: 1.4.1400"
+  # Trailing body. products/catalyst/chart/Chart.yaml accumulates a long
+  # KNOWN-BAD/superseded-artifact changelog under its version fields; this
+  # reproduces that shape at production scale.
+  awk 'BEGIN{ for(i=0;i<2200;i++) print "# superseded-artifact changelog padding line " i " — reproduces the real Chart.yaml trailing body" }'
+} > "${BIG_CHART}"
+
+# Vacuity check — if a future edit shrinks this fixture below the pipe
+# buffer, T6 silently stops testing anything. Assert the property FIRST.
+BIG_TOTAL="$(wc -c < "${BIG_CHART}")"
+BIG_BEFORE="$(awk '/^version:/{exit} {n+=length($0)+1} END{print n+0}' "${BIG_CHART}")"
+BIG_AFTER="$(( BIG_TOTAL - BIG_BEFORE ))"
+echo "fixture: total=${BIG_TOTAL} bytes, after-'version:'=${BIG_AFTER} bytes (pipe buffer = 65536)"
+if [ "${BIG_AFTER}" -le 65536 ]; then
+  fail "T6 VACUITY — fixture has only ${BIG_AFTER} bytes after 'version:', at or under the 65536-byte pipe buffer. This case can no longer reproduce the SIGPIPE it exists to catch; enlarge the padding."
+else
+  pass "T6a — fixture carries ${BIG_AFTER} bytes after 'version:', above the 65536-byte pipe buffer (real chart: 88958)."
+fi
+
+( cd "${BIG_CLONE}"
+  git config user.name  "seed"
+  git config user.email "seed@test.local"
+  git add products/catalyst/chart/Chart.yaml
+  git commit -m "seed: production-sized chart 1.4.1400/1.4.1400" >/dev/null
+  git push -u origin main >/dev/null 2>&1
+)
+
+set +e
+T6_OUT="$( cd "${BIG_CLONE}" && "${BUMP}" products/catalyst/chart/Chart.yaml 2>"${WORK}/t6.stderr" )"
+T6_RC=$?
+set -e
+echo "--- T6 bump stderr ---"
+cat "${WORK}/t6.stderr"
+echo "--- T6 exit=${T6_RC} stdout='${T6_OUT}' ---"
+
+if [ "${T6_RC}" -ne 0 ]; then
+  fail "T6 — bump-chart-version.sh exited ${T6_RC} on a production-sized Chart.yaml (141 = SIGPIPE, the 53-red-run defect). It must not care how large the chart is."
+else
+  pass "T6b — bump-chart-version.sh exited 0 on a ${BIG_TOTAL}-byte chart."
+fi
+
+if [ "${T6_OUT}" != "1.4.1401" ]; then
+  fail "T6 — expected next_version 1.4.1401 from baseline 1.4.1400/1.4.1400, got '${T6_OUT}'."
+else
+  pass "T6c — computed the correct next_version (1.4.1401) from the large chart."
+fi
+
+T6_WROTE_V="$(awk '/^version:/{print $2; exit}' "${BIG_CHART}")"
+T6_WROTE_A="$(awk '/^appVersion:/{print $2; exit}' "${BIG_CHART}")"
+if [ "${T6_WROTE_V}" != "1.4.1401" ] || [ "${T6_WROTE_A}" != "1.4.1401" ]; then
+  fail "T6 — working copy not written in lockstep (version=${T6_WROTE_V} appVersion=${T6_WROTE_A})."
+else
+  pass "T6d — wrote version/appVersion in lockstep into the large chart."
+fi
+echo
+
 if [ "${FAILED}" -ne 0 ]; then
   echo "=========================================================="
   echo "OVERALL: FAIL"
@@ -233,6 +326,7 @@ fi
 
 echo "=========================================================="
 echo "OVERALL: PASS — guard rejects the real incident (T1-T3), accepts a"
-echo "correct bump (T4), and the fixed atomic mechanism converges under a"
-echo "real concurrent race instead of repeating it (T5)."
+echo "correct bump (T4), the fixed atomic mechanism converges under a"
+echo "real concurrent race instead of repeating it (T5), and the bump"
+echo "survives a production-sized Chart.yaml (T6 — the 53-red-run SIGPIPE)."
 echo "=========================================================="

--- a/scripts/tests/test-delivery-workflow-health.sh
+++ b/scripts/tests/test-delivery-workflow-health.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+# test-delivery-workflow-health.sh — non-vacuity proof for #6049
+#
+# Drives scripts/check-delivery-workflow-health.sh through the ACTUAL
+# 2026-08-06 → 2026-08-10 `Build & Deploy Catalyst` outage (real conclusions,
+# real timestamps pulled from the Actions API), not a synthetic streak —
+# docs/PRINCIPLES.md A18: a guard proven only against invented input is how
+# the last one missed the incident it was written for.
+#
+#   H1  the real outage: last success 2026-08-06T07:34:08Z, then 53
+#       consecutive failures through 2026-08-10T17:37:50Z         -> RED
+#   H2  the same history, evaluated from a moment BEFORE the streak
+#       got long (latest run green)                               -> GREEN
+#   H3  one isolated failure on top of a fresh success — a flake, not a
+#       break. Must NOT fire, or the canary gets muted as noise.  -> GREEN
+#   H4  empty run history (workflow renamed/deleted, or the query is
+#       wrong). Absent evidence must be reported as FAILURE.      -> RED
+#   H5  unreadable/missing fixture — an ACCESS failure must not be
+#       laundered into a clean bill of health.                    -> RED
+#
+# Usage: bash scripts/tests/test-delivery-workflow-health.sh
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/../.." && pwd)"
+GUARD="${REPO_ROOT}/scripts/check-delivery-workflow-health.sh"
+[ -x "${GUARD}" ] || chmod +x "${GUARD}"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "${WORK}"' EXIT
+
+FAILED=0
+fail() { echo "FAIL: $*" >&2; FAILED=1; }
+pass() { echo "PASS: $*"; }
+
+# "now" pinned to just after the last observed failure of the real outage, so
+# the elapsed-hours arithmetic is deterministic forever.
+NOW_EPOCH="$(date -u -d '2026-08-10T18:00:00Z' +%s)"
+
+# ---------------------------------------------------------------------------
+# Real data. Last GREEN run of catalyst-build.yaml was 0e734aa1f at
+# 2026-08-06T07:34:08Z; every run after it failed, through cd5fb58c7 at
+# 2026-08-10T17:37:50Z. These four failure timestamps are verbatim from the
+# API; the streak between them is filled to the real depth of 53.
+# ---------------------------------------------------------------------------
+write_outage_fixture() {
+  local out="$1"
+  {
+    echo '{"workflow_runs":['
+    echo '{"conclusion":"failure","created_at":"2026-08-10T17:37:50Z"},'
+    echo '{"conclusion":"failure","created_at":"2026-08-10T16:33:25Z"},'
+    echo '{"conclusion":"failure","created_at":"2026-08-10T12:26:42Z"},'
+    echo '{"conclusion":"failure","created_at":"2026-08-07T03:47:34Z"},'
+    # remaining failures of the real 53-run streak
+    for _ in $(seq 1 49); do
+      echo '{"conclusion":"failure","created_at":"2026-08-08T00:00:00Z"},'
+    done
+    echo '{"conclusion":"success","created_at":"2026-08-06T07:34:08Z"},'
+    echo '{"conclusion":"success","created_at":"2026-08-06T07:33:28Z"}'
+    echo ']}'
+  } > "${out}"
+}
+
+# ---- H1: the real outage -------------------------------------------------
+echo "=========================================================="
+echo "H1 — the real 2026-08-06 → 2026-08-10 catalyst-build outage"
+echo "=========================================================="
+FX="${WORK}/h1"; mkdir -p "${FX}"
+write_outage_fixture "${FX}/catalyst-build.yaml.json"
+set +e
+OUT="$(FIXTURE_DIR="${FX}" HEALTH_NOW_EPOCH="${NOW_EPOCH}" "${GUARD}" catalyst-build.yaml 2>&1)"
+RC=$?
+set -e
+echo "${OUT}"
+if [ "${RC}" -eq 0 ]; then
+  fail "H1 — guard exited 0 on a 53-run, 4-day red streak. This is the exact history it was written for; if it cannot go red here it cannot go red at all."
+else
+  pass "H1 — guard went RED on the real outage (exit ${RC})."
+fi
+# The numbers themselves must be right, not just the verdict.
+if ! printf '%s' "${OUT}" | grep -q "consecutive failures    : 53"; then
+  fail "H1 — guard did not count 53 consecutive failures. Counted: $(printf '%s' "${OUT}" | grep 'consecutive failures' || echo '<nothing>')"
+else
+  pass "H1b — counted the streak correctly (53)."
+fi
+if ! printf '%s' "${OUT}" | grep -q "106h ago"; then
+  fail "H1 — expected 106h since last success (2026-08-06T07:34:08Z → 2026-08-10T18:00:00Z). Got: $(printf '%s' "${OUT}" | grep 'last success' || echo '<nothing>')"
+else
+  pass "H1c — computed 106h since the last success."
+fi
+echo
+
+# ---- H2: same history, before it got long --------------------------------
+echo "=========================================================="
+echo "H2 — healthy pipeline (latest main run green)"
+echo "=========================================================="
+FX="${WORK}/h2"; mkdir -p "${FX}"
+cat > "${FX}/catalyst-build.yaml.json" <<'JSON'
+{"workflow_runs":[
+{"conclusion":"success","created_at":"2026-08-06T07:34:08Z"},
+{"conclusion":"success","created_at":"2026-08-06T07:33:28Z"},
+{"conclusion":"failure","created_at":"2026-08-06T04:18:49Z"}
+]}
+JSON
+set +e
+OUT="$(FIXTURE_DIR="${FX}" HEALTH_NOW_EPOCH="$(date -u -d '2026-08-06T08:00:00Z' +%s)" "${GUARD}" catalyst-build.yaml 2>&1)"
+RC=$?
+set -e
+echo "${OUT}"
+if [ "${RC}" -ne 0 ]; then
+  fail "H2 — guard went red on a pipeline whose latest main run is green (exit ${RC}). A canary that cries on green gets muted."
+else
+  pass "H2 — guard stayed GREEN on a healthy pipeline."
+fi
+echo
+
+# ---- H3: an isolated flake ----------------------------------------------
+echo "=========================================================="
+echo "H3 — one isolated failure over a fresh success (flake, not a break)"
+echo "=========================================================="
+FX="${WORK}/h3"; mkdir -p "${FX}"
+cat > "${FX}/catalyst-build.yaml.json" <<'JSON'
+{"workflow_runs":[
+{"conclusion":"failure","created_at":"2026-08-06T07:50:00Z"},
+{"conclusion":"success","created_at":"2026-08-06T07:34:08Z"},
+{"conclusion":"success","created_at":"2026-08-06T07:33:28Z"}
+]}
+JSON
+set +e
+OUT="$(FIXTURE_DIR="${FX}" HEALTH_NOW_EPOCH="$(date -u -d '2026-08-06T08:00:00Z' +%s)" "${GUARD}" catalyst-build.yaml 2>&1)"
+RC=$?
+set -e
+echo "${OUT}"
+if [ "${RC}" -ne 0 ]; then
+  fail "H3 — guard fired on a single failure 16 minutes after a success. That is a flake; firing here trains everyone to ignore it."
+else
+  pass "H3 — guard tolerated an isolated flake (reported, not failed)."
+fi
+echo
+
+# ---- H4: empty history ---------------------------------------------------
+echo "=========================================================="
+echo "H4 — empty run history must be a FAILURE, not a pass"
+echo "=========================================================="
+FX="${WORK}/h4"; mkdir -p "${FX}"
+echo '{"workflow_runs":[]}' > "${FX}/catalyst-build.yaml.json"
+set +e
+OUT="$(FIXTURE_DIR="${FX}" HEALTH_NOW_EPOCH="${NOW_EPOCH}" "${GUARD}" catalyst-build.yaml 2>&1)"
+RC=$?
+set -e
+echo "${OUT}"
+if [ "${RC}" -eq 0 ]; then
+  fail "H4 — guard reported healthy from an EMPTY run list. A verdict from absent evidence is the defect class this guard exists to end."
+else
+  pass "H4 — guard treated absent evidence as failure (exit ${RC})."
+fi
+echo
+
+# ---- H5: unreadable fixture ---------------------------------------------
+echo "=========================================================="
+echo "H5 — unreadable history (access failure) must not read as healthy"
+echo "=========================================================="
+FX="${WORK}/h5"; mkdir -p "${FX}"   # deliberately no fixture file inside
+set +e
+OUT="$(FIXTURE_DIR="${FX}" HEALTH_NOW_EPOCH="${NOW_EPOCH}" "${GUARD}" catalyst-build.yaml 2>&1)"
+RC=$?
+set -e
+echo "${OUT}"
+if [ "${RC}" -eq 0 ]; then
+  fail "H5 — guard reported healthy when it could not read the run history at all."
+else
+  pass "H5 — guard treated an access failure as failure (exit ${RC})."
+fi
+echo
+
+if [ "${FAILED}" -ne 0 ]; then
+  echo "=========================================================="
+  echo "OVERALL: FAIL"
+  echo "=========================================================="
+  exit 1
+fi
+
+echo "=========================================================="
+echo "OVERALL: PASS — the canary goes red on the real 4-day outage (H1),"
+echo "stays green on a healthy pipeline (H2) and on an isolated flake (H3),"
+echo "and refuses to report health from absent evidence (H4, H5)."
+echo "=========================================================="


### PR DESCRIPTION
`Build & Deploy Catalyst` has failed on **every push to main since 2026-08-06T08:32Z — 54 consecutive runs across four days.** `services-build.yaml` has been down the same four days (10 red runs), **on the identical line, for the identical reason.**

Refs #6049

## The real error

Not the `build-ui` step name. The dominant failure, in 5 of the 8 runs I sampled across the window, was the `deploy` job:

```
scripts/bump-chart-version.sh: line 80: printf: write error: Broken pipe
##[error]Process completed with exit code 1.
```

```
BASE_VERSION="$(printf '%s\n' "${BASELINE}" | awk '/^version:/{print $2; exit}' | tr -d '"')"
```

`awk … {exit}` stops reading on match and closes the pipe. `products/catalyst/chart/Chart.yaml` carries **88,958 bytes after its `version:` line** — past the 64 KiB (65,536 B) Linux pipe buffer — so `printf` is still writing when the reader goes away, takes EPIPE, dies **141**, and `pipefail` + `set -e` abort the bump.

The defect is a function of **file size**, not of version arithmetic. `77a47f167` (#5758) is **both the commit that introduced this script and the first red run** — it has never once succeeded.

## Reproduction

```
$ bash scripts/bump-chart-version.sh products/catalyst/chart/Chart.yaml
exit_code=141
```

Control — same pipeline, only bytes-after-`version:` varied across the buffer:

| bytes after `version:` | exit |
|---|---|
| 1,011 | 0 |
| 32,013 | 0 |
| 65,013 | **141** |
| 88,971 | **141** |
| 200,013 | **141** |

After the fix, against the real 334,068-byte chart:

```
$ bash scripts/bump-chart-version.sh products/catalyst/chart/Chart.yaml
exit=0  next_version='1.4.1335'
OK — products/catalyst/chart/Chart.yaml: 1.4.1334/1.4.1334 -> 1.4.1335/1.4.1335 (forward, consistent)
```

## Second, independent break

From `05d3f639c` (08-10T12:26Z), `build-ui` also failed earlier, at the image build:

```
src/entities/deployment/model.ts(455,9): error TS6133: 'hasAuditComp' is declared but its value is never read.
```

#5979 removed the strongSwan profile rule and left its only input unread. `noUnusedLocals` makes that fatal to `tsc -b`. Reproduced with `npx tsc -b` (exit 2) and fixed (`npm run build` exit 0).

Both fixes are needed for green: `deploy` is gated on `build-ui`, so it was skipped entirely on the newest runs.

## Delivery consequence

- **catalyst-ui froze at `b2294fd`** (08-10T12:15Z).
- **catalyst-api kept publishing** — `cd5fb58` exists and carries `latest`. The two images have been drifting apart.
- **`Chart.yaml` stuck at 1.4.1334 since 08-06**, so no new `bp-catalyst-platform` chart was published. Image pins in `values.yaml` were still being committed, which is why this looked like it was working.

## Guards — each watched red, then green

**1. `test-chart-version-forward.sh` T6.** T5 *already* drove this script end-to-end through a real concurrent-push race and stayed green all four days — its fixture `Chart.yaml` is four lines, ~70 bytes, so the failure was structurally unreachable. T6 uses a production-shaped chart and vacuity-checks the fixture really exceeds the buffer.

Against the shipped script (T1–T5 all pass, which is the point):
```
PASS: T5b — final origin/main state moved strictly forward ...
fixture: total=216771 bytes, after-'version:'=216729 bytes (pipe buffer = 65536)
PASS: T6a — fixture carries 216729 bytes after 'version:', above the 65536-byte pipe buffer
--- T6 exit=141 stdout='' ---
FAIL: T6 — bump-chart-version.sh exited 141 on a production-sized Chart.yaml
OVERALL: FAIL   (suite exit 1)
```
After: **10 PASS, suite exit 0**, `T6 exit=0 stdout='1.4.1401'`.

**2. PR-time `tsc` gate** in `test-ungated-trees.yaml`. vitest strips types via esbuild and never runs `tsc`, so `model.ts` was green under 2,160 passing tests while refusing to compile. `npm run typecheck` already existed in `package.json`; nothing called it. Red: exit 2 with the TS6133. Green: exit 0.

**3. `check-delivery-workflow-health.sh` + scheduled workflow.** Every `check-*.yaml` here answers "is THIS commit good?"; none asked "is the pipeline still shipping?", so a break landing after merge in a non-required workflow was invisible by construction. Fixtures are built from this outage's real conclusions and timestamps.

```
H1 real outage      -> RED  (53 consecutive failures, 106h since last success)
H2 healthy pipeline -> GREEN
H3 isolated flake   -> GREEN   (so it does not get muted as noise)
H4 empty history    -> RED     (absent evidence is never health)
H5 unreadable       -> RED
9 PASS, suite exit 0
```

Run live against the API right now, it reports the true current state:
```
catalyst-build.yaml : 54 consecutive failures, last success 2026-08-06T07:34:08Z (106h ago)
services-build.yaml : 10 consecutive failures, last success 2026-08-06T03:58:47Z (109h ago)
OVERALL: FAIL
```

## Verification

- `scripts/tests/test-chart-version-forward.sh` — 10 PASS, exit 0
- `scripts/tests/test-delivery-workflow-health.sh` — 9 PASS, exit 0
- `npm run typecheck` — exit 0; `npm run build` — exit 0
- `npm test` — 235 files, 2,160 passed, 1 expected fail
- `shellcheck -S error` clean; both workflow YAMLs parse

A note for review: this changes no chart version and no image pin by hand — it repairs the mechanism that does. The first green `deploy` run will bump 1.4.1334 to 1.4.1335 itself.
