### PR TITLE
fix(catalyst-api): refuse to persist a credential-less secondary kubeconfig

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/secondary_kubeconfig_completeness.go
+++ b/products/catalyst/bootstrap/api/internal/handler/secondary_kubeconfig_completeness.go
@@ -1,0 +1,142 @@
+// secondary_kubeconfig_completeness.go — refuse to PERSIST a secondary
+// kubeconfig that cannot produce a client.
+//
+// Root cause (measured live on hw293, dep a0077ba47e3720e5, region
+// me-east-215-b-1):
+//
+//	The chroot's PVC held
+//	`/var/lib/catalyst/kubeconfigs/a0077ba47e3720e5-me-east-215-b-1.yaml`
+//	at **95 bytes** — `apiVersion`, `kind: Config`, one `clusters[]` entry
+//	carrying only a `server:` URL, and then nothing: the document ends
+//	mid-token on `  name: c` with no trailing newline. No `contexts`, no
+//	`users`, no `current-context`, no `certificate-authority-data`. Beside
+//	it sat the healthy region-a file at **1109 bytes** carrying all five
+//	top-level keys. A credential-less shell had taken region B's slot.
+//
+//	HandleSovereignSecondaryKubeconfig produced that file. Its ONLY content
+//	check was `strings.TrimSpace(body.KubeconfigYAML) == ""`, so a 95-byte
+//	shell passed as readily as a complete 2959-byte kubeconfig. The bytes
+//	were written to disk FIRST; the parse that would have caught them —
+//	k8sCache.AddCluster's `clientcmd.RESTConfigFromKubeConfig` — ran 21
+//	lines LATER. When it failed, the handler returned HTTP 500 and left the
+//	unusable file exactly where it had put it. Twice, on the record:
+//
+//	  18:03:41  AddCluster failed … invalid configuration: no configuration
+//	            has been provided, try setting KUBERNETES_MASTER …
+//	  18:03:41  POST /api/v1/sovereign/secondary-kubeconfig status=500 elapsedMs=6002
+//	  18:04:19  POST /api/v1/sovereign/secondary-kubeconfig status=500 elapsedMs=6001
+//
+//	Two 500s, and the 95-byte file still on disk after both. A 500 that
+//	leaves its own failure durable is not a rejection — it is a write with
+//	a complaint attached. Every later reader (buildRegionSlots, the jobs
+//	informer, the placement resolver, onDiskSecondaryKubeconfigKeys) then
+//	sees region B as DELIVERED, because delivery was being measured by the
+//	presence of a file rather than by the usability of its contents.
+//
+//	The 6002ms/6001ms is the second cost: `elapsedMs` is two 3-second
+//	`secondaryDialTimeout` probes — hostReachable + apiserverCertPrivateSANs
+//	— which the #4000 self-heal spent dialling the stub's server host. Six
+//	seconds of request-path latency burned on a document that could never
+//	register no matter which host it pointed at.
+//
+// This file adds the gate that was missing: validate BEFORE persisting,
+// and name what is absent. Two properties matter and are pinned by
+// TestSecondaryKubeconfig* :
+//
+//  1. An unusable document is REFUSED (422) and never reaches disk — so it
+//     cannot displace a good file that a previous delivery already landed.
+//     Any sender may be buggy; the region-B slot stays credible regardless.
+//  2. A complete kubeconfig is still accepted unchanged (the vacuity arm) —
+//     a gate that cannot pass is as useless as one that cannot fail.
+//
+// The decisive check is `clientcmd.RESTConfigFromKubeConfig`, which is the
+// EXACT call k8scache.AddCluster makes (internal/k8scache/factory.go:710).
+// Binding to the consumer's own parser is deliberate: a bespoke structural
+// re-implementation could drift from what actually builds a client, and
+// then this gate would pass documents the cache still rejects. The
+// structural walk exists only to NAME the missing sections for the operator
+// — it never overrides the parser's verdict.
+//
+// Refs #6015, #6040.
+
+package handler
+
+import (
+	"sort"
+	"strings"
+
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// secondaryKubeconfigDefects reports why raw cannot produce a working
+// client, as a stable, sorted list of section names for the log + the HTTP
+// response. An empty slice means the document is usable.
+//
+// The returned names are deliberately the kubeconfig's own top-level keys
+// ("clusters", "contexts", "users", "current-context") so an operator
+// reading the 422 can diff the rejected document against a healthy one
+// without needing this source file.
+func secondaryKubeconfigDefects(raw string) []string {
+	if strings.TrimSpace(raw) == "" {
+		return []string{"empty"}
+	}
+
+	cfg, err := clientcmd.Load([]byte(raw))
+	if err != nil || cfg == nil {
+		return []string{"unparseable"}
+	}
+
+	missing := map[string]struct{}{}
+
+	// A cluster entry with no server URL is the shape the hw293 stub had
+	// AFTER its truncation point removed everything else: the section is
+	// present, so a "has clusters?" check passes, yet nothing dialable is
+	// declared. Assert on the VALUE, not the presence of the KEY.
+	hasServer := false
+	for _, c := range cfg.Clusters {
+		if c != nil && strings.TrimSpace(c.Server) != "" {
+			hasServer = true
+			break
+		}
+	}
+	if !hasServer {
+		missing["clusters"] = struct{}{}
+	}
+	if len(cfg.Contexts) == 0 {
+		missing["contexts"] = struct{}{}
+	}
+	if len(cfg.AuthInfos) == 0 {
+		missing["users"] = struct{}{}
+	}
+	if strings.TrimSpace(cfg.CurrentContext) == "" {
+		missing["current-context"] = struct{}{}
+	}
+
+	// Decisive gate — the consumer's own parser. A document that satisfies
+	// every structural check above but still cannot build a rest.Config
+	// (unresolvable current-context, a context naming a cluster or user
+	// that does not exist, a user carrying no credential at all) is
+	// rejected here rather than at AddCluster time, which is what the
+	// pre-fix ordering deferred until after the write.
+	if _, rerr := clientcmd.RESTConfigFromKubeConfig([]byte(raw)); rerr != nil {
+		if len(missing) == 0 {
+			missing["client-unbuildable"] = struct{}{}
+		}
+	} else if len(missing) == 0 {
+		return nil
+	}
+
+	out := make([]string, 0, len(missing))
+	for k := range missing {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// secondaryKubeconfigUsable reports whether raw can produce a client — the
+// boolean form of secondaryKubeconfigDefects for call sites that do not
+// need to name the gap.
+func secondaryKubeconfigUsable(raw string) bool {
+	return len(secondaryKubeconfigDefects(raw)) == 0
+}

--- a/products/catalyst/bootstrap/api/internal/handler/secondary_kubeconfig_completeness_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/secondary_kubeconfig_completeness_test.go
@@ -1,0 +1,238 @@
+// secondary_kubeconfig_completeness_test.go — the guard for the hw293
+// credential-less region-B kubeconfig.
+//
+// Pinned to the LIVE artefact, not to a paraphrase of it. hw293StubKubeconfig
+// below is a byte-for-byte reconstruction of what sat on the chroot's PVC at
+// /var/lib/catalyst/kubeconfigs/a0077ba47e3720e5-me-east-215-b-1.yaml:
+// 95 bytes, ending mid-token on `  name: c` with no trailing newline, while
+// the healthy region-a file beside it measured 1109 bytes and carried all
+// five top-level keys.
+//
+// Every arm here fails against the pre-fix handler, which persisted the
+// document first and only discovered it was unusable 21 lines later at
+// AddCluster — returning 500 while leaving the file exactly where it had put
+// it.
+//
+// Refs #6015, #6040.
+
+package handler
+
+import (
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// hw293StubKubeconfig is the measured live artefact. Do not reformat: the
+// byte count is an assertion, and the absent trailing newline is part of the
+// evidence that the document was cut mid-token rather than generated short.
+const hw293StubKubeconfig = "apiVersion: v1\n" +
+	"kind: Config\n" +
+	"clusters:\n" +
+	"- cluster:\n" +
+	"    server: https://212.72.24.6:6443\n" +
+	"  name: c"
+
+// hw293StubBytes — the size measured on the chroot PVC (`wc -c`).
+const hw293StubBytes = 95
+
+// completeKubeconfigSameCluster is the CONTROL that shares the suspect
+// property. It keeps the stub's exact cluster block — same single entry,
+// same `server:` URL, same `name: c` — and adds ONLY the three sections the
+// stub is missing. If it were the server URL, the cluster count, or the
+// document's brevity that made the stub unusable, this control would be
+// refused too. It is accepted, which isolates contexts/users/current-context
+// as the discriminator.
+const completeKubeconfigSameCluster = `apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://212.72.24.6:6443
+  name: c
+contexts:
+- name: c
+  context:
+    cluster: c
+    user: c
+current-context: c
+users:
+- name: c
+  user:
+    token: fake-token
+`
+
+func newCompletenessTestHandler(t *testing.T, dir string) *Handler {
+	t.Helper()
+	t.Setenv("CATALYST_K8SCACHE_KUBECONFIGS_DIR", dir)
+	t.Setenv("SOVEREIGN_FQDN", "") // mothership: no dial-based self-heal in unit tests
+	return &Handler{
+		log:      slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		k8sCache: newK8sCacheWithClusters(t, nil),
+	}
+}
+
+// TestHw293Stub_ShapeIsPinned states the defect in numbers: 95 bytes, and
+// exactly which top-level sections are absent versus a complete document.
+func TestHw293Stub_ShapeIsPinned(t *testing.T) {
+	if got := len(hw293StubKubeconfig); got != hw293StubBytes {
+		t.Fatalf("stub fixture drifted from the live artefact: %d bytes, want %d", got, hw293StubBytes)
+	}
+	if strings.HasSuffix(hw293StubKubeconfig, "\n") {
+		t.Error("stub fixture gained a trailing newline; the live file ended mid-token")
+	}
+
+	got := strings.Join(secondaryKubeconfigDefects(hw293StubKubeconfig), ",")
+	const want = "contexts,current-context,users"
+	if got != want {
+		t.Fatalf("defects = %q, want %q", got, want)
+	}
+
+	// The control shares the cluster block and is usable — so brevity and
+	// the server URL are not what disqualifies the stub.
+	if d := secondaryKubeconfigDefects(completeKubeconfigSameCluster); len(d) != 0 {
+		t.Fatalf("control with the SAME cluster block was refused: %v", d)
+	}
+	if len(completeKubeconfigSameCluster) <= hw293StubBytes {
+		t.Fatal("control must be the larger document for the comparison to mean anything")
+	}
+}
+
+// TestSecondaryKubeconfig_RefusesIncompleteBeforeWriting is the core guard.
+// Pre-fix this POST returned 500 AND left the 95-byte file on disk.
+func TestSecondaryKubeconfig_RefusesIncompleteBeforeWriting(t *testing.T) {
+	dir := t.TempDir()
+	h := newCompletenessTestHandler(t, dir)
+
+	rec := postSecondaryKubeconfig(t, h, map[string]string{
+		"deploymentId":   "a0077ba47e3720e5",
+		"regionKey":      "me-east-215-b-1",
+		"kubeconfigYaml": hw293StubKubeconfig,
+	})
+
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, want 422; body = %s", rec.Code, rec.Body.String())
+	}
+	if body := rec.Body.String(); !strings.Contains(body, "kubeconfig-incomplete") {
+		t.Errorf("response does not name the refusal: %s", body)
+	}
+
+	path := filepath.Join(dir, "a0077ba47e3720e5-me-east-215-b-1.yaml")
+	if st, err := os.Stat(path); err == nil {
+		t.Fatalf("unusable kubeconfig was persisted anyway (%d bytes at %s)", st.Size(), path)
+	} else if !os.IsNotExist(err) {
+		t.Fatalf("unexpected stat error: %v", err)
+	}
+}
+
+// TestSecondaryKubeconfig_IncompleteCannotDisplaceGoodFile is the property
+// that actually kept hw293's region B dark: whatever the sender does, a
+// kubeconfig that already works must survive a later malformed delivery.
+func TestSecondaryKubeconfig_IncompleteCannotDisplaceGoodFile(t *testing.T) {
+	dir := t.TempDir()
+	h := newCompletenessTestHandler(t, dir)
+	path := filepath.Join(dir, "a0077ba47e3720e5-me-east-215-b-1.yaml")
+
+	// A healthy delivery lands first.
+	if rec := postSecondaryKubeconfig(t, h, map[string]string{
+		"deploymentId":   "a0077ba47e3720e5",
+		"regionKey":      "me-east-215-b-1",
+		"kubeconfigYaml": secondaryKubeconfigFixture,
+	}); rec.Code != http.StatusCreated {
+		t.Fatalf("seed POST status = %d, want 201; body = %s", rec.Code, rec.Body.String())
+	}
+	before, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("seed kubeconfig not on disk: %v", err)
+	}
+
+	// The malformed delivery follows, exactly as it did live (twice).
+	if rec := postSecondaryKubeconfig(t, h, map[string]string{
+		"deploymentId":   "a0077ba47e3720e5",
+		"regionKey":      "me-east-215-b-1",
+		"kubeconfigYaml": hw293StubKubeconfig,
+	}); rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("stub POST status = %d, want 422; body = %s", rec.Code, rec.Body.String())
+	}
+
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("good kubeconfig disappeared: %v", err)
+	}
+	if string(after) != string(before) {
+		t.Fatalf("good kubeconfig was displaced: %d bytes -> %d bytes", len(before), len(after))
+	}
+	if len(after) == hw293StubBytes {
+		t.Fatalf("region slot now holds the %d-byte stub", hw293StubBytes)
+	}
+}
+
+// TestSecondaryKubeconfig_CompleteStillAccepted is the vacuity arm. Without
+// it the guard above could be satisfied by a handler that refuses
+// everything.
+func TestSecondaryKubeconfig_CompleteStillAccepted(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		yaml string
+	}{
+		{"iac fixture", secondaryKubeconfigFixture},
+		{"stub cluster block plus the three missing sections", completeKubeconfigSameCluster},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			h := newCompletenessTestHandler(t, dir)
+
+			rec := postSecondaryKubeconfig(t, h, map[string]string{
+				"deploymentId":   "a0077ba47e3720e5",
+				"regionKey":      "me-east-215-b-1",
+				"kubeconfigYaml": tc.yaml,
+			})
+			if rec.Code != http.StatusCreated {
+				t.Fatalf("status = %d, want 201; body = %s", rec.Code, rec.Body.String())
+			}
+			onDisk, err := os.ReadFile(filepath.Join(dir, "a0077ba47e3720e5-me-east-215-b-1.yaml"))
+			if err != nil {
+				t.Fatalf("complete kubeconfig was not persisted: %v", err)
+			}
+			if len(onDisk) <= hw293StubBytes {
+				t.Fatalf("persisted %d bytes, no larger than the %d-byte stub", len(onDisk), hw293StubBytes)
+			}
+		})
+	}
+}
+
+// TestSecondaryKubeconfigDefects_NamesEachGapIndividually keeps the 422's
+// `missing` field honest: each section is reported on its own evidence, so
+// an operator reading the response learns which part of the document the
+// sender dropped.
+func TestSecondaryKubeconfigDefects_NamesEachGapIndividually(t *testing.T) {
+	tests := []struct {
+		name string
+		yaml string
+		want string
+	}{
+		{"empty", "   ", "empty"},
+		{"not yaml", "\tthis: is: not: a: kubeconfig\n\t\t- [", "unparseable"},
+		{
+			"cluster present but server empty — the KEY exists, the VALUE does not",
+			"apiVersion: v1\nkind: Config\nclusters:\n- cluster:\n    server: \"\"\n  name: c\ncontexts:\n- name: c\n  context:\n    cluster: c\n    user: c\ncurrent-context: c\nusers:\n- name: c\n  user:\n    token: t\n",
+			"clusters",
+		},
+		{"the hw293 artefact", hw293StubKubeconfig, "contexts,current-context,users"},
+		{"complete", completeKubeconfigSameCluster, ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := strings.Join(secondaryKubeconfigDefects(tc.yaml), ",")
+			if got != tc.want {
+				t.Fatalf("defects = %q, want %q", got, tc.want)
+			}
+			if usable := secondaryKubeconfigUsable(tc.yaml); usable != (tc.want == "") {
+				t.Fatalf("secondaryKubeconfigUsable = %v, want %v", usable, tc.want == "")
+			}
+		})
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/sovereign_secondary_kubeconfig.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sovereign_secondary_kubeconfig.go
@@ -198,6 +198,36 @@ func (h *Handler) HandleSovereignSecondaryKubeconfig(w http.ResponseWriter, r *h
 		return
 	}
 
+	// Completeness gate — validate BEFORE anything touches the disk.
+	//
+	// Pre-fix, non-empty was the whole contract: a 95-byte credential-less
+	// shell (no contexts, no users, no current-context) was persisted over
+	// region B's slot on hw293 and only THEN failed to parse at AddCluster,
+	// leaving a 500 response and the unusable file both. See
+	// secondary_kubeconfig_completeness.go for the measured record.
+	//
+	// Refusing here has two effects the post-write parse could not have.
+	// First, a good kubeconfig a previous delivery already landed survives
+	// — a later malformed POST can no longer displace it, so the region
+	// stays reachable through whatever bad delivery follows. Second, the
+	// #3991 rewrite and the #4000 self-heal below are skipped for a
+	// document that can never register, which is where the two live
+	// requests each burned 6002ms/6001ms of dial timeouts.
+	if defects := secondaryKubeconfigDefects(raw); len(defects) > 0 {
+		h.log.Warn("secondary-kubeconfig: REFUSED — document cannot produce a client; not persisted (region keeps any previously-delivered kubeconfig)",
+			"depId", body.DeploymentID,
+			"region", body.RegionKey,
+			"bytes", len(raw),
+			"missing", strings.Join(defects, ","),
+		)
+		writeJSON(w, http.StatusUnprocessableEntity, map[string]string{
+			"error":   "kubeconfig-incomplete",
+			"detail":  "kubeconfigYaml does not describe a usable cluster; nothing was written",
+			"missing": strings.Join(defects, ","),
+		})
+		return
+	}
+
 	// #3991 — cross-region datapath fix. The IaC stamps the secondary
 	// region's `server:` URL to its PUBLIC EIP so the external mothership
 	// (outside the per-region VPCs) can reach it. But the IN-CLUSTER


### PR DESCRIPTION
## The artefact, in numbers

Measured on hw293's chroot PVC (`hw293.omantel.biz`, dep `a0077ba47e3720e5`), `kubectl exec … wc -c`:

| file | bytes | top-level keys present |
|---|---|---|
| `a0077ba47e3720e5.yaml` (region A) | **1109** | `clusters`, `contexts`, `current-context`, `kind`, `users` |
| `a0077ba47e3720e5-me-east-215-b-1.yaml` (region B) | **95** | `kind`, `clusters` |

The 95-byte file carries `apiVersion`, `kind: Config`, and one `clusters[]` entry holding nothing but a `server:` URL. It then stops **mid-token** on `  name: c`, with no trailing newline — `tail -c 24 | od -c` ends `n a m e :   c`. No `contexts`, no `users`, no `current-context`, no `certificate-authority-data`. Region B's slot was occupied by a credential-less shell.

The mothership's own copy of the same region is **2959 bytes** and complete, with a matching 12-byte `.nodeip` sidecar. The corruption is on the receiving side, not in the source of truth.

## What writes it, and why it emits a stub

`HandleSovereignSecondaryKubeconfig`. Its only content check was `strings.TrimSpace(body.KubeconfigYAML) == ""`, so a 95-byte shell passed exactly as readily as a complete document. It emits a stub because a stub is what it was handed and nothing in the endpoint could tell the two apart.

The parse that *would* have caught it — `k8sCache.AddCluster` → `clientcmd.RESTConfigFromKubeConfig` (`internal/k8scache/factory.go:710`) — ran **21 lines after** the `os.WriteFile`. When it failed, the handler returned 500 and left the unusable file exactly where it had put it. Twice, on the live record:

```
18:03:41  WARN  secondary-kubeconfig: AddCluster failed  id=a0077ba47e3720e5-me-east-215-b-1
                err="parse kubeconfig …: invalid configuration: no configuration has been
                     provided, try setting KUBERNETES_MASTER environment variable"
18:03:41  POST /api/v1/sovereign/secondary-kubeconfig  status=500  elapsedMs=6002
18:04:19  POST /api/v1/sovereign/secondary-kubeconfig  status=500  elapsedMs=6001
```

Two 500s, and the 95-byte file still on disk after both. **A 500 that leaves its own failure durable is not a rejection — it is a write with a complaint attached.** Every later reader (`buildRegionSlots`, the jobs informer, the placement resolver, `onDiskSecondaryKubeconfigKeys`) then counted region B as *delivered*, because delivery was being measured by the presence of a file rather than by the usability of its contents.

## The change

Validate **before** persisting. An unusable document is refused `422 kubeconfig-incomplete`, names what is absent, and never reaches disk.

The property that matters is not the status code — it is that a kubeconfig an earlier delivery already landed now **survives** a later malformed one. Whichever sender is at fault, the region slot stays credible.

The decisive check is `clientcmd.RESTConfigFromKubeConfig`, the exact call the consumer makes, so the gate cannot drift from what actually builds a client. The structural walk exists only to name the missing sections for the operator; it never overrides the parser's verdict. It also asserts on the **value** rather than the key — a `clusters:` section whose only entry has an empty `server:` is reported as missing `clusters`, not as present.

Refusing early also skips the #3991 rewrite and the #4000 self-heal for a document that can never register, which is where each of those two live requests spent its 6002 ms / 6001 ms.

## Guard, watched failing first

Reverted the gate, kept the guard, ran it. Both handler arms failed on the pre-fix behaviour, and the failure text names the file it had already written:

```
--- FAIL: TestSecondaryKubeconfig_RefusesIncompleteBeforeWriting (0.00s)
    status = 500, want 422; body = {"error":"add-cluster-failed",
      "detail":"parse kubeconfig \"…/a0077ba47e3720e5-me-east-215-b-1.yaml\": …"}
--- FAIL: TestSecondaryKubeconfig_IncompleteCannotDisplaceGoodFile (6.00s)
    stub POST status = 500, want 422
```

Restored the gate — all five arms pass, and the full `internal/handler` package is green (294 s, `go vet` clean).

The fixture is the live artefact byte-for-byte: `TestHw293Stub_ShapeIsPinned` fails if it drifts from **95** bytes, if it gains a trailing newline, or if its defect list stops being exactly `contexts,current-context,users`.

**Vacuity arm**: a complete kubeconfig is still accepted 201 and still written — a gate that cannot pass is as useless as one that cannot fail.

**Control sharing the suspect property**: `completeKubeconfigSameCluster` keeps the stub's *exact* cluster block — same single entry, same `https://212.72.24.6:6443`, same `name: c` — and adds only the three absent sections. It is accepted. So the discriminator is isolated to `contexts`/`users`/`current-context`, not the document's brevity, its cluster count, or its server URL.

## Scope

Receiver only — the site that actually writes the file. The two forwarders (`waitForSecondaryKubeconfig`, `reforwardSecondaryKubeconfigsToChild`) also treat non-empty as usable; tightening them would additionally invalidate existing fixtures that deliberately use `apiVersion: v1\nkind: Config\n` placeholders, so they are left for a follow-up. The receiver gate is sufficient to keep an unusable document off the region slot no matter which sender produced it.

Refs #6015, #6040
