### PR TITLE
fix(org-delete): grant the missing delete verb and stop reporting a 403 as 204

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1356,7 +1356,15 @@ spec:
       #   umbrella, so the new pin only reaches a Sovereign once the umbrella
       #   republishes and this pin advances (#5734). Lockstep w/
       #   products/catalyst/chart/Chart.yaml + slot-06a (0.1.177).
-      version: 1.4.1340
+      # 1.4.1341 (#5426): the cutover-driver ClusterRole gains `delete` on
+      #   orgs.openova.io/organizations — the verb the console's Organization
+      #   DELETE needs to fire the org-controller finalizer cascade. It had
+      #   create but not delete, so on hw293 the DELETE answered 204 while the
+      #   CR survived with deletionTimestamp null and the namespace + vcluster
+      #   StatefulSet came back 138s later. RBAC ships inside this umbrella, so
+      #   the grant only reaches a Sovereign once this pin advances. Lockstep
+      #   w/ products/catalyst/chart/Chart.yaml.
+      version: 1.4.1341
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/bootstrap/api/internal/handler/org_tenant_org_cr.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_tenant_org_cr.go
@@ -133,13 +133,32 @@ func (h *Handler) createOrgOrganizationCR(ctx context.Context, rec store.Organiz
 // stale artifact transiently re-applies is pruned on the next source fetch,
 // and the cascade itself removes the per-Org Flux sources.
 //
-// Best-effort like the sibling teardown steps, but a failure is logged at
-// Error level (a silent skip IS the #5426 bug): the CR survives, so
-// re-running the DELETE — every step of which is idempotent — retries the
-// cascade trigger. NotFound is success (kubectl-side delete or a prior
-// DELETE already triggered / completed the cascade). Nil-tolerant on the
-// dynamic client for CI / out-of-cluster, matching createOrgOrganizationCR.
-func (h *Handler) deleteOrgOrganizationCR(ctx context.Context, rec store.OrganizationProvisionRecord) {
+// RETURNS THE APISERVER FAILURE — it is NOT best-effort like the sibling
+// teardown steps (#5426 second half). This function used to be `void`: it
+// logged the apiserver error at Error level and returned, and the caller
+// then wrote 204 No Content. On hw293 (2026-08-10) that produced a DELETE
+// which reported success while the CR kept deletionTimestamp: null and its
+// finalizer, and the namespace + vcluster StatefulSet came BACK 138s later
+// under a new uid. A permission error reported as success is a lie the
+// caller cannot detect — the console, a script and a User all read 204 as
+// "deleted" — and that is precisely what let the missing RBAC verb sit
+// undiscovered. The log line was there the whole time and nobody was
+// looking at it, because the status code said everything was fine.
+//
+// Contract:
+//   - invalid slug  -> nil. createOrgOrganizationCR never minted a CR for
+//     it, so there is genuinely nothing to cascade.
+//   - no dyn client -> nil. CI / out-of-cluster; there is no apiserver to
+//     refuse anything, matching createOrgOrganizationCR.
+//   - NotFound      -> nil. Idempotent success: a kubectl-side delete or a
+//     prior DELETE already triggered / completed the cascade.
+//   - anything else -> the error, unwrapped, so the caller can classify it
+//     (apierrors.IsForbidden etc.) and surface it verbatim.
+//
+// The DELETE endpoint is idempotent end-to-end, so the honest failure the
+// caller now receives is directly actionable: fix the grant, re-issue the
+// same DELETE.
+func (h *Handler) deleteOrgOrganizationCR(ctx context.Context, rec store.OrganizationProvisionRecord) error {
 	slug := strings.ToLower(strings.TrimSpace(rec.Subdomain))
 	if !orgSlugRE.MatchString(slug) {
 		// createOrgOrganizationCR never mints a CR for an invalid slug, so
@@ -148,27 +167,28 @@ func (h *Handler) deleteOrgOrganizationCR(ctx context.Context, rec store.Organiz
 			"subdomain", rec.Subdomain,
 			"org_tenant_id", rec.OrganizationID,
 		)
-		return
+		return nil
 	}
 
 	deps, err := h.sovereignDepsFor()
 	if err != nil || deps == nil || deps.dyn == nil {
 		h.log.Info("org-tenant: Organization CR delete skipped — no in-cluster dynamic client",
 			"org_tenant_id", rec.OrganizationID, "err", err)
-		return
+		return nil
 	}
 
 	if err := deps.dyn.Resource(organizationGVR()).Delete(ctx, slug, metav1.DeleteOptions{}); err != nil {
 		if apierrors.IsNotFound(err) {
 			// Already gone — idempotent success.
-			return
+			return nil
 		}
 		h.log.Error("org-tenant: Organization CR delete FAILED — finalizer cascade NOT triggered; namespace/vCluster/realm/Flux sources leak until this DELETE is retried (#5426)",
 			"slug", slug, "org_tenant_id", rec.OrganizationID, "err", err)
-		return
+		return err
 	}
 	h.log.Info("org-tenant: Organization CR deleted — org-controller finalizer cascade triggered",
 		"slug", slug, "org_tenant_id", rec.OrganizationID)
+	return nil
 }
 
 // ensureOrganizationCR builds the Organization CR from the Organization record

--- a/products/catalyst/bootstrap/api/internal/handler/org_tenant_org_cr_delete_denial_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_tenant_org_cr_delete_denial_test.go
@@ -1,0 +1,174 @@
+// org_tenant_org_cr_delete_denial_test.go — #5426 second half.
+//
+// The sibling file org_tenant_org_cr_delete_test.go proves the handler
+// CALLS Delete. That is not the property that failed live on hw293: the
+// call was made, the apiserver REFUSED it, and the handler returned 204
+// anyway. Measured on hw293 2026-08-10:
+//
+//	DELETE /api/v1/organizations/{id}  ->  204 No Content
+//	catalyst-api log: organizations.orgs.openova.io is forbidden:
+//	  User "system:serviceaccount:catalyst:catalyst-api-cutover-driver"
+//	  cannot delete resource "organizations" in API group
+//	  "orgs.openova.io" at the cluster scope
+//	Organization CR:  deletionTimestamp: null, finalizer still attached,
+//	                  resourceVersion frozen
+//	T+138s:           namespace + vcluster StatefulSet BACK under a new uid
+//	                  (the surviving CR's Flux sources rebuilt them)
+//
+// A permission error reported as success is a lie the caller cannot
+// detect — the console, a script and a User all read 204 as "deleted".
+// That is what let the defect sit undiscovered. These guards assert the
+// property the previous suite could not fail on: WHEN THE APISERVER
+// DENIES THE DELETE, DOES THE CALLER LEARN.
+//
+// The fake dynamic client in the sibling harness has no RBAC, so its
+// Delete can never be refused — these tests install a reactor that
+// returns the real apierrors.NewForbidden the apiserver returns.
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	k8stesting "k8s.io/client-go/testing"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/store"
+)
+
+// forbidOrganizationDelete makes the fake apiserver refuse `delete
+// organizations` exactly the way the live one did — same GroupResource,
+// same verb, so err is apierrors.IsForbidden and the message names the
+// resource and the ServiceAccount.
+func forbidOrganizationDelete(dyn *dynamicfake.FakeDynamicClient) {
+	dyn.PrependReactor("delete", "organizations", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		name := ""
+		if da, ok := action.(k8stesting.DeleteAction); ok {
+			name = da.GetName()
+		}
+		return true, nil, apierrors.NewForbidden(
+			schema.GroupResource{Group: "orgs.openova.io", Resource: "organizations"},
+			name,
+			// Verbatim shape of the live denial (hw293, catalyst-api log).
+			errRBACDeniedLiveShape,
+		)
+	})
+}
+
+var errRBACDeniedLiveShape = &forbiddenDetail{}
+
+type forbiddenDetail struct{}
+
+func (e *forbiddenDetail) Error() string {
+	return `User "system:serviceaccount:catalyst:catalyst-api-cutover-driver" ` +
+		`cannot delete resource "organizations" in API group "orgs.openova.io" ` +
+		`at the cluster scope`
+}
+
+// TestDeleteOrganization_ApiserverDenialIsNotReportedAsSuccess is the
+// decisive guard. A 403 from the apiserver MUST NOT become a 204.
+func TestDeleteOrganization_ApiserverDenialIsNotReportedAsSuccess(t *testing.T) {
+	h, dyn, _, _ := newOrgDeleteCascadeHarness(t)
+	rec := seedOrgRecordAndCR(t, h, dyn, "denyprobe")
+	forbidOrganizationDelete(dyn)
+
+	w := deleteOrgViaHandler(t, h, rec.OrganizationID)
+
+	if w.Code == http.StatusNoContent {
+		t.Fatalf("apiserver DENIED the Organization CR delete and the handler still answered "+
+			"204 No Content — the caller is told the Organization was deleted when nothing was "+
+			"deleted (#5426, measured live on hw293). body=%q", w.Body.String())
+	}
+	if w.Code < 500 || w.Code > 599 {
+		t.Fatalf("want a 5xx on an upstream apiserver denial, got %d body=%q", w.Code, w.Body.String())
+	}
+	if w.Code != http.StatusBadGateway {
+		t.Fatalf("want 502 Bad Gateway (the upstream apiserver refused), got %d body=%q", w.Code, w.Body.String())
+	}
+}
+
+// TestDeleteOrganization_DenialBodyNamesWhatWasDenied — the status code
+// alone tells a script something failed; the body must tell an operator
+// WHAT, or the next session repeats the hw293 investigation from zero.
+func TestDeleteOrganization_DenialBodyNamesWhatWasDenied(t *testing.T) {
+	h, dyn, _, _ := newOrgDeleteCascadeHarness(t)
+	rec := seedOrgRecordAndCR(t, h, dyn, "denybody")
+	forbidOrganizationDelete(dyn)
+
+	w := deleteOrgViaHandler(t, h, rec.OrganizationID)
+
+	// map[string]any, not map[string]string: writeJSON also stamps a
+	// NUMERIC `status` alongside the string fields.
+	var body map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("denial response body is not JSON: %v (raw=%q)", err, w.Body.String())
+	}
+	str := func(k string) string {
+		s, _ := body[k].(string)
+		return s
+	}
+	if str("error") == "" {
+		t.Fatalf("denial response carries no `error` key: %v", body)
+	}
+	// The detail must name the resource the apiserver refused, so an
+	// operator can go straight to the ClusterRole.
+	joined := strings.ToLower(str("error") + " " + str("detail"))
+	if !strings.Contains(joined, "organization") {
+		t.Fatalf("denial body never names the denied resource: %v", body)
+	}
+	if !strings.Contains(joined, "forbidden") && !strings.Contains(joined, "cannot delete") {
+		t.Fatalf("denial body never says the delete was refused: %v", body)
+	}
+}
+
+// TestDeleteOrganization_DenialLeavesRecordUndeleted — the store must not
+// be stamped STSDeleted when the CR survives. A "deleted" audit row on a
+// live Organization is the same lie one layer down: the console list drops
+// the Org while its namespace, vCluster and Keycloak realm keep running.
+func TestDeleteOrganization_DenialLeavesRecordUndeleted(t *testing.T) {
+	h, dyn, _, _ := newOrgDeleteCascadeHarness(t)
+	rec := seedOrgRecordAndCR(t, h, dyn, "denystate")
+	forbidOrganizationDelete(dyn)
+
+	_ = deleteOrgViaHandler(t, h, rec.OrganizationID)
+
+	got, ok := h.orgTenantDeps.Store.Get(rec.OrganizationID)
+	if !ok {
+		t.Fatalf("record vanished from the store after a FAILED delete")
+	}
+	if got.State == store.STSDeleted {
+		t.Fatalf("record stamped STSDeleted while the Organization CR is still live — "+
+			"the console will hide an Organization whose namespace/vCluster/realm keep running "+
+			"(state=%s)", got.State)
+	}
+
+	// And the CR really is still there — the control on this assertion.
+	if _, err := dyn.Resource(organizationGVR()).Get(context.Background(), "denystate", metav1.GetOptions{}); err != nil {
+		t.Fatalf("precondition broken: the reactor should have BLOCKED the delete, CR get: %v", err)
+	}
+}
+
+// TestDeleteOrganization_SuccessStillReturns204 is the control: with the
+// apiserver allowing the delete (no reactor), the honest path is unchanged.
+// Without this a "fix" that always 502s would pass the three guards above.
+func TestDeleteOrganization_SuccessStillReturns204(t *testing.T) {
+	h, dyn, _, _ := newOrgDeleteCascadeHarness(t)
+	rec := seedOrgRecordAndCR(t, h, dyn, "allowprobe")
+
+	w := deleteOrgViaHandler(t, h, rec.OrganizationID)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("permitted delete: want 204 got %d body=%q", w.Code, w.Body.String())
+	}
+	got, ok := h.orgTenantDeps.Store.Get(rec.OrganizationID)
+	if !ok || got.State != store.STSDeleted {
+		t.Fatalf("permitted delete must stamp STSDeleted, got ok=%v state=%v", ok, got.State)
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/organization_provisioning.go
+++ b/products/catalyst/bootstrap/api/internal/handler/organization_provisioning.go
@@ -1005,8 +1005,14 @@ func (h *Handler) HandleReconcileOrganization(w http.ResponseWriter, r *http.Req
 // (publishTenantDeleted → teardownPerOrgFlux → teardownTenantNetworking
 // → iac-bootstrap → per-org-realm), the ONLY complete teardown (#5426)
 // — unregisters from the host registry, and emits the deletion event.
-// Each step is idempotent + best-effort; partial failure leaves a
-// STSDeleted audit row so the reconciler can finish on the next pass.
+// Every step is idempotent, so the whole DELETE is safe to re-issue.
+//
+// The CR delete is the ONE step that is NOT best-effort (#5426): if the
+// apiserver refuses it the Organization is still live, so the handler
+// answers 502 and stops rather than writing 204 over a failure. The
+// surrounding steps (overlay reap, registry, DNS, event emit) stay
+// best-effort and leave a STSDeleted audit row so the reconciler can
+// finish them on the next pass.
 //
 // Ordering is load-bearing (#4459/R17): the overlay reap commits FIRST
 // so Flux cannot recreate what the cascade tears down, THEN the CR
@@ -1043,7 +1049,38 @@ func (h *Handler) HandleDeleteOrganization(w http.ResponseWriter, r *http.Reques
 	// deletionTimestamp and every one of those surfaces leaked — proven live
 	// on hw292 (r17probe) and hw290 (gamma-corp/delta-corp). Runs strictly
 	// AFTER the overlay reap above per the #4459/R17 recreate-race order.
-	h.deleteOrgOrganizationCR(r.Context(), rec)
+	//
+	// #5426 second half — the apiserver's answer is the RESPONSE, not a log
+	// line. Before this the outcome was discarded and the handler wrote 204
+	// unconditionally: on hw293 a 403 ("cannot delete resource
+	// \"organizations\" at the cluster scope") was reported to the caller as
+	// success while the CR, its finalizer and every downstream surface
+	// survived. Bail out here rather than continuing: the Organization is
+	// still LIVE, so reaping its registry entry and its DNS records would
+	// strip the front door off a running Organization and compound the
+	// damage. Every step of this handler is idempotent, so the correct
+	// operator action is to fix the grant and re-issue the same DELETE.
+	if err := h.deleteOrgOrganizationCR(r.Context(), rec); err != nil {
+		// Persist the reason on the audit row WITHOUT stamping STSDeleted —
+		// a "deleted" row for a live Organization is the same lie one layer
+		// down (the console list would drop an Org whose namespace, vCluster
+		// and Keycloak realm keep running).
+		rec.LastError = "organization_cr_delete:" + truncate(err.Error(), 256)
+		if perr := deps.Store.Put(rec); perr != nil {
+			h.log.Warn("org-tenant: persist delete failure failed", "err", perr)
+		}
+		writeJSON(w, http.StatusBadGateway, map[string]string{
+			"error": "organization-cr-delete-failed",
+			// Verbatim apiserver text — on an RBAC denial this names the
+			// ServiceAccount, the verb and the resource, which is the whole
+			// diagnosis.
+			"detail": truncate(err.Error(), 512),
+			"hint": "the Organization CR survives, so the org-controller finalizer cascade never ran " +
+				"and the namespace / vCluster / Keycloak realm / per-Org Flux sources are still live; " +
+				"this DELETE is idempotent — re-issue it once the apiserver permits the call",
+		})
+		return
+	}
 	if deps.TenantRegistry != nil {
 		host := deriveConsoleHost(rec)
 		if host != "" {

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3764,7 +3764,18 @@ name: bp-catalyst-platform
 #   Sovereign would keep installing cutover 0.1.176 while the seed in git
 #   claimed 0.1.177 — check-umbrella-republish-gate.py (#5734). Lockstep w/
 #   slot-13 pin.
-version: 1.4.1340
+# 1.4.1341 (#5426): templates/clusterrole-cutover-driver.yaml grants
+#   catalyst-api `delete` on orgs.openova.io/organizations. The SA had
+#   get/list/watch (#3978) and create (#4921) but never delete, so the ONE
+#   apiserver call that fires the org-controller finalizer cascade was 403'd
+#   on every console Organization delete. Measured on hw293 2026-08-10:
+#   `auth can-i delete organizations` -> no (create -> yes); DELETE
+#   /api/v1/organizations/{id} -> 204 while the CR kept deletionTimestamp
+#   null + its finalizer, and the namespace + vcluster StatefulSet returned
+#   138s later under a new uid. A ClusterRole is delivered only by the
+#   published umbrella, so the grant reaches a Sovereign only once this
+#   version advances. Lockstep w/ slot-13 pin.
+version: 1.4.1341
 # 1.4.1229 — #5389: catalog-seed bp-newapi declares its `ui` endpoint
 #   (newapi.<fqdn>, ssoEnabled, launchDefault, ssoInitPath "/") instead of
 #   `endpoints: []`. The empty list made userUIGatePasses fail closed, which
@@ -3919,7 +3930,7 @@ version: 1.4.1340
 # scripts/check-chart-version-forward.sh (#5743) fails unless the two match —
 # main was carrying a pre-existing 1.4.1330/1.4.1329 split, so this bump heals
 # it in the same commit, exactly as the documented self-heal contract does.
-appVersion: 1.4.1340
+appVersion: 1.4.1341
 # 1.4.239 — Wave 3 / Issue #2140 (2026-05-23): Huawei provider
 # implementation lands behind the Wave 2 CloudProvider interface.
 # Adds the OpenTofu module at infra/providers/huawei/ (VPC + Subnet +

--- a/products/catalyst/chart/templates/clusterrole-cutover-driver.yaml
+++ b/products/catalyst/chart/templates/clusterrole-cutover-driver.yaml
@@ -716,6 +716,50 @@ rules:
     verbs: ["create"]
 
   # ───────────────────────────────────────────────────────────────
+  # Issue #5426 — ORGANIZATION DELETE. The create verb above landed with
+  # #4921; the matching DELETE never did, so the teardown half of the
+  # same lifecycle was 403'd on every call. Measured on hw293
+  # 2026-08-10:
+  #
+  #   kubectl auth can-i delete organizations.orgs.openova.io \
+  #     --as=system:serviceaccount:catalyst:catalyst-api-cutover-driver
+  #   -> no          (create -> yes)
+  #
+  #   DELETE /api/v1/organizations/{id} -> 204 No Content
+  #   catalyst-api log: organizations.orgs.openova.io is forbidden:
+  #     ... cannot delete resource "organizations" at the cluster scope
+  #   Organization CR: deletionTimestamp null, finalizer still attached,
+  #     resourceVersion frozen
+  #   T+138s: namespace + vcluster StatefulSet BACK under a new uid —
+  #     the surviving CR's per-Org Flux sources rebuilt them
+  #
+  # org_tenant_org_cr.go deleteOrgOrganizationCR issues exactly ONE
+  # apiserver call, and it is the ONLY trigger for the org-controller's
+  # `orgs.openova.io/tenant-networking` finalizer cascade
+  # (publishTenantDeleted -> teardownPerOrgFlux -> teardownTenantNetworking
+  # -> iac-bootstrap -> per-org-realm) — the only complete teardown of an
+  # Organization's namespace / vCluster / Keycloak realm / per-Org Flux
+  # sources / gateway listeners.
+  #
+  # SCOPE — `delete` on organizations and NOTHING else. The cascade's own
+  # Flux teardown (per_org_flux.go teardownPerOrgFlux) deletes the per-Org
+  # Kustomizations + GitRepository under the ORGANIZATION-CONTROLLER's SA,
+  # which already carries delete on both kinds
+  # (templates/controllers/organization-controller-clusterrole.yaml
+  # rules for kustomize.toolkit.fluxcd.io/kustomizations +
+  # source.toolkit.fluxcd.io/gitrepositories). catalyst-api never deletes
+  # a Flux object, so widening it to those kinds would be an unearned
+  # grant. tests/cutover-driver-organization-delete-rbac.sh asserts BOTH
+  # halves — the verb that must be present and the ones that must not.
+  #
+  # `delete` needs no resourceNames (the DELETE addresses one named CR,
+  # and pinning names here would break every future Org slug).
+  # ───────────────────────────────────────────────────────────────
+  - apiGroups: ["orgs.openova.io"]
+    resources: ["organizations"]
+    verbs: ["delete"]
+
+  # ───────────────────────────────────────────────────────────────
   # Issues #5364 / #5649 — ORG-CONSOLE ORPHAN REAP, the teardown mirror
   # of the #5635 create-side reconcile. reapOrgConsoleTLSOrphans
   # (org_console_tls_reap.go), run inside the reconcileOrgConsoleTLSOnce

--- a/products/catalyst/chart/tests/cutover-driver-organization-delete-rbac.sh
+++ b/products/catalyst/chart/tests/cutover-driver-organization-delete-rbac.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# bp-catalyst-platform — catalyst-api MUST be able to DELETE an Organization (#5426).
+#
+# Measured live on hw293 2026-08-10:
+#
+#   $ kubectl auth can-i delete organizations.orgs.openova.io \
+#       --as=system:serviceaccount:catalyst:catalyst-api-cutover-driver
+#   no
+#   $ kubectl auth can-i create organizations.orgs.openova.io --as=<same SA>
+#   yes
+#
+# DELETE /api/v1/organizations/{id} answered 204 No Content while the
+# Organization CR kept deletionTimestamp: null and its
+# `orgs.openova.io/tenant-networking` finalizer, resourceVersion frozen.
+# 138 seconds later the namespace and its vcluster StatefulSet were BACK
+# under a new uid — the surviving CR's per-Org Flux sources rebuilt them.
+#
+# templates/clusterrole-cutover-driver.yaml granted the SA
+# get/list/watch on organizations (#3978 block) and, separately, create
+# (#4921 block). Nothing anywhere in the file granted delete, so the ONE
+# apiserver call that fires the org-controller finalizer cascade — the
+# only complete teardown of an Organization's namespace / vCluster /
+# Keycloak realm / per-Org Flux sources / gateway listeners — was 403'd
+# on every console delete.
+#
+# This gate renders the ClusterRole and asserts the rule set actually
+# grants `delete` on organizations, so a future rule-block reshuffle that
+# drops the verb fails Blueprint Release publish BEFORE the OCI artifact
+# reaches a Sovereign. It is deliberately a RENDER assertion, not a grep
+# of the template source: a `{{- if }}` that gates the rule off would
+# leave the source string present and the live SA still denied.
+#
+# Least privilege is asserted too — see the NOT-GRANTED section: the
+# cascade's own Flux teardown (per_org_flux.go teardownPerOrgFlux) runs
+# under the organization-controller SA, which already carries delete on
+# kustomizations + gitrepositories
+# (templates/controllers/organization-controller-clusterrole.yaml). The
+# catalyst-api SA must NOT be widened to those.
+#
+# Usage: bash tests/cutover-driver-organization-delete-rbac.sh [CHART_DIR]
+
+set -euo pipefail
+
+CHART_DIR="${1:-$(cd "$(dirname "$0")/.." && pwd)}"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+cd "$CHART_DIR"
+
+TEMPLATE="templates/clusterrole-cutover-driver.yaml"
+
+helm template rbacgate . --show-only "${TEMPLATE}" > "$TMP/cr.yaml"
+
+# Vacuity check — a render that produced nothing would make every
+# "verb is granted" assertion below trivially unfalsifiable in the
+# other direction, and every "verb is NOT granted" assertion pass on air.
+if ! grep -q "kind: ClusterRole" "$TMP/cr.yaml"; then
+  echo "FAIL: ${TEMPLATE} rendered no ClusterRole — the gate would be testing nothing."
+  exit 1
+fi
+RULE_COUNT=$(grep -c '^\s*- apiGroups:' "$TMP/cr.yaml" || true)
+if [ "${RULE_COUNT:-0}" -lt 20 ]; then
+  echo "FAIL: rendered ClusterRole has only ${RULE_COUNT} rules — render looks truncated."
+  exit 1
+fi
+
+# ── verbs_for <apiGroup> <resource> ───────────────────────────────────
+# Prints one verb per line for every rule in the rendered ClusterRole
+# that covers <apiGroup>/<resource>. RBAC rules merge additively, so the
+# effective grant is the UNION across rules — which is exactly why a
+# source grep for a single block is not evidence.
+verbs_for() {
+  local group="$1" resource="$2"
+  python3 - "$TMP/cr.yaml" "$group" "$resource" <<'PY'
+import sys, yaml
+path, group, resource = sys.argv[1], sys.argv[2], sys.argv[3]
+verbs = set()
+for doc in yaml.safe_load_all(open(path)):
+    if not doc or doc.get("kind") != "ClusterRole":
+        continue
+    for rule in doc.get("rules") or []:
+        groups = rule.get("apiGroups") or []
+        resources = rule.get("resources") or []
+        if group not in groups and "*" not in groups:
+            continue
+        if resource not in resources and "*" not in resources:
+            continue
+        verbs.update(rule.get("verbs") or [])
+for v in sorted(verbs):
+    print(v)
+PY
+}
+
+fail=0
+
+assert_granted() {
+  local group="$1" resource="$2" verb="$3" why="${4:-required by the delete path}"
+  if verbs_for "$group" "$resource" | grep -qx "$verb"; then
+    echo "PASS: ${group}/${resource} grants '${verb}'"
+  else
+    echo "FAIL: ${group}/${resource} does NOT grant '${verb}' — ${why}"
+    echo "      granted verbs: $(verbs_for "$group" "$resource" | tr '\n' ' ')"
+    fail=1
+  fi
+}
+
+assert_not_granted() {
+  local group="$1" resource="$2" verb="$3" why="${4:-not needed by any catalyst-api code path}"
+  if verbs_for "$group" "$resource" | grep -qx "$verb"; then
+    echo "FAIL: ${group}/${resource} grants '${verb}' — ${why}"
+    fail=1
+  else
+    echo "PASS: ${group}/${resource} correctly withholds '${verb}'"
+  fi
+}
+
+echo "── GRANTED — the verbs the delete operation actually needs ──"
+# The whole point of the #5426 fix.
+assert_granted orgs.openova.io organizations delete \
+  "HandleDeleteOrganization's apiserver Delete is the ONLY trigger for the org-controller finalizer cascade; without it the console DELETE tears down nothing (hw293)."
+# The pre-existing grants the delete path also reads/writes — asserted so
+# a reshuffle that adds delete while dropping these still fails.
+assert_granted orgs.openova.io organizations get
+assert_granted orgs.openova.io organizations list
+assert_granted orgs.openova.io organizations create
+
+echo "── NOT GRANTED — least privilege, the control on this gate ──"
+# A "fix" that widened the SA to '*' or bolted delete onto the Flux kinds
+# would pass every assertion above. These make the gate discriminate.
+assert_not_granted kustomize.toolkit.fluxcd.io kustomizations delete \
+  "the per-Org Flux teardown runs under the organization-controller SA, which already carries this verb; catalyst-api never deletes a Kustomization."
+assert_not_granted source.toolkit.fluxcd.io gitrepositories delete \
+  "same — organization-controller-clusterrole.yaml already grants it; catalyst-api never deletes a GitRepository."
+assert_not_granted orgs.openova.io organizations '*' \
+  "wildcard verbs on the tenancy root are never least privilege."
+
+if [ "$fail" -ne 0 ]; then
+  echo
+  echo "cutover-driver-organization-delete-rbac: FAILED"
+  exit 1
+fi
+echo
+echo "cutover-driver-organization-delete-rbac: all assertions passed"


### PR DESCRIPTION
Refs #5426

`DELETE /api/v1/organizations/{id}` returns **204 No Content** and deletes nothing. Two independent defects sit behind that one response, and the second is what kept the first hidden.

## Root cause 1 — the verb was never granted

`products/catalyst/chart/templates/clusterrole-cutover-driver.yaml` grants ServiceAccount `catalyst-api-cutover-driver`:

| line | apiGroup / resource | verbs |
|---|---|---|
| 456-459 | `orgs.openova.io/organizations` | `get, list, watch` (#3978) |
| 713-716 | `orgs.openova.io/organizations` | `create` (#4921) |

Nothing anywhere in the file grants `delete`. Measured on hw293, 2026-08-10:

```
$ kubectl auth can-i delete organizations.orgs.openova.io \
    --as=system:serviceaccount:catalyst:catalyst-api-cutover-driver
no
$ kubectl auth can-i create organizations.orgs.openova.io --as=<same SA>
yes
```

catalyst-api's own log names it:

```
organizations.orgs.openova.io is forbidden: ... cannot delete
resource "organizations" ... at the cluster scope
```

`internal/handler/org_tenant_org_cr.go` `deleteOrgOrganizationCR` issues exactly one apiserver call, and it is the **only** trigger for the org-controller's `orgs.openova.io/tenant-networking` finalizer cascade (`publishTenantDeleted` → `teardownPerOrgFlux` → `teardownTenantNetworking` → `iac-bootstrap` → per-org-realm) — the only complete teardown of an Organization's namespace, vCluster, Keycloak realm, per-Org Flux sources and gateway listeners. With the verb missing, the CR kept `deletionTimestamp: null` and its finalizer, resourceVersion frozen. **T+138s the namespace and its `vcluster` StatefulSet were back under a new uid** — the surviving CR's per-Org Flux sources rebuilt them.

## Root cause 2 — the handler reported the refusal as success

`internal/handler/org_tenant_org_cr.go:142` returned `void`. It logged the 403 at Error level and returned. `internal/handler/organization_provisioning.go:1046` discarded the outcome and `:1080` wrote `w.WriteHeader(http.StatusNoContent)` unconditionally.

So the console, a script and a User all read **204 = deleted** while the Organization kept running. A permission error reported as success is undetectable at the caller, and that is exactly why a missing RBAC verb survived undiscovered — the log line was there the whole time, and the status code said everything was fine.

## The fix

**RBAC** — `delete` on `orgs.openova.io/organizations`, and nothing else. Checked before adding: the cascade's own Flux teardown (`core/controllers/organization/internal/controller/per_org_flux.go` `teardownPerOrgFlux`) deletes the per-Org Kustomizations + GitRepository under the **organization-controller's** SA, which already carries `delete` on both kinds (`templates/controllers/organization-controller-clusterrole.yaml:164-168`). catalyst-api never deletes a Flux object, so widening it there would be an unearned grant.

**Handler** — `deleteOrgOrganizationCR` now returns its error. NotFound stays idempotent success; invalid-slug and no-dynamic-client stay `nil`. `HandleDeleteOrganization` returns **502 Bad Gateway** carrying the verbatim apiserver text (on an RBAC denial that names the SA, the verb and the resource — the whole diagnosis) and **stops there** rather than continuing: the Organization is still live, so reaping its registry entry and DNS records would strip the front door off a running Organization. The audit row records the reason without being stamped `STSDeleted`. Every step is idempotent, so the operator action is: fix the grant, re-issue the same DELETE.

**Chart version** — a ClusterRole reaches a Sovereign only via the published umbrella, so `1.4.1340 → 1.4.1341`, computed by `scripts/bump-chart-version.sh` rather than hand-pinned (the deploy-bot moved the umbrella three times while this PR was open; earlier hand-pinned values were overtaken twice and correctly caught by the `Chart-version-bumped` guard, which is the #6021 defect class).

Lockstep sites, all verified rather than assumed:

| site | state |
|---|---|
| `products/catalyst/chart/Chart.yaml` `version` + `appVersion` | 1.4.1341 |
| `clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml` pin | 1.4.1341 |
| catalog-seed **card** `spec.version` | renders `{{ .Chart.Version }}` — self-maintaining (#4432) |
| catalog-seed **delivery** `source.version` | renders `{{ .Chart.Version }}` — self-maintaining (#4432) |
| `products/catalyst/blueprint.yaml` | does not exist for this chart |

Both catalog-seed pins were checked directly at `products/catalyst/chart/templates/catalog-seed/blueprints.yaml:3634` and `:3651` — neither is hard-pinned, so the card-only-edit trap does not apply here.

## Guards — watched failing first

Two new guards. The pre-existing suite in `org_tenant_org_cr_delete_test.go` could not have caught this: its fake dynamic client has no RBAC, so its Delete can never be refused. It tests that the handler *calls* Delete. The property that failed live is *when the apiserver denies the delete, does the caller learn*.

### `internal/handler/org_tenant_org_cr_delete_denial_test.go`

Installs a reactor returning the real `apierrors.NewForbidden` with the live message shape.

RED — against the pre-fix handler:

```
--- FAIL: TestDeleteOrganization_ApiserverDenialIsNotReportedAsSuccess (0.73s)
    apiserver DENIED the Organization CR delete and the handler still answered
    204 No Content — the caller is told the Organization was deleted when
    nothing was deleted (#5426, measured live on hw293). body=""
--- FAIL: TestDeleteOrganization_DenialBodyNamesWhatWasDenied (0.00s)
    denial response body is not JSON: unexpected end of JSON input (raw="")
--- FAIL: TestDeleteOrganization_DenialLeavesRecordUndeleted (0.00s)
    record stamped STSDeleted while the Organization CR is still live — the
    console will hide an Organization whose namespace/vCluster/realm keep
    running (state=deleted)
FAIL
```

GREEN — with the fix, alongside the whole pre-existing delete suite:

```
--- PASS: TestDeleteOrganization_ApiserverDenialIsNotReportedAsSuccess (0.00s)
--- PASS: TestDeleteOrganization_DenialBodyNamesWhatWasDenied (0.00s)
--- PASS: TestDeleteOrganization_DenialLeavesRecordUndeleted (0.00s)
--- PASS: TestDeleteOrganization_SuccessStillReturns204 (0.00s)
--- PASS: TestDeleteOrganization_DeletesOrganizationCR (0.00s)
--- PASS: TestDeleteOrganization_OverlayReapBeforeCRDelete (0.00s)
--- PASS: TestDeleteOrganization_CRAlreadyGoneIsIdempotent (0.00s)
--- PASS: TestDeleteOrganization_RemovesFromRegistry (5.00s)
--- PASS: TestDeleteOrganization_DeprovisionsDNS (5.00s)
ok  	.../internal/handler	10.029s
```

`TestDeleteOrganization_SuccessStillReturns204` is the control — it passed both before and after, so a "fix" that always 502s cannot sneak through.

### `products/catalyst/chart/tests/cutover-driver-organization-delete-rbac.sh`

Renders the ClusterRole and unions the verbs across every matching rule (RBAC merges additively, so a source grep of one block is not evidence). Picked up automatically by `blueprint-release.yaml`.

RED — exit 1:

```
── GRANTED — the verbs the delete operation actually needs ──
FAIL: orgs.openova.io/organizations does NOT grant 'delete' — ...
      granted verbs: create get list watch
PASS: orgs.openova.io/organizations grants 'get'
PASS: orgs.openova.io/organizations grants 'list'
PASS: orgs.openova.io/organizations grants 'create'
── NOT GRANTED — least privilege, the control on this gate ──
PASS: kustomize.toolkit.fluxcd.io/kustomizations correctly withholds 'delete'
PASS: source.toolkit.fluxcd.io/gitrepositories correctly withholds 'delete'
PASS: orgs.openova.io/organizations correctly withholds '*'

cutover-driver-organization-delete-rbac: FAILED
```

GREEN — exit 0, all eight assertions pass. The three NOT-GRANTED assertions are the control: a fix that widened the SA to `*`, or bolted `delete` onto the Flux kinds, passes every GRANTED assertion and fails these. The script also carries a vacuity check (render must produce a ClusterRole with ≥20 rules) so the withholds-assertions cannot pass on an empty render.

## Gates

Each run bare and gated on its exit code, never piped:

```
scripts/check-chart-version-bumped.sh origin/main HEAD          EXIT=0
   OK   products/catalyst/chart: 1.4.1340 -> 1.4.1341
scripts/check-bootstrap-kit-pin-sync.sh                         EXIT=0
   Checked 67 chart->pin pair(s) ... PASS
scripts/check-release-lockstep-writer.py                        EXIT=0
   PASS: the release writer moves all five lockstep sites
scripts/check-chart-version-not-claimed-by-open-pr.py --pr 6051  EXIT=0
   PR #6051 claims 1.4.1341, compared against 35 open PR(s) — no collision
products/catalyst/chart/tests/cutover-driver-organization-delete-rbac.sh  EXIT=0
go vet ./internal/handler/                                      clean
go test ./internal/handler/ -run TestDeleteOrganization_        ok 10.039s
```

## Delivery

RBAC ships in the umbrella, so this needs the umbrella republished at 1.4.1336 to reach a Sovereign. The handler half ships in the catalyst-api **image** and needs an image roll — merged will not mean delivered for either half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)