### PR TITLE
fix(jobs): surface per-Organization Application installs on the Jobs page

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/jobs.go
+++ b/products/catalyst/bootstrap/api/internal/handler/jobs.go
@@ -32,6 +32,7 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
+	"k8s.io/client-go/dynamic"
 
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/helmwatch"
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/jobs"
@@ -405,6 +406,22 @@ func (h *Handler) chrootSeedJobsStoreIfEmpty(ctx context.Context, dep *Deploymen
 	// a hasBootstrapKit=true chroot.
 	h.chrootSeedSecondaryRegions(ctx, dep, bridge)
 
+	// #6045 — per-Organization Application installs. The bootstrap-kit
+	// seed above lists flux-system and keeps `bp-` names, which is every
+	// PLATFORM component and NO Application: the application-controller
+	// authors an Application's HelmRelease in the Org's own namespace
+	// under the Application's name. So the only installs a User can
+	// actually cause to fail were invisible on /jobs in every filter
+	// state — a real install failed and the page said "No jobs match the
+	// current filters."
+	//
+	// Runs UNCONDITIONALLY relative to hasBootstrapKit, for the same
+	// reason chrootSeedSecondaryRegions does (TBD-A63): Applications are
+	// installed long after bootstrap, so gating this on a missing
+	// bootstrap-kit group would mean a converged Sovereign — the only
+	// kind that HAS Applications — never seeds a single one.
+	h.chrootSeedApplicationInstalls(ctx, dep, bridge)
+
 	// §5a generic reconciler ingestion (issue #3646). The helmwatch seed
 	// above surfaces ONLY HelmRelease installs — so a green install-openbao
 	// leaf masks a Failed openbao-snapshot CronJob, a stuck cnpg-pair join
@@ -525,6 +542,80 @@ func regionFromSecondaryClusterID(clusterID, depID, chrootFallbackID string) str
 //
 // Idempotent — bridge.SeedJobsFromInformerList monotonic-merges so a
 // re-read after a re-attached watch doesn't dup Job rows.
+// chrootSeedApplicationInstalls seeds the per-Organization Application
+// install rows into the per-deployment jobs.Store (#6045), across the
+// primary cluster and every registered secondary region.
+//
+// helmwatch.ListAndSnapshotJobsProjection returns the bootstrap-kit rows
+// UNION the Application rows; the bootstrap-kit half is a monotonic-merge
+// no-op here because the seeds above already wrote it (Bridge.lastState
+// dedupes identical (component, state) pairs), so the net effect of this
+// pass is the Application rows.
+//
+// ERROR CONTRACT — the projection returns rows AND an error when only its
+// Application leg failed, so the bootstrap-kit rows it did obtain still
+// reach the store. That is why this seeds `snap` even when err != nil,
+// and why the error is logged rather than swallowed: an empty Application
+// set must never be reported as "this Sovereign has no Applications" when
+// what actually happened is that the list was refused.
+func (h *Handler) chrootSeedApplicationInstalls(ctx context.Context, dep *Deployment, bridge *jobs.Bridge) {
+	if bridge == nil {
+		return
+	}
+	seedFrom := func(dyn dynamic.Interface, region string) {
+		if dyn == nil {
+			return
+		}
+		snap, err := helmwatch.ListAndSnapshotJobsProjection(ctx, dyn)
+		if err != nil {
+			h.log.Warn("jobs seed: Application-install projection degraded — the page may be "+
+				"missing per-Organization installs (#6045)",
+				"depId", dep.ID, "region", region, "err", err)
+		}
+		if len(snap) == 0 {
+			return
+		}
+		seeds := snapshotsToSeedsForRegion(snap, region)
+		jobsCount, execsSeeded, serr := bridge.SeedJobsFromInformerList(seeds)
+		if serr != nil {
+			h.log.Warn("jobs seed: Application-install bridge seed failed",
+				"depId", dep.ID, "region", region, "err", serr)
+			return
+		}
+		h.log.Info("jobs seed: per-Organization Application installs projected",
+			"depId", dep.ID, "region", region,
+			"helmReleases", len(snap),
+			"jobsWritten", jobsCount,
+			"executionsSeeded", execsSeeded,
+		)
+	}
+
+	if dyn, err := h.sovereignDynamicClient(dep); err != nil {
+		h.log.Debug("jobs seed: sovereignDynamicClient unavailable for Application installs",
+			"depId", dep.ID, "err", err)
+	} else {
+		seedFrom(dyn, "")
+	}
+
+	if h.k8sCache == nil {
+		return
+	}
+	chrootPrimaryID := "sovereign-" + strings.TrimSpace(os.Getenv("SOVEREIGN_FQDN"))
+	for _, cid := range h.k8sCache.Clusters() {
+		region := regionFromSecondaryClusterID(cid, dep.ID, chrootPrimaryID)
+		if region == "" {
+			continue
+		}
+		dyn, err := h.k8sCache.DynamicClientFor(cid)
+		if err != nil || dyn == nil {
+			h.log.Debug("jobs seed: secondary DynamicClientFor unavailable for Application installs",
+				"depId", dep.ID, "clusterID", cid, "err", err)
+			continue
+		}
+		seedFrom(dyn, region)
+	}
+}
+
 func (h *Handler) chrootSeedSecondaryRegions(ctx context.Context, dep *Deployment, bridge *jobs.Bridge) {
 	if h.k8sCache == nil || bridge == nil {
 		return

--- a/products/catalyst/bootstrap/api/internal/handler/jobs_perorg_install_6045_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/jobs_perorg_install_6045_test.go
@@ -1,0 +1,242 @@
+// jobs_perorg_install_6045_test.go — #6045, at the surface the User
+// actually looks at.
+//
+// The helmwatch-level guards (jobs_projection_6045_test.go) prove the
+// projection. This file proves the wiring: that a GET
+// /api/v1/deployments/{depId}/jobs returns a row for a per-Organization
+// Application install, and that the `failed` filter — the filter a User
+// reaches for when their install breaks — actually contains it.
+//
+// Before the fix the page answered "No jobs match the current filters"
+// for the only class of install a User can cause to fail.
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/helmwatch"
+)
+
+// perOrgAppHR builds the HelmRelease the application-controller authors
+// for a per-Org Application: named after the Application, in the Org's
+// own namespace, carrying catalyst.openova.io/organization. Stalled ⇒
+// the Stalled=True / Ready=False+RetriesExceeded terminal pair.
+func perOrgAppHR(ns, name string, stalled bool) *unstructured.Unstructured {
+	now := time.Now().UTC().Format(time.RFC3339)
+	conds := []any{map[string]any{
+		"type": "Ready", "status": string(metav1.ConditionTrue),
+		"reason": "ReconciliationSucceeded", "message": "Helm install succeeded",
+		"lastTransitionTime": now,
+	}}
+	if stalled {
+		conds = []any{
+			map[string]any{
+				"type": "Ready", "status": string(metav1.ConditionFalse),
+				"reason": "RetriesExceeded", "message": "Helm install failed: timed out",
+				"lastTransitionTime": now,
+			},
+			map[string]any{
+				"type": "Stalled", "status": string(metav1.ConditionTrue),
+				"reason": "RetriesExceeded", "message": "Failed to install after 3 attempt(s)",
+				"lastTransitionTime": now,
+			},
+		}
+	}
+	u := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "helm.toolkit.fluxcd.io/v2",
+		"kind":       "HelmRelease",
+		"metadata": map[string]any{
+			"name": name, "namespace": ns,
+			"labels": map[string]any{
+				"app.kubernetes.io/managed-by":     "application-controller",
+				"catalyst.openova.io/application":  name,
+				"catalyst.openova.io/organization": ns,
+			},
+		},
+		"spec":   map[string]any{},
+		"status": map[string]any{"conditions": conds},
+	}}
+	u.SetGroupVersionKind(schema.GroupVersionKind{
+		Group: "helm.toolkit.fluxcd.io", Version: "v2", Kind: "HelmRelease",
+	})
+	return u
+}
+
+// perOrgVClusterHR — the control. Every Organization has one of these in
+// namespace <slug> (organization-controller gitops vclusterTemplate). Not
+// bp- prefixed, not in flux-system, and it genuinely goes
+// Stalled/RetriesExceeded on a cold Harbor pull. It must NOT appear.
+func perOrgVClusterHR(ns string) *unstructured.Unstructured {
+	u := perOrgAppHR(ns, "vcluster", true)
+	u.SetLabels(map[string]string{
+		"openova.io/organization":      ns,
+		"openova.io/vcluster":          ns,
+		"app.kubernetes.io/managed-by": "flux",
+	})
+	return u
+}
+
+func listJobs6045(t *testing.T, r http.Handler, depID, query string) []map[string]any {
+	t.Helper()
+	url := "/api/v1/deployments/" + depID + "/jobs"
+	if query != "" {
+		url += "?" + query
+	}
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, url, nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET %s: want 200 got %d body=%s", url, w.Code, w.Body.String())
+	}
+	var body struct {
+		Jobs []map[string]any `json:"jobs"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode /jobs: %v (raw=%s)", err, w.Body.String())
+	}
+	return body.Jobs
+}
+
+func jobNames6045(rows []map[string]any) []string {
+	out := make([]string, 0, len(rows))
+	for _, j := range rows {
+		if n, ok := j["jobName"].(string); ok {
+			out = append(out, n)
+		}
+	}
+	return out
+}
+
+// perOrgDynamicFactory registers every list kind chrootSeedJobsStoreIfEmpty
+// touches (the reconciler-observation leg lists Kustomizations / CronJobs /
+// Jobs / Deployments too), so the fake serves an empty list instead of
+// panicking — same set as fakeReseedDynamicClient.
+func perOrgDynamicFactory(objs ...runtime.Object) func(string) (dynamic.Interface, error) {
+	return func(_ string) (dynamic.Interface, error) {
+		scheme := runtime.NewScheme()
+		for _, lk := range []schema.GroupVersionKind{
+			{Group: "helm.toolkit.fluxcd.io", Version: "v2", Kind: "HelmReleaseList"},
+			{Group: "kustomize.toolkit.fluxcd.io", Version: "v1", Kind: "KustomizationList"},
+			{Group: "batch", Version: "v1", Kind: "CronJobList"},
+			{Group: "batch", Version: "v1", Kind: "JobList"},
+			{Group: "apps", Version: "v1", Kind: "DeploymentList"},
+		} {
+			scheme.AddKnownTypeWithName(lk, &unstructured.UnstructuredList{})
+		}
+		return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+			map[schema.GroupVersionResource]string{
+				helmwatch.HelmReleaseGVR: "HelmReleaseList",
+				{Group: "kustomize.toolkit.fluxcd.io", Version: "v1", Resource: "kustomizations"}: "KustomizationList",
+				{Group: "batch", Version: "v1", Resource: "cronjobs"}:                             "CronJobList",
+				{Group: "batch", Version: "v1", Resource: "jobs"}:                                 "JobList",
+				{Group: "apps", Version: "v1", Resource: "deployments"}:                           "DeploymentList",
+			}, objs...), nil
+	}
+}
+
+func newPerOrgJobsHarness(t *testing.T) (http.Handler, string) {
+	t.Helper()
+	r, _, h := newBackfillRouter(t)
+	h.dynamicFactory = perOrgDynamicFactory(
+		// bootstrap-kit — must keep rendering
+		makeReadyHR("bp-cilium"),
+		makeReadyHR("bp-openbao"),
+		// the per-Org Application install a User caused to FAIL
+		perOrgAppHR("acme", "marketing-site", true),
+		// a healthy per-Org Application install
+		perOrgAppHR("acme", "docs-site", false),
+		// CONTROL — per-Org infrastructure that must stay off the page
+		perOrgVClusterHR("acme"),
+	)
+	depID := "d6045"
+	makeDeploymentForBackfill(t, h, depID, "apiVersion: v1\nkind: Config\n")
+	return r, depID
+}
+
+// TestJobsPage_ShowsPerOrgApplicationInstall — the decisive surface-level
+// guard. Asserts on the VALUE: a row that IS the acme/marketing-site
+// install, not merely that the list is non-empty.
+func TestJobsPage_ShowsPerOrgApplicationInstall(t *testing.T) {
+	r, depID := newPerOrgJobsHarness(t)
+	rows := listJobs6045(t, r, depID, "")
+
+	var found map[string]any
+	for _, j := range rows {
+		if n, _ := j["jobName"].(string); strings.Contains(n, "acme:marketing-site") {
+			found = j
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("no /jobs row for the per-Org Application install acme/marketing-site — the only "+
+			"installs a User can cause to fail are invisible on the page (#6045). %d rows: %v",
+			len(rows), jobNames6045(rows))
+	}
+	if st, _ := found["status"].(string); st != "failed" {
+		t.Errorf("acme/marketing-site is Stalled=True reason=RetriesExceeded — the row must read "+
+			"failed, got %q", st)
+	}
+}
+
+// TestJobsPage_FailedFilterContainsPerOrgInstall — the `failed` filter is
+// where a User goes when their install breaks. A row that exists but is
+// unreachable through that filter is still invisible in practice.
+func TestJobsPage_FailedFilterContainsPerOrgInstall(t *testing.T) {
+	r, depID := newPerOrgJobsHarness(t)
+	rows := listJobs6045(t, r, depID, "status=failed")
+
+	for _, j := range rows {
+		if n, _ := j["jobName"].(string); strings.Contains(n, "acme:marketing-site") {
+			return
+		}
+	}
+	t.Fatalf("the `failed` filter does not contain the failing per-Org Application install — "+
+		"a User watching a real install fail still sees \"No jobs match the current filters\". "+
+		"%d failed rows: %v", len(rows), jobNames6045(rows))
+}
+
+// TestJobsPage_ExcludesPerOrgInfrastructure — the CONTROL. A fix that
+// simply listed every namespace and dropped the `bp-` filter passes both
+// tests above while putting a spurious Failed `vcluster` row on the page
+// for every Organization on the Sovereign.
+func TestJobsPage_ExcludesPerOrgInfrastructure(t *testing.T) {
+	r, depID := newPerOrgJobsHarness(t)
+	for _, j := range listJobs6045(t, r, depID, "") {
+		n, _ := j["jobName"].(string)
+		if strings.Contains(n, "vcluster") {
+			t.Fatalf("per-Org INFRASTRUCTURE leaked onto /jobs as %q — it is not an Application a "+
+				"User installed, and it legitimately goes Stalled/RetriesExceeded on a cold "+
+				"Harbor pull, so this is one spurious Failed row per Organization", n)
+		}
+	}
+}
+
+// TestJobsPage_StillShowsBootstrapKit — the widening must not cost the
+// platform rows the page already had.
+func TestJobsPage_StillShowsBootstrapKit(t *testing.T) {
+	r, depID := newPerOrgJobsHarness(t)
+	names := jobNames6045(listJobs6045(t, r, depID, ""))
+	for _, want := range []string{"install-cilium", "install-openbao"} {
+		hit := false
+		for _, n := range names {
+			if n == want {
+				hit = true
+			}
+		}
+		if !hit {
+			t.Fatalf("bootstrap-kit row %q disappeared from /jobs after the #6045 widening. rows: %v",
+				want, names)
+		}
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/secondary_kubeconfig_coverage_6015_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/secondary_kubeconfig_coverage_6015_test.go
@@ -454,39 +454,11 @@ func TestSecondaryKubeconfigDelivery_RunsOnFailedDeployment_6015(t *testing.T) {
 	dep.Status = "failed"
 	dep.mu.Unlock()
 
-	// The cleanup must WAIT for this goroutine, not merely signal it.
-	// It ticks every 5ms and reads the package-level
-	// secondaryKubeconfigForwardClient (via
-	// reforwardSecondaryKubeconfigsToChild); withChrootForwardClient's own
-	// cleanup RESTORES that var. Cleanups run LIFO and this one is
-	// registered later, so it runs first — but setting Status alone only
-	// asks the loop to stop, it does not observe it stopping. Under -race
-	// the restore then landed while the goroutine was still mid-tick:
-	//
-	//   WARNING: DATA RACE
-	//   Write ... withChrootForwardClient.func2()   (this file, cleanup)
-	//   Previous read ... reforwardSecondaryKubeconfigsToChild()
-	//                     deployment_handover_export.go:503
-	//   --- FAIL: TestSecondaryKubeconfigDelivery_RunsOnFailedDeployment_6015
-	//       race detected during execution of test
-	//
-	// Timing-dependent, so it only fires in the full-package -race run —
-	// which is exactly the required `test` gate.
-	deliveryDone := make(chan struct{})
-	go func() {
-		defer close(deliveryDone)
-		h.runSecondaryKubeconfigDelivery(dep)
-	}()
+	go h.runSecondaryKubeconfigDelivery(dep)
 	t.Cleanup(func() {
 		dep.mu.Lock()
 		dep.Status = "wiped" // ends the loop
 		dep.mu.Unlock()
-		select {
-		case <-deliveryDone:
-		case <-time.After(10 * time.Second):
-			t.Error("runSecondaryKubeconfigDelivery did not exit after Status=wiped — " +
-				"the goroutine outlives the test and races the forward-client restore")
-		}
 	})
 
 	if !waitForRegionPost(chroot, "me-east-215-b-1", 3*time.Second) {

--- a/products/catalyst/bootstrap/api/internal/handler/secondary_kubeconfig_coverage_6015_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/secondary_kubeconfig_coverage_6015_test.go
@@ -454,11 +454,39 @@ func TestSecondaryKubeconfigDelivery_RunsOnFailedDeployment_6015(t *testing.T) {
 	dep.Status = "failed"
 	dep.mu.Unlock()
 
-	go h.runSecondaryKubeconfigDelivery(dep)
+	// The cleanup must WAIT for this goroutine, not merely signal it.
+	// It ticks every 5ms and reads the package-level
+	// secondaryKubeconfigForwardClient (via
+	// reforwardSecondaryKubeconfigsToChild); withChrootForwardClient's own
+	// cleanup RESTORES that var. Cleanups run LIFO and this one is
+	// registered later, so it runs first — but setting Status alone only
+	// asks the loop to stop, it does not observe it stopping. Under -race
+	// the restore then landed while the goroutine was still mid-tick:
+	//
+	//   WARNING: DATA RACE
+	//   Write ... withChrootForwardClient.func2()   (this file, cleanup)
+	//   Previous read ... reforwardSecondaryKubeconfigsToChild()
+	//                     deployment_handover_export.go:503
+	//   --- FAIL: TestSecondaryKubeconfigDelivery_RunsOnFailedDeployment_6015
+	//       race detected during execution of test
+	//
+	// Timing-dependent, so it only fires in the full-package -race run —
+	// which is exactly the required `test` gate.
+	deliveryDone := make(chan struct{})
+	go func() {
+		defer close(deliveryDone)
+		h.runSecondaryKubeconfigDelivery(dep)
+	}()
 	t.Cleanup(func() {
 		dep.mu.Lock()
 		dep.Status = "wiped" // ends the loop
 		dep.mu.Unlock()
+		select {
+		case <-deliveryDone:
+		case <-time.After(10 * time.Second):
+			t.Error("runSecondaryKubeconfigDelivery did not exit after Status=wiped — " +
+				"the goroutine outlives the test and races the forward-client restore")
+		}
 	})
 
 	if !waitForRegionPost(chroot, "me-east-215-b-1", 3*time.Second) {

--- a/products/catalyst/bootstrap/api/internal/helmwatch/helmwatch.go
+++ b/products/catalyst/bootstrap/api/internal/helmwatch/helmwatch.go
@@ -2690,39 +2690,78 @@ func ListAndSnapshotHelmReleases(ctx context.Context, dyn dynamic.Interface) ([]
 		if !strings.HasPrefix(name, "bp-") {
 			continue
 		}
-		conds, _ := extractConditions(u)
-		state := DeriveState(conds)
-		// Wave 5.103 (#2447): suspended HRs report as StateInstalled to
-		// avoid blocking Phase 1 readiness. See SetEventHandler comment.
-		// #5485 defect 4: the suspension is ALSO carried as its own flag
-		// so the Reconciliation DAG can render Suspended distinctly.
-		suspended, okSusp, _ := unstructured.NestedBool(u.Object, "spec", "suspend")
-		suspended = okSusp && suspended
-		if suspended {
-			state = StateInstalled
-		}
-		message := messageFromConditions(conds, state)
-		var lastTransitionAt time.Time
-		if ready := findCondition(conds, "Ready"); ready != nil {
-			lastTransitionAt = ready.LastTransitionTime.Time
-		}
-		ns := u.GetNamespace()
-		if ns == "" {
-			ns = FluxNamespace
-		}
-		out = append(out, ComponentSnapshot{
-			AppID:            ComponentIDFromHelmRelease(name),
-			Status:           state,
-			HelmReleaseName:  name,
-			Namespace:        ns,
-			LastTransitionAt: lastTransitionAt.UTC(),
-			Message:          message,
-			DependsOn:        extractDependsOn(u),
-			Stalled:          state == StateFailed && IsStalledHelmRelease(u),
-			Suspended:        suspended,
-		})
+		out = append(out, snapshotFromHelmRelease(u, ComponentIDFromHelmRelease(name)))
 	}
 	return out, nil
+}
+
+// snapshotFromHelmRelease projects ONE HelmRelease into a
+// ComponentSnapshot under the supplied AppID. Extracted from
+// ListAndSnapshotHelmReleases so the #6045 per-Organization Application
+// leg (jobs_projection.go) derives status, staleness and suspension by
+// exactly the same rules as the bootstrap-kit leg — the AppID is the only
+// thing the two callers decide differently. Without this seam the two
+// projections would drift, and a per-Org install would render its status
+// by subtly different logic from a platform component's.
+func snapshotFromHelmRelease(u *unstructured.Unstructured, appID string) ComponentSnapshot {
+	conds, _ := extractConditions(u)
+	state := DeriveState(conds)
+	// Wave 5.103 (#2447): suspended HRs report as StateInstalled to
+	// avoid blocking Phase 1 readiness. See SetEventHandler comment.
+	// #5485 defect 4: the suspension is ALSO carried as its own flag
+	// so the Reconciliation DAG can render Suspended distinctly.
+	suspended, okSusp, _ := unstructured.NestedBool(u.Object, "spec", "suspend")
+	suspended = okSusp && suspended
+	if suspended {
+		state = StateInstalled
+	}
+	// #6045 defect 2 — READ-SIDE terminal reclassification. DeriveState
+	// recognises only the InstallFailed / UpgradeFailed / ChartPullError /
+	// ChartLoadError / ArtifactFailed reason family as StateFailed
+	// (:2384); a Ready=False whose reason is anything else falls through
+	// to StateDegraded on the "flux flips it back to True once the
+	// deployment recovers" assumption (:2394).
+	//
+	// That assumption is FALSE for RetriesExceeded. IsStalledHelmRelease
+	// (:2417) treats exactly that reason as stably failed — Flux has
+	// exhausted remediation.retries and will not reconcile again without
+	// a spec change or a manual reconcile. So a HelmRelease whose Ready
+	// reason IS RetriesExceeded was classified `degraded`, and because
+	// the Stalled flag was gated on `state == StateFailed` it ALSO lost
+	// its Stalled marker — the read-side anti-flap rule in
+	// snapshotsToSeedsForRegion (#3916) then had nothing to distinguish
+	// it from a transient wobble. A terminally failed install rendered as
+	// a degraded, still-working one and never reached the `failed` filter.
+	//
+	// Scoped to this read-side projection ONLY. DeriveState itself is
+	// untouched, so the live Phase-1 Watcher's processEvent path keeps
+	// its existing eager-StateFailed semantics and Phase-1 termination
+	// behaviour is unchanged.
+	stalled := IsStalledHelmRelease(u)
+	if stalled && state == StateDegraded {
+		state = StateFailed
+	}
+
+	message := messageFromConditions(conds, state)
+	var lastTransitionAt time.Time
+	if ready := findCondition(conds, "Ready"); ready != nil {
+		lastTransitionAt = ready.LastTransitionTime.Time
+	}
+	ns := u.GetNamespace()
+	if ns == "" {
+		ns = FluxNamespace
+	}
+	return ComponentSnapshot{
+		AppID:            appID,
+		Status:           state,
+		HelmReleaseName:  u.GetName(),
+		Namespace:        ns,
+		LastTransitionAt: lastTransitionAt.UTC(),
+		Message:          message,
+		DependsOn:        extractDependsOn(u),
+		Stalled:          state == StateFailed && stalled,
+		Suspended:        suspended,
+	}
 }
 
 // Subscribe registers a callback the Watcher invokes for EVERY event

--- a/products/catalyst/bootstrap/api/internal/helmwatch/jobs_projection.go
+++ b/products/catalyst/bootstrap/api/internal/helmwatch/jobs_projection.go
@@ -1,0 +1,182 @@
+// jobs_projection.go — #6045. The /jobs projection, widened to include
+// per-Organization Application installs.
+//
+// THE DEFECT. ListAndSnapshotHelmReleases (helmwatch.go:2678) lists
+// exactly one namespace — Namespace(FluxNamespace), and FluxNamespace is
+// the constant "flux-system" (:86) — then keeps only `bp-` prefixed
+// names. The informer path (:1116) and the ticker recensus (:1396/:1408)
+// are scoped the same way. A per-Organization Application install is
+// neither of those things:
+//
+//   - NAMESPACE. The application-controller authors the HelmRelease in
+//     the Application's own namespace, or the vCluster's host namespace
+//     (core/controllers/pkg/render/manifests.go, `namespace:
+//     {{ .HRNamespace }}`). Never flux-system.
+//   - NAME. It is named after the Application (`name: {{ .AppName }}`),
+//     or `<app>-<cluster>` on the topology fan-out path. `bp-` names a
+//     Blueprint; an Application is `<purpose>` — see docs/GLOSSARY.md.
+//
+// So the only installs a User can actually cause to fail were
+// structurally invisible in EVERY filter state, the `failed` filter
+// included. A User watched a real install fail and /jobs answered "No
+// jobs match the current filters."
+//
+// WHAT THE `bp-` FILTER WAS PROTECTING, and why this does not remove it.
+// Two distinct things, both real:
+//
+//  1. THE PHASE-1 TERMINATION GATE. The informer's FilterFunc (:1116)
+//     feeds processEvent, which closes the `terminated` channel once
+//     every OBSERVED HelmRelease is terminal. Widening THAT filter would
+//     let a per-Org Application install — which can appear at any moment,
+//     long after bootstrap — hold Phase-1 convergence open forever. This
+//     file does not touch the informer. The bootstrap-kit leg below is
+//     ListAndSnapshotHelmReleases verbatim.
+//
+//  2. INFRASTRUCTURE NOISE IN PER-ORG NAMESPACES. Every Organization gets
+//     a `vcluster` HelmRelease in namespace `<slug>`
+//     (core/controllers/organization/internal/gitops/manifests.go
+//     vclusterTemplate). It is not `bp-` prefixed and it does not live in
+//     flux-system, so a naive "list all namespaces, drop the prefix
+//     filter" fix would surface it — and that template's OWN comment
+//     records that it lands Stalled=True / RetriesExceeded on a cold
+//     Sovereign-Harbor pull. One spurious Failed row per Organization on
+//     the Sovereign, which is worse than the empty page.
+//
+// THE DISCRIMINATOR. Application-install HelmReleases are stamped by two
+// different renderers with two different label sets:
+//
+//	single-HR host path (render/manifests.go:352)
+//	  app.kubernetes.io/managed-by: application-controller
+//	  catalyst.openova.io/application: <app>
+//	  catalyst.openova.io/organization: <org>      <-- shared
+//	topology fan-out (render/fanout.go:218 over fanoutOwnerLabels)
+//	  catalyst.openova.io/app: <app>
+//	  catalyst.openova.io/app-uid: <uid>
+//	  catalyst.openova.io/organization: <org>      <-- shared
+//
+// `catalyst.openova.io/organization` is the ONE label both paths emit, so
+// it is the discriminator. Keying on either of the others silently misses
+// half the Applications on the Sovereign. Crucially the per-Org vcluster
+// HR carries `openova.io/organization` — a DIFFERENT key, no
+// `catalyst.` prefix — so an existence selector on the catalyst-scoped
+// key includes exactly the Application installs and excludes the
+// infrastructure. The selector is server-side, so the apiserver does the
+// filtering and the response never carries the noise at all.
+package helmwatch
+
+import (
+	"context"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/dynamic"
+)
+
+// ApplicationOrgLabel is stamped on every Application-install HelmRelease
+// by BOTH application-controller render paths, and by nothing else that
+// produces a HelmRelease. Its presence is what makes a HelmRelease a
+// per-Organization Application install rather than platform plumbing.
+//
+// If a future renderer stops emitting it, per-Org installs silently
+// vanish from /jobs again — jobs_projection_6045_test.go pins both label
+// sets so that regression fails in CI rather than on a Sovereign.
+const ApplicationOrgLabel = "catalyst.openova.io/organization"
+
+// ApplicationComponentID builds the AppID for a per-Org Application
+// install: `<namespace>:<name>`.
+//
+// Namespace-qualified because jobs.Store is keyed by AppID and an
+// Application may legitimately be named after a platform component — an
+// Org's Application called `cilium` would otherwise land on AppID
+// "cilium" and overwrite the bootstrap-kit component's row (or be
+// overwritten by it), so a User's failing install would silently replace
+// a platform component's status.
+//
+// ":" and not "/": snapshotsToSeedsForRegion already uses ":" as its
+// region separator for exactly this reason — the resulting JobName
+// renders as /jobs/install-<ns>:<name> without TanStack Router splitting
+// it into path segments.
+func ApplicationComponentID(namespace, name string) string {
+	return namespace + ":" + name
+}
+
+// ListAndSnapshotJobsProjection returns the union of
+//
+//   - the bootstrap-kit projection (flux-system, `bp-` prefixed) exactly
+//     as ListAndSnapshotHelmReleases produces it, and
+//   - every per-Organization Application install, across all namespaces,
+//     selected by ApplicationOrgLabel.
+//
+// ERROR CONTRACT — read this before calling. A failure of the
+// bootstrap-kit leg is fatal: (nil, err), matching
+// ListAndSnapshotHelmReleases. A failure of the Application leg returns
+// the bootstrap-kit rows it DID obtain ALONGSIDE a non-nil error. So a
+// non-nil error here does NOT mean "no rows", and an empty Application
+// set is only trustworthy when err is nil. Callers must seed whatever
+// comes back and log the error — never treat err != nil as an empty
+// projection, and never treat a returned slice as complete without
+// checking err. That split exists so an RBAC gap or an apiserver blip on
+// the cluster-wide labelled list can never blank the bootstrap-kit rows
+// that used to render fine.
+func ListAndSnapshotJobsProjection(ctx context.Context, dyn dynamic.Interface) ([]ComponentSnapshot, error) {
+	bootstrap, err := ListAndSnapshotHelmReleases(ctx, dyn)
+	if err != nil {
+		return nil, err
+	}
+
+	apps, appErr := listApplicationInstallSnapshots(ctx, dyn)
+	if appErr != nil {
+		// Bootstrap-kit rows still render; the caller logs appErr so an
+		// operator sees that the Application half is degraded rather than
+		// reading an incomplete page as complete.
+		return bootstrap, appErr
+	}
+
+	if len(apps) == 0 {
+		return bootstrap, nil
+	}
+	out := make([]ComponentSnapshot, 0, len(bootstrap)+len(apps))
+	out = append(out, bootstrap...)
+	out = append(out, apps...)
+	return out, nil
+}
+
+// listApplicationInstallSnapshots lists Application-install HelmReleases
+// across every namespace via a server-side existence selector on
+// ApplicationOrgLabel and projects them into ComponentSnapshots.
+//
+// Returns an empty slice (not nil) when nothing matches.
+func listApplicationInstallSnapshots(ctx context.Context, dyn dynamic.Interface) ([]ComponentSnapshot, error) {
+	if dyn == nil {
+		return nil, fmt.Errorf("helmwatch: dynamic client is required")
+	}
+	list, err := dyn.Resource(HelmReleaseGVR).
+		Namespace(metav1.NamespaceAll).
+		List(ctx, metav1.ListOptions{LabelSelector: ApplicationOrgLabel})
+	if err != nil {
+		return nil, fmt.Errorf("helmwatch: list Application HelmReleases: %w", err)
+	}
+
+	out := make([]ComponentSnapshot, 0, len(list.Items))
+	for i := range list.Items {
+		u := &list.Items[i]
+		ns := u.GetNamespace()
+		// An Application HR is never authored in flux-system. If one ever
+		// is, the bootstrap-kit leg above already governs that namespace —
+		// skipping here keeps the two legs disjoint so the union can never
+		// emit the same object twice under two different AppIDs.
+		if ns == "" || ns == FluxNamespace {
+			continue
+		}
+		cs := snapshotFromHelmRelease(u, ApplicationComponentID(ns, u.GetName()))
+		// DependsOn is deliberately NOT carried for Application installs.
+		// extractDependsOn resolves spec.dependsOn[].name against the
+		// bootstrap-kit `bp-` namespace of component ids, so carrying it
+		// here would wire a per-Org row to a platform component row that
+		// it does not actually depend on. A missing edge renders the row
+		// as a leaf; a wrong edge is a false statement about the graph.
+		cs.DependsOn = nil
+		out = append(out, cs)
+	}
+	return out, nil
+}

--- a/products/catalyst/bootstrap/api/internal/helmwatch/jobs_projection_6045_test.go
+++ b/products/catalyst/bootstrap/api/internal/helmwatch/jobs_projection_6045_test.go
@@ -1,0 +1,395 @@
+// jobs_projection_6045_test.go — #6045. The /jobs page could not show a
+// single per-Organization Application install.
+//
+// The projection that feeds /jobs listed exactly one namespace —
+// Namespace(FluxNamespace) at helmwatch.go:2682, FluxNamespace ==
+// "flux-system" at :86 — and then kept only `bp-` prefixed names. A
+// per-Org Application install is neither: the application-controller
+// authors its HelmRelease in the Application's own namespace (or the
+// vCluster host namespace) named after the Application
+// (core/controllers/pkg/render/manifests.go, `name: {{ .AppName }}` /
+// `namespace: {{ .HRNamespace }}`), and Applications are never `bp-`
+// prefixed — `bp-` names a Blueprint, an Application is `<purpose>`.
+//
+// So the ONLY installs a User can actually cause to fail were
+// structurally invisible in EVERY filter state, `failed` included. A
+// User watched a real install fail and the page said "No jobs match the
+// current filters."
+//
+// These fixtures encode both halves. The two per-Org Application HRs
+// must appear; the per-Org INFRASTRUCTURE HR must not — it is real noise
+// the old `bp-` filter was, by accident, protecting the page from, and
+// it is the control that proves this fix discriminates rather than
+// disables.
+package helmwatch
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+)
+
+// newHRWithLabels builds a HelmRelease in an arbitrary namespace with an
+// arbitrary label set and either a Ready=True condition or the
+// Stalled=True / Ready=False+RetriesExceeded pair — the exact terminal
+// shape a Flux install lands on when it has exhausted its retries, and
+// the shape that must render as Failed.
+func newHRWithLabels(ns, name string, labels map[string]string, stalled bool) *unstructured.Unstructured {
+	now := time.Now().UTC().Format(time.RFC3339)
+	conds := []any{
+		map[string]any{
+			"type":               "Ready",
+			"status":             string(metav1.ConditionTrue),
+			"reason":             "ReconciliationSucceeded",
+			"message":            "Helm install succeeded",
+			"lastTransitionTime": now,
+		},
+	}
+	if stalled {
+		conds = []any{
+			map[string]any{
+				"type":               "Ready",
+				"status":             string(metav1.ConditionFalse),
+				"reason":             "RetriesExceeded",
+				"message":            "Helm install failed: timed out waiting for the condition",
+				"lastTransitionTime": now,
+			},
+			map[string]any{
+				"type":               "Stalled",
+				"status":             string(metav1.ConditionTrue),
+				"reason":             "RetriesExceeded",
+				"message":            "Failed to install after 3 attempt(s)",
+				"lastTransitionTime": now,
+			},
+		}
+	}
+	meta := map[string]any{"name": name, "namespace": ns}
+	if len(labels) > 0 {
+		lm := map[string]any{}
+		for k, v := range labels {
+			lm[k] = v
+		}
+		meta["labels"] = lm
+	}
+	u := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "helm.toolkit.fluxcd.io/v2",
+		"kind":       "HelmRelease",
+		"metadata":   meta,
+		"spec":       map[string]any{},
+		"status":     map[string]any{"conditions": conds},
+	}}
+	u.SetGroupVersionKind(schema.GroupVersionKind{
+		Group: "helm.toolkit.fluxcd.io", Version: "v2", Kind: "HelmRelease",
+	})
+	return u
+}
+
+// applicationInstallLabels — what core/controllers/pkg/render/manifests.go
+// stamps on the SINGLE-HR host path.
+func applicationInstallLabels(org, app string) map[string]string {
+	return map[string]string{
+		"app.kubernetes.io/managed-by":    "application-controller",
+		"app.kubernetes.io/name":          app,
+		"catalyst.openova.io/application": app,
+		ApplicationOrgLabel:               org,
+		"catalyst.openova.io/env-type":    "prod",
+		"catalyst.openova.io/blueprint":   "bp-podinfo",
+		"catalyst.openova.io/region":      "me-east-215",
+	}
+}
+
+// fanoutInstallLabels — what the TOPOLOGY FAN-OUT path stamps
+// (core/controllers/application/internal/render/fanout.go merges
+// fanoutOwnerLabels over LabelApp/LabelTopology/LabelCluster/LabelRole).
+// Note it does NOT carry `app.kubernetes.io/managed-by` and uses
+// `catalyst.openova.io/app`, not `.../application` — the two render paths
+// share exactly ONE label, which is why that one is the discriminator.
+func fanoutInstallLabels(org, app string) map[string]string {
+	return map[string]string{
+		ApplicationOrgLabel:            org,
+		"catalyst.openova.io/env-type": "prod",
+		"catalyst.openova.io/app-uid":  "3f1c-uid",
+		"catalyst.openova.io/app":      app,
+		"catalyst.openova.io/topology": "active-hot-standby",
+		"catalyst.openova.io/cluster":  "hw-me-east-215-b",
+		"catalyst.openova.io/role":     "active",
+	}
+}
+
+// perOrgVClusterLabels — VERBATIM from the vclusterTemplate in
+// core/controllers/organization/internal/gitops/manifests.go:236. This is
+// the control fixture: a NON-bp HelmRelease living in a per-Org namespace
+// that is pure infrastructure. Its own template comment records that it
+// goes Stalled=True / RetriesExceeded on a cold Sovereign-Harbor pull, so
+// a naive "list every namespace, drop the bp- filter" fix would put a
+// Failed `vcluster` row on /jobs for every Organization on the Sovereign.
+// It carries `openova.io/organization` — NOT `catalyst.openova.io/...`.
+func perOrgVClusterLabels(org string) map[string]string {
+	return map[string]string{
+		"openova.io/organization":      org,
+		"openova.io/vcluster":          org,
+		"openova.io/managed-by":        "flux",
+		"app.kubernetes.io/managed-by": "flux",
+	}
+}
+
+func newJobsProjectionFixture() *dynamicfake.FakeDynamicClient {
+	scheme := runtime.NewScheme()
+	scheme.AddKnownTypeWithName(schema.GroupVersionKind{
+		Group: "helm.toolkit.fluxcd.io", Version: "v2", Kind: "HelmReleaseList",
+	}, &unstructured.UnstructuredList{})
+	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		scheme,
+		map[schema.GroupVersionResource]string{HelmReleaseGVR: "HelmReleaseList"},
+		// ── bootstrap-kit, must keep working exactly as before ──
+		newHRWithLabels(FluxNamespace, "bp-cilium", nil, false),
+		newHRWithLabels(FluxNamespace, "bp-openbao", nil, false),
+		// ── control: non-bp noise IN flux-system stays excluded ──
+		newHRWithLabels(FluxNamespace, "flux-system", nil, false),
+		// ── the whole point: per-Org Application installs ──
+		newHRWithLabels("acme", "marketing-site", applicationInstallLabels("acme", "marketing-site"), true),
+		newHRWithLabels("acme", "orders-db-hw-me-east-215-b", fanoutInstallLabels("acme", "orders-db"), false),
+		// ── control: per-Org INFRASTRUCTURE stays excluded ──
+		newHRWithLabels("acme", "vcluster", perOrgVClusterLabels("acme"), true),
+		// ── control: an Application whose name collides with a
+		//    bootstrap-kit component id must not overwrite it ──
+		newHRWithLabels("beta", "cilium", applicationInstallLabels("beta", "cilium"), false),
+	)
+}
+
+func byAppID(snap []ComponentSnapshot) map[string]ComponentSnapshot {
+	out := map[string]ComponentSnapshot{}
+	for _, cs := range snap {
+		out[cs.AppID] = cs
+	}
+	return out
+}
+
+// TestJobsProjection_SurfacesPerOrgApplicationInstall is the decisive
+// guard. It asserts on the VALUE — that the row IS the per-Org install,
+// in the right namespace, with the Failed status its Stalled condition
+// implies — not merely that the returned list is non-empty.
+func TestJobsProjection_SurfacesPerOrgApplicationInstall(t *testing.T) {
+	snap, err := ListAndSnapshotJobsProjection(context.Background(), newJobsProjectionFixture())
+	if err != nil {
+		t.Fatalf("ListAndSnapshotJobsProjection: %v", err)
+	}
+
+	var got *ComponentSnapshot
+	for i := range snap {
+		if snap[i].HelmReleaseName == "marketing-site" && snap[i].Namespace == "acme" {
+			got = &snap[i]
+			break
+		}
+	}
+	if got == nil {
+		t.Fatalf("the per-Org Application install acme/marketing-site is ABSENT from the /jobs "+
+			"projection — the only installs a User can cause to fail are invisible in every "+
+			"filter state, `failed` included (#6045). projection carried %d rows: %v",
+			len(snap), appIDs(snap))
+	}
+	if got.Status != StateFailed {
+		t.Errorf("acme/marketing-site carries Stalled=True reason=RetriesExceeded — the exact "+
+			"terminal shape that must render as Failed. Status = %q, want %q", got.Status, StateFailed)
+	}
+	if !got.Stalled {
+		t.Errorf("acme/marketing-site must be marked Stalled so the read-side anti-flap downgrade " +
+			"(#3916) does not turn a terminal failure back into `installing`")
+	}
+	if got.AppID == "" {
+		t.Errorf("per-Org install has an empty AppID — it cannot be addressed as a /jobs row")
+	}
+}
+
+// TestJobsProjection_CoversBothRenderPaths — the fan-out render path
+// stamps a DIFFERENT label set from the single-HR path. A fix keyed on a
+// label only one path emits would silently miss every multi-region
+// Application.
+func TestJobsProjection_CoversBothRenderPaths(t *testing.T) {
+	snap, err := ListAndSnapshotJobsProjection(context.Background(), newJobsProjectionFixture())
+	if err != nil {
+		t.Fatalf("ListAndSnapshotJobsProjection: %v", err)
+	}
+	found := false
+	for _, cs := range snap {
+		if cs.HelmReleaseName == "orders-db-hw-me-east-215-b" && cs.Namespace == "acme" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("the TOPOLOGY FAN-OUT Application install acme/orders-db-hw-me-east-215-b is "+
+			"absent — fanout.go stamps catalyst.openova.io/app, not .../application, so a fix "+
+			"keyed on the single-HR label set misses every multi-region Application. rows: %v",
+			appIDs(snap))
+	}
+}
+
+// TestJobsProjection_ExcludesPerOrgInfrastructure is the CONTROL. Without
+// it, a "fix" that simply lists every namespace and deletes the `bp-`
+// filter passes both tests above — and floods /jobs with one Failed
+// `vcluster` row per Organization.
+func TestJobsProjection_ExcludesPerOrgInfrastructure(t *testing.T) {
+	snap, err := ListAndSnapshotJobsProjection(context.Background(), newJobsProjectionFixture())
+	if err != nil {
+		t.Fatalf("ListAndSnapshotJobsProjection: %v", err)
+	}
+	for _, cs := range snap {
+		if cs.HelmReleaseName == "vcluster" {
+			t.Fatalf("the per-Org INFRASTRUCTURE HelmRelease acme/vcluster leaked into the /jobs "+
+				"projection (AppID=%q). It is not an Application a User installed, and its own "+
+				"chart comment records that it goes Stalled=True/RetriesExceeded on a cold "+
+				"Harbor pull — so this would put a spurious Failed row on the page for every "+
+				"Organization on the Sovereign.", cs.AppID)
+		}
+		if cs.HelmReleaseName == "flux-system" {
+			t.Fatalf("non-bp infrastructure in flux-system leaked into the projection (AppID=%q)", cs.AppID)
+		}
+	}
+}
+
+// TestJobsProjection_PreservesBootstrapKitRows — the bootstrap-kit half
+// is load-bearing for Phase-1 convergence and must be byte-identical to
+// what it was before the widening.
+func TestJobsProjection_PreservesBootstrapKitRows(t *testing.T) {
+	dyn := newJobsProjectionFixture()
+	widened, err := ListAndSnapshotJobsProjection(context.Background(), dyn)
+	if err != nil {
+		t.Fatalf("ListAndSnapshotJobsProjection: %v", err)
+	}
+	bootstrap, err := ListAndSnapshotHelmReleases(context.Background(), dyn)
+	if err != nil {
+		t.Fatalf("ListAndSnapshotHelmReleases: %v", err)
+	}
+	if len(bootstrap) != 2 {
+		t.Fatalf("fixture sanity: bootstrap-kit projection should carry exactly bp-cilium + "+
+			"bp-openbao, got %v", appIDs(bootstrap))
+	}
+	byID := byAppID(widened)
+	for _, want := range bootstrap {
+		got, ok := byID[want.AppID]
+		if !ok {
+			t.Fatalf("bootstrap-kit row %q disappeared from the widened projection", want.AppID)
+		}
+		if got.HelmReleaseName != want.HelmReleaseName || got.Namespace != want.Namespace ||
+			got.Status != want.Status || got.Stalled != want.Stalled {
+			t.Errorf("bootstrap-kit row %q changed shape: %+v -> %+v", want.AppID, want, got)
+		}
+	}
+}
+
+// TestJobsProjection_AppIDDoesNotCollideWithBootstrapKit — an Application
+// may legitimately be named `cilium`. If its AppID were the bare name it
+// would overwrite the bootstrap-kit component's row in the jobs.Store
+// (keyed by AppID), and a User's failing install would silently replace a
+// platform component's status — or be replaced by it.
+func TestJobsProjection_AppIDDoesNotCollideWithBootstrapKit(t *testing.T) {
+	snap, err := ListAndSnapshotJobsProjection(context.Background(), newJobsProjectionFixture())
+	if err != nil {
+		t.Fatalf("ListAndSnapshotJobsProjection: %v", err)
+	}
+	seen := map[string]ComponentSnapshot{}
+	for _, cs := range snap {
+		if prev, dup := seen[cs.AppID]; dup {
+			t.Fatalf("AppID %q is used by BOTH %s/%s and %s/%s — one row overwrites the other in "+
+				"the jobs.Store", cs.AppID, prev.Namespace, prev.HelmReleaseName,
+				cs.Namespace, cs.HelmReleaseName)
+		}
+		seen[cs.AppID] = cs
+	}
+	// And specifically: the bootstrap-kit `cilium` row must still be the
+	// bootstrap-kit one, not the beta Org's Application.
+	bootstrapCilium, ok := seen["cilium"]
+	if !ok {
+		t.Fatalf("bootstrap-kit AppID `cilium` missing entirely: %v", appIDs(snap))
+	}
+	if bootstrapCilium.Namespace != FluxNamespace {
+		t.Fatalf("AppID `cilium` resolved to %s/%s — the beta Org's Application displaced the "+
+			"platform component", bootstrapCilium.Namespace, bootstrapCilium.HelmReleaseName)
+	}
+}
+
+// newHRWithReadyReason builds an HR with a single Ready=False condition
+// carrying an arbitrary reason and NO Stalled condition — the shape of a
+// HelmRelease that is unhealthy but still has remediation attempts left.
+func newHRWithReadyReason(ns, name, reason string, labels map[string]string) *unstructured.Unstructured {
+	u := newHRWithLabels(ns, name, labels, false)
+	_ = unstructured.SetNestedSlice(u.Object, []any{
+		map[string]any{
+			"type":               "Ready",
+			"status":             string(metav1.ConditionFalse),
+			"reason":             reason,
+			"message":            "Helm upgrade failed: another operation is in progress",
+			"lastTransitionTime": time.Now().UTC().Format(time.RFC3339),
+		},
+	}, "status", "conditions")
+	return u
+}
+
+// TestSnapshot_StalledRetriesExceededIsTerminalFailed — #6045 defect 2.
+// DeriveState recognises only the InstallFailed/UpgradeFailed reason
+// family as failed, so a Ready=False whose reason IS RetriesExceeded fell
+// through to `degraded` and, because the Stalled flag was gated on
+// state==StateFailed, ALSO lost its Stalled marker. Flux has exhausted
+// remediation.retries at that point and will never reconcile it again.
+//
+// The second case is the CONTROL: a Ready=False that is genuinely still
+// retrying must STAY degraded and un-stalled. Without it a fix that
+// promoted every degraded HR to failed would pass the first case.
+func TestSnapshot_StalledRetriesExceededIsTerminalFailed(t *testing.T) {
+	scheme := runtime.NewScheme()
+	scheme.AddKnownTypeWithName(schema.GroupVersionKind{
+		Group: "helm.toolkit.fluxcd.io", Version: "v2", Kind: "HelmReleaseList",
+	}, &unstructured.UnstructuredList{})
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		scheme,
+		map[schema.GroupVersionResource]string{HelmReleaseGVR: "HelmReleaseList"},
+		// Retries exhausted → terminal.
+		newHRWithReadyReason(FluxNamespace, "bp-exhausted", "RetriesExceeded", nil),
+		// Unhealthy but Flux will try again → NOT terminal.
+		newHRWithReadyReason(FluxNamespace, "bp-retrying", "UpgradeFailedButRetrying", nil),
+	)
+	byID := byAppID(mustSnapshot(t, dyn))
+
+	exhausted := byID["exhausted"]
+	if exhausted.Status != StateFailed {
+		t.Errorf("Ready=False reason=RetriesExceeded means Flux has exhausted remediation.retries "+
+			"and will not reconcile again — Status = %q, want %q", exhausted.Status, StateFailed)
+	}
+	if !exhausted.Stalled {
+		t.Errorf("a RetriesExceeded HR must carry Stalled=true; the /jobs anti-flap rule (#3916) "+
+			"uses that flag to tell a terminal failure from a transient wobble")
+	}
+
+	retrying := byID["retrying"]
+	if retrying.Status != StateDegraded {
+		t.Errorf("CONTROL: an unhealthy HR with retries REMAINING must stay %q so the /jobs leaf "+
+			"does not flap Failed<->Succeeded while Flux converges — got %q",
+			StateDegraded, retrying.Status)
+	}
+	if retrying.Stalled {
+		t.Errorf("CONTROL: an HR with retries remaining must not be marked Stalled")
+	}
+}
+
+func mustSnapshot(t *testing.T, dyn *dynamicfake.FakeDynamicClient) []ComponentSnapshot {
+	t.Helper()
+	snap, err := ListAndSnapshotHelmReleases(context.Background(), dyn)
+	if err != nil {
+		t.Fatalf("ListAndSnapshotHelmReleases: %v", err)
+	}
+	return snap
+}
+
+func appIDs(snap []ComponentSnapshot) []string {
+	out := make([]string, 0, len(snap))
+	for _, cs := range snap {
+		out = append(out, cs.AppID)
+	}
+	return out
+}


