### PR TITLE
fix(handover): make the secondary-kubeconfig forward-client seam safe to swap concurrently

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/deployment_handover_export.go
+++ b/products/catalyst/bootstrap/api/internal/handler/deployment_handover_export.go
@@ -500,7 +500,9 @@ func (h *Handler) reforwardSecondaryKubeconfigsToChild(dep *Deployment) {
 		return
 	}
 	url := "https://api." + fqdn + "/api/v1/sovereign/secondary-kubeconfig"
-	client := secondaryKubeconfigForwardClient()
+	// #6058 — resolve the seam through its guarded accessor; a test's
+	// t.Cleanup restore can land while this loop is mid-tick.
+	client := currentSecondaryKubeconfigForwardClient()
 	for _, regionKey := range keys {
 		path := filepath.Join(dir, depID+"-"+regionKey+".yaml")
 		raw, err := os.ReadFile(path)

--- a/products/catalyst/bootstrap/api/internal/handler/secondary_kubeconfig_coverage_6015_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/secondary_kubeconfig_coverage_6015_test.go
@@ -593,11 +593,12 @@ func TestSecondaryKubeconfigDelivery_DeclinesSingleRegion_6015(t *testing.T) {
 // in the production loop).
 func withChrootForwardClient(t *testing.T, srv *httptest.Server) {
 	t.Helper()
-	prev := secondaryKubeconfigForwardClient
-	secondaryKubeconfigForwardClient = func() *http.Client {
+	// #6058 — swap through the guarded accessor. A plain assign here raced
+	// the detached runSecondaryKubeconfigDelivery goroutine this suite
+	// spawns, which reads the same var every tick.
+	t.Cleanup(swapSecondaryKubeconfigForwardClient(func() *http.Client {
 		return &http.Client{Timeout: 5 * time.Second, Transport: newRoundTripperToServer(srv)}
-	}
-	t.Cleanup(func() { secondaryKubeconfigForwardClient = prev })
+	}))
 }
 
 func waitForRegionPost(chroot *fakeChrootServer, region string, budget time.Duration) bool {

--- a/products/catalyst/bootstrap/api/internal/handler/secondary_kubeconfig_forward_client.go
+++ b/products/catalyst/bootstrap/api/internal/handler/secondary_kubeconfig_forward_client.go
@@ -1,0 +1,70 @@
+// secondary_kubeconfig_forward_client.go — #6058.
+//
+// `secondaryKubeconfigForwardClient` (deployment_handover_export.go) is the
+// test seam that lets the #6015 suite drive the REAL
+// reforwardSecondaryKubeconfigsToChild / runSecondaryKubeconfigDelivery
+// against an httptest server instead of re-implementing the production loop.
+// Keeping that seam is right — a test that re-implements the loop cannot fail
+// on a defect in the loop.
+//
+// What was wrong is that it was a PLAIN package var, written by one goroutine
+// and read by another with nothing in between:
+//
+//	WRITE  withChrootForwardClient's t.Cleanup restore, on the test goroutine
+//	READ   reforwardSecondaryKubeconfigsToChild's
+//	       `client := secondaryKubeconfigForwardClient()`, on the detached
+//	       runSecondaryKubeconfigDelivery goroutine the #6015 tests spawn
+//
+// The #6015 tests ask that goroutine to stop (dep.Status = "wiped") but never
+// observe it stopping, so the restore can land mid-tick. Caught by the
+// required `test` gate on two branches whose diffs touch neither participant
+// (PR #6053 run 31419094457; PR #6051 run 31425591597, which also took
+// TestMarkPhase1Done_FailedOutcomeStillStartsDelivery_6015 down with it).
+//
+// Waiting longer in the test was tried on #6053 and reverted: each tick POSTs
+// once per region through postSecondaryKubeconfigWithRetry, so a bounded wait
+// converts a rare flake into a deterministic timeout. The seam itself has to
+// be safe to read while another goroutine swaps it — which is what these two
+// helpers provide, at the cost of one uncontended RLock per delivery tick
+// (the loop runs every 5 minutes in production).
+//
+// Every access to the var now goes through here.
+package handler
+
+import (
+	"net/http"
+	"sync"
+)
+
+// secondaryKubeconfigForwardClientMu guards secondaryKubeconfigForwardClient.
+// RWMutex rather than atomic.Value because the seam holds a func value and
+// tests swap it to a closure over their httptest server.
+var secondaryKubeconfigForwardClientMu sync.RWMutex
+
+// currentSecondaryKubeconfigForwardClient resolves the seam and builds a
+// client. This is the ONLY read path; reforwardSecondaryKubeconfigsToChild
+// calls it once per pass.
+func currentSecondaryKubeconfigForwardClient() *http.Client {
+	secondaryKubeconfigForwardClientMu.RLock()
+	build := secondaryKubeconfigForwardClient
+	secondaryKubeconfigForwardClientMu.RUnlock()
+	return build()
+}
+
+// swapSecondaryKubeconfigForwardClient installs a new builder and returns the
+// restore func. This is the ONLY write path — tests must use it rather than
+// assigning the var, so the write is ordered against a concurrent read.
+//
+// The returned restore is safe to call from a t.Cleanup while the delivery
+// goroutine is still running.
+func swapSecondaryKubeconfigForwardClient(build func() *http.Client) func() {
+	secondaryKubeconfigForwardClientMu.Lock()
+	prev := secondaryKubeconfigForwardClient
+	secondaryKubeconfigForwardClient = build
+	secondaryKubeconfigForwardClientMu.Unlock()
+	return func() {
+		secondaryKubeconfigForwardClientMu.Lock()
+		secondaryKubeconfigForwardClient = prev
+		secondaryKubeconfigForwardClientMu.Unlock()
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/secondary_kubeconfig_forward_client_race_6058_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/secondary_kubeconfig_forward_client_race_6058_test.go
@@ -1,0 +1,125 @@
+// secondary_kubeconfig_forward_client_race_6058_test.go — #6058.
+//
+// `secondaryKubeconfigForwardClient` is a plain package-level var. It is
+// WRITTEN by withChrootForwardClient's t.Cleanup restore
+// (secondary_kubeconfig_coverage_6015_test.go) and READ by
+// reforwardSecondaryKubeconfigsToChild, which runs on the detached
+// runSecondaryKubeconfigDelivery goroutine the #6015 tests spawn. Nothing
+// synchronises the two.
+//
+// The #6015 tests signal that goroutine to stop (dep.Status = "wiped") but
+// never observe it stopping, so the restore can land while the loop is
+// mid-tick. That reds the required `test` gate intermittently — twice
+// caught in CI on branches whose diffs touch neither participant:
+//
+//	PR #6053, run 31419094457:
+//	  WARNING: DATA RACE
+//	  Write ... withChrootForwardClient.func2()
+//	      secondary_kubeconfig_coverage_6015_test.go:600
+//	  Previous read ... reforwardSecondaryKubeconfigsToChild()
+//	      deployment_handover_export.go:503
+//	  --- FAIL: TestSecondaryKubeconfigDelivery_RunsOnFailedDeployment_6015
+//	      race detected during execution of test
+//
+//	PR #6051, run 31425591597: the same, plus
+//	  --- FAIL: TestMarkPhase1Done_FailedOutcomeStillStartsDelivery_6015
+//
+// The failure is timing-dependent, so it does not reproduce from the #6015
+// tests alone — it needs the full package under -race and load. This guard
+// makes it DETERMINISTIC by exercising the same write/read pair directly:
+// it fails on every run under -race before the fix, and passes after.
+//
+// Fixing by "waiting longer" in the #6015 test was tried and reverted on
+// #6053: each loop tick POSTs once per region through
+// postSecondaryKubeconfigWithRetry, so a bounded wait turns a rare flake
+// into a deterministic timeout. The seam itself has to be safe to read
+// while another goroutine swaps it, which is what this guards.
+package handler
+
+import (
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestSecondaryKubeconfigForwardClientSeam_IsRaceFree drives the exact
+// write/read pair from the CI stack trace concurrently. Under -race this
+// FAILS on the unsynchronised package var and PASSES once the seam is
+// accessed through its mutex-guarded helpers.
+func TestSecondaryKubeconfigForwardClientSeam_IsRaceFree(t *testing.T) {
+	restore := swapSecondaryKubeconfigForwardClient(func() *http.Client {
+		return &http.Client{Timeout: time.Second}
+	})
+	t.Cleanup(restore)
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	// The READER — stands in for reforwardSecondaryKubeconfigsToChild's
+	// `client := secondaryKubeconfigForwardClient()` on the detached
+	// delivery goroutine.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			if c := currentSecondaryKubeconfigForwardClient(); c == nil {
+				t.Error("forward-client seam resolved to a nil *http.Client")
+				return
+			}
+		}
+	}()
+
+	// The WRITER — stands in for withChrootForwardClient's cleanup restore
+	// firing while that goroutine is still mid-tick.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 2000; i++ {
+			undo := swapSecondaryKubeconfigForwardClient(func() *http.Client {
+				return &http.Client{Timeout: 2 * time.Second}
+			})
+			undo()
+		}
+	}()
+
+	// Let the writer finish, then stop the reader.
+	done := make(chan struct{})
+	go func() { wg.Wait(); close(done) }()
+	time.Sleep(150 * time.Millisecond)
+	close(stop)
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("seam race guard did not converge")
+	}
+}
+
+// TestSecondaryKubeconfigForwardClientSeam_SwapRestoresPrevious is the
+// CONTROL: the swap helper must still behave like the plain assignment it
+// replaces, or every #6015 test that relies on the seam silently stops
+// binding to its httptest server and starts hitting the real network.
+func TestSecondaryKubeconfigForwardClientSeam_SwapRestoresPrevious(t *testing.T) {
+	marker := &http.Client{Timeout: 4321 * time.Millisecond}
+
+	before := currentSecondaryKubeconfigForwardClient()
+	restore := swapSecondaryKubeconfigForwardClient(func() *http.Client { return marker })
+
+	if got := currentSecondaryKubeconfigForwardClient(); got != marker {
+		t.Fatalf("swap did not take effect: the seam still resolves to %p, want the injected %p", got, marker)
+	}
+
+	restore()
+	after := currentSecondaryKubeconfigForwardClient()
+	if after == marker {
+		t.Fatalf("restore did not undo the swap — the injected client is still live")
+	}
+	if after.Timeout != before.Timeout {
+		t.Fatalf("restore returned a different client shape: timeout %v, want %v", after.Timeout, before.Timeout)
+	}
+}


