### PR TITLE
fix(clustermesh): re-base the shared-pg hub readiness gate on the replica's mesh alias, not a substring of the source host

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/clustermesh.go
+++ b/products/catalyst/bootstrap/api/internal/handler/clustermesh.go
@@ -186,7 +186,7 @@ const (
 	// durable fix routes peers to the clustermesh-proxy host-socket on a
 	// dedicated non-2379 port (bp-cilium clustermesh-proxy DaemonSet) via
 	// this override; Hetzner keeps the default 2379 behind hcloud-ccm.
-	clusterMeshAPIServerPort    = 2379
+	clusterMeshAPIServerPort = 2379
 	// clusterMeshProxyDialPort — the bp-cilium clustermesh-proxy DaemonSet
 	// hostPort (#4784). On a no-CCM cloud (Huawei/kom4dc) there is no real
 	// LoadBalancer: the clustermesh-apiserver Service's ingress IP is the
@@ -640,6 +640,145 @@ func sharedPGConsumerCredentialFingerprint(s *corev1.Secret) string {
 // replica) during the brief window before region-A's own slot-16{a,c,d} upgrade
 // lands. Single-region / pre-flip hubs carry `-rw` and are correctly skipped.
 const sharedPGMeshRWHostMarker = "-mesh-rw."
+
+// sharedPGLocalRWHostLabelSuffix / sharedPGMeshRWServiceSuffix / ciliumGlobalServiceAnnotation
+// — the pieces of the #6072 host REWRITE that replaced the string-proxy
+// readiness gate above.
+//
+// WHY THE STRING PROXY WAS NOT A READINESS SIGNAL (hw293, dep a0077ba47e3720e5,
+// measured 2026-08-11):
+//
+// The gate's premise is "a `host` without `-mesh-rw` means region-A has not
+// rendered the mesh alias yet, so the alias cannot resolve on the replica."
+// That premise is FALSE, and the two halves are wired to different signals:
+//
+//   - The mesh alias SERVICE renders on `bp-postgres.meshAliasesActive` —
+//     clusterMesh.enabled AND both `topology.primary.region` and
+//     `topology.replica.region` non-empty. #4460 DELIBERATELY decoupled it from
+//     `activeHotStandby` precisely so the alias exists BEFORE the flip.
+//   - The hub Secret's `host` renders on `bp-postgres.activeHotStandby` —
+//     `topology.crossRegion`, which the bootstrap-kit slots wire to
+//     `${SOVEREIGN_ENABLE_CNPG_PAIR}`, patched ONLY by enableCNPGPairAfterFullMesh.
+//
+// role-secrets.yaml never received #4460's decoupling. So the `host` string
+// turns `-mesh-rw` at the cnpg-pair flip — the very flip #5230 hoisted this
+// sync OUT of. The hoist is therefore INERT: the sync runs early and defers
+// 100% of its Secrets until the flip happens anyway, and if the flip never
+// happens the deferral is PERMANENT. Measured on hw293: all three region-A
+// CNPG clusters healthy at 1 instance, all nine hub Secrets carrying
+// `shared-pg{,-b,-c}-rw.shared-data.svc.cluster.local`, region-B holding 0 of
+// 13 hub Secrets while holding all 12 CNPG-operator-minted ones — and
+// `keycloak-0` in region-B stuck `Init:0/1` on
+// `MountVolume.SetUp failed … secret "keycloak-database-secret" not found`,
+// 232 occurrences over 7h38m. All six `-mesh-rw` Services existed in BOTH
+// regions the whole time.
+//
+// WHAT THE GATE ACTUALLY WANTS is a real property, and it is worth keeping:
+// never hand the replica a write host that does not route there. The
+// region-local `<instance>-rw` Service is exactly that hazard — on hw293
+// region-B's `shared-pg-rw` exists with ZERO endpoints, so a pushed `-rw` host
+// resolves to a black hole. But that question is answerable directly, on the
+// replica, from positive evidence: does the replica publish the mesh-global
+// `<instance>-mesh-rw` alias? On hw293 it does — a zero-backend stub annotated
+// `service.cilium.io/global: "true"`, which Cilium merges with region-A's
+// backed alias so writes cross the mesh to the primary (region-A's carries the
+// only endpoint, 10.42.5.35).
+//
+// So a `-rw` source is no longer DEFERRED — it is REWRITTEN onto the alias the
+// replica provably publishes, and only then propagated. The credential itself
+// (which after #5224/#5228 the replica can never mint for itself) is copied
+// byte-for-byte from region-A; only the host is rewritten, and only to a name
+// the replica already resolves.
+const (
+	// sharedPGLocalRWHostLabelSuffix — the first DNS label of the region-LOCAL
+	// write host role-secrets.yaml renders pre-flip (`<instance>-rw`).
+	sharedPGLocalRWHostLabelSuffix = "-rw"
+	// sharedPGMeshRWServiceSuffix — the ClusterMesh-global write alias
+	// bp-postgres publishes (`<instance>-mesh-rw`, see
+	// `bp-postgres.writeServiceName`).
+	sharedPGMeshRWServiceSuffix = "-mesh-rw"
+	// (The ClusterMesh-global marker itself is ciliumGlobalServiceAnnotation,
+	// already declared in org_app_surface_mesh.go — its presence WITH value
+	// "true" on the replica's alias is the positive evidence that a rewritten
+	// host routes cross-mesh rather than into a region-local black hole.)
+)
+
+// meshRWHostRewrite maps a region-LOCAL shared-pg write host
+// (`<instance>-rw.<ns>.svc.cluster.local`) onto its ClusterMesh-global alias
+// (`<instance>-mesh-rw.<ns>.svc.cluster.local`), returning the rewritten host,
+// the bare alias Service name, and whether the input was in the local-rw shape
+// at all.
+//
+// ok=false for anything that is not that exact shape — an empty host, a host
+// with no domain part, a host whose first label does not end in `-rw`, or a
+// host that is ALREADY a `-mesh-rw` alias (guarded so a caller that skips the
+// marker check can never produce `<instance>-mesh-mesh-rw`). Callers DEFER on
+// ok=false, which keeps every non-shared-pg / unrecognised host on the
+// pre-#6072 behaviour.
+func meshRWHostRewrite(host string) (meshHost string, aliasName string, ok bool) {
+	label, domain, found := strings.Cut(host, ".")
+	if !found || domain == "" {
+		return "", "", false
+	}
+	instance, cut := strings.CutSuffix(label, sharedPGLocalRWHostLabelSuffix)
+	if !cut || instance == "" {
+		return "", "", false
+	}
+	// Already a mesh alias (`<instance>-mesh-rw`) — not a local-rw host, and
+	// rewriting it again would fabricate `<instance>-mesh-mesh-rw`.
+	if strings.HasSuffix(instance, "-mesh") {
+		return "", "", false
+	}
+	alias := instance + sharedPGMeshRWServiceSuffix
+	return alias + "." + domain, alias, true
+}
+
+// rewriteHubSecretHost returns a DEEP COPY of src with every value that embeds
+// oldHost re-pointed at newHost. It rewrites by VALUE, not by key name, so it
+// covers the whole connection contract role-secrets.yaml assembles — `host`,
+// the `uri` that embeds it, and any `reflect.hostKeys` / `hostPortKeys`
+// (`<host>:5432`) a binding declares — without this function needing to know
+// their names. Credential-bearing values (password, username, dbname) never
+// contain the host, so they are copied through untouched and region-A stays
+// the single source of truth for them.
+func rewriteHubSecretHost(src *corev1.Secret, oldHost, newHost string) *corev1.Secret {
+	out := src.DeepCopy()
+	oldB, newB := []byte(oldHost), []byte(newHost)
+	for k, v := range out.Data {
+		if bytes.Contains(v, oldB) {
+			out.Data[k] = bytes.ReplaceAll(v, oldB, newB)
+		}
+	}
+	for k, v := range out.StringData {
+		if strings.Contains(v, oldHost) {
+			out.StringData[k] = strings.ReplaceAll(v, oldHost, newHost)
+		}
+	}
+	return out
+}
+
+// replicaPublishesMeshAlias reports whether the replica cluster publishes
+// `alias` in `namespace` as a ClusterMesh-GLOBAL Service — the positive
+// evidence that a host rewritten onto that alias will resolve and route to the
+// current primary from this replica.
+//
+// A missing Service reads as (false, nil): not ready, defer and let the
+// level-triggered re-run re-check. A Service that exists WITHOUT
+// `service.cilium.io/global: "true"` also reads false — it would be a
+// region-local name, i.e. exactly the black hole the readiness gate exists to
+// prevent. Only a genuine API error is returned as an error.
+func (h *Handler) replicaPublishesMeshAlias(ctx context.Context, cs kubernetes.Interface, namespace, alias string) (bool, error) {
+	getCtx, cancel := context.WithTimeout(ctx, clusterMeshCallTimeout)
+	defer cancel()
+	svc, err := cs.CoreV1().Services(namespace).Get(getCtx, alias, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return svc.Annotations[ciliumGlobalServiceAnnotation] == "true", nil
+}
 
 // keycloakAdminSecretNamespace / keycloakAdminSecretName / keycloakAdminSecretNames
 // — the HOST-cluster namespace + Secret names of the keycloak master-realm admin
@@ -2028,14 +2167,31 @@ func (h *Handler) syncSharedPGConsumerHubSecrets(ctx context.Context, dep *Deplo
 				"id", dep.ID, "namespace", sharedPGNamespace, "secret", name)
 			continue
 		}
-		// READINESS GATE: only propagate once region-A has rendered the
-		// `-mesh-rw` write host. A `-rw`-only host means region-A hasn't
-		// reconciled crossRegion yet — pushing it would NXDOMAIN on the
-		// replica, so wait for the next level-trigger pass.
-		if host := string(src.Data["host"]); !strings.Contains(host, sharedPGMeshRWHostMarker) {
-			h.log.Info("clustermesh: shared-pg consumer-hub sync: source host not yet topology-aware (-mesh-rw) — deferring (region-A crossRegion upgrade still landing; best-effort, re-run converges)",
-				"id", dep.ID, "secret", name, "host", host)
-			continue
+		// READINESS GATE (#6072 — was a `-mesh-rw` substring test on this
+		// host; see sharedPGLocalRWHostLabelSuffix for why that test could
+		// never answer "yes" pre-flip and deferred hw293 PERMANENTLY).
+		//
+		// The property worth guarding is unchanged: never hand the replica a
+		// write host that does not route there. It is now answered against the
+		// REPLICA's own Service inventory rather than a substring of the
+		// source:
+		//
+		//   - host already carries `-mesh-rw` → propagate as-is. Byte-identical
+		//     to the pre-#6072 path, so the post-flip behaviour never changes.
+		//   - host is the region-local `<instance>-rw` form → propagate ONLY to
+		//     replicas that publish a mesh-global `<instance>-mesh-rw`, with the
+		//     host rewritten onto that alias (per-replica, below).
+		//   - anything else → DEFER, exactly as before.
+		srcHost := string(src.Data["host"])
+		srcHostIsMeshRW := strings.Contains(srcHost, sharedPGMeshRWHostMarker)
+		meshHost, meshAlias, rewritable := "", "", false
+		if !srcHostIsMeshRW {
+			meshHost, meshAlias, rewritable = meshRWHostRewrite(srcHost)
+			if !rewritable {
+				h.log.Info("clustermesh: shared-pg consumer-hub sync: source host is neither the `-mesh-rw` alias nor the region-local `<instance>-rw` form — deferring (unrecognised write host; best-effort, re-run converges)",
+					"id", dep.ID, "secret", name, "host", srcHost)
+				continue
+			}
 		}
 		// #5317 — a Secret name goes into `synced` (the HONEST count) ONLY
 		// when a read-back confirms it present+matching on EVERY replica
@@ -2049,7 +2205,35 @@ func (h *Handler) syncSharedPGConsumerHubSecrets(ctx context.Context, dep *Deplo
 				verifiedOnAllReplicas = false
 				continue
 			}
-			delivered, verified, err := h.copyAndVerifyConsumerHubSecret(ctx, src, replica.clientset, sharedPGNamespace)
+			// #6072 — the per-replica half of the readiness gate. A source
+			// still on the region-local `<instance>-rw` host is delivered ONLY
+			// where the replica itself publishes the mesh-global
+			// `<instance>-mesh-rw` alias, with the host rewritten onto it. No
+			// alias (or a non-global same-named Service) → this replica is NOT
+			// ready, so defer it and leave the Secret uncounted; the
+			// level-triggered re-run re-checks. `effSrc` is what gets copied,
+			// read-back-verified AND handed to the #4878 restart reconcile, so
+			// all three see identical bytes.
+			effSrc := src
+			if !srcHostIsMeshRW {
+				publishes, aliasErr := h.replicaPublishesMeshAlias(ctx, replica.clientset, sharedPGNamespace, meshAlias)
+				if aliasErr != nil {
+					h.log.Warn("clustermesh: shared-pg consumer-hub sync: mesh-alias lookup on replica failed — deferring this Secret/region (best-effort, re-run converges)",
+						"id", dep.ID, "region", replica.key, "namespace", sharedPGNamespace, "secret", name, "alias", meshAlias, "err", aliasErr)
+					verifiedOnAllReplicas = false
+					continue
+				}
+				if !publishes {
+					h.log.Info("clustermesh: shared-pg consumer-hub sync: replica does not publish the ClusterMesh-global write alias yet — deferring (a region-local `-rw` host would not route from the replica; best-effort, re-run converges)",
+						"id", dep.ID, "region", replica.key, "namespace", sharedPGNamespace, "secret", name, "alias", meshAlias, "host", srcHost)
+					verifiedOnAllReplicas = false
+					continue
+				}
+				effSrc = rewriteHubSecretHost(src, srcHost, meshHost)
+				h.log.Info("clustermesh: shared-pg consumer-hub sync: rewrote the region-local write host onto the replica's ClusterMesh-global alias before delivery (#6072 — region-A's crossRegion flip has not landed, but the alias resolves on the replica today)",
+					"id", dep.ID, "region", replica.key, "namespace", sharedPGNamespace, "secret", name, "fromHost", srcHost, "toHost", meshHost)
+			}
+			delivered, verified, err := h.copyAndVerifyConsumerHubSecret(ctx, effSrc, replica.clientset, sharedPGNamespace)
 			if err != nil {
 				h.log.Warn("clustermesh: shared-pg consumer-hub sync: copy to replica failed — skipping this Secret/region (best-effort, re-run converges)",
 					"id", dep.ID, "region", replica.key, "namespace", sharedPGNamespace, "secret", name, "err", err)
@@ -2093,7 +2277,12 @@ func (h *Handler) syncSharedPGConsumerHubSecrets(ctx context.Context, dep *Deplo
 			// #3241/#3583 no-thrash contract). `changed` no longer gates it; the
 			// level-trigger re-run drives it to consistency.
 			if target, ok := sharedPGConsumerRestartTargets[name]; ok {
-				h.reconcileSharedPGConsumerRestart(ctx, dep, replica, name, target, src)
+				// #6072 — effSrc, not src: the consistency gate inside compares
+				// the consumer-namespace copy against these bytes, and what the
+				// reflector re-pushes there is what we DELIVERED (host rewritten
+				// onto the mesh alias). Passing the un-rewritten src would make
+				// that comparison never match and silently disable the restart.
+				h.reconcileSharedPGConsumerRestart(ctx, dep, replica, name, target, effSrc)
 			}
 		}
 		if verifiedOnAllReplicas {
@@ -3562,20 +3751,20 @@ func (h *Handler) rolloutRestartClusterMeshTargets(ctx context.Context, dep *Dep
 // Instead this reconciles the restart against CONSISTENCY on every ~2-min
 // level-trigger pass:
 //
-//	1. CONSISTENCY GATE — read the consumer-namespace copy of the hub Secret on
-//	   the replica. If it is absent, or its effective bytes do NOT yet match
-//	   region-A's authoritative hub Secret (`src`), the reflector has not
-//	   propagated the corrected credential — DEFER (no restart; the re-run
-//	   re-checks). Because region-A mints the hub Secret AND the PG role password
-//	   from the same source, and keycloak/gitea/harbor dial the `-mesh-rw` alias
-//	   that routes writes to region-A's primary, `consumer-ns == src`
-//	   transitively means the mounted password matches the LIVE PG role password
-//	   on the primary — so no in-process DB probe is needed to prove (c).
-//	2. IDEMPOTENCY / RESTART — hand the authoritative credential's fingerprint to
-//	   rolloutRestartConsumerWorkload, which restarts ONLY when the workload's pod
-//	   template was not already rolled onto this exact fingerprint. So a
-//	   steady-state / already-healed pass never restarts (the #3241/#3583
-//	   no-thrash contract) while a genuine future rotation re-fires exactly once.
+//  1. CONSISTENCY GATE — read the consumer-namespace copy of the hub Secret on
+//     the replica. If it is absent, or its effective bytes do NOT yet match
+//     region-A's authoritative hub Secret (`src`), the reflector has not
+//     propagated the corrected credential — DEFER (no restart; the re-run
+//     re-checks). Because region-A mints the hub Secret AND the PG role password
+//     from the same source, and keycloak/gitea/harbor dial the `-mesh-rw` alias
+//     that routes writes to region-A's primary, `consumer-ns == src`
+//     transitively means the mounted password matches the LIVE PG role password
+//     on the primary — so no in-process DB probe is needed to prove (c).
+//  2. IDEMPOTENCY / RESTART — hand the authoritative credential's fingerprint to
+//     rolloutRestartConsumerWorkload, which restarts ONLY when the workload's pod
+//     template was not already rolled onto this exact fingerprint. So a
+//     steady-state / already-healed pass never restarts (the #3241/#3583
+//     no-thrash contract) while a genuine future rotation re-fires exactly once.
 //
 // Net effect: the restart fires ONCE, AFTER the mounted credential is consistent
 // — the single clean restart the #4878 goal wanted — and the level-trigger

--- a/products/catalyst/bootstrap/api/internal/handler/clustermesh_hub_meshrw_rewrite_6072_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/clustermesh_hub_meshrw_rewrite_6072_test.go
@@ -1,0 +1,381 @@
+package handler
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	kfake "k8s.io/client-go/kubernetes/fake"
+)
+
+// #6072 — the shared-pg consumer-hub readiness gate tested a string, not a
+// readiness fact, and on hw293 (dep a0077ba47e3720e5, measured 2026-08-11) that
+// string could never turn true.
+//
+// MEASURED SHAPE THIS FILE ENCODES:
+//
+//   - All three region-A CNPG clusters healthy, 1 instance each; all nine hub
+//     Secrets carrying `shared-pg{,-b,-c}-rw.shared-data.svc.cluster.local`,
+//     because role-secrets.yaml renders `-mesh-rw` only under
+//     `bp-postgres.activeHotStandby` (= `topology.crossRegion`, patched only by
+//     enableCNPGPairAfterFullMesh).
+//   - Region-B holding 0 of the 13 hub Secrets, while holding all 12
+//     CNPG-operator-minted `-ca`/`-replication`/`-server`/`-superuser` ones —
+//     the control proving the namespace, its Flux ownership and the operator
+//     all work there, and only cross-region delivery was absent.
+//   - All six `-mesh-rw` Services present in BOTH regions the entire time.
+//     Region-B's `shared-pg-mesh-rw` is the correct zero-backend stub annotated
+//     `service.cilium.io/global: "true"`; region-A's carries the only endpoint.
+//     So the alias the gate was waiting to see named in a string was live and
+//     routable on the replica the whole time.
+//   - Downstream: `keycloak-0` in region-B stuck `Init:0/1` on
+//     `MountVolume.SetUp failed … secret "keycloak-database-secret" not found`,
+//     232 occurrences over 7h38m.
+//
+// The deferral is PERMANENT, not a timing window: the `host` string only turns
+// `-mesh-rw` at the cnpg-pair flip, which is the very flip #5230 hoisted this
+// sync OUT of — so the hoist was inert, and where the flip never lands the
+// Secrets never land either.
+//
+// These tests are written so the CONTROL cases fail loudly if a future change
+// "fixes" this by weakening the gate instead of re-basing it on evidence.
+
+// seedMeshAliasService creates the ClusterMesh-global write alias Service the
+// replica publishes (`<instance>-mesh-rw` in shared-data). global=false seeds a
+// same-named Service WITHOUT the cilium global annotation — a region-local
+// name, which must NOT satisfy the readiness gate.
+func seedMeshAliasService(t *testing.T, cs kubernetes.Interface, name string, global bool) {
+	t.Helper()
+	ctx := context.Background()
+	if _, err := cs.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: sharedPGNamespace},
+	}, metav1.CreateOptions{}); err != nil && !apierrors.IsAlreadyExists(err) {
+		t.Fatalf("create shared-data namespace: %v", err)
+	}
+	annotations := map[string]string{"service.cilium.io/affinity": "local"}
+	if global {
+		annotations[ciliumGlobalServiceAnnotation] = "true"
+	}
+	if _, err := cs.CoreV1().Services(sharedPGNamespace).Create(ctx, &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   sharedPGNamespace,
+			Annotations: annotations,
+		},
+		Spec: corev1.ServiceSpec{
+			Type:     corev1.ServiceTypeClusterIP,
+			Ports:    []corev1.ServicePort{{Name: "postgres", Port: 5432}},
+			Selector: map[string]string{"cnpg.io/cluster": "shared-pg", "cnpg.io/instanceRole": "primary"},
+		},
+	}, metav1.CreateOptions{}); err != nil && !apierrors.IsAlreadyExists(err) {
+		t.Fatalf("create mesh alias Service %s: %v", name, err)
+	}
+}
+
+// TestMeshRWHostRewrite pins the pure host mapping, including the shapes that
+// must NOT be rewritten.
+func TestMeshRWHostRewrite(t *testing.T) {
+	cases := []struct {
+		name      string
+		host      string
+		wantHost  string
+		wantAlias string
+		wantOK    bool
+	}{
+		{
+			name:      "region-local rw host maps onto the mesh alias",
+			host:      "shared-pg-rw.shared-data.svc.cluster.local",
+			wantHost:  "shared-pg-mesh-rw.shared-data.svc.cluster.local",
+			wantAlias: "shared-pg-mesh-rw",
+			wantOK:    true,
+		},
+		{
+			name:      "instance-b (the hw293 grafana/pdns/pda hub host)",
+			host:      "shared-pg-b-rw.shared-data.svc.cluster.local",
+			wantHost:  "shared-pg-b-mesh-rw.shared-data.svc.cluster.local",
+			wantAlias: "shared-pg-b-mesh-rw",
+			wantOK:    true,
+		},
+		{
+			name:      "instance-c (the hw293 org/newapi/openova-flow hub host)",
+			host:      "shared-pg-c-rw.shared-data.svc.cluster.local",
+			wantHost:  "shared-pg-c-mesh-rw.shared-data.svc.cluster.local",
+			wantAlias: "shared-pg-c-mesh-rw",
+			wantOK:    true,
+		},
+		// An ALREADY-mesh host must be rejected outright: rewriting it again
+		// would fabricate `shared-pg-mesh-mesh-rw`, a name nothing publishes.
+		{name: "already a mesh alias is not rewritable", host: "shared-pg-mesh-rw.shared-data.svc.cluster.local"},
+		{name: "empty host", host: ""},
+		{name: "no domain part", host: "shared-pg-rw"},
+		{name: "first label does not end in -rw", host: "shared-pg-ro.shared-data.svc.cluster.local"},
+		{name: "read alias is not a write host", host: "shared-pg-r.shared-data.svc.cluster.local"},
+		{name: "bare -rw with no instance name", host: "-rw.shared-data.svc.cluster.local"},
+		{name: "external managed database host", host: "db.example.com"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotHost, gotAlias, ok := meshRWHostRewrite(tc.host)
+			if ok != tc.wantOK {
+				t.Fatalf("meshRWHostRewrite(%q) ok = %v, want %v", tc.host, ok, tc.wantOK)
+			}
+			if !tc.wantOK {
+				return
+			}
+			if gotHost != tc.wantHost {
+				t.Errorf("host = %q, want %q", gotHost, tc.wantHost)
+			}
+			if gotAlias != tc.wantAlias {
+				t.Errorf("alias = %q, want %q", gotAlias, tc.wantAlias)
+			}
+		})
+	}
+}
+
+// TestSyncSharedPGConsumerHubSecretsRewritesLocalRWHost is the hw293 regression.
+//
+// RED against the pre-#6072 gate: the source host is the region-local `-rw`
+// form, so `strings.Contains(host, "-mesh-rw.")` is false and the Secret is
+// deferred — the replica gains NOTHING and keycloak stays Init:0/1.
+func TestSyncSharedPGConsumerHubSecretsRewritesLocalRWHost(t *testing.T) {
+	h := &Handler{log: silentLogger()}
+	dep := &Deployment{ID: "dep-6072"}
+
+	// The hw293 shape: region-A hub Secrets on the region-local `-rw` host
+	// (crossRegion never flipped), region-B publishing the mesh-global alias.
+	primaryCS := kfake.NewSimpleClientset()
+	replicaCS := kfake.NewSimpleClientset()
+	seedHubSecret(t, primaryCS, "keycloak-database-secret",
+		"shared-pg-rw.shared-data.svc.cluster.local", "region-A-authoritative-pw")
+	seedMeshAliasService(t, replicaCS, "shared-pg-mesh-rw", true)
+
+	slots := []regionSlot{
+		{key: "", clientset: primaryCS},
+		{key: "me-east-215-b-1", clientset: replicaCS},
+	}
+	h.syncSharedPGConsumerHubSecrets(context.Background(), dep, slots)
+
+	got, ok := getSharedDataSecret(t, replicaCS, "keycloak-database-secret")
+	if !ok {
+		t.Fatalf("replica did not receive keycloak-database-secret — this is the hw293 defect: " +
+			"the readiness gate defers every hub Secret while region-A's host is the region-local `-rw` " +
+			"form, and that string only turns `-mesh-rw` at the cnpg-pair flip. keycloak-0 stays Init:0/1.")
+	}
+
+	// ASSERT ON THE VALUE, not on existence.
+	//
+	// The host must be the mesh alias — delivering region-A's literal `-rw`
+	// host would point the replica at a Service that on hw293 has ZERO
+	// endpoints in region-B.
+	wantHost := "shared-pg-mesh-rw.shared-data.svc.cluster.local"
+	if h := string(got.Data["host"]); h != wantHost {
+		t.Errorf("replica host = %q, want %q (the region-local `-rw` host does not route from the replica)", h, wantHost)
+	}
+	// The credential must be region-A's, byte-for-byte. This is what #5224 /
+	// #5228 made un-mintable on the replica side, so a wrong value here is a
+	// regression of that fix.
+	if p := string(got.Data["password"]); p != "region-A-authoritative-pw" {
+		t.Errorf("replica password = %q, want region-A's authoritative value — the replica cannot mint its own since #5228", p)
+	}
+	// The `uri` embeds the host, so it must have been rewritten with it — and
+	// must still carry region-A's password.
+	uri := string(got.Data["uri"])
+	if !strings.Contains(uri, wantHost) {
+		t.Errorf("replica uri = %q, want it to embed the mesh alias host %q", uri, wantHost)
+	}
+	if strings.Contains(uri, "shared-pg-rw.shared-data") {
+		t.Errorf("replica uri = %q still embeds the region-local `-rw` host — the host rewrite missed the uri", uri)
+	}
+	if !strings.Contains(uri, "region-A-authoritative-pw") {
+		t.Errorf("replica uri = %q lost region-A's password", uri)
+	}
+	// The reflector annotations must survive so region-B's own reflector
+	// re-pushes the Secret into the keycloak namespace (the object the pod
+	// actually mounts).
+	if got.Annotations["reflector.v1.k8s.emberstack.com/reflection-auto-enabled"] != "true" {
+		t.Errorf("replica hub Secret lost the reflection-auto annotation — the consumer namespace would never get the copy")
+	}
+
+	// The SOURCE must be untouched: region-A stays on its own region-local
+	// host, which is correct for region-A. The rewrite is a delivery-time
+	// transform, not a mutation of the authoritative copy.
+	srcAfter, _ := getSharedDataSecret(t, primaryCS, "keycloak-database-secret")
+	if h := string(srcAfter.Data["host"]); h != "shared-pg-rw.shared-data.svc.cluster.local" {
+		t.Errorf("primary host = %q, want it UNCHANGED — the rewrite must not mutate region-A's authoritative Secret", h)
+	}
+}
+
+// TestSyncSharedPGConsumerHubSecretsDeferralControls is THE decisive control
+// set. A fix that merely removes the gate delivers Secrets to a replica that
+// cannot route them, and would sail through the happy-path test above. Each
+// case here must still DEFER after the fix.
+func TestSyncSharedPGConsumerHubSecretsDeferralControls(t *testing.T) {
+	h := &Handler{log: silentLogger()}
+	dep := &Deployment{ID: "dep-6072-controls"}
+
+	// CONTROL 1 — the replica does not publish the alias at all. A `-rw` host
+	// pushed here would be a black hole, so nothing may be delivered. This is
+	// the pre-flip state of a replica whose bp-postgres has not rendered yet.
+	t.Run("no-mesh-alias-on-replica-still-defers", func(t *testing.T) {
+		primaryCS := kfake.NewSimpleClientset()
+		replicaCS := kfake.NewSimpleClientset()
+		seedHubSecret(t, primaryCS, "keycloak-database-secret",
+			"shared-pg-rw.shared-data.svc.cluster.local", "region-A-pw")
+		// Deliberately NO mesh alias Service on the replica.
+		slots := []regionSlot{{key: "", clientset: primaryCS}, {key: "secondary", clientset: replicaCS}}
+		h.syncSharedPGConsumerHubSecrets(context.Background(), dep, slots)
+
+		if _, ok := getSharedDataSecret(t, replicaCS, "keycloak-database-secret"); ok {
+			t.Errorf("replica received a hub Secret although it publishes no `shared-pg-mesh-rw` alias — " +
+				"the delivered host would resolve nowhere. The readiness gate must survive the fix, not be deleted.")
+		}
+	})
+
+	// CONTROL 2 — the alias NAME exists on the replica but is not
+	// ClusterMesh-global. It is then a region-local name: on hw293 region-B's
+	// local `shared-pg-rw` had zero endpoints, which is exactly this hazard.
+	// Name-presence alone must not satisfy the gate.
+	t.Run("non-global-alias-on-replica-still-defers", func(t *testing.T) {
+		primaryCS := kfake.NewSimpleClientset()
+		replicaCS := kfake.NewSimpleClientset()
+		seedHubSecret(t, primaryCS, "keycloak-database-secret",
+			"shared-pg-rw.shared-data.svc.cluster.local", "region-A-pw")
+		seedMeshAliasService(t, replicaCS, "shared-pg-mesh-rw", false) // no service.cilium.io/global
+		slots := []regionSlot{{key: "", clientset: primaryCS}, {key: "secondary", clientset: replicaCS}}
+		h.syncSharedPGConsumerHubSecrets(context.Background(), dep, slots)
+
+		if _, ok := getSharedDataSecret(t, replicaCS, "keycloak-database-secret"); ok {
+			t.Errorf("replica received a hub Secret although its `shared-pg-mesh-rw` Service is NOT annotated "+
+				"%q=true — a non-global Service is region-local and would not route to the primary", ciliumGlobalServiceAnnotation)
+		}
+	})
+
+	// CONTROL 3 — an unrecognised write host is not rewritable, so it defers
+	// regardless of what the replica publishes. Guards against the rewrite
+	// inventing an alias for a host shape it does not understand.
+	t.Run("unrecognised-host-still-defers", func(t *testing.T) {
+		primaryCS := kfake.NewSimpleClientset()
+		replicaCS := kfake.NewSimpleClientset()
+		seedHubSecret(t, primaryCS, "keycloak-database-secret", "db.example.com", "region-A-pw")
+		seedMeshAliasService(t, replicaCS, "shared-pg-mesh-rw", true)
+		slots := []regionSlot{{key: "", clientset: primaryCS}, {key: "secondary", clientset: replicaCS}}
+		h.syncSharedPGConsumerHubSecrets(context.Background(), dep, slots)
+
+		if _, ok := getSharedDataSecret(t, replicaCS, "keycloak-database-secret"); ok {
+			t.Errorf("replica received a hub Secret whose host is neither the `-mesh-rw` alias nor the " +
+				"region-local `<instance>-rw` form — an unrecognised host must defer")
+		}
+	})
+
+	// CONTROL 4 — MIXED replicas. One publishes the alias, one does not. The
+	// ready replica must be served; the unready one must not; and the Secret
+	// must NOT be counted as synced-everywhere. Pins that the gate is decided
+	// per-replica rather than once for the whole fan-out.
+	t.Run("mixed-replicas-serve-only-the-ready-one", func(t *testing.T) {
+		primaryCS := kfake.NewSimpleClientset()
+		readyCS := kfake.NewSimpleClientset()
+		unreadyCS := kfake.NewSimpleClientset()
+		seedHubSecret(t, primaryCS, "keycloak-database-secret",
+			"shared-pg-rw.shared-data.svc.cluster.local", "region-A-pw")
+		seedMeshAliasService(t, readyCS, "shared-pg-mesh-rw", true)
+		slots := []regionSlot{
+			{key: "", clientset: primaryCS},
+			{key: "ready", clientset: readyCS},
+			{key: "unready", clientset: unreadyCS},
+		}
+		h.syncSharedPGConsumerHubSecrets(context.Background(), dep, slots)
+
+		got, ok := getSharedDataSecret(t, readyCS, "keycloak-database-secret")
+		if !ok {
+			t.Fatalf("the READY replica did not receive the hub Secret")
+		}
+		if hst := string(got.Data["host"]); hst != "shared-pg-mesh-rw.shared-data.svc.cluster.local" {
+			t.Errorf("ready replica host = %q, want the mesh alias", hst)
+		}
+		if _, ok := getSharedDataSecret(t, unreadyCS, "keycloak-database-secret"); ok {
+			t.Errorf("the UNREADY replica (no mesh alias) received the hub Secret — the gate must be per-replica")
+		}
+	})
+}
+
+// TestSyncSharedPGConsumerHubSecretsMeshRWSourceNeedsNoAlias pins that the
+// POST-FLIP path is byte-identical to pre-#6072: a source already carrying the
+// `-mesh-rw` host propagates without the replica needing to publish anything.
+// Without this, the fix could silently add a new precondition to the one path
+// that already worked (the failure mode the #5230 hoist itself hit).
+func TestSyncSharedPGConsumerHubSecretsMeshRWSourceNeedsNoAlias(t *testing.T) {
+	h := &Handler{log: silentLogger()}
+	dep := &Deployment{ID: "dep-6072-postflip"}
+
+	primaryCS := kfake.NewSimpleClientset()
+	replicaCS := kfake.NewSimpleClientset()
+	seedHubSecret(t, primaryCS, "keycloak-database-secret",
+		"shared-pg-mesh-rw.shared-data.svc.cluster.local", "region-A-pw")
+	// NO alias Service seeded on the replica on purpose.
+
+	slots := []regionSlot{{key: "", clientset: primaryCS}, {key: "secondary", clientset: replicaCS}}
+	h.syncSharedPGConsumerHubSecrets(context.Background(), dep, slots)
+
+	got, ok := getSharedDataSecret(t, replicaCS, "keycloak-database-secret")
+	if !ok {
+		t.Fatalf("an already `-mesh-rw` source was not propagated — #6072 must not add a precondition to the post-flip path")
+	}
+	if hst := string(got.Data["host"]); hst != "shared-pg-mesh-rw.shared-data.svc.cluster.local" {
+		t.Errorf("replica host = %q, want the source's `-mesh-rw` host passed through untouched", hst)
+	}
+	if p := string(got.Data["password"]); p != "region-A-pw" {
+		t.Errorf("replica password = %q, want region-A's", p)
+	}
+}
+
+// TestRewriteHubSecretHostLeavesCredentialsAlone pins that the rewrite is a
+// host transform and nothing else — it must never touch a credential, and must
+// cover every host-bearing key the role-secrets.yaml connection contract can
+// emit (`host`, the `uri` embedding it, `reflect.hostKeys`, and
+// `hostPortKeys` in `<host>:5432` form) without knowing their names.
+func TestRewriteHubSecretHostLeavesCredentialsAlone(t *testing.T) {
+	const oldHost = "shared-pg-b-rw.shared-data.svc.cluster.local"
+	const newHost = "shared-pg-b-mesh-rw.shared-data.svc.cluster.local"
+
+	src := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "grafana-database-env", Namespace: sharedPGNamespace},
+		Type:       corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			"host":                     []byte(oldHost),
+			"uri":                      []byte("postgresql://grafana:pw@" + oldHost + ":5432/grafana"),
+			"GF_DATABASE_HOST":         []byte(oldHost + ":5432"), // hostPortKeys shape
+			"GF_DATABASE_HOST_NO_PORT": []byte(oldHost),           // hostKeys shape
+			"password":                 []byte("pw"),
+			"username":                 []byte("grafana"),
+			"dbname":                   []byte("grafana"),
+			"port":                     []byte("5432"),
+		},
+	}
+	out := rewriteHubSecretHost(src, oldHost, newHost)
+
+	for _, k := range []string{"host", "GF_DATABASE_HOST_NO_PORT"} {
+		if v := string(out.Data[k]); v != newHost {
+			t.Errorf("%s = %q, want %q", k, v, newHost)
+		}
+	}
+	if v := string(out.Data["GF_DATABASE_HOST"]); v != newHost+":5432" {
+		t.Errorf("GF_DATABASE_HOST = %q, want the host:port form rewritten", v)
+	}
+	if v := string(out.Data["uri"]); v != "postgresql://grafana:pw@"+newHost+":5432/grafana" {
+		t.Errorf("uri = %q, want the embedded host rewritten", v)
+	}
+	// Credentials and non-host values pass through untouched.
+	for k, want := range map[string]string{"password": "pw", "username": "grafana", "dbname": "grafana", "port": "5432"} {
+		if v := string(out.Data[k]); v != want {
+			t.Errorf("%s = %q, want %q untouched — the rewrite must only re-point hosts", k, v, want)
+		}
+	}
+	// The source must not be mutated (it is region-A's authoritative object).
+	if v := string(src.Data["host"]); v != oldHost {
+		t.Errorf("source host mutated to %q — rewriteHubSecretHost must deep-copy", v)
+	}
+}