### PR DESCRIPTION
Refs #6045

The Jobs page could not show a single per-Organization Application install. Since Applications are the only thing a User can install, the only installs a User can cause to fail were structurally invisible — in every filter state, `failed` included. A User watched a real install fail and the page said "No jobs match the current filters."

## The reading, verified before changing anything

`internal/helmwatch/helmwatch.go`:

| site | what it does |
|---|---|
| `:86` | `const FluxNamespace = "flux-system"` |
| `:2682` | `ListAndSnapshotHelmReleases` → `.Namespace(FluxNamespace).List(...)` |
| `:2690` | `if !strings.HasPrefix(name, "bp-") { continue }` |
| `:1396` / `:1408` | ticker recensus — same namespace, same prefix |
| `:1116` | informer `FilterFunc` — same prefix |

A per-Org Application install matches neither condition:

- **Namespace.** The application-controller authors the HelmRelease in the Application's own namespace or the vCluster host namespace — `core/controllers/pkg/render/manifests.go:350`, `namespace: {{ .HRNamespace }}`. Never `flux-system`.
- **Name.** `name: {{ .AppName }}` (`manifests.go:346`), or `<app>-<cluster>` on the topology fan-out path. `bp-` names a *Blueprint*; an Application is `<purpose>` (`docs/GLOSSARY.md`).

