### PR TITLE
fix(console): the cutover trigger was not on the nav — make Sovereignty a first-class surface (Refs #3379)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/SettingsPage.anchor-highlight-160.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/SettingsPage.anchor-highlight-160.test.tsx
@@ -1,0 +1,136 @@
+/**
+ * SettingsPage.anchor-highlight-160.test.tsx — UAT row 160 / #3379, second half.
+ *
+ * The clause asks the `#sovereignty` anchor to "scroll to + HIGHLIGHT the
+ * Cluster-sovereignty panel". The hw293-2026-08-10 walk found the scroll
+ * working — the panel's bounding-box top moved 3055px -> 896px — and recorded
+ * the highlight as absent in the most literal terms available: "the target's
+ * class stays 'scroll-mt-20' before and after the click".
+ *
+ * That residual is not cosmetic on this particular panel. /settings stacks
+ * TWELVE sections; arriving at the bottom one with nothing marking it leaves
+ * the operator looking at an unannotated card and asking whether the anchor
+ * did anything. The cutover is the Pillar-5 trigger, so "did I land on the
+ * right thing" is a question worth answering in the UI.
+ *
+ * THE DISCRIMINATING CONTROL is the third case below. Highlighting whatever is
+ * addressed is the feature; highlighting the sovereignty panel unconditionally
+ * would satisfy a naive assertion while being a different, worse behaviour. So
+ * `#dns` must light the DNS section and leave sovereignty dark, and the
+ * no-hash case must leave BOTH dark.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, cleanup, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import {
+  RouterProvider,
+  createRouter,
+  createRootRoute,
+  createRoute,
+  createMemoryHistory,
+  Outlet,
+} from '@tanstack/react-router'
+
+import { SettingsPage } from './SettingsPage'
+import { useWizardStore } from '@/entities/deployment/store'
+import { INITIAL_WIZARD_STATE } from '@/entities/deployment/model'
+
+const DEP = 'dep160'
+
+function renderSettings(hash = '') {
+  const rootRoute = createRootRoute({ component: () => <Outlet /> })
+  const settingsRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/provision/$deploymentId/settings',
+    component: () => <SettingsPage disableStream />,
+  })
+  const catchAll = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/$',
+    component: () => <div />,
+  })
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([settingsRoute, catchAll]),
+    history: createMemoryHistory({
+      initialEntries: [`/provision/${DEP}/settings${hash}`],
+    }),
+  })
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } })
+  return render(
+    <QueryClientProvider client={qc}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>,
+  )
+}
+
+beforeEach(() => {
+  useWizardStore.setState({ ...INITIAL_WIZARD_STATE })
+  // jsdom ships neither EventSource (SovereigntyCard opens its own stream) nor
+  // Element.scrollIntoView. Both are shimmed rather than mocked away, because
+  // the page must be allowed to call them.
+  if (typeof (globalThis as unknown as { EventSource?: unknown }).EventSource === 'undefined') {
+    class StubEventSource {
+      url: string
+      readyState = 0
+      onopen: ((this: EventSource, ev: Event) => unknown) | null = null
+      onmessage: ((this: EventSource, ev: MessageEvent) => unknown) | null = null
+      onerror: ((this: EventSource, ev: Event) => unknown) | null = null
+      static readonly CLOSED = 2
+      constructor(url: string) {
+        this.url = url
+      }
+      addEventListener(): void {}
+      removeEventListener(): void {}
+      close(): void {}
+    }
+    ;(globalThis as unknown as { EventSource: typeof EventSource }).EventSource =
+      StubEventSource as unknown as typeof EventSource
+  }
+  if (!('scrollIntoView' in Element.prototype)) {
+    Object.defineProperty(Element.prototype, 'scrollIntoView', {
+      value: vi.fn(),
+      writable: true,
+    })
+  }
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => new Response('{}', { status: 200, headers: { 'content-type': 'application/json' } })),
+  )
+})
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+})
+
+function highlighted(testId: string): string | null {
+  return screen.getByTestId(testId).getAttribute('data-anchor-highlighted')
+}
+
+describe('SettingsPage — row 160: arriving at an anchor highlights THAT panel', () => {
+  it('control — with no hash, nothing is highlighted', async () => {
+    renderSettings()
+    await screen.findByTestId('settings-sovereignty')
+    expect(highlighted('settings-sovereignty')).toBeNull()
+    expect(highlighted('settings-section-dns')).toBeNull()
+  })
+
+  it('#sovereignty highlights the Cluster-sovereignty panel', async () => {
+    renderSettings('#sovereignty')
+    const panel = await screen.findByTestId('settings-sovereignty')
+    await waitFor(() => expect(panel.getAttribute('data-anchor-highlighted')).toBe('true'))
+    // Assert on the VALUE of the class, not merely on the flag: the walk's
+    // finding was literally "the class stays scroll-mt-20", so the rendered
+    // class must actually gain something a human can see.
+    expect(panel.className).not.toBe('scroll-mt-20')
+    expect(panel.className).toContain('ring')
+  })
+
+  it('#dns highlights DNS and leaves sovereignty dark — the highlight follows the anchor', async () => {
+    renderSettings('#dns')
+    await screen.findByTestId('settings-sovereignty')
+    await waitFor(() => expect(highlighted('settings-section-dns')).toBe('true'))
+    expect(highlighted('settings-sovereignty')).toBeNull()
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/SettingsPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/SettingsPage.tsx
@@ -51,8 +51,8 @@
  * never read into the DOM.
  */
 
-import { useMemo } from 'react'
-import { Link, useParams } from '@tanstack/react-router'
+import { useEffect, useMemo } from 'react'
+import { Link, useParams, useRouterState } from '@tanstack/react-router'
 
 import { PortalShell } from './PortalShell'
 import { useDeploymentEvents } from './useDeploymentEvents'
@@ -129,6 +129,48 @@ function desc(id: string): string {
   return SECTIONS.find((s) => s.id === id)?.description ?? ''
 }
 
+/* ── Anchor arrival — row 160 / #3379 ───────────────────────────────
+ *
+ * This page stacks twelve sections, so an anchor that only scrolls leaves the
+ * operator looking at an unannotated card with no confirmation they landed on
+ * the thing they asked for. The hw293-2026-08-10 walk recorded exactly that
+ * for `#sovereignty`: the panel scrolled (bounding-box top 3055px -> 896px)
+ * and "the target's class stays 'scroll-mt-20' before and after the click".
+ *
+ * Two distinct jobs, and only the first is browser-native:
+ *
+ *   SCROLL   a full page load with a fragment scrolls by itself. A CLIENT-side
+ *            navigation — which is what the new Sovereignty nav entry performs
+ *            — does not, because the document never reloads. So the effect
+ *            below scrolls explicitly rather than trusting the browser.
+ *   HIGHLIGHT nothing in the platform did this. The addressed section now
+ *            carries `data-anchor-highlighted="true"` plus a visible ring.
+ *
+ * It follows the ANCHOR, not one privileged section: `#dns` lights DNS and
+ * leaves the cutover panel dark. Highlighting the sovereignty panel
+ * unconditionally would satisfy the row while being a different behaviour.
+ */
+function useAnchorArrival(): string {
+  const hash = useRouterState({ select: (s) => s.location.hash })
+  const anchor = (hash ?? '').replace(/^#/, '')
+  useEffect(() => {
+    if (!anchor) return
+    // The section is rendered by this same commit, so the element exists by
+    // the time effects run; the null-check is for a fragment that names no
+    // section (a stale bookmark), where the honest behaviour is to do nothing
+    // rather than to throw.
+    const el = document.getElementById(anchor)
+    if (!el || typeof el.scrollIntoView !== 'function') return
+    el.scrollIntoView({ behavior: 'smooth', block: 'start' })
+  }, [anchor])
+  return anchor
+}
+
+/** Ring applied to the section a fragment addresses. Shared by SectionCard and
+ *  the SovereigntyCard mount, which is not a SectionCard. */
+const ANCHOR_RING = 'ring-2 ring-[var(--color-accent)] ring-offset-2 ring-offset-[var(--color-bg)]'
+
+
 /* ── Page ───────────────────────────────────────────────────────── */
 
 export interface SettingsPageProps {
@@ -154,6 +196,9 @@ export function SettingsPage({ disableStream = false }: SettingsPageProps = {}) 
   const scopedToProvisionRoute = Boolean(params.deploymentId)
 
   const store = useWizardStore()
+
+  // Row 160 — scroll to AND mark the section the fragment addresses.
+  const anchor = useAnchorArrival()
 
   const { snapshot } = useDeploymentEvents({
     deploymentId,
@@ -247,7 +292,7 @@ export function SettingsPage({ disableStream = false }: SettingsPageProps = {}) 
           {/* ── Right pane — sections stacked ─────────────────── */}
           <main className="flex min-w-0 flex-1 flex-col gap-6">
             {/* 1. Organization */}
-            <SectionCard id="organization" title="Organization" description={desc('organization')}>
+            <SectionCard id="organization" anchored={anchor === 'organization'} title="Organization" description={desc('organization')}>
               <FieldGrid>
                 <Field label="Name" value={orgName} testId="settings-org-name" />
                 <Field label="Billing email" value={orgEmail} testId="settings-org-email" />
@@ -257,7 +302,7 @@ export function SettingsPage({ disableStream = false }: SettingsPageProps = {}) 
             </SectionCard>
 
             {/* 2. Sovereign */}
-            <SectionCard id="sovereign" title="Sovereign" description={desc('sovereign')}>
+            <SectionCard id="sovereign" anchored={anchor === 'sovereign'} title="Sovereign" description={desc('sovereign')}>
               <FieldGrid>
                 <Field label="Sovereign FQDN" value={sovereignFQDN} mono testId="settings-sov-fqdn" />
                 <Field label="Region" value={region} mono testId="settings-sov-region" />
@@ -286,6 +331,7 @@ export function SettingsPage({ disableStream = false }: SettingsPageProps = {}) 
             {/* 3. API tokens */}
             <SectionCard
               id="api-tokens"
+              anchored={anchor === 'api-tokens'}
               title="API tokens"
               description={desc('api-tokens')}
               actionLabel="Create token"
@@ -325,6 +371,7 @@ export function SettingsPage({ disableStream = false }: SettingsPageProps = {}) 
             {/* 4. Cloud credentials */}
             <SectionCard
               id="cloud-credentials"
+              anchored={anchor === 'cloud-credentials'}
               title="Cloud credentials"
               description={desc('cloud-credentials')}
               pendingApi
@@ -337,7 +384,7 @@ export function SettingsPage({ disableStream = false }: SettingsPageProps = {}) 
             </SectionCard>
 
             {/* 5. DNS */}
-            <SectionCard id="dns" title="DNS" description={desc('dns')}>
+            <SectionCard id="dns" anchored={anchor === 'dns'} title="DNS" description={desc('dns')}>
               <FieldGrid>
                 <Field label="Pool domain" value={poolDomain} mono testId="settings-dns-pool-domain" />
                 <Field
@@ -356,7 +403,7 @@ export function SettingsPage({ disableStream = false }: SettingsPageProps = {}) 
             </SectionCard>
 
             {/* 6. Domain mode */}
-            <SectionCard id="domain-mode" title="Domain mode" description={desc('domain-mode')}>
+            <SectionCard id="domain-mode" anchored={anchor === 'domain-mode'} title="Domain mode" description={desc('domain-mode')}>
               <FieldGrid>
                 <Field label="Mode" value={domainMode} testId="settings-domain-mode-value" />
                 <Field
@@ -372,20 +419,21 @@ export function SettingsPage({ disableStream = false }: SettingsPageProps = {}) 
                 route into this anchor section, consistent with #dns +
                 the move Marketplace already got. Same ParentDomainsSection
                 the standalone /organizations/domains page renders. */}
-            <SectionCard id="parent-domains" title="Parent domains" description={desc('parent-domains')}>
+            <SectionCard id="parent-domains" anchored={anchor === 'parent-domains'} title="Parent domains" description={desc('parent-domains')}>
               <ParentDomainsSection />
             </SectionCard>
 
             {/* 8. Marketplace — Wave 5 (2026-05-17): moved here from
                 the retired /settings/marketplace standalone page +
                 Settings sub-nav child. */}
-            <SectionCard id="marketplace" title="Marketplace" description={desc('marketplace')}>
+            <SectionCard id="marketplace" anchored={anchor === 'marketplace'} title="Marketplace" description={desc('marketplace')}>
               <MarketplaceSection />
             </SectionCard>
 
             {/* 9. Notifications */}
             <SectionCard
               id="notifications"
+              anchored={anchor === 'notifications'}
               title="Notifications"
               description={desc('notifications')}
               pendingApi
@@ -397,7 +445,7 @@ export function SettingsPage({ disableStream = false }: SettingsPageProps = {}) 
             </SectionCard>
 
             {/* 10. Members — link to existing User Access page */}
-            <SectionCard id="members" title="Members" description={desc('members')}>
+            <SectionCard id="members" anchored={anchor === 'members'} title="Members" description={desc('members')}>
               <p className="text-sm text-[var(--color-text-dim)]">
                 Operators are managed on the dedicated User Access page so role bindings, app
                 grants, and namespace scopes share one editor.
@@ -436,6 +484,7 @@ export function SettingsPage({ disableStream = false }: SettingsPageProps = {}) 
             {/* 11. Danger zone */}
             <SectionCard
               id="danger-zone"
+              anchored={anchor === 'danger-zone'}
               title="Danger zone"
               description={desc('danger-zone')}
               tone="danger"
@@ -476,7 +525,12 @@ export function SettingsPage({ disableStream = false }: SettingsPageProps = {}) 
                 Self-contained widget: renders its own header/badge/CTA and
                 self-fetches cutover status, so it is not wrapped in a
                 SectionCard. */}
-            <div id="sovereignty" className="scroll-mt-20" data-testid="settings-sovereignty">
+            <div
+              id="sovereignty"
+              className={`scroll-mt-20 rounded-xl${anchor === 'sovereignty' ? ` ${ANCHOR_RING}` : ''}`}
+              data-testid="settings-sovereignty"
+              data-anchor-highlighted={anchor === 'sovereignty' ? 'true' : undefined}
+            >
               <SovereigntyCard />
             </div>
           </main>
@@ -502,6 +556,8 @@ interface SectionCardProps {
   pendingApi?: boolean
   /** Tone — danger sections render with a rose border. */
   tone?: 'default' | 'danger'
+  /** True when the page fragment addresses THIS section (row 160). */
+  anchored?: boolean
 }
 
 function SectionCard({
@@ -513,6 +569,7 @@ function SectionCard({
   actionTestId,
   pendingApi,
   tone = 'default',
+  anchored = false,
 }: SectionCardProps) {
   const borderClass =
     tone === 'danger'
@@ -523,7 +580,8 @@ function SectionCard({
       id={id}
       data-testid={`settings-section-${id}`}
       data-pending-api={pendingApi ? 'true' : undefined}
-      className={`scroll-mt-20 rounded-xl border ${borderClass} p-5`}
+      data-anchor-highlighted={anchored ? 'true' : undefined}
+      className={`scroll-mt-20 rounded-xl border ${borderClass} p-5${anchored ? ` ${ANCHOR_RING}` : ''}`}
     >
       <header className="mb-4 flex items-start justify-between gap-3">
         <div>

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/SovereignSidebar.sovereignty-160.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/SovereignSidebar.sovereignty-160.test.tsx
@@ -1,0 +1,148 @@
+/**
+ * SovereignSidebar.sovereignty-160.test.tsx — UAT row 160 / #3379.
+ *
+ * THE CLAUSE: "Console nav + Settings sidebar expose a dedicated Sovereignty
+ * anchor (#sovereignty) that scrolls to + highlights the Cluster-sovereignty
+ * panel — the cutover trigger is a first-class surface."
+ *
+ * The hw293-2026-08-10 walk found HALF of it holding. The Settings table of
+ * contents did expose `Sovereignty` -> `#sovereignty`, and clicking it really
+ * scrolled (the panel's bounding-box top moved 3055px -> 896px). The CONSOLE
+ * NAV did not: enumerating `sov-console-nav` on /dashboard returned exactly
+ * eleven entries — Dashboard, Cloud, Apps, Catalog, Agenity, Jobs, Compliance,
+ * Users, Organizations, Billing, Settings — and none of them was Sovereignty.
+ * `/sovereignty` on the same origin rendered "Not Found". So the cutover
+ * trigger — the whole of Pillar 5 — was reachable only by scrolling to the
+ * bottom of Settings, which is the opposite of a first-class surface.
+ *
+ * THE CONTROL MATTERS MORE THAN THE ASSERTION HERE, because the failing half
+ * is an ABSENCE and a zero is exactly what a broken selector also returns. The
+ * walk handled this by finding `Sovereignty::#sovereignty` in the Settings TOC
+ * with the SAME text-and-href enumeration that returned zero for the nav; this
+ * file does the same thing in miniature. `enumerateNav()` is asserted to return
+ * the known-good entries first, so a zero for Sovereignty is a real null.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import {
+  RouterProvider,
+  createRouter,
+  createRootRoute,
+  createRoute,
+  createMemoryHistory,
+  Outlet,
+} from '@tanstack/react-router'
+
+const scopeMock = vi.fn()
+vi.mock('@/shared/lib/useConsoleScope', () => ({
+  useConsoleScope: () => scopeMock(),
+}))
+vi.mock('@/lib/console-ui.api', () => ({
+  getSidebarEntries: async () => [],
+}))
+vi.mock('@/shared/lib/useResolvedDeploymentId', () => ({
+  useResolvedDeploymentId: () => ({ deploymentId: '' }),
+}))
+
+import { SovereignSidebar } from './SovereignSidebar'
+
+function renderSidebar(at = '/dashboard') {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  const rootRoute = createRootRoute({ component: () => <Outlet /> })
+  const catchAll = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/$',
+    component: () => <SovereignSidebar sovereignFQDN="hw293.omantel.biz" />,
+  })
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([catchAll]),
+    history: createMemoryHistory({ initialEntries: [at] }),
+  })
+  return render(
+    <QueryClientProvider client={qc}>
+      <RouterProvider router={router as never} />
+    </QueryClientProvider>,
+  )
+}
+
+/** The walk's enumeration, in miniature: every nav entry as (text, href). */
+function enumerateNav(): Array<{ text: string; href: string }> {
+  const nav = screen.getByTestId('sov-console-nav')
+  return Array.from(nav.querySelectorAll('a')).map((a) => ({
+    text: (a.textContent ?? '').trim(),
+    href: a.getAttribute('href') ?? '',
+  }))
+}
+
+describe('SovereignSidebar — row 160: Sovereignty is a first-class console-nav surface', () => {
+  beforeEach(() => {
+    scopeMock.mockReset()
+    scopeMock.mockReturnValue({ orgScoped: false, org: null, loading: false })
+  })
+  afterEach(() => cleanup())
+
+  it('the enumeration itself works — control, so a zero below is a real null', async () => {
+    renderSidebar()
+    await screen.findByTestId('sov-console-nav-dashboard')
+    const entries = enumerateNav()
+    // Not a length assertion: adding a nav entry is legitimate and must not
+    // break the control. What the control proves is that this selector CAN see
+    // labels and hrefs, which is the only way a zero for Sovereignty means
+    // anything.
+    expect(entries.length).toBeGreaterThanOrEqual(11)
+    expect(entries.map((e) => e.text)).toContain('Settings')
+    expect(entries.find((e) => e.text === 'Settings')?.href).toBe('/settings')
+    expect(entries.map((e) => e.text)).toContain('Jobs')
+  })
+
+  it('the console nav exposes a Sovereignty entry whose href carries the #sovereignty anchor', async () => {
+    renderSidebar()
+    await screen.findByTestId('sov-console-nav-dashboard')
+    const entries = enumerateNav()
+    const sovereignty = entries.filter((e) => e.text === 'Sovereignty')
+    expect(
+      sovereignty.length,
+      `console nav exposed ${entries.length} entries and none was Sovereignty: ` +
+        entries.map((e) => e.text).join(', '),
+    ).toBe(1)
+    // Assert on the VALUE of the href, not merely that an entry exists — an
+    // entry pointing at /settings with no anchor lands the operator at the top
+    // of an eleven-section page, which is the state the walk already recorded
+    // as failing.
+    expect(sovereignty[0].href).toBe('/settings#sovereignty')
+  })
+
+  it('has its own testid so a walker can address it directly', async () => {
+    renderSidebar()
+    expect(await screen.findByTestId('sov-console-nav-sovereignty')).toBeTruthy()
+  })
+
+  it('highlights on /settings#sovereignty and NOT on plain /settings', async () => {
+    // The nav highlight is what makes a surface first-class rather than a
+    // shortcut: arriving at the panel must light its own entry, and arriving at
+    // Settings proper must not. Pinning BOTH directions is what stops the fix
+    // degrading into "Sovereignty is always lit".
+    const plain = renderSidebar('/settings')
+    await screen.findByTestId('sov-console-nav-settings')
+    expect(screen.getByTestId('sov-console-nav-settings').getAttribute('aria-current')).toBe('page')
+    expect(screen.getByTestId('sov-console-nav-sovereignty').getAttribute('aria-current')).toBeNull()
+    plain.unmount()
+
+    renderSidebar('/settings#sovereignty')
+    await screen.findByTestId('sov-console-nav-sovereignty')
+    expect(screen.getByTestId('sov-console-nav-sovereignty').getAttribute('aria-current')).toBe('page')
+    expect(screen.getByTestId('sov-console-nav-settings').getAttribute('aria-current')).toBeNull()
+  })
+
+  it('stays hidden on an Org-scoped console — the cutover is a sovereign-admin act', async () => {
+    // #4110: an Org-scoped customer session sees only its own estate. The
+    // cutover severs the whole Sovereign from the mothership, so exposing its
+    // trigger to a customer would be a worse defect than the one being fixed.
+    scopeMock.mockReturnValue({ orgScoped: true, org: 'walkone', loading: false })
+    renderSidebar()
+    await screen.findByTestId('sov-console-nav-apps')
+    expect(screen.queryByTestId('sov-console-nav-sovereignty')).toBeNull()
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/SovereignSidebar.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/SovereignSidebar.tsx
@@ -56,9 +56,15 @@ const CLOUD_ICON =
   'M6.657 18c-2.572 0 -4.657 -2.007 -4.657 -4.483c0 -2.475 2.085 -4.482 4.657 -4.482c.393 -1.762 1.794 -3.2 3.675 -3.773c1.88 -.572 3.956 -.193 5.444 1c1.488 1.19 2.162 3.007 1.77 4.769h.99c1.913 0 3.464 1.56 3.464 3.486c0 1.927 -1.551 3.487 -3.465 3.487h-11.878'
 
 interface FlatNavItem {
-  id: 'apps' | 'catalog' | 'sandbox' | 'jobs' | 'compliance' | 'dashboard' | 'cloud' | 'users' | 'organizations' | 'billing' | 'settings'
+  id: 'apps' | 'catalog' | 'sandbox' | 'jobs' | 'compliance' | 'dashboard' | 'cloud' | 'users' | 'organizations' | 'billing' | 'sovereignty' | 'settings'
   label: string
   to: string
+  /** Optional fragment appended to `to`. An entry that targets an anchor
+   *  SECTION of a page rather than a page carries it here so the rendered
+   *  href is `/page#anchor` and the operator lands ON the panel — landing at
+   *  the top of an eleven-section page is the state row 160 recorded as
+   *  failing, so the anchor is the substance of the entry, not decoration. */
+  hash?: string
   icon: string
 }
 
@@ -188,6 +194,34 @@ const FLAT_NAV: FlatNavItem[] = [
     to: '/billing',
     icon: 'M3 10h18M5 6h14a2 2 0 012 2v8a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2zm2 10h4',
   },
+  // Sovereignty (UAT row 160, #3379). The cutover is Pillar 5 — the single
+  // act that severs the eight mothership tethers — and until now its only
+  // reachable trigger was the LAST section of an eleven-section /settings
+  // page. The hw293-2026-08-10 walk enumerated this nav and got exactly
+  // eleven entries, none of them Sovereignty, while /sovereignty rendered
+  // "Not Found": the trigger existed but was not a surface.
+  //
+  // It is an ANCHOR entry, not a page. #793 deliberately mounted the cutover
+  // card as `<div id="sovereignty">` inside SettingsPage rather than giving it
+  // a route, so that the operator sees it in the context of the Sovereign's
+  // own configuration; duplicating it behind /sovereignty would give the
+  // cutover two front doors and two places for its state to disagree. The
+  // `hash` field carries the anchor so the rendered href is
+  // /settings#sovereignty and the entry lands ON the panel.
+  //
+  // RBAC: NOT in ORG_SCOPED_NAV_IDS. The cutover severs the whole Sovereign;
+  // exposing its trigger to an Org-scoped customer session would be a worse
+  // defect than the one this entry fixes.
+  //
+  // Icon: a shield-with-severed-link glyph in the single-stroke family — the
+  // same shield the Compliance entry uses, with the tether broken.
+  {
+    id: 'sovereignty',
+    label: 'Sovereignty',
+    to: '/settings',
+    hash: 'sovereignty',
+    icon: 'M12 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016A11.955 11.955 0 0112 2.944zM10 9.5l-1 1a2.121 2.121 0 003 3l1-1m1-1.5l1-1a2.121 2.121 0 00-3-3l-1 1',
+  },
 ]
 
 const SETTINGS_ITEM: FlatNavItem = {
@@ -223,11 +257,23 @@ const SETTINGS_ITEM: FlatNavItem = {
 
 // ── Active-state derivation ───────────────────────────────────────────────────
 
-type ActiveSection = 'apps' | 'catalog' | 'sandbox' | 'jobs' | 'compliance' | 'dashboard' | 'cloud' | 'users' | 'organizations' | 'billing' | 'settings'
+type ActiveSection = 'apps' | 'catalog' | 'sandbox' | 'jobs' | 'compliance' | 'dashboard' | 'cloud' | 'users' | 'organizations' | 'billing' | 'sovereignty' | 'settings'
 
 const CLOUD_PATH_RE = /^\/(cloud|infrastructure)(\/|$)/
 
-function deriveActiveSection(pathname: string): ActiveSection {
+/**
+ * @param pathname router location pathname
+ * @param hash     router location hash, with or without its leading `#`.
+ *   Two nav entries now share `/settings` — Settings and Sovereignty — so the
+ *   pathname alone can no longer decide which is active, and an entry that can
+ *   never light is not a first-class surface. The hash is the discriminator,
+ *   and it is normalised here because TanStack Router reports it without the
+ *   `#` while `location.hash` in the DOM includes it.
+ */
+function deriveActiveSection(pathname: string, hash = ''): ActiveSection {
+  const fragment = hash.replace(/^#/, '')
+  // Checked BEFORE the /settings rule below, which would otherwise swallow it.
+  if (/^\/settings(\/|$)/.test(pathname) && fragment === 'sovereignty') return 'sovereignty'
   if (CLOUD_PATH_RE.test(pathname)) return 'cloud'
   if (/^\/dashboard(\/|$)/.test(pathname)) return 'dashboard'
   // /catalog(/*) → 'catalog' (#3601) so the Catalog nav item highlights
@@ -266,7 +312,8 @@ function deriveActiveSection(pathname: string): ActiveSection {
 
 export function SovereignSidebar({ sovereignFQDN }: SovereignSidebarProps) {
   const pathname = useRouterState({ select: (s) => s.location.pathname })
-  const activeSection = deriveActiveSection(pathname)
+  const hash = useRouterState({ select: (s) => s.location.hash })
+  const activeSection = deriveActiveSection(pathname, hash)
 
   // #4110 — Org-console scoping. When the backend reports an Org-scoped
   // session (whoami.orgScoped), filter the nav to the Org-safe items only.
@@ -460,6 +507,17 @@ export function SovereignSidebar({ sovereignFQDN }: SovereignSidebarProps) {
             <Link
               key={item.id}
               to={item.to as never}
+              hash={item.hash as never}
+              // Two entries now share the `/settings` pathname, and TanStack's
+              // Link owns `aria-current` — it sets `page` from its OWN match,
+              // which by default ignores the fragment. Without this, Sovereignty
+              // reads as the current page while the operator is on plain
+              // /settings, and Settings reads as current while they are on the
+              // cutover panel: both entries announce themselves as the location
+              // at once. Scoped to entries that carry a hash (plus the pinned
+              // Settings entry below) rather than applied blanket, so no other
+              // nav entry changes its match semantics.
+              activeOptions={item.hash ? { includeHash: true } : undefined}
               className={`mx-2 flex items-center gap-3 rounded-lg px-3 py-2 text-sm no-underline transition-colors ${cls}`}
               data-testid={`sov-console-nav-${item.id}`}
               aria-current={isActive ? 'page' : undefined}
@@ -503,6 +561,9 @@ export function SovereignSidebar({ sovereignFQDN }: SovereignSidebarProps) {
           return (
             <Link
               to={SETTINGS_ITEM.to as never}
+              // The other half of the pair above: on /settings#sovereignty this
+              // entry must NOT claim to be the current page.
+              activeOptions={{ includeHash: true }}
               className={`mx-2 mt-0.5 flex items-center gap-3 rounded-lg px-3 py-2 text-sm no-underline transition-colors ${cls}`}
               data-testid={`sov-console-nav-${SETTINGS_ITEM.id}`}
               aria-current={isActive ? 'page' : undefined}


### PR DESCRIPTION
UAT row 160 asks the console nav **and** the Settings sidebar to expose a dedicated Sovereignty anchor (`#sovereignty`) that scrolls to **and highlights** the Cluster-sovereignty panel — "the cutover trigger is a first-class surface".

The hw293-2026-08-10 walk found one third of it holding. `settings-toc-sovereignty` rendered `Sovereignty` → `#sovereignty`, the target `id="sovereignty"` existed, and clicking it genuinely scrolled: the panel's bounding-box top moved **3055px → 896px**. Two halves failed.

## Failing half one — the console nav had no Sovereignty entry

Enumerating `sov-console-nav` on `/dashboard` returned exactly **eleven** entries and none of them was Sovereignty. So the Pillar-5 trigger — the single act that severs all eight mothership tethers — was reachable only by scrolling to the bottom of a twelve-section Settings page, which is the opposite of what the clause asks for.

### Red

```
$ npx vitest run src/pages/sovereign/SovereignSidebar.sovereignty-160.test.tsx
     × the console nav exposes a Sovereignty entry whose href carries the #sovereignty anchor 25ms
     × has its own testid so a walker can address it directly 1007ms
     × highlights on /settings#sovereignty and NOT on plain /settings 17ms
AssertionError: console nav exposed 11 entries and none was Sovereignty:
  Dashboard, Cloud, Apps, Catalog, Agenity, Jobs, Compliance, Users, Organizations, Billing, Settings
  expected +0 to be 1
 Test Files  1 failed (1)
      Tests  3 failed | 2 passed (5)
```

Eleven, and that exact label list, is what the browser walk reported — the test reproduces the live finding rather than approximating it.

**The control is the two that passed.** The failing half is an *absence*, and a zero is also what a broken selector returns. The walk handled this by finding `Sovereignty::#sovereignty` in the Settings TOC with the same text-and-href enumeration that returned zero for the nav; the first test does the same in miniature — it asserts the enumeration can read labels and hrefs (`Settings` → `/settings`, `Jobs` present) before the second test is allowed to mean anything.

### Green

```
$ npx vitest run src/pages/sovereign/SovereignSidebar.sovereignty-160.test.tsx
 Test Files  1 passed (1)
      Tests  5 passed (5)
```

### What changed

`FLAT_NAV` gains a `sovereignty` entry carrying a new optional `hash` field, so the rendered href is `/settings#sovereignty` and the entry lands **on** the panel. It is an anchor entry rather than a page on purpose: #793 deliberately mounted the cutover card inside `SettingsPage` instead of giving it a route, and standing up `/sovereignty` as a second mount would give the cutover two front doors and two places for its state to disagree.

It is deliberately **not** in `ORG_SCOPED_NAV_IDS`. The cutover severs the whole Sovereign; putting its trigger on an Org-scoped customer console would be a worse defect than the one being fixed. A fifth test pins that null.

One thing the edit site did not make obvious until it was measured: two entries now share the `/settings` pathname, and TanStack's `Link` owns `aria-current` from its **own** match, which ignores the fragment by default. Left alone, Sovereignty announced itself as the current page while the operator was on plain `/settings`, and Settings did the same on the cutover panel — both entries claiming to be the location at once. That is what the third red assertion caught. Fixed with `activeOptions={{ includeHash: true }}`, scoped to the two entries that share the path rather than applied blanket, so no other nav entry's match semantics move. Both directions are pinned, so the fix cannot degrade into "Sovereignty is always lit".

## Failing half two — nothing was highlighted on arrival

The walk recorded this in the most literal terms available: *"no highlight is applied on arrival — the target's class stays `scroll-mt-20` before and after the click"*.

### Red

```
$ npx vitest run src/pages/sovereign/SettingsPage.anchor-highlight-160.test.tsx
     × #sovereignty highlights the Cluster-sovereignty panel 1089ms
     × #dns highlights DNS and leaves sovereignty dark — the highlight follows the anchor 1071ms
AssertionError: expected null to be 'true'
AssertionError: expected null to be 'true'
 Test Files  1 failed (1)
      Tests  2 failed | 1 passed (3)
```

### Green

```
$ npx vitest run src/pages/sovereign/SettingsPage.anchor-highlight-160.test.tsx
 Test Files  1 passed (1)
      Tests  3 passed (3)
```

### What changed

`SettingsPage` now follows the fragment. The addressed section carries `data-anchor-highlighted="true"` plus a visible ring, and the page scrolls **explicitly**: a full page load with a fragment scrolls by itself, but a client-side navigation — which is exactly what the new nav entry performs — never reloads the document and so never fires the native anchor scroll.

**The discriminating control is the third test.** Highlighting whatever the fragment addresses is the feature; highlighting the sovereignty panel unconditionally would satisfy a naive assertion while being a different, worse behaviour. So `#dns` must light DNS and leave sovereignty dark, and the no-hash case must leave both dark. The `#sovereignty` assertion also checks the rendered class **value** rather than just the flag, because "the class stays `scroll-mt-20`" is precisely what was wrong.

## No regressions

```
$ npx vitest run
 Test Files  237 passed (237)
      Tests  2168 passed | 1 expected fail (2169)
```

`tsc -b --noEmit` reports one error, in `src/entities/deployment/model.ts` — a file this branch does not touch; it is pre-existing on `main`.

## Not done here, and why

`/sovereignty` still renders "Not Found". The walk noted it, but as corroboration that no dedicated route existed rather than as something the clause requires — the clause asks for the `#sovereignty` **anchor** on two surfaces, which is what this delivers. Adding a second URL for the same panel is a product call about how many front doors the cutover should have, and is not taken here.

## Delivery

Front-end only. No Go change, so this is unaffected by the stale mothership `catalyst-api` image; it lands with the next `catalyst-ui` build.

Refs #3379
