### PR TITLE
fix(bp-postgres): release 0.2.19 — #6021's fix was merged with no version bump, so it could not reach any Sovereign

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1364,7 +1364,7 @@ spec:
       #   StatefulSet came back 138s later. RBAC ships inside this umbrella, so
       #   the grant only reaches a Sovereign once this pin advances. Lockstep
       #   w/ products/catalyst/chart/Chart.yaml.
-      version: 1.4.1347
+      version: 1.4.1348
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/clusters/_template/bootstrap-kit/16a-bp-postgres-shared.yaml
+++ b/clusters/_template/bootstrap-kit/16a-bp-postgres-shared.yaml
@@ -167,7 +167,7 @@ spec:
       # instance's region-B replica stayed read-only for the whole outage (keycloak
       # unrecoverable in region-B) because ONLY bp-cnpg-pair shipped a promoter. sync-
       # only fence; autoPromote.hr.name above targets THIS HR. Lockstep 16a/16c/16d.
-      version: 0.2.18
+      version: 0.2.19
       sourceRef:
         kind: HelmRepository
         name: bp-postgres

--- a/clusters/_template/bootstrap-kit/16c-bp-postgres-shared-b.yaml
+++ b/clusters/_template/bootstrap-kit/16c-bp-postgres-shared-b.yaml
@@ -103,7 +103,7 @@ spec:
       # dr-promoter + failover-readiness + topology.promoted HR-value seam on the
       # active-hot-standby replica half (autoPromote.hr.name above targets THIS HR,
       # bp-postgres-shared-b). sync-only fence. Lockstep 16a/16c/16d.
-      version: 0.2.18
+      version: 0.2.19
       sourceRef:
         kind: HelmRepository
         name: bp-postgres

--- a/clusters/_template/bootstrap-kit/16d-bp-postgres-shared-c.yaml
+++ b/clusters/_template/bootstrap-kit/16d-bp-postgres-shared-c.yaml
@@ -91,7 +91,7 @@ spec:
       # dr-promoter + failover-readiness + topology.promoted HR-value seam on the
       # active-hot-standby replica half (autoPromote.hr.name above targets THIS HR,
       # bp-postgres-shared-c). sync-only fence. Lockstep 16a/16c/16d.
-      version: 0.2.18
+      version: 0.2.19
       sourceRef:
         kind: HelmRepository
         name: bp-postgres

--- a/platform/postgres/blueprint.yaml
+++ b/platform/postgres/blueprint.yaml
@@ -30,7 +30,7 @@ spec:
   # auto-promotes the survivor (keycloak et al. writable in region-B) instead of
   # leaving it pg_is_in_recovery()=t for the whole outage (hw292 G12). sync-only
   # data fence; default-OFF preserved for singleton/primary/async.
-  version: 0.2.18
+  version: 0.2.19
   card:
     title: PostgreSQL
     summary: |

--- a/platform/postgres/chart/Chart.yaml
+++ b/platform/postgres/chart/Chart.yaml
@@ -291,8 +291,8 @@ name: bp-postgres
 #   the singleton render is byte-identical to 0.2.9 (the ipBlock only rendered
 #   under crossRegion, which singletons never set). Lockstep slot pins 16a/16c/
 #   16d → 0.2.10. tests/postgres-render.sh Case 4e/4f added.