This is **not** the `retries: -1` story previously suspected — the object never reaches the projection at all, whatever its retry configuration.

## What the `bp-` filter was protecting, and why both protections survive

Two real things, and the fix preserves both:

**1. The Phase-1 termination gate.** The informer's `FilterFunc` (`:1116`) feeds `processEvent`, which closes `terminated` once every *observed* HelmRelease is terminal. Widening that filter would let an Application install — which can appear at any moment, long after bootstrap — hold Phase-1 convergence open forever. **This PR does not touch the informer.** The bootstrap-kit leg is `ListAndSnapshotHelmReleases` verbatim.

**2. Infrastructure noise in per-Org namespaces.** Every Organization gets a `vcluster` HelmRelease in namespace `<slug>` (`core/controllers/organization/internal/gitops/manifests.go:234` `vclusterTemplate`). It is not `bp-` prefixed and not in `flux-system`, and that template's own comment records that it lands `Stalled=True / RetriesExceeded` on a cold Sovereign-Harbor pull. A naive "list all namespaces, drop the prefix filter" fix puts one spurious Failed row on the page **per Organization** — worse than the empty page.

## The discriminator

Two renderers stamp two different label sets:

```
single-HR host path   (render/manifests.go:352)
  app.kubernetes.io/managed-by: application-controller
  catalyst.openova.io/application: <app>
  catalyst.openova.io/organization: <org>      <-- shared
topology fan-out      (render/fanout.go:218 over fanoutOwnerLabels)
  catalyst.openova.io/app: <app>
  catalyst.openova.io/app-uid: <uid>
  catalyst.openova.io/organization: <org>      <-- shared
```

