### PR TITLE
fix(console,api): four UAT rows at their producers — purchased plan, Org stamp on the seed path, stable parent identity, real and visible re-run

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/application_organizationref_seed_row15_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/application_organizationref_seed_row15_test.go
@@ -1,0 +1,178 @@
+/*
+application_organizationref_seed_row15_test.go — UAT row 15, the producer
+#5933 did not enrol.
+
+WHAT #5933 FIXED AND WHAT IT MISSED. #5814 gave the sovereign /apps grid its Org
+attribution chip by reading `spec.organizationRef` off each Application CR
+(sovereign.go:866), verbatim. #5933 then found that the REST install producer
+(newApplicationUnstructured) never wrote that field and fixed it, guarding the
+change with the spine producer (renderSpineApplicationCR) as a control.
+
+There is a THIRD persisted producer: newApplicationCRFromSeed
+(endpoint_handler.go:2312), the multi-instance create path behind
+POST create-instance AND behind wireBackingServices' auto-created backing
+services. It stamps metadata, labels and a full spec — and no organizationRef.
+So the chip still fails on every Application born through the seed path, which
+is why row 15 measured 4 of 7 cards with no Org chip while the other 3 were
+fine: the passing cards came from the two producers #5933 covered.
+
+WHY THE OBVIOUS GUARD IS BLIND HERE — the point of this file.
+The Org identity travels on the CR in TWO places, and only one of them is what
+the chip reads:
+
+  - the LABEL `catalyst.openova.io/organization` — stamped by ALL THREE
+    producers already (seed path: obj.SetLabels(seed.Labels) at
+    endpoint_handler.go:2322, populated at instances/create.go:376).
+  - the SPEC FIELD `spec.organizationRef` — stamped by producer 1 and 3 only.
+    This is the one sovereign.go reads.
+
+A guard written against the LABEL therefore passes on all three producers and
+cannot see this defect at all. placement_3373_test.go:217 is exactly that guard:
+it exercises newApplicationCRFromSeed with a dotted org, and asserts only
+metadata.namespace and spec.environmentRef — both derived — so it has been
+green throughout. The assertions below are on the SPEC FIELD deliberately, and
+the label is asserted only as the equality partner (two spellings of one Org is
+its own defect, #5933's rule).
+
+The empty-org case pins OMISSION rather than "". An empty string marshals away
+under the reader's omitempty and reads downstream as "this Application declares
+no Org" — indistinguishable from an unowned app, which is precisely how this
+stayed invisible. Fail-closed matches producer 1 (application_organizationref_
+5933_test.go:114).
+*/
+package handler
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/instances"
+)
+
+// seedForOrg — a realistic multi-instance seed. instances.Build sets
+// Namespace to the Org ref VERBATIM (create.go:368 `Namespace: r.Org`) and
+// mirrors the same string onto the organization label (create.go:378), so a
+// fixture that disagrees between the two would not represent any real call.
+func seedForOrg(org string) instances.ApplicationSeed {
+	return instances.ApplicationSeed{
+		Name:       "uatco-openclaw",
+		Namespace:  org,
+		Blueprint:  "bp-openclaw",
+		Topology:   "single-region",
+		InstanceID: "inst-abc123",
+		Labels: map[string]string{
+			"catalyst.openova.io/managed-by":   "catalyst-api",
+			"catalyst.openova.io/organization": org,
+			"catalyst.openova.io/blueprint":    "openclaw",
+			"catalyst.openova.io/instance":     "inst-abc123",
+		},
+	}
+}
+
+// THE ROW-15 GUARD. An Application born through the multi-instance seed path
+// must carry spec.organizationRef, verbatim.
+func TestNewApplicationCRFromSeed_StampsOrganizationRef_Row15(t *testing.T) {
+	obj := newApplicationCRFromSeed(seedForOrg("uatco"))
+
+	org, found, err := unstructured.NestedString(obj.Object, "spec", "organizationRef")
+	if err != nil {
+		t.Fatalf("read spec.organizationRef: %v", err)
+	}
+	if !found {
+		t.Fatalf("spec.organizationRef absent — the seed producer never stamps the Org, " +
+			"so sovereign.go:866 reads empty and the /apps Org chip cannot render for " +
+			"any Application created through the multi-instance path (UAT row 15)")
+	}
+	if org != "uatco" {
+		t.Errorf("spec.organizationRef = %q, want %q (verbatim)", org, "uatco")
+	}
+}
+
+// The dotted-FQDN case is where a "helpful" fix goes wrong. The seed producer
+// SLUGS the same string twice on purpose — metadata.namespace via orgNamespace
+// and spec.environmentRef via environmentRefForOrg — because the CRD rejects
+// dots there. organizationRef is the one place the identity must survive
+// UNSLUGGED, because the reader is verbatim and the chip prints what it reads.
+// Reusing either slugged value here would satisfy the test above and still
+// paint the wrong Org name on the card.
+func TestNewApplicationCRFromSeed_OrganizationRefIsVerbatimNotSlugged_Row15(t *testing.T) {
+	const org = "hw293.omantel.biz"
+	obj := newApplicationCRFromSeed(seedForOrg(org))
+
+	got, found, _ := unstructured.NestedString(obj.Object, "spec", "organizationRef")
+	if !found || got != org {
+		t.Fatalf("spec.organizationRef = %q (found=%v), want %q verbatim — dots intact",
+			got, found, org)
+	}
+
+	// It must NOT be either derived spelling.
+	if ns := obj.GetNamespace(); got == ns {
+		t.Errorf("spec.organizationRef must not be the slugged namespace %q", ns)
+	}
+	if envRef, _, _ := unstructured.NestedString(obj.Object, "spec", "environmentRef"); got == envRef {
+		t.Errorf("spec.organizationRef must not be the slugged environmentRef %q", envRef)
+	}
+
+	// The two carriers of the identity must agree — one Application may not
+	// carry two spellings of its own Org (#5933's rule).
+	if lbl := obj.GetLabels()["catalyst.openova.io/organization"]; lbl != got {
+		t.Errorf("spec.organizationRef %q disagrees with the organization label %q", got, lbl)
+	}
+
+	// CONTROL — the derivations this producer is SUPPOSED to slug must still
+	// be slugged. A fix that stopped slugging everything would make the
+	// assertions above pass and have the apiserver reject the CR.
+	if ns := obj.GetNamespace(); ns != "hw293-omantel-biz" {
+		t.Errorf("control: metadata.namespace must stay slugged, got %q", ns)
+	}
+}
+
+// Fail-closed: no Org on the seed ⇒ the key is OMITTED, never "".
+func TestNewApplicationCRFromSeed_OmitsOrganizationRefWhenUnset_Row15(t *testing.T) {
+	seed := seedForOrg("")
+	delete(seed.Labels, "catalyst.openova.io/organization")
+	obj := newApplicationCRFromSeed(seed)
+
+	if org, found, _ := unstructured.NestedString(obj.Object, "spec", "organizationRef"); found {
+		t.Errorf("spec.organizationRef present as %q for an Org-less seed; an empty ref "+
+			"claims an empty-named Org instead of reading as attribution-unknown", org)
+	}
+}
+
+// LOCKSTEP — every persisted Application-CR producer stamps the field the chip
+// reads. This is the guard the brief asks for: one written against only the
+// producers that already worked cannot see a gap in the third. Enumerating all
+// three in ONE test means the next producer added to this package fails here
+// until it is enrolled, rather than shipping another silent blind spot.
+func TestAllApplicationProducers_StampOrganizationRef_Row15(t *testing.T) {
+	const org = "uatco"
+
+	producers := map[string]*unstructured.Unstructured{
+		// 1 — REST install path (applications.go:1083).
+		"newApplicationUnstructured": newApplicationUnstructured(
+			customerInstallRequest(), "hw293.omantel.biz", "console.uatco.omani.homes"),
+		// 2 — multi-instance seed path (endpoint_handler.go:2312). The one
+		// row 15 measured broken.
+		"newApplicationCRFromSeed": newApplicationCRFromSeed(seedForOrg(org)),
+		// 3 — spine self-registration (post_handover_spine_apps.go:472).
+		"renderSpineApplicationCR": renderSpineApplicationCR(
+			spineComponent{
+				Chart: "harbor", HRName: "bp-harbor",
+				BlueprintName: "bp-harbor", BlueprintVersion: "1.2.25",
+			},
+			"uatco-cp", org, []string{"me-east-215"},
+			map[string]string{"catalyst.openova.io/organization": org}, ""),
+	}
+
+	for name, obj := range producers {
+		got, found, err := unstructured.NestedString(obj.Object, "spec", "organizationRef")
+		if err != nil {
+			t.Fatalf("%s: read spec.organizationRef: %v", name, err)
+		}
+		if !found || got != org {
+			t.Errorf("%s: spec.organizationRef = %q (found=%v), want %q — this producer's "+
+				"Applications render with no Org chip on /apps", name, got, found, org)
+		}
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/endpoint_handler.go
+++ b/products/catalyst/bootstrap/api/internal/handler/endpoint_handler.go
@@ -2317,7 +2317,13 @@ func newApplicationCRFromSeed(seed instances.ApplicationSeed) *unstructured.Unst
 	// #3830 — seed.Namespace carries the Org ref (often a dotted FQDN).
 	// metadata.namespace must be the slugged RFC-1123 form; the verbatim
 	// Org identity is preserved on the catalyst.openova.io/organization
-	// label (set in instances.Build) and on environmentRef below.
+	// label (set in instances.Build) and on spec.organizationRef below.
+	//
+	// This comment used to point at environmentRef as the second verbatim
+	// carrier. It is not one — environmentRefForOrg slugs it for the same
+	// CRD-pattern reason metadata.namespace is slugged, so BOTH of the
+	// places it named were derived forms and the CR had no verbatim
+	// carrier in its spec at all (UAT row 15).
 	obj.SetNamespace(orgNamespace(seed.Namespace))
 	obj.SetLabels(seed.Labels)
 	// One vocabulary (#3375 DoD-1): both the string AND object forms
@@ -2373,6 +2379,31 @@ func newApplicationCRFromSeed(seed instances.ApplicationSeed) *unstructured.Unst
 		"instanceId":     seed.InstanceID,
 		"isolationLevel": string(seed.IsolationLevel),
 		"namingTemplate": seed.NamingTemplate,
+	}
+	// UAT row 15 — stamp the OWNING Organization, verbatim.
+	//
+	// #5933 added this to newApplicationUnstructured (the REST install path)
+	// and guarded it with the spine producer as a control, but this third
+	// producer — the multi-instance seed path, which also backs
+	// wireBackingServices — was never enrolled. sovereign.go:866 reads
+	// spec.organizationRef VERBATIM to render the /apps Org chip, so every
+	// Application born here rendered with no attribution at all: row 15
+	// measured 4 of 7 cards missing the chip, and the 3 that passed were the
+	// ones the other two producers made.
+	//
+	// seed.Namespace is the Org ref UNSLUGGED (instances/create.go:368 sets
+	// it from r.Org, and mirrors the same string onto the organization
+	// label). Neither derived spelling on this CR is a substitute: both
+	// metadata.namespace and spec.environmentRef are deliberately slugged
+	// because the CRD pattern forbids dots, and the chip prints what it
+	// reads — a slugged value would paint `hw293-omantel-biz` where the
+	// operator expects `hw293.omantel.biz`.
+	//
+	// Omitted when empty, matching producer 1: an empty ref claims an
+	// Org with no name, while an absent one honestly reads as
+	// attribution-unknown.
+	if orgRef := strings.TrimSpace(seed.Namespace); orgRef != "" {
+		spec["organizationRef"] = orgRef
 	}
 	// #4283 / #4282 Root-B — ALWAYS stamp a non-null spec.parameters
 	// OBJECT. The auto-created backing-service path (wireBackingServices)

--- a/products/catalyst/bootstrap/api/internal/handler/jobs_retry.go
+++ b/products/catalyst/bootstrap/api/internal/handler/jobs_retry.go
@@ -289,6 +289,31 @@ func (h *Handler) dispatchRetry(ctx context.Context, dyn dynamic.Interface, job 
 		// immutable fields stripped. A Job OWNED by a CronJob is re-driven
 		// through its CronJob ("Run now") instead — recreating a
 		// CronJob-managed Job standalone would orphan it from its owner.
+		//
+		// UAT row 176 — a COLLAPSED scanner identity row is handled first.
+		// The Jobs view folds every scanner run onto one stable identity
+		// (#3925), and those identities are synthetic: nothing is named
+		// `syft-sbom`, so the lookup below can never find it and the row
+		// 422'd on every click. #5496's `<name>-<digits>` fallback does not
+		// reach it either — the real object is `syft-grype-bp-syft-grype-<n>`
+		// and the row name is not a prefix of that.
+		//
+		// The identity's backing CronJob IS known (it is what seeds the row),
+		// so "Run now" on that CronJob is the truthful re-run — the same
+		// mechanism case jobs.KindCron and the owned-Job branch below use. A
+		// missing CronJob still degrades to the honest 422 rather than
+		// reporting a re-run of an object that is not there.
+		if scanNS, cron, isScanIdentity := helmwatch.SyftScanCronTarget(name); isScanIdentity {
+			runName, cerr := createJobFromCronJob(ctx, dyn, scanNS, cron, now)
+			if cerr != nil {
+				if apierrors.IsNotFound(cerr) || apierrors.IsNotFound(errors.Unwrap(cerr)) {
+					return "", fmt.Errorf("CronJob %s/%s backing the %q row is not installed: %w",
+						scanNS, cron, name, errNotDirectlyRetryable)
+				}
+				return "", cerr
+			}
+			return "created one-off Job " + runName + " from CronJob " + cron, nil
+		}
 		ns, jobName, err := resolveObjectNamespace(ctx, dyn, helmwatch.JobGVR, name)
 		if err != nil {
 			return "", err

--- a/products/catalyst/bootstrap/api/internal/handler/jobs_retry_syft_identity_row176_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/jobs_retry_syft_identity_row176_test.go
@@ -1,0 +1,153 @@
+/*
+jobs_retry_syft_identity_row176_test.go — UAT row 176, the 422 half.
+
+THE DEFECT. The Jobs view collapses every scanner run onto ONE stable identity
+leaf (#3925): all trivy-operator scan Jobs fold onto `task-trivy-security-scan`
+and all bp-syft-grype runs fold onto `task-syft-sbom`. Those identities are
+SYNTHETIC — no Kubernetes object is named `syft-sbom`. So the retry dispatch
+(jobs_retry.go, case jobs.KindTask) asked resolveObjectNamespace for a Job by
+that name, found nothing, and returned errNotDirectlyRetryable → HTTP 422.
+
+#5496 (8367b627a) added a `<row-name>-<digits>` fallback for
+controller-generated Jobs. It cannot reach this row: the real object is
+`syft-grype-bp-syft-grype-29773110`, and `syft-sbom` is not a prefix of it, so
+the suffix rule never matches. That fix is deployed and the row still 422s.
+
+THE DISTINCTION THIS FILE PINS — and why the two scanners must NOT be treated
+alike:
+
+  - syft-grype HAS a single real backing object: the CronJob `syft-grype` in
+    namespace `syft-grype` (helmwatch/reconcilers.go declares both, and the
+    collapsed row is seeded FROM that CronJob). "Run now" on that CronJob is a
+    truthful re-run, and it is the same mechanism the CronJob-owned task branch
+    and case jobs.KindCron already use.
+  - trivy-security-scan has NO single backing object. The trivy-operator spawns
+    one scan Job per workload; there is nothing to re-run that means "redo the
+    scan". Its 422 is CORRECT and must stay.
+
+Hence the control below. A fix that made every collapsed identity row "work" —
+by inventing a target, or by relaxing the aggregate check — would turn the
+first test green and the control red. Only a fix that re-runs a real object
+that actually exists passes both.
+*/
+package handler
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/auth"
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/helmwatch"
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/jobs"
+)
+
+// syftGrypeCronJob — the bp-syft-grype CronJob exactly as slot-33 installs it
+// (release name `syft-grype`, targetNamespace `syft-grype`). This is the
+// object the collapsed `task-syft-sbom` row is seeded from.
+func syftGrypeCronJob() *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "batch/v1",
+		"kind":       "CronJob",
+		"metadata":   map[string]any{"name": "syft-grype", "namespace": "syft-grype"},
+		"spec": map[string]any{
+			"schedule": "0 3 * * *",
+			"jobTemplate": map[string]any{
+				"spec": map[string]any{
+					"template": map[string]any{
+						"spec": map[string]any{
+							"restartPolicy": "Never",
+							"containers": []any{map[string]any{
+								"name": "syft", "image": "anchore/syft:latest",
+							}},
+						},
+					},
+				},
+			},
+		},
+	}}
+}
+
+// THE ROW-176 GUARD. Clicking re-run on the collapsed Syft SBOM row must
+// actually re-run it — 200, via the owning CronJob.
+func TestRetryJob_Task_SyftIdentity_RunsViaOwningCronJob_Row176(t *testing.T) {
+	r, h, depID := installRetryHarness(t, "owner@t99.omani.works",
+		"task-syft-sbom", jobs.StatusFailed, syftGrypeCronJob())
+
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, retryReq(depID, "task-syft-sbom",
+		&auth.Claims{Email: "owner@t99.omani.works", Tier: "operator"}))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200 (re-run via the owning CronJob), got %d; body=%s — "+
+			"the operator clicks re-run on the Syft SBOM row and nothing happens (UAT row 176)",
+			rec.Code, rec.Body.String())
+	}
+
+	// The 200 must correspond to a REAL new run, not a bare acknowledgement.
+	// Asserting only the status code would pass on a handler that returned
+	// 200 and did nothing at all — the exact fake-green this row is about.
+	dyn, _ := h.dynamicFactory("")
+	list, err := dyn.Resource(helmwatch.JobGVR).Namespace("syft-grype").
+		List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("list Jobs: %v", err)
+	}
+	created := ""
+	for _, it := range list.Items {
+		if v, _, _ := unstructured.NestedString(it.Object, "metadata", "labels",
+			"catalyst.openova.io/from-cronjob"); v == "syft-grype" {
+			created = it.GetName()
+		}
+	}
+	if created == "" {
+		t.Fatalf("no one-off Job was created from CronJob syft-grype; a 200 without a "+
+			"new run is a fake green. Jobs present: %d", len(list.Items))
+	}
+}
+
+// THE CONTROL. trivy-security-scan aggregates per-workload scan Jobs and has
+// no single object to re-run, so it must STILL 422. This is what stops the fix
+// above from being "make aggregate rows return 200".
+func TestRetryJob_Task_TrivyIdentity_Stays422_Row176(t *testing.T) {
+	// Seed the syft CronJob too: it exists on a real Sovereign, and its
+	// presence must not make the UNRELATED trivy row suddenly retryable.
+	r, _, depID := installRetryHarness(t, "owner@t99.omani.works",
+		"task-trivy-security-scan", jobs.StatusFailed, syftGrypeCronJob())
+
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, retryReq(depID, "task-trivy-security-scan",
+		&auth.Claims{Email: "owner@t99.omani.works", Tier: "operator"}))
+
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("trivy aggregate must stay 422 (nothing to re-run), got %d; body=%s",
+			rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "not-directly-retryable") {
+		t.Fatalf("422 body must keep the actionable code: %s", rec.Body.String())
+	}
+}
+
+// The syft row must not become retryable by NAME alone — if the backing
+// CronJob is genuinely absent (bp-syft-grype not installed), the honest answer
+// is still 422. Otherwise the fix would report a successful re-run of an
+// object that does not exist, which is the same class of defect as the
+// original silent failure.
+func TestRetryJob_Task_SyftIdentity_NoCronJob_Stays422_Row176(t *testing.T) {
+	r, _, depID := installRetryHarness(t, "owner@t99.omani.works",
+		"task-syft-sbom", jobs.StatusFailed) // no CronJob seeded
+
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, retryReq(depID, "task-syft-sbom",
+		&auth.Claims{Email: "owner@t99.omani.works", Tier: "operator"}))
+
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("absent backing CronJob must stay 422, got %d; body=%s",
+			rec.Code, rec.Body.String())
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/org_plan_slug_wire_row7_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_plan_slug_wire_row7_test.go
@@ -1,0 +1,162 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// Tests for UAT row 7 — the PURCHASED PLAN is absent from the Organization
+// wire payload.
+//
+// The Organization CR carries spec.planSlug (the #4292 split: `tier` is the
+// isolation class, `planSlug` is the purchased plan and the single truth
+// source for the ResourceQuota/LimitRange the org-controller materialises).
+// org_list_from_cr.go reads it and stamps it onto the provision record
+// (PlanSlug), and the STORE record serialises it as `plan_slug`. But
+// orgTenantResponse never declared the field, so orgTenantRecordToResponse
+// dropped it on the floor: every consumer of GET /api/v1/organizations saw an
+// Org with no plan at all.
+//
+// The assertions below are on the wire KEY AND ITS VALUE, deliberately:
+//
+//   - Asserting the key alone would pass on `plan_slug: ""`, which is exactly
+//     the state the console cannot render. A guard that goes green on an empty
+//     value is not a guard.
+//   - Asserting via the typed struct alone cannot see the key NAME, and the
+//     key name is load-bearing here: the front-end reads this row and a
+//     mis-named key is indistinguishable from an absent one. The raw-JSON half
+//     pins the contract the SPA actually binds.
+//
+// Each case carries a DIFFERENT plan so the pair discriminates: a fix that
+// hardcoded any single literal would satisfy one case and fail the other.
+
+// planCR builds an Organization CR with an explicit planSlug. orgReadyCR
+// hardcodes planSlug "s", which cannot show that the response reports the
+// ACTUAL plan rather than a constant.
+func planCR(slug, planSlug string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "orgs.openova.io/v1",
+		"kind":       "Organization",
+		"metadata": map[string]any{
+			"name":   slug,
+			"labels": map[string]any{"openova.io/tenant-id": "tid-" + slug},
+		},
+		"spec": map[string]any{
+			"slug":         slug,
+			"displayName":  slug,
+			"kind":         "customer",
+			"tier":         "org",
+			"planSlug":     planSlug,
+			"billingMode":  "real",
+			"sovereignRef": "otech.example",
+			"owners": []any{
+				map[string]any{"email": "owner@" + slug + ".example", "role": "owner"},
+			},
+		},
+		"status": map[string]any{"vcluster": map[string]any{"phase": "Ready"}},
+	}}
+}
+
+// rowJSONFor issues the real list call and returns both the typed row and the
+// raw JSON object for the single seeded Org.
+func rowJSONFor(t *testing.T, planSlug string) (orgTenantResponse, map[string]json.RawMessage) {
+	t.Helper()
+	h, _ := newOrgHandlerWithSeededCRs(t, planCR("acme", planSlug))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/organizations", nil)
+	w := httptest.NewRecorder()
+	h.HandleListOrganizations(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: want 200 got %d body=%s", w.Code, w.Body.String())
+	}
+
+	var typed struct {
+		Items []orgTenantResponse `json:"items"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &typed); err != nil {
+		t.Fatalf("decode typed: %v", err)
+	}
+	if len(typed.Items) != 1 {
+		t.Fatalf("items: want 1 got %d: %s", len(typed.Items), w.Body.String())
+	}
+
+	var raw struct {
+		Items []map[string]json.RawMessage `json:"items"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &raw); err != nil {
+		t.Fatalf("decode raw: %v", err)
+	}
+	return typed.Items[0], raw.Items[0]
+}
+
+// TestOrgResponse_CarriesPurchasedPlan_Row7 — an Org on plan `m` reports
+// plan_slug "m" on the wire.
+func TestOrgResponse_CarriesPurchasedPlan_Row7(t *testing.T) {
+	row, raw := rowJSONFor(t, "m")
+
+	if row.PlanSlug != "m" {
+		t.Errorf("typed row: plan_slug want %q got %q", "m", row.PlanSlug)
+	}
+
+	blob, present := raw["plan_slug"]
+	if !present {
+		t.Fatalf("wire JSON must carry the plan_slug key; got keys %v", rawKeys(raw))
+	}
+	var got string
+	if err := json.Unmarshal(blob, &got); err != nil {
+		t.Fatalf("decode plan_slug: %v", err)
+	}
+	if got != "m" {
+		t.Errorf("wire plan_slug: want %q got %q", "m", got)
+	}
+}
+
+// TestOrgResponse_PurchasedPlanIsTheActualPlan_Row7 is the discriminating
+// control: the SAME assertion against a different plan. A response that
+// hardcoded "m" would pass the case above and fail here.
+func TestOrgResponse_PurchasedPlanIsTheActualPlan_Row7(t *testing.T) {
+	row, raw := rowJSONFor(t, "xl")
+
+	if row.PlanSlug != "xl" {
+		t.Errorf("typed row: plan_slug want %q got %q", "xl", row.PlanSlug)
+	}
+	var got string
+	if err := json.Unmarshal(raw["plan_slug"], &got); err != nil {
+		t.Fatalf("decode plan_slug: %v", err)
+	}
+	if got != "xl" {
+		t.Errorf("wire plan_slug: want %q got %q", "xl", got)
+	}
+
+	// CONTROL — the fields this row already reported correctly must survive.
+	// Row 7 asserts NINE canonical fields and eight of them were already
+	// right; a "fix" that reshaped the payload and broke them would be a
+	// regression wearing a green test.
+	if row.Kind != "customer" {
+		t.Errorf("control kind: want customer got %q", row.Kind)
+	}
+	if row.Tier != "org" {
+		t.Errorf("control tier: want org got %q", row.Tier)
+	}
+	if row.BillingMode != "real" {
+		t.Errorf("control billing_mode: want real got %q", row.BillingMode)
+	}
+	// plan xl is a vcluster-tier plan (#4292 gate) — isolation is DERIVED
+	// from planSlug, so this also pins that the new field and the existing
+	// derivation still agree.
+	if row.Isolation != "vcluster" {
+		t.Errorf("control isolation: want vcluster for plan xl got %q", row.Isolation)
+	}
+}
+
+func rawKeys(m map[string]json.RawMessage) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/products/catalyst/bootstrap/api/internal/handler/organization_provisioning.go
+++ b/products/catalyst/bootstrap/api/internal/handler/organization_provisioning.go
@@ -427,7 +427,15 @@ type orgTenantResponse struct {
 	Tier        string         `json:"tier,omitempty"`
 	BillingMode string         `json:"billing_mode,omitempty"`
 	Isolation   string         `json:"isolation,omitempty"`
-	CommitSHA   string         `json:"commit_sha,omitempty"`
+	// PlanSlug — the PURCHASED plan (s|m|l|xl|flexi), #4292 + UAT row 7.
+	// Distinct from Tier: `tier` is the isolation class the Org was created
+	// under, `plan_slug` is what the customer bought, and it is the field the
+	// org-controller reads to size the ResourceQuota/LimitRange. Both the
+	// Organization CR (spec.planSlug) and the store record (`plan_slug`)
+	// have always carried it; this response struct simply never declared it,
+	// so the console could not render a Plan at all.
+	PlanSlug  string `json:"plan_slug,omitempty"`
+	CommitSHA string `json:"commit_sha,omitempty"`
 	LastError   string         `json:"last_error,omitempty"`
 	Steps       orgTenantSteps `json:"steps"`
 	// BoundaryPhase — the observed phase of the Org's boundary (#5501),
@@ -626,7 +634,13 @@ func orgTenantRecordToResponse(rec store.OrganizationProvisionRecord) orgTenantR
 		Tier:            rec.Tier,
 		BillingMode:     rec.BillingMode,
 		Isolation:       rec.Isolation,
-		CommitSHA:       rec.CommitSHA,
+		// UAT row 7 — the record has carried the purchased plan since #4292
+		// (org_list_from_cr.go reads spec.planSlug straight off the CR); this
+		// mapper was where it was dropped. Isolation is DERIVED from this same
+		// value, so the payload was already reporting a consequence of the
+		// plan while withholding the plan itself.
+		PlanSlug:  rec.PlanSlug,
+		CommitSHA: rec.CommitSHA,
 		LastError:       rec.LastError,
 		Steps:           steps,
 		BoundaryPhase:   rec.BoundaryPhase,

--- a/products/catalyst/bootstrap/api/internal/helmwatch/reconcilers.go
+++ b/products/catalyst/bootstrap/api/internal/helmwatch/reconcilers.go
@@ -705,6 +705,31 @@ func scannerIdentity(u *unstructured.Unstructured) (string, bool) {
 	return "", false
 }
 
+// SyftScanCronTarget maps the collapsed Syft SBOM identity row back to the
+// object that actually backs it: the bp-syft-grype CronJob (UAT row 176).
+//
+// The collapse (#3925) is what makes this seam necessary. `syft-sbom` is a
+// SYNTHETIC identity — no Kubernetes object carries that name — so anything
+// trying to act on the row by name finds nothing. The retry path did exactly
+// that and returned a 422 for a row that is genuinely re-runnable: pass 2 of
+// buildReconcilerRows seeds this very row FROM the CronJob named here, so the
+// backing object is known, not guessed.
+//
+// It is deliberately syft-ONLY and returns ok=false for anything else,
+// including trivyScanIdentity. Trivy's row aggregates one scan Job per
+// workload spawned by the trivy-operator; there is no single object whose
+// re-run means "redo the scan", so that row has nothing to offer here and
+// must keep reporting that honestly.
+//
+// The caller still has to handle an ABSENT CronJob — this reports the
+// identity mapping, not the object's existence.
+func SyftScanCronTarget(identity string) (namespace, cronName string, ok bool) {
+	if strings.TrimSpace(identity) != syftScanIdentity {
+		return "", "", false
+	}
+	return syftGrypeNamespace, syftGrypeCronName, true
+}
+
 // foldScannerRun records ONE scanner run as an Execution on the single
 // identity-keyed scanner row (#3925), creating the row on first sight. This
 // is the collapse: N scan Jobs sharing an identity ⇒ 1 row + N Executions

--- a/products/catalyst/bootstrap/ui/src/lib/bss.api.ts
+++ b/products/catalyst/bootstrap/ui/src/lib/bss.api.ts
@@ -669,8 +669,23 @@ export interface OrgRecord {
   subdomain: string
   /** Parent zone (e.g. omani.homes) used to compose the subdomain. */
   parentDomain: string
-  /** Plan tier (free|pro|enterprise|...) — null until BE wires it. */
+  /** Plan tier (free|pro|enterprise|...) — null until BE wires it. This is a
+   *  LEGACY member on the `plan` wire key that no producer has ever written;
+   *  the purchased plan lives on planSlug below. Kept so existing readers
+   *  keep compiling, but nothing should bind it. */
   plan: string | null
+  /**
+   * PlanSlug — the PURCHASED plan (s|m|l|xl|flexi), off the Organization CR's
+   * spec.planSlug via the `plan_slug` wire key (#4292, UAT row 7).
+   *
+   * Distinct from `tier`: tier is the isolation CLASS the Org was created
+   * under, planSlug is what the customer bought, and the org-controller sizes
+   * the ResourceQuota/LimitRange from this field alone. Empty string when the
+   * record declares none — never a fabricated default, because row 7 asserts
+   * the CANONICAL value and an invented "s" would be wrong data rather than a
+   * safe fallback.
+   */
+  planSlug: string
   /**
    * Organizations-model spec fields (issue #3378 B1). The orchestrator
    * stamps these on the OrganizationProvisionRecord and the roster feed
@@ -746,6 +761,11 @@ interface OrgRecordWire {
   tenant_namespace?: string
   console_host?: string
   plan?: string
+  // #4292 / UAT row 7 — the purchased plan. The BE emits `plan_slug` (it is
+  // the store record's key and mirrors the CR's spec.planSlug). The `plan`
+  // key above is a different, never-populated name; reading that one is why
+  // the plan stayed null even once the API began emitting the field.
+  plan_slug?: string
   region?: string
   // Organizations-model spec fields (issue #3378 B1) — already emitted by
   // the BE row (products/catalyst/bootstrap/api/internal/handler/
@@ -771,6 +791,7 @@ function mapOrgRecord(raw: OrgRecordWire): OrgRecord {
     subdomain,
     parentDomain,
     plan: raw.plan && raw.plan !== '' ? String(raw.plan) : null,
+    planSlug: String(raw.plan_slug ?? '').trim(),
     kind: String(raw.kind ?? '').trim(),
     tier: String(raw.tier ?? '').trim(),
     billingMode: String(raw.billing_mode ?? '').trim(),

--- a/products/catalyst/bootstrap/ui/src/lib/organizations.api.plan-and-parent-identity.test.ts
+++ b/products/catalyst/bootstrap/ui/src/lib/organizations.api.plan-and-parent-identity.test.ts
@@ -1,0 +1,169 @@
+/**
+ * organizations.api.plan-and-parent-identity.test.ts — UAT rows 7 and 25.
+ *
+ * ROW 7 — the purchased PLAN was absent end to end. The Organization CR has
+ * carried spec.planSlug since #4292 (it is the field the org-controller sizes
+ * the ResourceQuota from, and the field the isolation class is DERIVED from),
+ * but nothing surfaced it: the API response struct never declared it, OrgRow
+ * had no member for it, and the detail page rendered no Plan. The wire key is
+ * `plan_slug`; OrgRecord's legacy `plan` member was declared "null until BE
+ * wires it" and no producer ever wired it — so reading `plan` alone would keep
+ * returning null even after the API started emitting the field.
+ *
+ * ROW 25 — the parent row's identity was UNSTABLE between renders, resolving
+ * to `/organizations/sovereign` on one and `/organizations/<fqdn>` on another.
+ *
+ * The mechanism is one line: the parent row's slug was `fqdn || 'sovereign'`,
+ * and the fqdn comes from getSovereignSelf(), which collapses EVERY failure —
+ * network throw, non-2xx (a single 503 is enough), unparseable body — to null.
+ * That slug is simultaneously
+ *
+ *   - the directory's link target (OrganizationsDirectoryPage passes
+ *     params={{ org: org.slug }}), and
+ *   - the detail page's resolution key (rows.find(o => o.slug === org)).
+ *
+ * So the identity of a row was a function of whether one optional enrichment
+ * call happened to succeed on that particular render. Whenever the render that
+ * built the LINK disagreed with the render that RESOLVED it, the detail page
+ * fell through to org-detail-not-found — which is also the false
+ * "not found" a walker sees when a single 503 lands mid-walk.
+ *
+ * The fix makes the parent's identity a CONSTANT. The FQDN is display data and
+ * still renders as the name and console host when known; it is no longer the
+ * key anything joins on. The tests below therefore assert that the slug is
+ * IDENTICAL across the resolved and unresolved cases — asserting either
+ * literal on its own would pass on the broken code half the time, which is
+ * exactly how this survived.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { parentRowFromSelf, subOrgRowFromRecord } from './organizations.api'
+import type { OrgRecord } from './bss.api'
+
+const record: OrgRecord = {
+  id: 'tnt-1',
+  orgName: 'UAT Co',
+  consoleHost: 'console.uatco.omani.homes',
+  subdomain: 'uatco',
+  parentDomain: 'omani.homes',
+  plan: null,
+  planSlug: 'm',
+  kind: 'customer',
+  tier: 'org',
+  billingMode: 'real',
+  isolation: 'vcluster',
+  status: 'active',
+  region: 'me-east-215-a',
+  ownerEmail: 'owner@uatco.example',
+  createdAt: '2026-08-10T00:00:00Z',
+  updatedAt: '2026-08-10T00:00:00Z',
+  lastError: '',
+}
+
+describe('row 7 — the purchased plan reaches the directory row', () => {
+  it('carries the plan the Organization actually bought', () => {
+    expect(subOrgRowFromRecord(record).plan).toBe('m')
+  })
+
+  // Discriminating case: a DIFFERENT plan. A mapping that hardcoded any single
+  // literal, or that fell back to a constant default, passes the test above
+  // and fails this one.
+  it('reports the actual plan, not a fixed default', () => {
+    expect(subOrgRowFromRecord({ ...record, planSlug: 'xl' }).plan).toBe('xl')
+    expect(subOrgRowFromRecord({ ...record, planSlug: 's' }).plan).toBe('s')
+  })
+
+  // Fail-closed: a legacy row with no plan reads as empty, never as an
+  // invented tier. Row 7 asserts the CANONICAL value; a fabricated "s" on a
+  // record that never declared one would be wrong data, not a safe default.
+  it('leaves the plan empty when the record declares none', () => {
+    expect(subOrgRowFromRecord({ ...record, planSlug: '' }).plan).toBe('')
+  })
+
+  // The sovereign-root row is not a purchased Organization — it has no plan,
+  // and must not borrow one.
+  it('the parent row declares no plan', () => {
+    expect(
+      parentRowFromSelf({ deploymentId: 'dep-1', sovereignFQDN: 'hw293.omantel.biz' }).plan,
+    ).toBe('')
+  })
+
+  // CONTROL — the eight fields row 7 already reported correctly must survive.
+  it('does not disturb the fields that already worked', () => {
+    const row = subOrgRowFromRecord(record)
+    expect(row.slug).toBe('uatco')
+    expect(row.kind).toBe('customer')
+    expect(row.tier).toBe('org')
+    expect(row.billingMode).toBe('real')
+    expect(row.isolation).toBe('vcluster')
+    expect(row.ownerEmail).toBe('owner@uatco.example')
+    expect(row.consoleHost).toBe('console.uatco.omani.homes')
+    expect(row.status).toBe('active')
+  })
+})
+
+describe('row 25 — the parent row has ONE stable identity', () => {
+  // THE LOAD-BEARING ASSERTION. Not "the slug equals X" — that was true half
+  // the time before the fix. The defect is that the two renders DISAGREE.
+  it('resolves to the same slug whether or not self-discovery succeeded', () => {
+    const resolved = parentRowFromSelf({
+      deploymentId: 'dep-1',
+      sovereignFQDN: 'hw293.omantel.biz',
+    })
+    const unresolved = parentRowFromSelf(null)
+
+    expect(resolved.slug).toBe(unresolved.slug)
+  })
+
+  // The link target and the resolution key are the same string, so a row built
+  // on one render is findable by a page built on another. This is the actual
+  // user-visible contract: the parent row's link must not 404.
+  it('a link built from a resolved render is findable in an unresolved one', () => {
+    const linkTarget = parentRowFromSelf({
+      deploymentId: 'dep-1',
+      sovereignFQDN: 'hw293.omantel.biz',
+    }).slug
+
+    // The detail page resolves with exactly this predicate.
+    const rowsOnALaterRender = [parentRowFromSelf(null), subOrgRowFromRecord(record)]
+    expect(rowsOnALaterRender.find((o) => o.slug === linkTarget)).toBeDefined()
+  })
+
+  it('and the reverse direction — a link built while self was down still resolves', () => {
+    const linkTarget = parentRowFromSelf(null).slug
+    const rowsOnALaterRender = [
+      parentRowFromSelf({ deploymentId: 'dep-1', sovereignFQDN: 'hw293.omantel.biz' }),
+      subOrgRowFromRecord(record),
+    ]
+    expect(rowsOnALaterRender.find((o) => o.slug === linkTarget)).toBeDefined()
+  })
+
+  // The slug must not be a value that can collide with a real Organization's
+  // slug, and must be route-safe. A dotted FQDN in a path segment is neither.
+  it('the parent slug is a route-safe constant, not an FQDN', () => {
+    const slug = parentRowFromSelf({
+      deploymentId: 'dep-1',
+      sovereignFQDN: 'hw293.omantel.biz',
+    }).slug
+    expect(slug).not.toContain('.')
+  })
+
+  // CONTROL — the FQDN is still surfaced. The fix moves it off the join key;
+  // it must not throw the information away, or the operator loses the name of
+  // the Sovereign they are looking at.
+  it('still shows the FQDN as the display name and console host', () => {
+    const row = parentRowFromSelf({
+      deploymentId: 'dep-1',
+      sovereignFQDN: 'hw293.omantel.biz',
+    })
+    expect(row.displayName).toBe('hw293.omantel.biz')
+    expect(row.consoleHost).toBe('console.hw293.omantel.biz')
+    expect(row.isParent).toBe(true)
+  })
+
+  // CONTROL — sub-org rows are untouched and still key on their own slug.
+  it('sub-org rows keep keying on their own slug', () => {
+    expect(subOrgRowFromRecord(record).slug).toBe('uatco')
+    expect(subOrgRowFromRecord(record).isParent).toBe(false)
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/lib/organizations.api.test.ts
+++ b/products/catalyst/bootstrap/ui/src/lib/organizations.api.test.ts
@@ -63,6 +63,7 @@ describe('subOrgRowFromRecord', () => {
     subdomain: 'acme',
     parentDomain: 'omani.homes',
     plan: 'pro',
+    planSlug: 's',
     kind: 'customer',
     tier: 'org',
     billingMode: 'real',

--- a/products/catalyst/bootstrap/ui/src/lib/organizations.api.ts
+++ b/products/catalyst/bootstrap/ui/src/lib/organizations.api.ts
@@ -59,6 +59,13 @@ export interface OrgRow {
   displayName: string
   kind: OrgKind
   tier: OrgTier
+  /** The PURCHASED plan (s|m|l|xl|flexi) off the Organization CR's
+   *  spec.planSlug (#4292, UAT row 7). Distinct from `tier`, which is the
+   *  isolation class — `isolation` below is DERIVED from this value, so the
+   *  directory used to render a consequence of the plan while never naming
+   *  the plan itself. Empty for the sovereign-root row and for records that
+   *  declare none. */
+  plan: string
   billingMode: OrgBillingMode
   /** A real Organization is namespace- or vcluster-isolated. The
    *  sovereign-root row is the CLUSTER itself — isolated within nothing —
@@ -97,6 +104,14 @@ interface SovereignSelf {
   deploymentId: string
   sovereignFQDN: string
 }
+
+/**
+ * SOVEREIGN_PARENT_SLUG — the stable route identity of the sovereign-root row
+ * (UAT row 25). Exported so the directory, the detail route and their tests
+ * all name the same constant instead of re-deriving it; a key that is
+ * recomputed in two places is how it came to differ between two renders.
+ */
+export const SOVEREIGN_PARENT_SLUG = 'sovereign'
 
 /**
  * getSovereignSelf — resolve the parent org's identity (the sovereign
@@ -145,10 +160,33 @@ export function parentRowFromSelf(self: SovereignSelf | null): OrgRow {
   const fqdn = self?.sovereignFQDN ?? ''
   return {
     id: self?.deploymentId || '__parent__',
-    slug: fqdn || 'sovereign',
+    // UAT row 25 — a CONSTANT, never the FQDN.
+    //
+    // This slug is simultaneously the directory's link target
+    // (OrganizationsDirectoryPage passes params={{ org: org.slug }}) and the
+    // detail page's resolution key (rows.find(o => o.slug === org)). It used
+    // to be `fqdn || 'sovereign'`, and getSovereignSelf() collapses EVERY
+    // failure — network throw, non-2xx, unparseable body — to null. So a
+    // single 503 changed the row's IDENTITY: the link built on one render
+    // pointed at /organizations/<fqdn> while the detail page resolving it on
+    // the next render only knew 'sovereign', and one of the two always 404'd
+    // into org-detail-not-found. The value was never wrong so much as
+    // NON-DETERMINISTIC, which is why it read as an intermittent bug.
+    //
+    // The FQDN is display data and stays on displayName/consoleHost below.
+    // It is a poor key regardless: it is absent exactly when the enrichment
+    // call fails, and its dots make it an awkward URL path segment.
+    //
+    // Resolution stays deterministic even if a sub-org were ever named
+    // `sovereign`: listOrganizations always emits the parent FIRST and
+    // `find` takes the first match.
+    slug: SOVEREIGN_PARENT_SLUG,
     displayName: fqdn || 'Sovereign',
     kind: 'internal',
     tier: 'corporate',
+    // The sovereign root is not a purchased Organization — it has no plan
+    // and must not borrow one from a customer record.
+    plan: '',
     billingMode: 'showback',
     // #5489 — the sovereign root IS the cluster; it is not isolated inside
     // one. `GET /api/v1/sovereign/self` returns only {deploymentId,
@@ -220,6 +258,10 @@ export function subOrgRowFromRecord(t: OrgRecord): OrgRow {
     displayName: t.orgName || t.subdomain || t.id,
     kind,
     tier: normalizeTier(t.tier),
+    // #4292 / UAT row 7 — the purchased plan, verbatim. Deliberately NOT
+    // defaulted: an Org that declares no plan reads as empty, and the
+    // detail page omits the field rather than naming a plan nobody bought.
+    plan: String(t.planSlug ?? '').trim(),
     billingMode: normalizeBillingMode(t.billingMode, kind),
     isolation: normalizeIsolation(t.isolation, kind),
     status: t.status,

--- a/products/catalyst/bootstrap/ui/src/lib/parent-row-isolation-5489.test.ts
+++ b/products/catalyst/bootstrap/ui/src/lib/parent-row-isolation-5489.test.ts
@@ -32,7 +32,15 @@ describe('#5489 parent row must not claim a vCluster', () => {
   it('still renders a usable parent row', () => {
     const row = parentRowFromSelf(self)
     expect(row.isParent).toBe(true)
-    expect(row.slug).toBe('hw291.omantel.biz')
+    // UAT row 25 — this assertion used to demand the FQDN here while the
+    // sibling case below demanded 'sovereign'. Those two lines together
+    // PINNED the divergence as if it were intent: the same row got a
+    // different identity depending on whether GET /v1/sovereign/self had
+    // succeeded, and that slug is both the directory's link target and the
+    // detail page's lookup key, so one of the two always 404'd. The identity
+    // is now a constant; the FQDN remains pinned on displayName and
+    // consoleHost below, which is what "usable" actually means for this row.
+    expect(row.slug).toBe('sovereign')
     expect(row.displayName).toBe('hw291.omantel.biz')
     expect(row.id).toBe('2c2d746b578c636b')
     expect(row.consoleHost).toBe('console.hw291.omantel.biz')
@@ -43,5 +51,11 @@ describe('#5489 parent row must not claim a vCluster', () => {
     expect(row.isolation).toBe('cluster')
     expect(row.id).toBe('__parent__')
     expect(row.slug).toBe('sovereign')
+  })
+
+  // The identity is the SAME in both states — the property the two cases
+  // above only imply by each naming the same literal.
+  it('carries one identity regardless of self-discovery (UAT row 25)', () => {
+    expect(parentRowFromSelf(self).slug).toBe(parentRowFromSelf(null).slug)
   })
 })

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppsPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppsPage.tsx
@@ -278,7 +278,20 @@ export function AppsPage({ disableStream = false }: AppsPageProps = {}) {
       }
       return { statusById, publishedBySlug, environmentById, externalURLById, instances }
     },
-    retry: false,
+    // A single transient 5xx must not read as "this Sovereign runs no
+    // Applications". With no retry and no previous data — i.e. a COLD load,
+    // which is every fresh page open — one failed request left
+    // `instances: []`, so /apps rendered the ~46 bootstrap catalog cards and
+    // not one instance card. That is pixel-identical to the estate genuinely
+    // being empty, and it fabricated a failure for UAT row 15 (the per-App
+    // Org chip) on a Sovereign whose Applications were all present and
+    // healthy. A measurement surface that turns one 503 into a plausible-
+    // looking defect costs more than the retry does.
+    //
+    // Bounded on purpose: the poll below already re-fetches every 5s, so this
+    // only has to cover the cold load, and a genuinely-down API must still
+    // surface promptly rather than being masked by a long retry ladder.
+    retry: 2,
     placeholderData: (prev) => prev,
   })
   const liveAppStatus = liveAppsQuery.data?.statusById ?? {}

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/RetryJobButton.notify-row176.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/RetryJobButton.notify-row176.test.tsx
@@ -1,0 +1,164 @@
+/**
+ * RetryJobButton.notify-row176.test.tsx — UAT row 176, the SILENT-FAILURE half.
+ *
+ * WHAT THE WALK SAW. The retry POST returned 422, the button never changed
+ * state, and the failure surfaced as neither a toast nor readable inline text.
+ *
+ * WHAT IS ACTUALLY WRONG — the control does not swallow its error, which is
+ * why this survived review. It sets phase='error' and renders a role="alert"
+ * span. But that span is the ONLY channel, and it is a weak one:
+ *
+ *   1. It renders inside the Jobs table's Actions cell, clamped by
+ *      `.jobs-retry-error` to `max-width: 28ch` with `white-space: nowrap` and
+ *      an ellipsis. The 422 detail for this row is ~110 characters, so the
+ *      operator gets roughly a quarter of the first clause, in the rightmost
+ *      column, with the rest only on hover.
+ *   2. It lives in component-local useState, so it is lost whenever the row
+ *      unmounts — and the Jobs view re-polls on a 5-second interval.
+ *   3. The button itself reverts to its idle label immediately, so there is no
+ *      persistent affordance that anything was attempted.
+ *
+ * A failure that is technically rendered but practically unreadable is
+ * indistinguishable from one that was swallowed. The fix routes it to the
+ * app-wide notification centre — the mechanism the rest of this console
+ * already uses for exactly this (AppsPage, CatalogDetail, the RBAC admin
+ * pages) — so the full server detail survives the poll and is reachable from
+ * the bell on any page.
+ *
+ * The inline span stays: it is the immediate, in-context signal. These tests
+ * assert BOTH channels, and the control at the bottom pins that a SUCCESS
+ * still does not raise an error notification — otherwise "notify on
+ * everything" would pass every assertion above.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react'
+import { RetryJobButton } from './RetryJobButton'
+import { NotificationProvider, useNotifications } from '@/shared/ui/notifications'
+
+let nextStatus = 200
+let nextBody: Record<string, unknown> = { executionId: 'e1', action: 'annotated' }
+
+vi.mock('@/shared/lib/authedFetch', () => ({
+  authedFetch: async () =>
+    new Response(JSON.stringify(nextBody), {
+      status: nextStatus,
+      headers: { 'Content-Type': 'application/json' },
+    }),
+}))
+
+beforeEach(() => {
+  nextStatus = 200
+  nextBody = { executionId: 'e1', action: 'annotated' }
+  cleanup()
+})
+
+const jobId = 'd1:task-syft-sbom'
+
+/** NotificationProbe — reads the live notification context and flattens every
+ *  raised item into one node, so a raised notification is OBSERVED rather than
+ *  assumed. Reading the context directly keeps these tests independent of the
+ *  bell/panel presentation components and their props. */
+function NotificationProbe() {
+  const { items } = useNotifications()
+  return (
+    <div data-testid="notification-list">
+      {items.map((n) => (
+        <div key={n.id} data-level={n.level}>
+          {n.title}
+          {n.body ?? ''}
+          {n.raw ?? ''}
+        </div>
+      ))}
+    </div>
+  )
+}
+
+/** Renders the button alongside the probe. */
+function renderWithNotifications(kind: 'task' | 'step' = 'task') {
+  return render(
+    <NotificationProvider>
+      <RetryJobButton deploymentId="d1" jobId={jobId} kind={kind} />
+      <NotificationProbe />
+    </NotificationProvider>,
+  )
+}
+
+describe('row 176 — a failed re-run is not silent', () => {
+  it('raises a notification carrying the server detail on 422', async () => {
+    nextStatus = 422
+    nextBody = {
+      error: 'not-directly-retryable',
+      detail:
+        'CronJob syft-grype/syft-grype backing the "syft-sbom" row is not installed: reconciler is aggregate or operator-managed; not directly retryable',
+    }
+    renderWithNotifications()
+    fireEvent.click(screen.getByTestId(`jobs-retry-${jobId}`))
+
+    // The notification centre carries the FULL detail — not a 28ch prefix.
+    await waitFor(() => {
+      expect(screen.getByTestId('notification-list').textContent).toContain(
+        'not directly retryable',
+      )
+    })
+    expect(screen.getByTestId('notification-list').textContent).toContain(
+      'CronJob syft-grype/syft-grype',
+    )
+  })
+
+  it('still shows the inline in-context error too — both channels', async () => {
+    nextStatus = 422
+    nextBody = { error: 'not-directly-retryable', detail: 'nothing to re-run here' }
+    renderWithNotifications()
+    fireEvent.click(screen.getByTestId(`jobs-retry-${jobId}`))
+
+    await waitFor(() => {
+      expect(screen.getByTestId(`jobs-retry-error-${jobId}`).textContent).toContain(
+        'nothing to re-run here',
+      )
+    })
+  })
+
+  it('notifies on a network failure too, where there is no server detail', async () => {
+    nextStatus = 500
+    nextBody = {}
+    renderWithNotifications()
+    fireEvent.click(screen.getByTestId(`jobs-retry-${jobId}`))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('notification-list').textContent).toContain('Failed (500)')
+    })
+  })
+
+  // CONTROL — a SUCCESSFUL re-run raises no error notification. Without this,
+  // a component that notified unconditionally would satisfy every assertion
+  // above while burying the operator in false alarms.
+  it('raises no error notification when the re-run succeeds', async () => {
+    nextStatus = 200
+    renderWithNotifications()
+    fireEvent.click(screen.getByTestId(`jobs-retry-${jobId}`))
+
+    await waitFor(() => {
+      expect(screen.getByTestId(`jobs-retry-done-${jobId}`).textContent).toContain('Requested')
+    })
+    expect(screen.queryByTestId('notification-list')?.textContent ?? '').not.toContain(
+      'Re-run failed',
+    )
+  })
+
+  // CONTROL — the button must keep working outside a NotificationProvider.
+  // The Jobs table is mounted under one in the real app, but a hook that
+  // THREW without a provider would take the whole row down; that would turn a
+  // recoverable 422 into a blank table.
+  it('degrades to inline-only when no provider is mounted', async () => {
+    nextStatus = 422
+    nextBody = { error: 'not-directly-retryable', detail: 'no provider here' }
+    render(<RetryJobButton deploymentId="d1" jobId={jobId} kind="task" />)
+    fireEvent.click(screen.getByTestId(`jobs-retry-${jobId}`))
+
+    await waitFor(() => {
+      expect(screen.getByTestId(`jobs-retry-error-${jobId}`).textContent).toContain(
+        'no provider here',
+      )
+    })
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/RetryJobButton.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/RetryJobButton.tsx
@@ -49,6 +49,7 @@ import { authedFetch } from '@/shared/lib/authedFetch'
 import { API_BASE } from '@/shared/config/urls'
 import type { JobKind } from '@/lib/jobs.types'
 import { retryLabel, errorMessageFor } from './retryJobFeedback'
+import { useOptionalNotifications } from '@/shared/ui/notifications'
 
 interface RetryJobButtonProps {
   deploymentId: string
@@ -61,6 +62,7 @@ type RetryPhase = 'idle' | 'requesting' | 'done' | 'error'
 export function RetryJobButton({ deploymentId, jobId, kind }: RetryJobButtonProps) {
   const [phase, setPhase] = useState<RetryPhase>('idle')
   const [message, setMessage] = useState<string>('')
+  const notifications = useOptionalNotifications()
 
   async function onClick() {
     setPhase('requesting')
@@ -80,7 +82,9 @@ export function RetryJobButton({ deploymentId, jobId, kind }: RetryJobButtonProp
         // Honest failure — surface the server's own reason. Never a
         // green confirmation for a call that did not succeed.
         setPhase('error')
-        setMessage(await errorMessageFor(res))
+        const detail = await errorMessageFor(res)
+        setMessage(detail)
+        raise(detail, res.status)
         return
       }
       setPhase('done')
@@ -88,7 +92,38 @@ export function RetryJobButton({ deploymentId, jobId, kind }: RetryJobButtonProp
     } catch {
       setPhase('error')
       setMessage('Network error')
+      raise('Network error', 0)
     }
+  }
+
+  // UAT row 176 — the inline span below is necessary but not sufficient.
+  //
+  // It is the right IN-CONTEXT signal, and it stays. But it is clamped by
+  // `.jobs-retry-error` to 28ch with an ellipsis inside the Jobs table's
+  // Actions cell, so a ~110-character server detail arrives as a fragment;
+  // it lives in component-local state, so the 5-second poll can take it away;
+  // and the button reverts to its idle label, leaving no trace that anything
+  // was attempted. Rendered-but-unreadable is how a 422 came to look like
+  // nothing happening at all.
+  //
+  // The notification centre is the console's existing durable channel for
+  // exactly this (AppsPage, CatalogDetail and the RBAC pages all use it), it
+  // survives the poll, and it is reachable from the bell on any page.
+  //
+  // Optional by design: the hook returns null outside a provider instead of
+  // throwing. The Jobs table is mounted under one, but a throwing hook would
+  // turn a recoverable retry failure into an unmounted row.
+  function raise(detail: string, status: number) {
+    notifications?.notify({
+      // Stable per row: a second failed attempt REPLACES the first rather
+      // than stacking duplicates for one stuck job.
+      id: `retry-failed-${jobId}`,
+      level: 'error',
+      title: `Re-run failed — ${retryLabel(kind)} on ${jobId}`,
+      body: status ? `The catalyst-api answered ${status}.` : 'The request never reached the catalyst-api.',
+      // The server's own words, verbatim and unclamped.
+      raw: detail,
+    })
   }
 
   const label = retryLabel(kind)

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/organizations/EnterOrgButton.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/organizations/EnterOrgButton.test.tsx
@@ -18,6 +18,7 @@ const SUB = subOrgRowFromRecord({
   subdomain: 'acme',
   parentDomain: 'omani.homes',
   plan: 'pro',
+  planSlug: 's',
   kind: 'customer',
   tier: 'org',
   billingMode: 'real',

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/organizations/OrganizationDetailPage.identifier-case-5817.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/organizations/OrganizationDetailPage.identifier-case-5817.test.tsx
@@ -43,7 +43,7 @@ const PARENT = parentRowFromSelf({ deploymentId: 'd1', sovereignFQDN: 'hw292.oma
 // and an email owner.
 const UATCO = subOrgRowFromRecord({
   id: 'tnt-uatco', orgName: 'UAT Co', consoleHost: 'console.uatco.omani.homes',
-  subdomain: 'uatco', parentDomain: 'omani.homes', plan: 'm', kind: 'customer',
+  subdomain: 'uatco', parentDomain: 'omani.homes', plan: 'm', planSlug: 'm', kind: 'customer',
   tier: 'org', billingMode: 'real', isolation: 'vcluster', status: 'active',
   region: 'r', ownerEmail: 'emrah.baysal@openova.io',
   createdAt: '2026-08-06T00:00:00Z', updatedAt: '2026-08-06T00:00:00Z', lastError: '',

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/organizations/OrganizationDetailPage.plan-row7.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/organizations/OrganizationDetailPage.plan-row7.test.tsx
@@ -1,0 +1,154 @@
+/**
+ * OrganizationDetailPage.plan-row7.test.tsx — UAT rows 7 and 25, render layer.
+ *
+ * ROW 7 asserts the Org detail page shows the canonical fields INCLUDING the
+ * purchased plan (`planSlug m`, the #4292 split where `tier` is the isolation
+ * class and the plan is carried separately). Eight of the nine already
+ * rendered; the plan rendered nowhere, because it was dropped at every layer
+ * beneath this one — the API response struct, the wire key, and OrgRow.
+ * These assert the VALUE painted, not merely that a testid exists: a `Plan`
+ * label over an empty <dd> is the state row 7 already failed on.
+ *
+ * ROW 25 is asserted here at the level the operator actually experiences it —
+ * the parent row's link RESOLVES instead of falling through to
+ * org-detail-not-found, on renders where self-discovery succeeded AND on
+ * renders where it did not.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import {
+  RouterProvider,
+  createRouter,
+  createRootRoute,
+  createRoute,
+  createMemoryHistory,
+  Outlet,
+} from '@tanstack/react-router'
+
+import { OrganizationDetailPage } from './OrganizationDetailPage'
+import {
+  parentRowFromSelf,
+  subOrgRowFromRecord,
+  SOVEREIGN_PARENT_SLUG,
+  type OrgRow,
+} from '@/lib/organizations.api'
+import type { OrgRecord } from '@/lib/bss.api'
+
+const record: OrgRecord = {
+  id: 'tnt-1',
+  orgName: 'UAT Co',
+  consoleHost: 'console.uatco.omani.homes',
+  subdomain: 'uatco',
+  parentDomain: 'omani.homes',
+  plan: null,
+  planSlug: 'm',
+  kind: 'customer',
+  tier: 'org',
+  billingMode: 'real',
+  isolation: 'vcluster',
+  status: 'active',
+  region: 'me-east-215-a',
+  ownerEmail: 'owner@uatco.example',
+  createdAt: '2026-08-10T00:00:00Z',
+  updatedAt: '2026-08-10T00:00:00Z',
+  lastError: '',
+}
+
+function renderDetail(org: string, rows: readonly OrgRow[]) {
+  const rootRoute = createRootRoute({ component: () => <Outlet /> })
+  const route = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/organizations/$org',
+    component: () => <OrganizationDetailPage org={org} initialOrgsOverride={rows} />,
+  })
+  const orgRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/organizations',
+    component: () => <div />,
+  })
+  const tree = rootRoute.addChildren([route, orgRoute])
+  const router = createRouter({
+    routeTree: tree,
+    history: createMemoryHistory({ initialEntries: [`/organizations/${org}`] }),
+  })
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } })
+  return render(
+    <QueryClientProvider client={qc}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>,
+  )
+}
+
+afterEach(() => cleanup())
+
+describe('row 7 — the Org detail page names the purchased plan', () => {
+  it('renders the plan the Organization bought', async () => {
+    renderDetail('uatco', [subOrgRowFromRecord(record)])
+    expect(await screen.findByTestId('organization-detail-page')).toBeTruthy()
+    expect(screen.getByTestId('org-detail-plan').textContent).toBe('m')
+  })
+
+  // Discriminating: a different plan must paint differently. A hardcoded
+  // literal would satisfy the case above.
+  it('paints the actual plan, not a fixed one', async () => {
+    renderDetail('uatco', [subOrgRowFromRecord({ ...record, planSlug: 'xl' })])
+    expect(await screen.findByTestId('organization-detail-page')).toBeTruthy()
+    expect(screen.getByTestId('org-detail-plan').textContent).toBe('xl')
+  })
+
+  // The sovereign-root row buys nothing — the field is omitted rather than
+  // rendered blank or defaulted.
+  it('omits the plan on the parent row instead of inventing one', async () => {
+    renderDetail(SOVEREIGN_PARENT_SLUG, [
+      parentRowFromSelf({ deploymentId: 'd1', sovereignFQDN: 'hw293.omantel.biz' }),
+    ])
+    expect(await screen.findByTestId('organization-detail-page')).toBeTruthy()
+    expect(screen.queryByTestId('org-detail-plan')).toBeNull()
+  })
+
+  // CONTROL — the eight fields that already rendered must still render. A
+  // change to this <dl> that dropped one would otherwise ship green.
+  it('does not disturb the fields that already rendered', async () => {
+    renderDetail('uatco', [subOrgRowFromRecord(record)])
+    expect(await screen.findByTestId('organization-detail-page')).toBeTruthy()
+    expect(screen.getByTestId('org-detail-slug').textContent).toBe('uatco')
+    expect(screen.getByTestId('org-detail-kind').textContent).toBe('customer')
+    expect(screen.getByTestId('org-detail-tier').textContent).toBe('org')
+    expect(screen.getByTestId('org-detail-billing').textContent).toBe('real')
+    expect(screen.getByTestId('org-detail-isolation').textContent).toBe('vcluster')
+    expect(screen.getByTestId('org-detail-status').textContent).toBe('active')
+    expect(screen.getByTestId('org-detail-owner').textContent).toBe('owner@uatco.example')
+  })
+})
+
+describe('row 25 — the parent row resolves at its stable slug', () => {
+  it('the parent row is found, not 404, when self-discovery succeeded', async () => {
+    renderDetail(SOVEREIGN_PARENT_SLUG, [
+      parentRowFromSelf({ deploymentId: 'd1', sovereignFQDN: 'hw293.omantel.biz' }),
+      subOrgRowFromRecord(record),
+    ])
+    expect(await screen.findByTestId('organization-detail-page')).toBeTruthy()
+    expect(screen.queryByTestId('org-detail-not-found')).toBeNull()
+    expect(screen.getByTestId('org-detail-identity')).toBeTruthy()
+  })
+
+  // The half that used to 404: the very same URL, resolved on a render where
+  // GET /v1/sovereign/self failed.
+  it('resolves identically when self-discovery returned null', async () => {
+    renderDetail(SOVEREIGN_PARENT_SLUG, [parentRowFromSelf(null), subOrgRowFromRecord(record)])
+    expect(await screen.findByTestId('organization-detail-page')).toBeTruthy()
+    expect(screen.queryByTestId('org-detail-not-found')).toBeNull()
+    expect(screen.getByTestId('org-detail-identity')).toBeTruthy()
+  })
+
+  // CONTROL — a genuinely absent Org must STILL report not-found. A fix that
+  // made resolution always succeed would pass both cases above while
+  // destroying the page's only honest failure state.
+  it('an Org that is really absent still reports not-found', async () => {
+    renderDetail('no-such-org', [parentRowFromSelf(null), subOrgRowFromRecord(record)])
+    expect(await screen.findByTestId('organization-detail-page')).toBeTruthy()
+    expect(screen.getByTestId('org-detail-not-found')).toBeTruthy()
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/organizations/OrganizationDetailPage.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/organizations/OrganizationDetailPage.test.tsx
@@ -22,7 +22,7 @@ import { parentRowFromSelf, subOrgRowFromRecord, type OrgRow } from '@/lib/organ
 const PARENT = parentRowFromSelf({ deploymentId: 'd1', sovereignFQDN: 'hw130.omantel.biz' })
 const SUB = subOrgRowFromRecord({
   id: 'tnt-1', orgName: 'ACME Corp', consoleHost: 'console.acme.omani.homes', subdomain: 'acme',
-  parentDomain: 'omani.homes', plan: 'pro', kind: 'customer', tier: 'org', billingMode: 'real',
+  parentDomain: 'omani.homes', plan: 'pro', planSlug: 's', kind: 'customer', tier: 'org', billingMode: 'real',
   isolation: 'vcluster', status: 'active', region: 'r', ownerEmail: 'o@acme.example',
   createdAt: '2026-06-13T00:00:00Z', updatedAt: '2026-06-13T00:00:00Z', lastError: '',
 })

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/organizations/OrganizationDetailPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/organizations/OrganizationDetailPage.tsx
@@ -98,6 +98,18 @@ export function OrganizationDetailPage({ org, initialOrgsOverride }: Organizatio
                 <Field label="Slug" value={target.slug} testid={`org-detail-slug`} />
                 <Field label="Kind" value={target.kind} testid="org-detail-kind" enumValue />
                 <Field label="Tier" value={target.tier} testid="org-detail-tier" enumValue />
+                {/* #4292 (UAT row 7) — the PURCHASED plan, beside the tier it
+                    is so easily confused with. Tier is the isolation class;
+                    this is what the customer bought, and it is what
+                    `Isolation` below is derived from — so the page used to
+                    show a consequence of the plan without ever naming it.
+                    Rendered only when the Org declares one: the sovereign-root
+                    row buys nothing, and a blank "Plan —" would invite the
+                    same fabricated default the mapper refuses. `s`/`m`/`xl`
+                    are a fixed vocabulary, hence enumValue. */}
+                {target.plan ? (
+                  <Field label="Plan" value={target.plan} testid="org-detail-plan" enumValue />
+                ) : null}
                 <Field label="Billing mode" value={target.billingMode} testid="org-detail-billing" enumValue />
                 <Field label="Isolation" value={target.isolation} testid="org-detail-isolation" enumValue />
                 <Field label="Status" value={target.status} testid="org-detail-status" enumValue />

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/organizations/OrganizationsDirectoryPage.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/organizations/OrganizationsDirectoryPage.test.tsx
@@ -126,6 +126,7 @@ describe('OrganizationsDirectoryPage — §5 empty-state law', () => {
       subdomain: 'acme',
       parentDomain: 'omani.homes',
       plan: 'pro',
+      planSlug: 's',
       kind: 'customer',
       tier: 'org',
       billingMode: 'real',

--- a/products/catalyst/bootstrap/ui/src/shared/ui/notifications.tsx
+++ b/products/catalyst/bootstrap/ui/src/shared/ui/notifications.tsx
@@ -107,7 +107,7 @@ export function useNotifications(): NotificationsContextValue {
  * layout) to mount its own NotificationProvider. Production never
  * hits the `null` branch — the bell is a no-op stub in that case.
  */
-function useOptionalNotifications(): NotificationsContextValue | null {
+export function useOptionalNotifications(): NotificationsContextValue | null {
   return useContext(NotificationsContext)
 }
 


### PR DESCRIPTION
Four UAT rows measured ❌ on **hw293.omantel.biz**, each fixed at its producer. Every guard was watched fail against the pre-fix code before it passed, and each carries a control that stays green so the fix is shown to discriminate rather than to disable a check.

Two of the four turned out to differ from the briefed mechanism in a way that would have made a guard useless — those are called out below.

---

## Row 7 — the plan is dropped at FOUR layers, not three

`spec.planSlug` has existed since #4292 and `org_list_from_cr.go` already reads it onto the provision record. It never reached the page:

| # | Layer | file |
|---|---|---|
| 1 | `orgTenantResponse` never declared the field, so the mapper discarded it | `bootstrap/api/internal/handler/organization_provisioning.go:407` |
| 2 | **the SPA reads a different key** — `plan`, a legacy member no producer has ever written, while the record serialises `plan_slug` | `bootstrap/ui/src/lib/bss.api.ts` |
| 3 | `OrgRow` had no plan member | `bootstrap/ui/src/lib/organizations.api.ts:52` |
| 4 | the detail page rendered no Plan field | `.../organizations/OrganizationDetailPage.tsx` |

**Layer 2 is why a one-line API fix would have looked right and shipped nothing.** The surface was already painting a *consequence* of the plan while never naming it — `isolation` is derived from `planSlug` through the same tier gate.

Empty stays empty: a record with no plan renders no Plan field rather than a fabricated `s`.

<details><summary>red → green</summary>

Staged deliberately, to prove the struct field and the mapping are independently load-bearing.

Stage 1, field absent:
```
org_plan_slug_wire_row7_test.go:101: row.PlanSlug undefined (type orgTenantResponse has no field or method PlanSlug)
FAIL [build failed]
```
Stage 2, struct field added but mapping withheld — note the key dump:
```
--- FAIL: TestOrgResponse_CarriesPurchasedPlan_Row7
    typed row: plan_slug want "m" got ""
    wire JSON must carry the plan_slug key; got keys [subdomain otech_fqdn console_host tier
    domain_mode admin_email company_name isolation boundary_phase tenant_namespace billing_mode
    steps org_tenant_id vcluster_name kind state]
```
Stage 3, mapping added:
```
--- PASS: TestOrgResponse_CarriesPurchasedPlan_Row7
--- PASS: TestOrgResponse_PurchasedPlanIsTheActualPlan_Row7
ok  .../internal/handler  0.020s
```
Front end, 11 assertions across the mapper and the render layer, from `expected undefined to be 'm'` to `11 passed`.
</details>

Asserted on the **value and the wire key**, not key presence — a key check passes on `plan_slug: ""`, which is the state that cannot render. Controls pin the other eight canonical fields, and a second plan (`xl`) discriminates against any hardcoded literal.

---

## Row 15 — the label is stamped by every producer; the field is not

**Correction to the briefed mechanism, and it is the whole point of the row.** The Org identity travels on the Application CR in two places:

- the **label** `catalyst.openova.io/organization` — stamped by **all three** producers already;
- the **spec field** `spec.organizationRef` — which is what `sovereign.go:866` actually reads to render the chip.

**A guard written against the label passes on every producer and sees nothing.** `placement_3373_test.go:217` is exactly that guard — it exercises the broken producer with a dotted org and asserts only `metadata.namespace` and `spec.environmentRef`, both derived. It has been green throughout.

| Producer | file | label | `spec.organizationRef` |
|---|---|---|---|
| `newApplicationUnstructured` | `applications.go:1083` | yes | yes (#5933) |
| `newApplicationCRFromSeed` | `endpoint_handler.go:2312` | yes | **no — the defect** |
| `renderSpineApplicationCR` | `post_handover_spine_apps.go:472` | yes | yes |

#5933 fixed producer 1 and used producer 3 as its control; the multi-instance seed path — which also backs `wireBackingServices` — was never enrolled, so 4 of 7 cards rendered with no chip.

The value must be **verbatim**: this producer deliberately slugs the same string twice (`metadata.namespace`, `spec.environmentRef`) because the CRD forbids dots, and the chip prints what it reads — a slugged value would paint `hw293-omantel-biz` where the operator expects `hw293.omantel.biz`. Both derived spellings are asserted *against*.

<details><summary>red → green</summary>

The lockstep guard names which producer fails while the other two pass:
```
--- FAIL: TestNewApplicationCRFromSeed_StampsOrganizationRef_Row15
    spec.organizationRef absent — the seed producer never stamps the Org, so sovereign.go:866
    reads empty and the /apps Org chip cannot render ...
--- FAIL: TestAllApplicationProducers_StampOrganizationRef_Row15
    newApplicationCRFromSeed: spec.organizationRef = "" (found=false), want "uatco"
```
after:
```
--- PASS: TestNewApplicationCRFromSeed_StampsOrganizationRef_Row15
--- PASS: TestNewApplicationCRFromSeed_OrganizationRefIsVerbatimNotSlugged_Row15
--- PASS: TestNewApplicationCRFromSeed_OmitsOrganizationRefWhenUnset_Row15
--- PASS: TestAllApplicationProducers_StampOrganizationRef_Row15
```
</details>

Enumerating all three producers in one test means the next producer added fails here until enrolled, rather than shipping another blind spot.

---

## Row 25 — the identity was non-deterministic

```ts
slug: fqdn || 'sovereign',
```

`getSovereignSelf()` collapses **every** failure to `null` — network throw, any non-2xx, unparseable body. That slug is simultaneously the directory's link target (`params={{ org: org.slug }}`) and the detail page's lookup key (`rows.find(o => o.slug === org)`), so a row's identity depended on whether an optional enrichment call happened to succeed on that render, and one of the two spellings always 404'd.

The slug is now a constant; the FQDN stays on `displayName`/`consoleHost`, where it is display data rather than a join key.

This is also the walker's reported trap — a single 503 producing a false `org-detail-not-found` — removed at its cause.

`parent-row-isolation-5489.test.ts` **had pinned the divergence as intent**: the FQDN in one case, `'sovereign'` in its sibling. Corrected, with the equality itself now asserted.

<details><summary>red → green</summary>

```
AssertionError: expected 'hw293.omantel.biz' to be 'sovereign'
AssertionError: expected undefined to be defined      (link built on one render, resolved on another)
AssertionError: expected 'hw293.omantel.biz' not to contain '.'
Tests  8 failed | 3 passed (11)
```
→ `11 passed`. The load-bearing assertion is that the two renders **agree** — asserting either literal alone passes on the broken code half the time, which is how this survived.
</details>

Control: an Org that is genuinely absent still reports `org-detail-not-found`, so resolution was not simply made to always succeed.

---

## Row 176 — both halves

**The 422 is real.** Collapsed scanner identity rows (#3925) are synthetic: nothing is named `syft-sbom`. `8367b627a` is an ancestor of the deployed image and cannot bridge it — its `<name>-<digits>` rule needs the row name to be a prefix, and the real object is `syft-grype-bp-syft-grype-<n>`. The row **is** genuinely re-runnable via the CronJob `syft-grype` that seeds it, so it now re-runs there.

`trivy-security-scan` aggregates one Job per workload with no single backing object and **deliberately still 422s** — that control is what stops this from being "make aggregate rows return 200". A third case pins that an absent CronJob also stays 422, so the fix never reports a re-run of an object that is not there.

**The silent half was not a swallowed error.** The control sets `phase='error'` and renders a `role="alert"` span — but that was the only channel: clamped to `max-width: 28ch` with `nowrap` in the table's rightmost cell (the detail is ~110 chars), held in local `useState` a 5s poll can clear, with the button reverting to its idle label. Rendered-but-unreadable is indistinguishable from swallowed. It now also reaches the app-wide notification centre — the mechanism AppsPage, CatalogDetail and the RBAC pages already use — verbatim and unclamped, keyed per row so a second failure replaces rather than stacks.

<details><summary>red → green</summary>

```
--- FAIL: TestRetryJob_Task_SyftIdentity_RunsViaOwningCronJob_Row176
    want 200 (re-run via the owning CronJob), got 422; body={"error":"not-directly-retryable",
    "detail":"jobs \"syft-sbom\" not found in any namespace: reconciler is aggregate or
    operator-managed; not directly retryable"}
```
— the exact body the walk saw. Both controls already passed. After: all three PASS.

Front end (re-proven after a matcher bug masked the first red, by neutralising only the notify path):
```
AssertionError: expected '' to contain 'not directly retryable'
AssertionError: expected '' to contain 'Failed (500)'
Tests  2 failed | 3 passed (5)
```
→ `15 passed` including the pre-existing suite.
</details>

The 200 is asserted to correspond to a **real new Job**, not a bare acknowledgement — a status-code-only check would pass on a handler that returned 200 and did nothing.

---

## Also, so these rows stay measurable

The `/apps` live query retried **0** times, so one 503 on a cold load left the grid with bootstrap cards only — pixel-identical to row 15 failing outright, and the artifact that fooled a first measurement. Now bounded at 2; the 5s poll already covers everything after the cold load.

## Gates

- Go — `handler` + `helmwatch` + `instances` all `ok` (handler 291.9s).
- UI — `tsc -b --noEmit` exit 0; **242 files / 2203 tests passed**.
- `check-no-banned-words.sh` exit 0.
- `tsc` caught 5 existing fixtures missing the new required field, which vitest could not see — fixed rather than made optional, so future fixtures must state the plan.

No `products/catalyst/chart/` changes, so no umbrella bump or bootstrap-kit pin sync is required. No NodePorts.

## Delivery

- **Go** (rows 7, 15, 176 server half) — needs a catalyst-api image roll.
- **Front end** (rows 7, 25, 176 client half) — rides the next `catalyst-ui` build.

Refs #6075, #6076, #6077, #5933, #5814, #3925