-version: 0.2.18
-appVersion: "0.1.2"
+version: 0.2.19
+appVersion: 0.2.19
 description: |
   Catalyst-authored data-instance Blueprint for a shareable, reusable
   PostgreSQL engine. Each install of bp-postgres = ONE

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-10T15:41:24.823Z",
+  "generatedAt": "2026-08-10T21:54:13.249Z",
   "blueprints": [
     {
       "id": "bp-agenity",
@@ -4083,7 +4083,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "listed",
-      "version": "0.2.18",
+      "version": "0.2.19",
       "section": "pts-4-1-data-services",
       "depends": [
         "bp-cnpg",

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -4218,7 +4218,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "listed",
-    "version": "0.2.18",
+    "version": "0.2.19",
     "section": "pts-4-1-data-services",
     "depends": [
       "bp-cnpg",

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3775,7 +3775,7 @@ name: bp-catalyst-platform
 #   138s later under a new uid. A ClusterRole is delivered only by the
 #   published umbrella, so the grant reaches a Sovereign only once this
 #   version advances. Lockstep w/ slot-13 pin.
-version: 1.4.1347
+version: 1.4.1348
 # 1.4.1229 — #5389: catalog-seed bp-newapi declares its `ui` endpoint
 #   (newapi.<fqdn>, ssoEnabled, launchDefault, ssoInitPath "/") instead of
 #   `endpoints: []`. The empty list made userUIGatePasses fail closed, which
@@ -3930,7 +3930,7 @@ version: 1.4.1347
 # scripts/check-chart-version-forward.sh (#5743) fails unless the two match —
 # main was carrying a pre-existing 1.4.1330/1.4.1329 split, so this bump heals
 # it in the same commit, exactly as the documented self-heal contract does.
-appVersion: 1.4.1347
+appVersion: 1.4.1348
 # 1.4.239 — Wave 3 / Issue #2140 (2026-05-23): Huawei provider
 # implementation lands behind the Wave 2 CloudProvider interface.
 # Adds the OpenTofu module at infra/providers/huawei/ (VPC + Subnet +

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5805,7 +5805,7 @@ spec:
   # 0.2.14 (#5473): replication-source Service selectorType r -> rw (primary only).
   # 0.2.18 (#5623): region-B AUTOMATIC DR promotion — ported bp-cnpg-pair dr-promoter
   # + failover-readiness + topology.promoted HR-value seam on the AHS replica half.
-  version: "0.2.18"
+  version: "0.2.19"
   visibility: listed
   # Shareability + Contexts (#3370) — seeded verbatim from
   # platform/postgres/blueprint.yaml (lockstep-guarded). One instance
@@ -5927,7 +5927,7 @@ spec:
     # 0.2.13 (#5224): role-secrets side-gate (replica-role region mints nothing).
     # 0.2.18 (#5623): region-B automatic DR promotion (dr-promoter + failover-readiness
     # + topology.promoted seam) on the active-hot-standby replica half.
-    version: "0.2.18"
+    version: "0.2.19"
   # Seeded verbatim from platform/postgres/blueprint.yaml spec.topology.
   # singleton = single-instance Cluster; active-hot-standby = sync
   # replication across regions (ADR-0004 Pillar-3 zero-tx-loss) via the


### PR DESCRIPTION
`cc011ba1e` (#6021) fixed the replica side naming a role Secret it never renders — and did **not** bump `version:`.

| | before |
|---|---|
| main's `platform/postgres/chart/Chart.yaml` | 0.2.18 |
| newest tag on ghcr | 0.2.18 |

So the fix was merged and undeliverable. UAT rows 67 and 69 carried the tag *"the fix is merged, it closes on a roll"* — a roll re-pulls the same 0.2.18 artifact, so that would never have come true.

The lockstep guards watch for a **partial** bump. This arrived through the one door they do not watch: a chart edit with **no version change at all**.

## What moves

bp-postgres 0.2.18 → 0.2.19 across its lockstep sites — chart `Chart.yaml` (which also reconciles the `appVersion: 0.1.2` drift), `blueprint.yaml`, bootstrap-kit slots 16a/16c/16d, and **both** catalog-seed pins: the display CARD version and the delivery `source.version`. The delivery pin is what Flux actually pulls; a card-only edit renders clean and ships nothing.

## Why the umbrella bump is deliberately absent

Two earlier revisions of this branch pinned the umbrella by hand and each was overtaken mid-review by the deploy-bot. Worse, **1.4.1335 had already published carrying the OLD 0.2.18 seed pin** — merging on that version would have pushed different content under a version already on ghcr, and the registry keeps the first push. The republish is left to the deploy-bot, which now works: `bump-chart-version.sh` was SIGPIPE-dying on any chart larger than the 64 KiB pipe buffer (fixed in #6050).

## Gates

- `check-bootstrap-kit-pin-sync.sh` — 67 chart→pin pairs, 0 drift
- `check-release-lockstep-writer.py` — all five sites converge

Refs #6021