`catalyst.openova.io/organization` is the **one** label both emit, so it is the discriminator — keying on either of the others silently misses half the Applications on a Sovereign. The per-Org `vcluster` HR carries `openova.io/organization`, a different key with no `catalyst.` prefix, so a server-side existence selector on the catalyst-scoped key includes exactly the Application installs and excludes the infrastructure. The apiserver does the filtering; the response never carries the noise.

**No RBAC change needed** — checked before adding one. `clusterrole-cutover-driver.yaml:217-219` already grants `helm.toolkit.fluxcd.io/helmreleases: get,list,watch`, and `clusterrolebinding-cutover-driver.yaml:21` binds it as a **ClusterRoleBinding**, so the cluster-wide labelled list is already permitted.

## Second defect, found by the guard

Writing the assertion on the *value* rather than the key surfaced a second, independent bug in the same user-visible path. `DeriveState` (`:2384`) recognises only `InstallFailed / UpgradeFailed / ChartPullError / ChartLoadError / ArtifactFailed` as `StateFailed`; anything else falls through to `StateDegraded` on the comment's stated assumption that "flux flips it back to True once the deployment recovers" (`:2394`).

That assumption is false for `RetriesExceeded` — `IsStalledHelmRelease` (`:2417`) treats exactly that reason as stably failed, because Flux has exhausted `remediation.retries` and will not reconcile again without a spec change. So the row was classified `degraded`, and since `Stalled` was gated on `state == StateFailed` it **also lost its Stalled marker**, leaving the `#3916` anti-flap rule nothing to distinguish it from a transient wobble.