### PR DESCRIPTION
## What this fixes

`syncSharedPGConsumerHubSecrets` deferred every shared-pg consumer-hub Secret whose source `host` lacked the `-mesh-rw` marker. On **hw293** (dep `a0077ba47e3720e5`) that deferred all nine plain hub Secrets on every pass, permanently.

**Measured, read-only, 2026-08-11:**

| | region A | region B |
|---|---|---|
| consumer-hub Secrets (of 13) | 13 | **0** |
| CNPG-operator-minted (`-ca`/`-replication`/`-server`/`-superuser`) | 12 | **12** |
| `-mesh-rw` Services | 3 | **3** |

The second row is the control: the namespace, its Flux ownership and the CNPG operator all work in region B. Only cross-region hub delivery was absent. Downstream, `keycloak-0` in region B sat `Init:0/1` on `MountVolume.SetUp failed … secret "keycloak-database-secret" not found` — **232 occurrences over 7h38m**.

## Why the gate could never pass

All nine sources carried the region-LOCAL host (`shared-pg{,-b,-c}-rw.shared-data.svc.cluster.local`), because two halves of bp-postgres ride different signals and only one got #4460's decoupling:

- the mesh alias **Service** renders on `meshAliasesActive` (clusterMesh + both region fields set) — #4460 decoupled it from `activeHotStandby` deliberately, so it exists BEFORE the flip;
- the hub Secret's **`host`** (`role-secrets.yaml` `$consumerHost`) renders on `activeHotStandby` = `topology.crossRegion` = `SOVEREIGN_ENABLE_CNPG_PAIR`, patched only by `enableCNPGPairAfterFullMesh`.