### PR DESCRIPTION
Refs #6058

The required `test` gate goes red intermittently on a data race that has nothing to do with the branch under test. Caught twice today, on two branches whose diffs touch neither participant:

- PR #6053, run `31419094457` — `TestSecondaryKubeconfigDelivery_RunsOnFailedDeployment_6015`
- PR #6051, run `31425591597` — the same, plus `TestMarkPhase1Done_FailedOutcomeStillStartsDelivery_6015`

```
WARNING: DATA RACE
Write at 0x00000685a840 by goroutine 10422:
  handler.withChrootForwardClient.func2()
      secondary_kubeconfig_coverage_6015_test.go:600
  testing.(*common).Cleanup.func1()

Previous read at 0x00000685a840 by goroutine 10424:
  handler.reforwardSecondaryKubeconfigsToChild()
      deployment_handover_export.go:503
  handler.runSecondaryKubeconfigDelivery()
      deployment_handover_export.go:627
```

## Root cause

`secondaryKubeconfigForwardClient` (`deployment_handover_export.go:474`) is a plain package-level var. It is the seam that lets the #6015 suite drive the **real** delivery loop against an httptest server — worth keeping, because a test that re-implements the loop cannot fail on a defect in the loop. What was wrong is that nothing ordered its two accessors:

| | who | where |
|---|---|---|
| **write** | `withChrootForwardClient`'s `t.Cleanup` restore | test goroutine |
| **read** | `client := secondaryKubeconfigForwardClient()` | the detached `runSecondaryKubeconfigDelivery` goroutine |

