### PR TITLE
fix(org-gitops): the per-Org writer picked a witness that cannot take a lease and a secrets seam that is not per-Org (Refs #6071 #5987)

### DIFF
--- a/core/controllers/continuum/internal/witness/witness_backend_functional_test.go
+++ b/core/controllers/continuum/internal/witness/witness_backend_functional_test.go
@@ -1,0 +1,185 @@
+// Behavioural proof of WHICH lease witness can actually take a lease —
+// the control behind UAT row G3 (#6071).
+//
+// THE RECORDED DIAGNOSIS FOR G3 WAS WRONG, AND THIS FILE IS WHY.
+//
+// G3 was filed as "the Continuum's leaseClient.config.resolvers are
+// hardcoded 10.43.0.10/.11/.12 while this cluster's kube-dns is
+// 10.96.0.10", with the implied fix "derive the resolver set from the
+// cluster". Three independent measurements below show that fix cannot
+// work — it is not that it is insufficient, it is that it is not
+// expressible and would not help if it were:
+//
+//	TestDNSQuorumRejectsADerivedResolverSet
+//	  a cluster has ONE kube-dns Service IP; dns-quorum refuses to
+//	  construct with fewer than 3 servers. "Derive from the cluster"
+//	  produces a config the factory rejects outright.
+//
+//	TestDNSQuorumWriterIsNilForEveryResolverSet
+//	  the registered factory hands back a client whose TXTWriter is nil
+//	  for EVERY resolver set, including correct ones — so Acquire can
+//	  never reach a write. This is the root cause, asserted structurally
+//	  and without touching the network.
+//
+//	TestDNSQuorumFailsWithPlaceholderResolvers
+//	  end-to-end reproduction of the live hw293 symptom.
+//
+//	TestK8sLeaseAcquiresLease
+//	  the PAIRED POSITIVE CONTROL on the same dispatch path. Without it
+//	  the suite would be satisfied by a world in which every backend is
+//	  broken, which would prove nothing about the fix.
+//
+// All of these go through witness.DefaultSelector — the production
+// dispatch path the continuum-controller itself uses — so a wiring
+// change that bypasses the registry is caught too.
+package witness_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+
+	"github.com/openova-io/openova/core/controllers/continuum/internal/witness"
+	"github.com/openova-io/openova/core/controllers/continuum/internal/witness/dnsquorum"
+	"github.com/openova-io/openova/core/controllers/continuum/internal/witness/k8slease"
+)
+
+// leaseGVR mirrors the (unexported) GVR the k8slease witness uses.
+var leaseGVR = schema.GroupVersionResource{
+	Group:    "coordination.k8s.io",
+	Version:  "v1",
+	Resource: "leases",
+}
+
+func newFakeDynForSelector() *dynamicfake.FakeDynamicClient {
+	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{leaseGVR: "LeaseList"},
+	)
+}
+
+func selectDNSQuorum(t *testing.T, resolvers []string) (witness.Client, error) {
+	t.Helper()
+	sel := &witness.DefaultSelector{}
+	return sel.Select("dns-quorum", map[string]any{
+		"slot":      "g7doora/bp-wordpress-tenant",
+		"domain":    "lease.openova.io",
+		"resolvers": resolvers,
+	})
+}
+
+// TestDNSQuorumRejectsADerivedResolverSet — the fix G3 asked for cannot
+// even be built. A Kubernetes cluster exposes exactly ONE kube-dns
+// Service ClusterIP (measured on hw293: region A 10.96.0.10, region B
+// 10.97.0.10 — and note they DIFFER, so a single derived list could not
+// serve both regions of one DR pair either). dns-quorum needs 3.
+func TestDNSQuorumRejectsADerivedResolverSet(t *testing.T) {
+	// exactly what "derive the resolver set from the cluster" yields on
+	// hw293 region A.
+	_, err := selectDNSQuorum(t, []string{"10.96.0.10"})
+	if err == nil {
+		t.Fatal("expected dns-quorum to refuse a 1-server resolver set")
+	}
+	if !strings.Contains(err.Error(), "at least 3 servers") {
+		t.Fatalf("expected the 3-server quorum requirement, got: %v", err)
+	}
+	t.Logf("derive-from-cluster produces: %v", err)
+}
+
+// TestDNSQuorumWriterIsNilForEveryResolverSet — THE ROOT CAUSE,
+// asserted structurally so it needs no network and cannot flake.
+//
+// dnsquorum's factory ends with New(servers, tsigKey, domain, slot, nil,
+// nil) — the TXTWriter is a compile-time nil (client.go:213). writeQuorum
+// (client.go:435) therefore refuses before a packet is sent. Acquire can
+// never complete, whatever the resolvers say. This is why re-pointing
+// resolvers moves the failure later rather than fixing it.
+func TestDNSQuorumWriterIsNilForEveryResolverSet(t *testing.T) {
+	for _, resolvers := range [][]string{
+		{"10.43.0.10", "10.43.0.11", "10.43.0.12"}, // the placeholder set
+		{"10.96.0.10", "10.96.0.11", "10.96.0.12"}, // this cluster's CIDR
+		{"1.1.1.1", "8.8.8.8", "9.9.9.9"},          // resolvers that genuinely answer
+	} {
+		c, err := selectDNSQuorum(t, resolvers)
+		if err != nil {
+			t.Fatalf("Select(dns-quorum, %v): %v", resolvers, err)
+		}
+		dq, ok := c.(*dnsquorum.DNSQuorumClient)
+		if !ok {
+			t.Fatalf("want *dnsquorum.DNSQuorumClient, got %T", c)
+		}
+		if dq.Writer != nil {
+			t.Fatalf("resolvers=%v: TXTWriter is non-nil — a real writer has been wired "+
+				"since this guard was written; re-evaluate whether dns-quorum is usable "+
+				"and whether producers may select it again", resolvers)
+		}
+		t.Logf("resolvers=%v -> TXTWriter is nil (Acquire can never write)", resolvers)
+	}
+}
+
+// TestDNSQuorumFailsWithPlaceholderResolvers reproduces the live hw293
+// symptom end-to-end: the continuum-controller logged
+// "witness read-quorum unavailable — check leaseClient resolvers/wiring"
+// every 10s against g7doora/bp-wordpress-tenant, and the CR sat
+// phase=Degraded, LeaseHeld=False, with no leaseHolder and no standby.
+func TestDNSQuorumFailsWithPlaceholderResolvers(t *testing.T) {
+	c, err := selectDNSQuorum(t, []string{"10.43.0.10", "10.43.0.11", "10.43.0.12"})
+	if err != nil {
+		t.Fatalf("Select: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	st, err := c.Acquire(ctx, "hw-me-east-215-a-rtz-prod", 30*time.Second)
+	if err == nil {
+		t.Fatal("dns-quorum Acquire unexpectedly succeeded against the placeholder resolvers")
+	}
+	// Assert on the VALUE that the row actually surfaces: an empty
+	// holder is what makes the console render singleton instead of DR.
+	if st.Holder != "" {
+		t.Fatalf("expected an empty holder on failure, got %q", st.Holder)
+	}
+	t.Logf("placeholder resolvers -> Acquire error: %v (holder empty, CR would go Degraded)", err)
+}
+
+// TestK8sLeaseAcquiresLease is the PAIRED POSITIVE CONTROL on the same
+// dispatch path: the backend this fix switches producers to genuinely
+// completes Acquire and returns the holder.
+func TestK8sLeaseAcquiresLease(t *testing.T) {
+	sel := &witness.DefaultSelector{}
+	c, err := sel.Select("k8s-lease", map[string]any{
+		"slot":      "g7doora/bp-wordpress-tenant",
+		"namespace": "catalyst-system",
+		"dyn":       k8slease.DynLeaseAccess(newFakeDynForSelector()),
+	})
+	if err != nil {
+		t.Fatalf("Select(k8s-lease): %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	const holder = "hw-me-east-215-a-rtz-prod"
+	st, err := c.Acquire(ctx, holder, 30*time.Second)
+	if err != nil {
+		t.Fatalf("k8s-lease Acquire failed: %v", err)
+	}
+	// Assert on the VALUE, not on the absence of an error: the row's
+	// symptom was an empty leaseHolder, which is exactly what the
+	// console reads to decide DR-vs-singleton.
+	if st.Holder != holder {
+		t.Fatalf("k8s-lease Acquire returned Holder=%q, want %q — an empty holder is "+
+			"precisely the state that renders the Continuum Degraded with no standby",
+			st.Holder, holder)
+	}
+	if !st.IsHeldBy(holder, time.Now()) {
+		t.Fatalf("k8s-lease: IsHeldBy(%q) false immediately after a successful Acquire "+
+			"(ExpiresAt=%v)", holder, st.ExpiresAt)
+	}
+	t.Logf("k8s-lease acquired: holder=%q expires=%v generation=%d",
+		st.Holder, st.ExpiresAt, st.Generation)
+}

--- a/products/catalyst/bootstrap/api/internal/handler/organization_active_hot_standby_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/organization_active_hot_standby_test.go
@@ -112,12 +112,38 @@ func TestRenderOrganizationOverlay_HotStandby_On_EmitsContinuumCR(t *testing.T) 
 		"- hz-hel-rtz-prod",
 		"rto: 30s",
 		"rpo: 5s",
-		"kind: dns-quorum",
+		"kind: k8s-lease",
 		"selector: ifurlup",
 		"url: https://wordpress.acme.otech.example/healthz",
 	} {
 		if !strings.Contains(cr, want) {
 			t.Errorf("continuum.yaml missing %q\n%s", want, cr)
+		}
+	}
+	// #3829 — the emitted witness kind must be one the controller can
+	// actually ACQUIRE a lease with. dns-quorum cannot: its registered
+	// factory builds the client with a nil TXTWriter, so Acquire always
+	// fails and the Continuum sits Degraded with no leaseHolder and no
+	// standby (measured live on hw293, g7doora/bp-wordpress-tenant).
+	// The behavioural proof — including that CORRECT resolvers do not
+	// rescue it — lives in
+	// core/controllers/continuum/internal/witness/witness_backend_functional_test.go.
+	for _, banned := range []string{
+		// assert on the VALUE of the selector field, not on the bare
+		// word — the template legitimately explains in a comment why
+		// dns-quorum is not used, and a substring match on the name
+		// would flag that explanation instead of a real selection.
+		"kind: dns-quorum",
+		// The placeholder resolver set. 10.43.0.0/16 is k3s's default
+		// service CIDR; these Sovereigns allocate from 10.96.0.0/12 and
+		// kube-dns is region-local (region A 10.96.0.10, region B
+		// 10.97.0.10), so no hardcoded resolver list can be correct for
+		// both regions of one DR pair.
+		"10.43.0.",
+		"resolvers:",
+	} {
+		if strings.Contains(cr, banned) {
+			t.Errorf("continuum.yaml must not contain %q (dead dns-quorum witness config)\n%s", banned, cr)
 		}
 	}
 	// kustomization.yaml MUST also list it under resources so Flux

--- a/products/catalyst/bootstrap/api/internal/handler/organization_gitops.go
+++ b/products/catalyst/bootstrap/api/internal/handler/organization_gitops.go
@@ -1527,23 +1527,48 @@ spec:
           # render until both are non-empty).
           accountId: ""
           contractRef: ""
-    # ── Catalyst integration — admin token for per-user key minting ──
-    # ADR-0003 §3.2: Catalyst's signup hook reads this Secret and POSTs
-    # against NewAPI's admin API with Authorization: Bearer header to
-    # issue per-user customer-API keys. The token is rotated per the
-    # convention in docs/CATALYST-CLI-AGENT.md.
+    # ── Catalyst integration — DELIBERATELY OFF for a per-Org release ──
+    # ADR-0003 §3.2's admin-token integration is SOVEREIGN-scoped, not
+    # per-Organization, and enabling it here is what broke UAT row G2
+    # (#5987).
+    #
+    # The consumer is a single catalyst-api Pod in catalyst-system, which
+    # reads ADMIN_API_TOKEN via secretKeyRef on ONE Secret named
+    # catalyst-newapi-admin-token, reflector-mirrored into catalyst-system
+    # (see the comment at platform/newapi/chart/templates/
+    # external-secret.yaml:55-70). There is exactly one such consumer and
+    # one such mirror for the whole Sovereign. Every per-Org release that
+    # switches this on therefore renders a SECOND ExternalSecret whose
+    # target carries reflection-allowed, so per-Org copies contend for the
+    # one catalyst-system mirror — and the paired PushSecret
+    # (templates/admin-token-pushsecret.yaml, driven off the SAME
+    # remoteRef.key) tries to overwrite the shared OpenBao path with THIS
+    # Org's own random token-signing-key ADMIN_SECRET, which would 401
+    # per-user key issuance for the entire Sovereign. That reasoning is
+    # already written out for the funnel path at
+    # core/services/provisioning/gitops/helmrelease_apps.go:512-527, which
+    # sets enabled:false for exactly these reasons; this per-Org GitOps
+    # writer was simply never brought into line with it.
+    #
+    # What row G2 actually measured on hw293 (dep a0077ba47e3720e5): the
+    # per-Org copy could not even get that far. Its remoteRef.key was
+    # sovereign/<fqdn>/newapi/<tenant>/admin-token, and ESO's OpenBao role
+    # is asymmetric — external-secrets-read covers secret/{data,metadata}/*
+    # (everything) while external-secrets-push grants create/update on the
+    # newapi admin-token path ONLY. So the PushSecret 403'd:
+    #   g7doora/catalyst-newapi-admin-token-push   Errored
+    #     PUT .../v1/secret/metadata/sovereign/... Code: 403 permission denied
+    #   newapi/catalyst-newapi-admin-token-push    Synced   (Sovereign-level, catalyst/ path)
+    # leaving the paired ExternalSecret in SecretSyncedError forever while
+    # the HelmRelease still reported Ready — a silent failure. Re-pointing
+    # the path would have made the write SUCCEED and turned a visible error
+    # into the destructive cross-Org clobber described above, which is why
+    # the fix is to turn the seam off rather than to move it.
+    #
+    # Nothing inside the per-Org release consumes the Secret, so off is
+    # both safe and complete.
     catalystIntegration:
-      enabled: true
-      existingSecret: catalyst-newapi-admin-token
-      externalSecret:
-        enabled: true
-        refreshInterval: 1h
-        secretStoreRef:
-          kind: ClusterSecretStore
-          name: vault-region1
-        remoteRef:
-          key: sovereign/{{.OTECHFQDN}}/newapi/{{.TenantID}}/admin-token
-          property: ADMIN_API_TOKEN
+      enabled: false
 `
 
 const orgTenantBPWordPress = `# bp-wordpress-tenant (#800, #915) — SSO-pre-wired WordPress per Organization.
@@ -1699,13 +1724,43 @@ spec:
 // HelmRelease (the per-Application unit in the Organization tenant model).
 // CRD shape per products/catalyst/chart/crds/continuum.yaml.
 //
-// Lease backend defaults to dns-quorum because the Sovereign-internal
-// PowerDNS already runs 3 resolver Pods and we don't want to pin
-// tenants to Cloudflare KV; operators that want cloudflare-kv can
-// follow up post-handover via a Continuum CR edit (the controller
-// supports both kinds — see core/controllers/continuum/internal/
-// witness/{cloudflarekv,dnsquorum}). Health-check URL points at the
-// tenant's WordPress public host.
+// Lease backend is k8s-lease (#3829). It is NOT dns-quorum, and the
+// difference is the whole reason a hot-standby tenant reaches Ready.
+//
+// This template used to emit `kind: dns-quorum` with resolvers
+// 10.43.0.10/.11/.12, on the belief that those were the Sovereign's
+// three in-cluster PowerDNS resolver Pods. They are not: 10.43.0.0/16
+// is k3s's DEFAULT service CIDR, and these Sovereigns allocate from
+// 10.96.0.0/12, so .11 and .12 were never anything at all and .10 was
+// at best kube-dns. Re-pointing them does NOT fix the row, for three
+// independent reasons:
+//
+//  1. dns-quorum's registered factory builds its client with a nil
+//     TXTWriter unconditionally
+//     (core/controllers/continuum/internal/witness/dnsquorum/client.go:213),
+//     so writeQuorum (same file:435) returns "Writer not configured
+//     (Phase-1 POC needs PDM /v1/txt — K-Cont-{4|5})" and Acquire can
+//     never take the lease no matter which resolvers it is given.
+//  2. kube-dns is not authoritative for the lease zone, so the read
+//     side finds no TXT record to reach a 2-of-3 majority either.
+//  3. kube-dns is REGION-LOCAL (measured on hw293: region A serves
+//     10.96.0.10, region B serves 10.97.0.10). A witness exists to let
+//     two regions arbitrate ONE slot; per-region resolver sets can
+//     never form the shared quorum that requires.
+//
+// k8s-lease stores the lease in a native coordination.k8s.io/v1 Lease
+// in the control-plane cluster — durable etcd CAS via resourceVersion,
+// zero external dependency (so it survives the Pillar-5 air-gap), and
+// the continuum-controller's ClusterRole already grants the verbs. It
+// is already the shipped default for bp-cnpg-pair
+// (platform/cnpg-pair/chart/values.yaml:613) and bp-postgres
+// (platform/postgres/chart/values.yaml:351); this per-Org writer was
+// the last producer still selecting the dead backend.
+//
+// No `config` block is needed: the reconciler stamps the Lease
+// namespace from CATALYST_LEASE_NS (already set to catalyst-system on
+// the deployed controller). Health-check URL points at the tenant's
+// WordPress public host.
 //
 // RTO 30s / RPO 5s match CLAUDE.md §0 deterministic step 10's
 // "≤30s failover" claim. autoFailover defaults to false so the first
@@ -1742,18 +1797,16 @@ spec:
   # Operator-driven for the first fresh-prov walk; flip to true on
   # the CR post-handover once the path is proven.
   autoFailover: false
-  # dns-quorum is the canonical Sovereign-internal lease backend
-  # (3 in-cluster PowerDNS resolvers). cloudflare-kv is the
-  # alternative when a public CF KV namespace is available.
+  # k8s-lease (#3829) — a native coordination.k8s.io/v1 Lease in the
+  # control-plane cluster. Air-gappable, durable etcd CAS, no resolvers
+  # to misconfigure. dns-quorum is NOT usable: its client is built with
+  # a nil TXTWriter, so Acquire always fails and the CR sits Degraded
+  # with no leaseHolder and no standby. See the Go comment above.
   leaseClient:
-    kind: dns-quorum
+    kind: k8s-lease
     config:
       ttlSeconds: 30
       renewSeconds: 10
-      resolvers:
-        - "10.43.0.10"
-        - "10.43.0.11"
-        - "10.43.0.12"
   luaRecord:
     selector: ifurlup
     healthCheck:

--- a/products/catalyst/bootstrap/api/internal/handler/organization_newapi_catalyst_integration_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/organization_newapi_catalyst_integration_test.go
@@ -1,0 +1,155 @@
+// Guard for UAT row G2 (#5987) — a per-Organization bp-newapi release
+// must NOT switch on the Sovereign-scoped catalystIntegration seam.
+//
+// WHAT ROW G2 SAW, AND WHY THE OBVIOUS READING WAS WRONG
+// ──────────────────────────────────────────────────────
+// G2 was recorded as "bp-newapi installs at chart 1.4.153 yet
+// `kubectl get externalsecrets` returned ZERO in the same namespace,
+// so the delivery half works and the ExternalSecret half does not."
+// Two separate things are wrong with that.
+//
+// First, the measurement: run without -n, `kubectl get externalsecrets`
+// reports on the `default` namespace, which legitimately holds none.
+// Live on hw293 (dep a0077ba47e3720e5) the cluster carried 22
+// ExternalSecrets, four of them in the tenant Org namespace g7doora.
+// The producer was never missing.
+//
+// Second, the direction: the per-Org ExternalSecret that DID exist was
+// failing, and the fix is to delete it rather than to repair it. The
+// admin-token seam is SOVEREIGN-scoped. Its consumer is a single
+// catalyst-api Pod in catalyst-system reading ADMIN_API_TOKEN via
+// secretKeyRef on ONE reflector-mirrored Secret (see
+// platform/newapi/chart/templates/external-secret.yaml:55-70). A per-Org
+// release that enables the seam renders a second ExternalSecret
+// contending for that one mirror, and its paired PushSecret — driven off
+// the SAME remoteRef.key — would overwrite the shared OpenBao path with
+// that Org's own random ADMIN_SECRET, 401-ing per-user key issuance for
+// the whole Sovereign.
+//
+// On hw293 it failed earlier than that, on a 403, because the per-Org
+// key used the `sovereign/` prefix while ESO's external-secrets-push
+// policy grants writes only on the newapi admin-token path:
+//
+//	g7doora/catalyst-newapi-admin-token-push   Errored  (403 permission denied)
+//	newapi/catalyst-newapi-admin-token-push    Synced   (Sovereign-level)
+//
+// so the ExternalSecret sat SecretSyncedError while the HelmRelease
+// still reported Ready. Merely re-pointing the path would have made the
+// write succeed and converted a visible error into a silent cross-Org
+// clobber — which is why this guard asserts the seam is OFF, not that
+// the path is prettier.
+//
+// core/services/provisioning/gitops/helmrelease_apps.go:512-527 already
+// reached this conclusion for the funnel path; this guard keeps the
+// per-Org GitOps writer from drifting back out of line with it.
+package handler
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestPerOrgNewAPIDoesNotEnableCatalystIntegration is the row-G2 guard.
+func TestPerOrgNewAPIDoesNotEnableCatalystIntegration(t *testing.T) {
+	files, err := renderOrganizationOverlay(d31TestRec(), OrganizationChartVersions{})
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+
+	newapi, ok := files["bp-newapi.yaml"]
+	if !ok {
+		t.Fatalf("bp-newapi.yaml missing from overlay; got %v", fileNames(files))
+	}
+
+	// Assert on the VALUE of the rendered toggle, not on the presence of
+	// the key: the key is present either way, and "present" was never
+	// the question.
+	got := catalystIntegrationEnabled(newapi)
+	if got != "false" {
+		t.Errorf("per-Org bp-newapi renders catalystIntegration.enabled=%q, want \"false\".\n"+
+			"The admin-token seam is Sovereign-scoped: one catalyst-api consumer, one\n"+
+			"reflector mirror in catalyst-system, one shared OpenBao path. A per-Org\n"+
+			"copy either 403s on write (what hw293 measured) or clobbers the\n"+
+			"Sovereign's token for every Org. See helmrelease_apps.go:512-527.", got)
+	}
+
+	// The seam being off must take its OpenBao path with it — a stray
+	// remoteRef would keep rendering the failing ExternalSecret.
+	//
+	// These checks run against COMMENT-STRIPPED yaml on purpose. The
+	// template documents the defect it fixes, so it legitimately mentions
+	// `sovereign/...` and ADMIN_API_TOKEN in prose; a raw substring match
+	// would flag the explanation rather than a live field. Assert on what
+	// renders into the object, not on what the file says.
+	live := stripYAMLComments(newapi)
+	if strings.Contains(live, "sovereign/") && strings.Contains(live, "admin-token") {
+		t.Errorf("per-Org bp-newapi still carries a sovereign/-prefixed newapi admin-token "+
+			"OpenBao path; ESO's external-secrets-push policy does not grant writes there "+
+			"(403 permission denied, measured on hw293 g7doora):\n%s", live)
+	}
+	if strings.Contains(live, "ADMIN_API_TOKEN") {
+		t.Errorf("per-Org bp-newapi still references ADMIN_API_TOKEN — the Sovereign-scoped "+
+			"admin-token seam should be fully absent from a per-Org release:\n%s", live)
+	}
+
+	// CONTROL — this change must not switch OFF the per-Org seams that
+	// legitimately work. The agenity mcp-bearer ExternalSecret reads
+	// catalyst/agenity/<subdomain>/mcp-bearer and is SecretSynced=True on
+	// hw293; ssoBridgeSync/oidc wiring likewise stays untouched. If this
+	// control goes red the change has over-reached from "disable one
+	// Sovereign-scoped seam" into "disable per-Org secret wiring".
+	all := strings.Join(overlayManifests(files), "\n")
+	if !strings.Contains(all, "catalyst/agenity/") {
+		t.Errorf("CONTROL FAILED: the per-Org agenity mcp-bearer OpenBao path " +
+			"(catalyst/agenity/<subdomain>/mcp-bearer, SecretSynced=True on hw293) " +
+			"disappeared — this fix must not touch working per-Org secret seams")
+	}
+	// CONTROL — the Sovereign-level install is a DIFFERENT code path
+	// (clusters/_template/bootstrap-kit/80-newapi.yaml) and must keep the
+	// seam ON. Its absence from this overlay is the expected asymmetry,
+	// so assert the overlay is genuinely the per-Org one.
+	if !strings.Contains(newapi, "bp-newapi") {
+		t.Fatalf("fixture drift: bp-newapi.yaml does not look like a bp-newapi release")
+	}
+}
+
+// catalystIntegrationEnabled returns the rendered value of
+// catalystIntegration.enabled, or "" when the block is absent.
+func catalystIntegrationEnabled(manifest string) string {
+	i := strings.Index(manifest, "catalystIntegration:")
+	if i < 0 {
+		return ""
+	}
+	for _, ln := range strings.Split(manifest[i:], "\n") {
+		t := strings.TrimSpace(ln)
+		if strings.HasPrefix(t, "enabled:") {
+			return strings.TrimSpace(strings.TrimPrefix(t, "enabled:"))
+		}
+	}
+	return ""
+}
+
+func overlayManifests(m map[string]string) []string {
+	out := make([]string, 0, len(m))
+	for _, v := range m {
+		out = append(out, v)
+	}
+	return out
+}
+
+// stripYAMLComments removes whole-line and trailing `#` comments so an
+// assertion sees only what actually renders into the object.
+func stripYAMLComments(manifest string) string {
+	var b strings.Builder
+	for _, ln := range strings.Split(manifest, "\n") {
+		if i := strings.Index(ln, "#"); i >= 0 {
+			ln = ln[:i]
+		}
+		if strings.TrimSpace(ln) == "" {
+			continue
+		}
+		b.WriteString(ln)
+		b.WriteString("\n")
+	}
+	return b.String()
+}


### PR DESCRIPTION
## Summary

UAT rows **G3** and **G2** are the fourth state — the fix is provably in the running artifact and the row fails anyway — so in both cases the recorded diagnosis was wrong. Both defects turn out to live in the **same producer**, `products/catalyst/bootstrap/api/internal/handler/organization_gitops.go`, and neither needed the change it was filed asking for.

Measured on **hw293.omantel.biz**, dep `a0077ba47e3720e5`, read-only.

## G3 (Refs #6071) — the witness cannot take a lease, and no resolver value changes that

Filed as: *resolvers are hardcoded `10.43.0.10/.11/.12` while kube-dns is `10.96.0.10`* — implying "derive the resolver set from the cluster".

The live failing CR is **not** the qa fixture the row pointed at. It is `g7doora/bp-wordpress-tenant`, labelled `kustomize.toolkit.fluxcd.io/name: org-tenants`, written by `organization_gitops.go:1749-1756`. It reads `phase: Degraded`, `LeaseHeld=False`, no `leaseHolder`, and the controller logs `witness read-quorum unavailable — check leaseClient resolvers/wiring` every 10s.

Re-pointing the resolvers cannot fix it, for three independent reasons:

1. `dnsquorum/client.go:213` builds the client with a **nil TXTWriter unconditionally**, so `writeQuorum` (`client.go:435`) refuses before a packet is sent — regardless of resolvers.
2. A cluster exposes **one** kube-dns ClusterIP and dns-quorum requires **at least 3 servers**, so "derive from the cluster" produces a config the factory rejects outright.
3. kube-dns is **region-local** — hw293 region A serves `10.96.0.10`, region B serves `10.97.0.10`. A witness exists so two regions can arbitrate one slot; per-region resolvers can never form that shared quorum.

The working backend already shipped as #3829 (`k8s-lease`) and is already the default for `bp-cnpg-pair` and `bp-postgres`. It is also already **in the deployed controller image** — `150ff73` descends from `9c91a7e10`, and `CATALYST_LEASE_NS=catalyst-system` is already set on the Deployment. The controller was always ready; this producer was the last one still selecting the dead backend.

## G2 (Refs #5987) — a Sovereign-scoped seam switched on per-Organization

Filed as: *`kubectl get externalsecrets` returned zero in the same namespace*.

Run without `-n`, that reports on the **`default`** namespace, which holds none. hw293 carried **22** ExternalSecrets, four in the tenant Org namespace `g7doora`. The producer was never missing — the "zero" was a measurement artifact.

What *is* broken is the per-Org copy of a **Sovereign-scoped** seam. Its consumer is a single `catalyst-api` Pod in `catalyst-system` reading `ADMIN_API_TOKEN` via `secretKeyRef` on **one** reflector-mirrored Secret (`platform/newapi/chart/templates/external-secret.yaml:55-70`). `bp-newapi` drives its ExternalSecret **and** its PushSecret off the same `remoteRef.key`, and ESO's OpenBao role is asymmetric — `external-secrets-read` covers everything, `external-secrets-push` grants writes on the newapi admin-token path only. So:

```
g7doora/catalyst-newapi-admin-token-push   Errored   403 permission denied on secret/metadata/sovereign/...
newapi/catalyst-newapi-admin-token-push    Synced    (Sovereign-level, catalyst/ path)
```

The write 403s, the path stays empty, the paired ExternalSecret sits `SecretSyncedError` forever — while the HelmRelease still reports `Ready`, which is why it reads as "delivery works, secrets do not".

Re-pointing the path would have made the write **succeed** and converted a visible error into a silent cross-Org clobber: every Org would overwrite the Sovereign's shared admin token with its own random `ADMIN_SECRET`. `core/services/provisioning/gitops/helmrelease_apps.go:512-527` already reached that conclusion for the funnel path and sets `enabled: false`; this per-Org GitOps writer was simply never brought into line. So the seam is turned **off**, not moved.

## Guards — each watched red before green

`TestRenderOrganizationOverlay_HotStandby_On_EmitsContinuumCR` and the new `TestPerOrgNewAPIDoesNotEnableCatalystIntegration`, against the pre-fix producer:

```
--- FAIL: TestRenderOrganizationOverlay_HotStandby_On_EmitsContinuumCR
    continuum.yaml missing "kind: k8s-lease"
    continuum.yaml must not contain "kind: dns-quorum"
    continuum.yaml must not contain "10.43.0."
    continuum.yaml must not contain "resolvers:"
--- FAIL: TestPerOrgNewAPIDoesNotEnableCatalystIntegration
    per-Org bp-newapi renders catalystIntegration.enabled="true", want "false".
    per-Org bp-newapi still carries a sovereign/-prefixed newapi admin-token OpenBao path
    per-Org bp-newapi still references ADMIN_API_TOKEN
FAIL   exit 1
```

After the fix both pass, and the whole `internal/handler` package and `core/controllers/continuum/...` are green.

`core/controllers/continuum/internal/witness/witness_backend_functional_test.go` is the behavioural control, and it is what makes the refutation more than an assertion:

```
--- PASS: TestDNSQuorumRejectsADerivedResolverSet
    derive-from-cluster produces: dnsquorum: at least 3 servers required, got 1
--- PASS: TestDNSQuorumWriterIsNilForEveryResolverSet
    resolvers=[10.43.0.10 10.43.0.11 10.43.0.12] -> TXTWriter is nil (Acquire can never write)
    resolvers=[10.96.0.10 10.96.0.11 10.96.0.12] -> TXTWriter is nil (Acquire can never write)
    resolvers=[1.1.1.1 8.8.8.8 9.9.9.9]          -> TXTWriter is nil (Acquire can never write)
--- PASS: TestDNSQuorumFailsWithPlaceholderResolvers
    placeholder resolvers -> witness: read quorum unavailable (holder empty, CR would go Degraded)
--- PASS: TestK8sLeaseAcquiresLease
    k8s-lease acquired: holder="hw-me-east-215-a-rtz-prod" generation=1
```

The correct-resolver case going red alongside the placeholder one is the decisive result; `TestK8sLeaseAcquiresLease` is the paired positive control on the same `DefaultSelector` dispatch path, so the suite discriminates between backends instead of being satisfied by a world where everything fails. Both producer guards assert on rendered **values** against comment-stripped YAML — an earlier draft matched raw substrings and flagged the template's own explanatory prose.

## Delivery

No chart surface changed, so no version bump and no lockstep pin moves. Both fixes reach a Sovereign on the next **catalyst-api image roll**; the continuum-controller needs no roll because `k8s-lease` is already in its deployed image.

## Not done here

- The same dead `dns-quorum` default still sits in `products/catalyst/chart/templates/qa-fixtures/continuum-qa.yaml` and `platform/openbao/chart/values.yaml:717`. Neither renders on hw293 (the cluster has exactly one Continuum, the one fixed here), and both would force chart + bootstrap-kit lockstep bumps, so they are left for a follow-up rather than widening this change.
- G2's row text asks for ExternalSecrets in the Application namespace. After this change the per-Org release intentionally emits none for the admin-token seam, so the row's clause needs re-adjudication against the Sovereign-level install — it is a row-wording question, not remaining code.

Refs #6071 #5987 #3829 #4477

🤖 Generated with [Claude Code](https://claude.com/claude-code)