So the `host` string turns `-mesh-rw` at the cnpg-pair flip — **the very flip #5230 hoisted this sync out of**. The #5230 hoist was therefore inert: the sync fired early and deferred everything until the flip landed anyway; where the flip never lands, the deferral is permanent. This is the sync **running and deferring every Secret**, not the sync **never running** — #5230's hoist out of `enableCNPGPairAfterFullMesh` is confirmed in place; the entry condition is `autoEstablishClusterMesh` being entered.

The gate's premise — "host lacks `-mesh-rw` ⟹ the alias is not ready on the replica" — is refuted by live state: all six aliases existed in **both** regions throughout. Region B's `shared-pg-mesh-rw` is the correct zero-backend stub annotated `service.cilium.io/global: "true"`; region A's carries the only endpoint (`10.42.5.35`).

## The change

The property worth guarding is kept — never hand the replica a write host that does not route there (region B's local `shared-pg-rw` exists with **zero endpoints**) — but it is now answered from positive evidence on the replica instead of a substring of the source:

- source already `-mesh-rw` → propagate as-is (post-flip path byte-identical);
- source region-local `-rw` → deliver **only** to replicas publishing a mesh-global `<instance>-mesh-rw`, with the host rewritten onto that alias, decided **per-replica**;
- anything else → defer, as before.

The rewrite is a delivery-time transform on a deep copy, re-pointing only values that literally embed the old host (`host`, the `uri` embedding it, `hostKeys`, `hostPortKeys`). Credentials are copied byte-for-byte from region A; region A's own Secret is never mutated. `effSrc` is also what the #4878 restart reconcile compares against, so its consistency gate still matches what was delivered.

**This does not re-introduce what #5224/#5228 removed.** Those removed the replica-side *mint* of role/hub Secrets, where each region ran its own `randAlphaNum` and `helm.sh/resource-policy: keep` preserved the divergent value forever (the hw273 harbor 28P01 lockout). Nothing is minted on the replica here — region A's authoritative bytes are copied, which is precisely the remedy #5228 designed for.

## Red before green

`clustermesh_hub_meshrw_rewrite_6072_test.go`, run against the pre-fix gate and then the fix, gated on exit code:

```
########## RED (pre-fix gate) ##########
--- FAIL: TestSyncSharedPGConsumerHubSecretsDeferralControls/mixed-replicas-serve-only-the-ready-one
        the READY replica did not receive the hub Secret
--- FAIL: TestSyncSharedPGConsumerHubSecretsRewritesLocalRWHost
        replica did not receive keycloak-database-secret — this is the hw293 defect
RED_EXIT=1
########## GREEN (fix) ##########
ok  github.com/openova-io/.../internal/handler  0.049s
GREEN_EXIT=0
```

Hub Secrets delivered to a ready replica: **0 → 1 of 1** in the single-replica case, **1 of 2 replicas served** in the mixed case (the unready one correctly still gets none).

**The decisive controls — these pass BOTH before and after, so the gate was re-based, not deleted:**

- `no-mesh-alias-on-replica-still-defers` — a `-rw` source with no alias on the replica delivers nothing.
- `non-global-alias-on-replica-still-defers` — the alias NAME present but without `service.cilium.io/global` is a region-local name, and must not satisfy the gate. This is the hw293 hazard exactly (region B's local `shared-pg-rw`, zero endpoints).
- `unrecognised-host-still-defers` — an external host is not rewritable regardless of what the replica publishes.
- the **pre-existing** `TestSyncSharedPGConsumerHubSecrets/region-local-rw-source-is-deferred` still passes untouched.
- `TestSyncSharedPGConsumerHubSecretsMeshRWSourceNeedsNoAlias` pins that the post-flip path gained no new precondition.

Assertions are on the **value**, not on existence: delivered `host` must equal the mesh alias, `uri` must embed it and must no longer embed the `-rw` host, `password` must equal region A's authoritative value, and the reflector annotations must survive. `TestRewriteHubSecretHostLeavesCredentialsAlone` pins that password/username/dbname/port pass through untouched and the source is not mutated.

Full `internal/handler` package: `ok … 290.870s`.

## Delivery

This is mothership-side Go. The mothership runs `b2294fd` with its Flux controllers at `replicas=0`, so this fix does not reach hw293 on merge and region B's Secrets will not appear there without a redeploy.

## Rows

Rows **32** and **36** are the confirmed downstream of the keycloak leg. Rows **67, 69, 70, 111, 235, 236, 237, R13** sit on this writer or its consequences.

Refs #6072 #5230 #5224 #5228 #4460 #3629 #5317 #5261