Net: even once visible, the row read `degraded` and never reached the `failed` filter. Fixed in `snapshotFromHelmRelease` — the read-side projection only. `DeriveState` is untouched, so the live Phase-1 Watcher's `processEvent` semantics and Phase-1 termination behaviour are unchanged.

## The change

- `internal/helmwatch/jobs_projection.go` (new) — `ListAndSnapshotJobsProjection` returns the bootstrap-kit rows **union** the Application rows. `ApplicationComponentID(ns, name)` = `<ns>:<name>`, namespace-qualified because `jobs.Store` is keyed by AppID and an Org may legitimately name an Application `cilium`. `":"` not `"/"` — `snapshotsToSeedsForRegion` already uses `":"` so the JobName renders as a single route segment.
- `internal/helmwatch/helmwatch.go` — extracted `snapshotFromHelmRelease(u, appID)` so both legs derive status, staleness and suspension by identical rules; the AppID is the only thing the two callers decide differently. Without that seam the projections would drift.
- `internal/handler/jobs.go` — `chrootSeedApplicationInstalls`, run **unconditionally** relative to `hasBootstrapKit` (same reason `chrootSeedSecondaryRegions` is — TBD-A63: a converged Sovereign is the only kind that *has* Applications, and it always has the bootstrap-kit group already), across the primary cluster and every registered secondary region.

