### PR TITLE
fix(console): the Topology tab returned before it ever read status.targets (UAT row 63)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.statusTargets-shadowed.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.statusTargets-shadowed.test.tsx
@@ -1,0 +1,186 @@
+/**
+ * TopologyTab.statusTargets-shadowed.test.tsx — UAT row 63 regression lock.
+ *
+ * Row 63 asserts an `active-hot-standby` Application renders its Primary +
+ * Standby pair on the Topology tab. On hw293 it rendered `Pattern: singleton`
+ * with a single region-A card and NO `topology-tab-dr-*` element at all —
+ * while the same page's Status panel read `Standby·Hot is reconciling`.
+ *
+ * Mechanism (TopologyTab.tsx, the `resolved` chain):
+ *
+ *   rung 1   /placement targets      → [] on this app
+ *   rung 2   spec.placement.targets  → absent (installed pre-#3969 shape)
+ *   rung 2b  status.perCluster       → [{cluster: <region-a>, role: 'singleton'}]
+ *            ...and this rung RETURNED, so
+ *   rung 2c  status.targets          → NEVER READ
+ *
+ * `status.perCluster` is an OBSERVATION of where workloads were seen; it has
+ * no standbyType, no vCluster, and a Standby whose Pods have not landed yet is
+ * simply absent from it. `status.targets` is the controller's own placement
+ * TARGET LIST and carried the correct pair on the very same object. So an
+ * incomplete observation shadowed the placement it is an observation OF, and
+ * the panel asserted `singleton` over data that said otherwise.
+ *
+ * The lock has two halves, and BOTH must hold:
+ *
+ *   • the AHS app renders Primary + Standby, `active-hot-standby`, and a DR
+ *     panel;
+ *   • the CONTROL — a genuine single-region app whose `status.targets` is
+ *     itself one Primary — still renders `singleton` with no DR panel. Without
+ *     that half this file would pass just as well against a change that
+ *     deleted the perCluster rung outright, or that made every app look
+ *     multi-region.
+ */
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest'
+import { render, screen, cleanup, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+const getApplicationStatus = vi.fn()
+const getCatalogItem = vi.fn()
+const getApplicationPlacement = vi.fn()
+const getHierarchicalInfrastructure = vi.fn()
+const getContinuumReplicationStatus = vi.fn()
+
+vi.mock('@/lib/catalog.api', () => ({
+  getApplicationStatus: (...a: unknown[]) => getApplicationStatus(...a),
+  getCatalogItem: (...a: unknown[]) => getCatalogItem(...a),
+  getApplicationPlacement: (...a: unknown[]) => getApplicationPlacement(...a),
+}))
+
+vi.mock('@/lib/continuum.api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/continuum.api')>()
+  return {
+    ...actual,
+    getContinuumReplicationStatus: (...a: unknown[]) => getContinuumReplicationStatus(...a),
+  }
+})
+
+vi.mock('@/lib/infrastructure.types', () => ({
+  getHierarchicalInfrastructure: (...a: unknown[]) => getHierarchicalInfrastructure(...a),
+}))
+
+vi.mock('@/widgets/topology/PlacementEditor', () => ({
+  PlacementEditor: () => <div data-testid="stub-placement-editor" />,
+}))
+
+import { TopologyTab } from './TopologyTab'
+
+function withProviders(node: React.ReactNode) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return <QueryClientProvider client={qc}>{node}</QueryClientProvider>
+}
+
+const REGION_A = 'hw-me-east-215-a-rtz-prod'
+const REGION_B = 'hw-me-east-215-b-rtz-prod'
+
+/**
+ * The hw293 shape, verbatim in structure: NO spec.placement, a perCluster
+ * observation that saw only region-A, and a status.targets that carries the
+ * real Primary + Standby·Hot pair.
+ */
+const AHS_APP_STATUS_TARGETS_ONLY = {
+  name: 'shared-pg',
+  namespace: 'shared-data',
+  spec: {},
+  status: {
+    perCluster: [{ cluster: REGION_A, role: 'singleton' }],
+    targets: [
+      { region: REGION_A, cluster: REGION_A, role: 'Primary' },
+      { region: REGION_B, cluster: REGION_B, role: 'Standby', standbyType: 'Hot' },
+    ],
+  },
+}
+
+/**
+ * THE CONTROL. A genuine singleton: one cluster observed, and a status.targets
+ * that agrees it is one Primary. This must keep rendering `singleton` with no
+ * DR panel — the fix has to DISCRIMINATE, not blanket-promote every app to a
+ * pair.
+ */
+const GENUINE_SINGLETON = {
+  name: 'marketing-site',
+  namespace: 'acme-prod',
+  spec: {},
+  status: {
+    perCluster: [{ cluster: REGION_A, role: 'singleton' }],
+    targets: [{ region: REGION_A, cluster: REGION_A, role: 'Primary' }],
+  },
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  // Rung 1 answers EMPTY — the hw293 condition that opens the fallback chain.
+  getApplicationPlacement.mockResolvedValue({ targets: [], derivedFromRuntime: true })
+  getCatalogItem.mockResolvedValue({ name: 'bp-postgres', placementCapability: 'active-hot-standby' })
+  getHierarchicalInfrastructure.mockResolvedValue({ regions: [] })
+  // No live Continuum backing — so the DR panel's presence is decided purely
+  // by the placement pair, which is the thing under test.
+  getContinuumReplicationStatus.mockResolvedValue({ source: 'pending' })
+})
+
+afterEach(() => cleanup())
+
+describe('row 63 — status.targets must not be shadowed by a poorer perCluster observation', () => {
+  it('renders the Primary + Standby pair when perCluster saw only one region', async () => {
+    getApplicationStatus.mockResolvedValue(AHS_APP_STATUS_TARGETS_ONLY)
+    render(
+      withProviders(
+        <TopologyTab sovereignId="dep-1" applicationName="shared-pg" namespace="shared-data" />,
+      ),
+    )
+
+    // Assert on the VALUE, not on the element existing: the pattern chip is
+    // present from first paint carrying `not reported`, so an element-presence
+    // assertion here would pass on nothing.
+    await waitFor(() =>
+      expect(screen.getByTestId('topology-tab-pattern').textContent).toContain('active-hot-standby'),
+    )
+    expect(screen.getByTestId('topology-tab-pattern').textContent).not.toContain('singleton')
+
+    const cards = await screen.findByTestId('topology-tab-target-cards')
+    expect(cards.textContent).toContain(REGION_A)
+    expect(cards.textContent).toContain(REGION_B)
+
+    // The DR panel is gated on the placement carrying a Standby. Its absence
+    // was the other half of the row-63 failure.
+    await waitFor(() => expect(screen.getByTestId('topology-tab-dr-panel')).toBeTruthy())
+  })
+
+  it('CONTROL — a genuine single-target app still renders singleton and no DR panel', async () => {
+    getApplicationStatus.mockResolvedValue(GENUINE_SINGLETON)
+    render(
+      withProviders(
+        <TopologyTab sovereignId="dep-1" applicationName="marketing-site" namespace="acme-prod" />,
+      ),
+    )
+
+    await waitFor(() =>
+      expect(screen.getByTestId('topology-tab-pattern').textContent).toContain('singleton'),
+    )
+
+    const cards = await screen.findByTestId('topology-tab-target-cards')
+    expect(cards.textContent).toContain(REGION_A)
+    expect(cards.textContent).not.toContain(REGION_B)
+
+    expect(screen.queryByTestId('topology-tab-dr-panel')).toBeNull()
+  })
+
+  it('CONTROL — perCluster still answers when status.targets is absent', async () => {
+    // #5420 must survive: with no status.targets, the perCluster observation is
+    // still the rung that answers, ahead of the legacy mode+regions projection
+    // that fabricates a Standby card for a region holding nothing.
+    getApplicationStatus.mockResolvedValue({
+      name: 'alloy',
+      namespace: 'alloy',
+      spec: { regions: [REGION_A, REGION_B], placement: 'active-hot-standby' },
+      status: { perCluster: [{ cluster: REGION_A, role: 'singleton' }] },
+    })
+    render(withProviders(<TopologyTab sovereignId="dep-1" applicationName="alloy" namespace="alloy" />))
+
+    await waitFor(() =>
+      expect(screen.getByTestId('topology-tab-pattern').textContent).toContain('singleton'),
+    )
+    const cards = await screen.findByTestId('topology-tab-target-cards')
+    expect(cards.textContent).not.toContain(REGION_B)
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.tsx
@@ -279,7 +279,38 @@ export function TopologyTab({
     // Legacy fallback: project from status.targets (recon rollup), else
     // from the legacy mode + regions.
     const status = (app?.status ?? {}) as Record<string, unknown>
-    // 2b. #5420 — EFFECTIVE per-cluster state, ahead of any projection from
+    // 2b. status.targets — the controller's own placement TARGET LIST.
+    //
+    //     #5420 put the `status.perCluster` projection ahead of the LEGACY
+    //     `mode + regions` fabrication, and that ordering is still right (see
+    //     2c below). But the rung it was placed ahead of was not the only one
+    //     underneath it: `status.targets` sat below the perCluster rung too,
+    //     and the perCluster rung RETURNS. So a perCluster observation that
+    //     saw one cluster shadowed a status.targets that named two — and the
+    //     panel printed `singleton` over data on the SAME object that said
+    //     active-hot-standby (UAT row 63, hw293: one region-A card, no DR
+    //     block, while the Status panel beside it read "Standby·Hot is
+    //     reconciling").
+    //
+    //     These two fields are not the same kind of thing:
+    //       • status.targets   — the placement, per target, with role AND
+    //         standbyType. Written by the controller from the desired
+    //         placement.
+    //       • status.perCluster — an OBSERVATION of clusters where workloads
+    //         were seen. Its role vocabulary is primary/active/singleton only;
+    //         it carries no standbyType and no vCluster, and a Standby whose
+    //         Pods have not landed yet is simply ABSENT from it.
+    //
+    //     An incomplete observation must not overwrite the placement it is an
+    //     observation OF. So targets is read first, and perCluster remains the
+    //     answer whenever targets is absent or empty. Both rungs are labelled
+    //     `declared` either way, so this changes WHICH declared source is
+    //     rendered, never whether a declared source is passed off as observed.
+    const statusTargetsFirst = status.targets
+    if (Array.isArray(statusTargetsFirst) && statusTargetsFirst.length > 0) {
+      return declared(statusTargetsFirst as PlacementTarget[])
+    }
+    // 2c. #5420 — EFFECTIVE per-cluster state, ahead of any projection from
     //     the DECLARED posture. `status.perCluster` says where this app's
     //     workloads were actually observed; the legacy `mode + regions`
     //     projection below maps over every DECLARED region and therefore
@@ -324,10 +355,6 @@ export function TopologyTab({
         })
         .filter((t): t is PlacementTarget => t !== null)
       if (effective.length > 0) return declared(effective)
-    }
-    const statusTargets = status.targets
-    if (Array.isArray(statusTargets) && statusTargets.length > 0) {
-      return declared(statusTargets as PlacementTarget[])
     }
     const statusRegions = (status.regions ?? []) as RegionStatus[]
     // status.placement is an OBJECT on a real (#3373/#3969) controller; only


### PR DESCRIPTION
UAT row 63 on hw293: an active-hot-standby Application rendered
`Pattern: singleton` with one region-A card and NO topology-tab-dr-* element
at all, while the Status panel beside it read "Standby Hot is reconciling".

The placement resolver in TopologyTab walks a fallback chain. `/placement`
answered `targets: []`, `spec.placement` was absent, so it reached the
`status.perCluster` rung -- which found a single `singleton` entry and
RETURNED. The rung below it, `status.targets`, carried the correct Primary +
Standby Hot pair on the same object and was never read.

The two fields are not the same kind of thing. `status.targets` is the
placement: one entry per target, with role AND standbyType. `status.perCluster`
is an OBSERVATION of clusters where workloads were seen -- its role vocabulary
is primary/active/singleton only, it carries no standbyType and no vCluster,
and a Standby whose Pods have not landed yet is simply ABSENT from it. So an
incomplete observation was overwriting the placement it is an observation OF.

#5420 put perCluster ahead of the legacy `mode + regions` projection, and that
ordering is still right -- that projection maps over every DECLARED region and
fabricates a Standby card for a region that may hold nothing. What #5420 did
not account for is that `status.targets` was underneath perCluster as well, and
perCluster returns. So `status.targets` moves above it; perCluster remains the
answer whenever targets is absent or empty. Both rungs are labelled `declared`
either way, so this changes WHICH declared source renders, never whether a
declared source is passed off as observed (#5568).

Knock-on, and the reason the row could not be evaluated rather than merely read
wrong: `hasStandby` derives from the resolved targets and `showDR = hasStandby
|| hasLiveDR`, so the false singleton suppressed the entire DR section.

Guard: TopologyTab.statusTargets-shadowed.test.tsx renders the real component
against the hw293 shape, and carries two controls that must stay green so the
fix is shown to discriminate rather than to disable the perCluster rung.

  RED (pre-fix, all three cases in one run):
    x renders the Primary + Standby pair when perCluster saw only one region
        AssertionError: expected 'singleton' to contain 'active-hot-standby'
    v CONTROL - a genuine single-target app still renders singleton, no DR panel
    v CONTROL - perCluster still answers when status.targets is absent
    Tests  1 failed | 2 passed (3)

  GREEN (post-fix, whole AppDetail suite incl. the #5420 / #5934 / #5945 /
  dr-honesty locks):
    Test Files  15 passed (15)
         Tests  111 passed (111)

Front-end only -- rides the next catalyst-ui build; no image roll of any Go
component is required.

Refs #6060 #3375 #5420 #5568 #960

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