The #6015 tests launch that goroutine with a 5ms tick and ask it to stop by setting `dep.Status = "wiped"`, but never observe it stopping. Cleanups run LIFO, so the restore executes right after the signal — while the loop may still be mid-tick.

## Why "wait for the goroutine" is not the fix

Tried on #6053 and reverted. Adding a bounded wait to the test makes shutdown deterministic but not *prompt*: each tick calls `reforwardSecondaryKubeconfigsToChild`, which POSTs once per region through `postSecondaryKubeconfigWithRetry`, so a two-region fixture can consume the whole budget before the loop re-checks `Status`. It converted a rare flake into a deterministic red:

```
--- FAIL: TestSecondaryKubeconfigDelivery_RunsOnFailedDeployment_6015 (10.01s)
    runSecondaryKubeconfigDelivery did not exit after Status=wiped —
    the goroutine outlives the test and races the forward-client restore
```

Reproduced identically locally and in CI (run `31420480951`). The seam itself has to be safe to read while another goroutine swaps it.

## The fix

`internal/handler/secondary_kubeconfig_forward_client.go` (new) — an `RWMutex` and the only two accessors:

- `currentSecondaryKubeconfigForwardClient()` — the sole read path, used by `reforwardSecondaryKubeconfigsToChild`
- `swapSecondaryKubeconfigForwardClient(build)` — the sole write path, returning a restore func that is safe to call from a `t.Cleanup` while the delivery goroutine is still running