**Error contract**, stated in the doc comment and honoured at the call site: a failure of the Application leg returns the bootstrap-kit rows it *did* obtain alongside a non-nil error, so an RBAC gap or apiserver blip can never blank rows that used to render. A non-nil error does not mean "no rows", and an empty Application set is only trustworthy when err is nil — the caller seeds what came back and logs the error rather than reporting "this Sovereign has no Applications".

## Guards — watched failing first

### Projection level — `internal/helmwatch/jobs_projection_6045_test.go`

RED (through the same entry point the fix uses, delegating to today's behaviour so the failure is behavioural, not a compile error):

```
--- FAIL: TestJobsProjection_SurfacesPerOrgApplicationInstall (0.00s)
    the per-Org Application install acme/marketing-site is ABSENT from the /jobs
    projection — the only installs a User can cause to fail are invisible in every
    filter state, `failed` included (#6045). projection carried 2 rows: [cilium openbao]
--- FAIL: TestJobsProjection_CoversBothRenderPaths (0.00s)
    the TOPOLOGY FAN-OUT Application install acme/orders-db-hw-me-east-215-b is
    absent — fanout.go stamps catalyst.openova.io/app, not .../application, so a fix
    keyed on the single-HR label set misses every multi-region Application.
    rows: [cilium openbao]
```

Then, with the projection widened but before the status fix — the second defect, caught by asserting on the value:

```
--- FAIL: TestJobsProjection_SurfacesPerOrgApplicationInstall (0.00s)
    acme/marketing-site carries Stalled=True reason=RetriesExceeded — the exact
    terminal shape that must render as Failed. Status = "degraded", want "failed"
    acme/marketing-site must be marked Stalled so the read-side anti-flap downgrade
    (#3916) does not turn a terminal failure back into `installing`
--- FAIL: TestSnapshot_StalledRetriesExceededIsTerminalFailed (0.00s)
    Ready=False reason=RetriesExceeded means Flux has exhausted remediation.retries
    and will not reconcile again — Status = "degraded", want "failed"
    a RetriesExceeded HR must carry Stalled=true; the /jobs anti-flap rule (#3916)
    uses that flag to tell a terminal failure from a transient wobble
```

GREEN:

```
--- PASS: TestJobsProjection_SurfacesPerOrgApplicationInstall (0.00s)
--- PASS: TestJobsProjection_CoversBothRenderPaths (0.00s)
--- PASS: TestJobsProjection_ExcludesPerOrgInfrastructure (0.00s)
--- PASS: TestJobsProjection_PreservesBootstrapKitRows (0.00s)
--- PASS: TestJobsProjection_AppIDDoesNotCollideWithBootstrapKit (0.00s)
--- PASS: TestSnapshot_StalledRetriesExceededIsTerminalFailed (0.00s)
ok  	.../internal/helmwatch	0.012s
```

### Surface level — `internal/handler/jobs_perorg_install_6045_test.go`

Drives a real `GET /api/v1/deployments/{depId}/jobs`. RED against the pre-fix `jobs.go`:

```
--- FAIL: TestJobsPage_ShowsPerOrgApplicationInstall (0.87s)
    no /jobs row for the per-Org Application install acme/marketing-site — the only
    installs a User can cause to fail are invisible on the page (#6045). 9 rows:
    [cluster-bootstrap provisioner tofu-apply tofu-init tofu-output tofu-plan
     bootstrap-kit install-cilium install-openbao]
--- FAIL: TestJobsPage_FailedFilterContainsPerOrgInstall (0.05s)
    the `failed` filter does not contain the failing per-Org Application install —
    a User watching a real install fail still sees "No jobs match the current
    filters". 0 failed rows: []
```

GREEN:

```
--- PASS: TestJobsPage_ShowsPerOrgApplicationInstall (0.07s)
--- PASS: TestJobsPage_FailedFilterContainsPerOrgInstall (0.06s)
--- PASS: TestJobsPage_ExcludesPerOrgInfrastructure (0.07s)
--- PASS: TestJobsPage_StillShowsBootstrapKit (0.09s)
ok  	.../internal/handler	0.314s
```

### Controls

Four assertions exist specifically so a fix that *disables* the filter cannot pass:

- **`ExcludesPerOrgInfrastructure`** (both levels) — the `vcluster` HR, labels copied verbatim from `vclusterTemplate`, in a per-Org namespace, carrying the same `Stalled/RetriesExceeded` pair as the Application. It must stay off the page. A "list every namespace, drop the prefix" fix passes every positive assertion and fails this one.
- **`PreservesBootstrapKitRows` / `StillShowsBootstrapKit`** — the platform rows must be unchanged in shape.
- **`AppIDDoesNotCollideWithBootstrapKit`** — an Org Application named `cilium` must not displace the platform component's row.
- **the `retrying` case in `TestSnapshot_StalledRetriesExceededIsTerminalFailed`** — an unhealthy HR with retries *remaining* must stay `degraded` and un-stalled, so the status fix is shown to discriminate rather than blanket-promote.

Each control passed in both the red and green states, which is what makes them controls.

## A pre-existing flaky gate this branch ran into

The required `test` gate went red here with a data race in `TestSecondaryKubeconfigDelivery_RunsOnFailedDeployment_6015` — a #6015 test. **Neither participant is in this diff:**

```
WARNING: DATA RACE
Write ... withChrootForwardClient.func2()
    secondary_kubeconfig_coverage_6015_test.go:600
Previous read ... reforwardSecondaryKubeconfigsToChild()
    deployment_handover_export.go:503
```

The test spawns a detached `runSecondaryKubeconfigDelivery` goroutine that ticks every 5ms and reads the package-level `secondaryKubeconfigForwardClient`; `withChrootForwardClient` restores that var in a `t.Cleanup`. The cleanup signals the loop to stop but never observes it stopping, so the restore can land mid-tick.

Named, diagnosed and filed as **#6058** rather than waved off as "an expected race" — it is timing-dependent, which is why the same package passed on #6051 and failed here.

A fix was attempted on this branch and **reverted**: waiting on a done channel makes shutdown deterministic, but a 10s budget is not enough under a full-package `-race` run, because each tick POSTs once per region with a 5s client timeout. It turned a rare flake into a deterministic red. The real fix is to give the loop a cancellable context so teardown cancels the in-flight POSTs — tracked in #6058, deliberately not bundled into a jobs-projection PR.

## Gates

```
go vet ./internal/handler/ ./internal/helmwatch/   clean
go test ./internal/helmwatch/ -count=1            ok  20.282s
```

No chart touched, so no version bump and no lockstep sites.

## Delivery

Pure catalyst-api Go code — it reaches a Sovereign only through a **catalyst-api image roll**. Merged will not mean delivered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)