Cost is one uncontended `RLock` per delivery tick; the loop runs every 5 minutes in production (`secondaryKubeconfigDeliveryIntervalDefault`). No behavioural change to the delivery loop, its retry budget, or its stop condition.

## Guard — watched failing first

The CI failure is timing-dependent and does not reproduce from the #6015 tests alone (3/3 clean in isolation on `main`; a full-package `-race` run on clean `main` failed on an unrelated network-dependent test instead). So the guard makes the latent race **deterministic** by driving the exact write/read pair from the stack trace concurrently.

RED — against the unsynchronised seam, on every run:

```
WARNING: DATA RACE
  handler.currentSecondaryKubeconfigForwardClient()
  handler.TestSecondaryKubeconfigForwardClientSeam_IsRaceFree.func2()
  handler.swapSecondaryKubeconfigForwardClient.2()
  handler.TestSecondaryKubeconfigForwardClientSeam_IsRaceFree.func3()
--- FAIL: TestSecondaryKubeconfigForwardClientSeam_IsRaceFree (0.15s)
FAIL
```

GREEN — with the fix, `-count=3`:

```
ok  	.../internal/handler	1.549s
```

And the family the gate was tripping on:

```
go test ./internal/handler/ -race -run 'TestSecondaryKubeconfigDelivery|TestMarkPhase1Done' -count=1
ok  	.../internal/handler	5.520s
```

### Control

`TestSecondaryKubeconfigForwardClientSeam_SwapRestoresPrevious` asserts the guarded swap still behaves like the plain assignment it replaces — the injected client takes effect, and `restore()` puts the original back with its original shape. Without it, a "fix" that made `swap` a no-op would pass the race guard while silently unbinding every #6015 test from its httptest server and pointing it at the real network.

## Gates

```
go vet ./internal/handler/    clean
gofmt -l <touched files>      clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
