### PR TITLE
fix(auth/session): four UAT rows at their producers — the Org directory a scoped console cannot read, the wrong Sovereign host for silent re-auth, the broker public-EIP hairpin, and the account console that hangs instead of refusing

### DIFF
--- a/clusters/_template/bootstrap-kit/09-keycloak.yaml
+++ b/clusters/_template/bootstrap-kit/09-keycloak.yaml
@@ -226,7 +226,7 @@ spec:
       #   values.yaml wires keycloak.auth.existingSecret=keycloak-admin so the
       #   password is reused (never regenerated) across reinstall + re-home. Chart
       #   + blueprint bumped in lockstep.
-      version: 1.5.7
+      version: 1.5.8
       sourceRef:
         kind: HelmRepository
         name: bp-keycloak

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1364,7 +1364,7 @@ spec:
       #   StatefulSet came back 138s later. RBAC ships inside this umbrella, so
       #   the grant only reaches a Sovereign once this pin advances. Lockstep
       #   w/ products/catalyst/chart/Chart.yaml.
-      version: 1.4.1350
+      version: 1.4.1351
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/platform/keycloak/blueprint.yaml
+++ b/platform/keycloak/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.5.7
+  version: 1.5.8
   card:
     title: keycloak
     summary: Keycloak — user identity. Topology decided by Sovereign CRD spec.keycloakTopology (per-organization for Organizations, shared-sovereign for corporate).

--- a/platform/keycloak/chart/Chart.yaml
+++ b/platform/keycloak/chart/Chart.yaml
@@ -436,7 +436,26 @@ name: bp-keycloak
 # retained (Tier-2 convention, guarded by g117-5-tier2-sso-clients.sh). Kept in
 # lockstep with bp-oidc-gate 0.1.7 instances.yaml. ONLY the powerdns-admin client
 # block changed — no other client's scopes touched.
-version: 1.5.7
+# 1.5.8 (#6087, UAT row 219): the catalyst-pin IdP's BACKCHANNEL legs move to the
+# in-cluster catalyst-api Service. tokenUrl/userInfoUrl/jwksUrl are dialed
+# SERVER-SIDE from inside the Keycloak Pod -- the realm template's own flow
+# comment says so ("KC server calls .../oidc/token to exchange", "KC validates
+# id_token signature via .../oidc/certs") -- but they named the PUBLIC
+# api.<sov-fqdn>, asking the Pod to hairpin out to the Sovereign's own EIP and
+# back through the gateway. On Huawei that does not work (#3241/#3844: "a Pod
+# cannot dial the Sovereign's own public EIP (ELB-DNAT'd, no hairpin)"), so the
+# broker's token exchange failed and Keycloak answered the browser HTTP 502 at
+# /realms/sovereign/broker/catalyst-pin/endpoint -- measured on hw293, blocking
+# every per-Org app behind catalyst-pin SSO. oidc-gate, hubble-ui, gitea and the
+# bp-agenity gate all took this frontchannel-public/backchannel-internal split
+# via a *InternalURL value in the #3844 wave; the catalyst-pin IdP was the one
+# federation seam that never did. New value `catalystAPIInternalURL` (default
+# the in-cluster catalyst-api Service; set "" to restore the all-public legs).
+# authorizationUrl stays PUBLIC (a browser resolves it) and issuer stays PUBLIC
+# (matched against the `iss` catalyst-api mints from SOVEREIGN_FQDN), so this
+# cannot trade a connectivity failure for a validation failure. Signature
+# validation is untouched and guarded.
+version: 1.5.8
 description: |
   1.5.2 (#4246): the per-tenant `openclaw-oidc-client-secret` Secret now
   emits BOTH `client-secret` AND `OIDC_CLIENT_SECRET` keys (it previously

--- a/platform/keycloak/chart/Chart.yaml
+++ b/platform/keycloak/chart/Chart.yaml
@@ -455,6 +455,20 @@ name: bp-keycloak
 # (matched against the `iss` catalyst-api mints from SOVEREIGN_FQDN), so this
 # cannot trade a connectivity failure for a validation failure. Signature
 # validation is untouched and guarded.
+#   ALSO in 1.5.8 (#6090, UAT row 109): the gateway now intercepts Keycloak's
+#   built-in account console. It cannot work on a Sovereign -- a Keycloak-native
+#   account console cannot mint a REST token from a PIN-brokered session (#688),
+#   definitional and permanent -- and left alone it did not refuse: it
+#   authenticated silently via catalyst-pin and then hung forever on the literal
+#   string "Loading the Account Console", 20+ seconds, no h1/h2, no error text,
+#   no way out, against a healthy backend (/account/config answered 200). The
+#   row requires a loud, legible failure; a silent infinite spinner is the one
+#   outcome a User cannot act on. Gateway API v1 has no direct-response filter,
+#   so the intercept is a 302 to console.<fqdn>/settings -- the surface that
+#   does render the signed-in owner's profile. Matched Exact on the two SPA
+#   entry paths ONLY: a PathPrefix would swallow /realms/<realm>/account/config
+#   and the rest of the account REST surface. New knob
+#   gateway.accountConsoleRedirect.
 version: 1.5.8
 description: |
   1.5.2 (#4246): the per-tenant `openclaw-oidc-client-secret` Secret now

--- a/platform/keycloak/chart/templates/configmap-sovereign-realm.yaml
+++ b/platform/keycloak/chart/templates/configmap-sovereign-realm.yaml
@@ -1185,11 +1185,40 @@ data:
             */ -}}
             "clientSecret": {{ include "bp-keycloak.pinBrokerClientSecret" . | quote }},
             "clientAuthMethod": "client_secret_post",
-            "authorizationUrl": "https://api.{{ .Values.sovereignFQDN }}/oidc/auth",
-            "tokenUrl": "https://api.{{ .Values.sovereignFQDN }}/oidc/token",
-            "userInfoUrl": "https://api.{{ .Values.sovereignFQDN }}/oidc/userinfo",
-            "jwksUrl": "https://api.{{ .Values.sovereignFQDN }}/oidc/certs",
-            "issuer": "https://api.{{ .Values.sovereignFQDN }}",
+            {{- /*
+            #6087 (UAT row 219) — FRONTCHANNEL PUBLIC, BACKCHANNEL INTERNAL.
+
+            The three URLs below the authorizationUrl are dialed SERVER-SIDE by
+            Keycloak, as this block's own flow comment states: "KC server calls
+            .../oidc/token to exchange" and "KC validates id_token signature via
+            .../oidc/certs". Rendering them against the PUBLIC api.<sov-fqdn>
+            asks the Keycloak Pod to hairpin out to the Sovereign's own EIP and
+            back in through the gateway. On Huawei that does not work — the
+            #3241/#3844 class, stated verbatim in
+            platform/oidc-gate/chart/Chart.yaml 0.1.5: "on Huawei a Pod cannot
+            dial the Sovereign's own public EIP (ELB-DNAT'd, no hairpin)".
+
+            Measured on hw293: the browser follows the gate's redirect to
+            /realms/sovereign/broker/catalyst-pin/endpoint?code=... and Keycloak
+            renders its own error page with HTTP 502 — the response
+            AbstractOAuth2IdentityProvider produces when the server-side leg
+            fails, while authorizationUrl (a browser redirect) works fine.
+
+            authorizationUrl stays PUBLIC because a browser resolves it.
+            issuer stays PUBLIC because it is compared against the `iss` claim
+            catalyst-api mints from its own SOVEREIGN_FQDN — pointing it inward
+            would trade a connectivity failure for a validation failure.
+            */ -}}
+            {{- $apiPublic := printf "https://api.%s" .Values.sovereignFQDN }}
+            {{- $apiBackchannel := $apiPublic }}
+            {{- with trim (.Values.catalystAPIInternalURL | default "") }}
+            {{- $apiBackchannel = trimSuffix "/" . }}
+            {{- end }}
+            "authorizationUrl": "{{ $apiPublic }}/oidc/auth",
+            "tokenUrl": "{{ $apiBackchannel }}/oidc/token",
+            "userInfoUrl": "{{ $apiBackchannel }}/oidc/userinfo",
+            "jwksUrl": "{{ $apiBackchannel }}/oidc/certs",
+            "issuer": "{{ $apiPublic }}",
             "defaultScope": "openid email profile groups",
             "syncMode": "FORCE",
             "validateSignature": "true",

--- a/platform/keycloak/chart/templates/httproute.yaml
+++ b/platform/keycloak/chart/templates/httproute.yaml
@@ -66,6 +66,60 @@ console stays reachable at its full path (break-glass untouched, law
               replaceFullPath: {{ printf "/admin/%s/console/" (.Values.gateway.bareURLAdminRedirect.realm | default "sovereign") | quote }}
             statusCode: 302
 {{- end }}
+{{- if and .Values.gateway.accountConsoleRedirect .Values.gateway.accountConsoleRedirect.enabled .Values.sovereignFQDN }}
+{{- /*
+ACCOUNT-CONSOLE INTERCEPT (#6090, UAT row 109 clause b).
+
+Keycloak's built-in account console CANNOT work on this Sovereign, and that
+is definitional rather than a defect: a Keycloak-native account console
+cannot mint a REST token from a PIN-brokered session (#688). What it did
+instead was worse than refusing. Measured on hw293: the User reaches
+/realms/<realm>/account/, the catalyst-pin IdP completes SILENTLY, and the
+browser lands on a page whose entire body text is "Loading the Account
+Console" — held 20+ seconds, document.title "Account Management", zero
+h1/h2, NO error text, no diagnosis, no way out. The backend was healthy
+(/account/config answered 200), so this is the stock keycloak.v2 SPA
+swallowing its own failed bootstrap behind the placeholder.
+
+Row 109 requires that reaching it directly "fails loud and legibly". An
+infinite silent spinner is the exact opposite, and it is the one outcome a
+User cannot act on.
+
+Gateway API v1 has no direct-response filter — RequestRedirect is the only
+mechanism here — so the intercept sends the User to the console surface that
+DOES serve their profile, which is the same surface clause (a) already passes
+on (/settings renders the owner with no second login). A visible one-hop
+bounce to a working page is legible; a spinner that never resolves is not.
+
+SCOPED TO THE TWO SPA ENTRY PATHS, deliberately Exact and never PathPrefix.
+`/realms/<realm>/account/config` and the rest of the account REST surface
+must keep answering — a PathPrefix here would capture them and turn a UI
+problem into an API outage. Catching only the document entry means the SPA
+never boots, so it never reaches the bootstrap it cannot complete.
+
+Loop-safety: the redirect leaves this host entirely (auth.<fqdn> →
+console.<fqdn>), so it cannot re-enter itself. Port is explicit 443 — the
+#3310 class the bare-URL rule above already records, where Gateway API
+otherwise copies the cilium listener port into Location.
+*/}}
+    - matches:
+        - path:
+            type: Exact
+            value: {{ printf "/realms/%s/account" (.Values.sovereignRealm.name | default "sovereign") | quote }}
+        - path:
+            type: Exact
+            value: {{ printf "/realms/%s/account/" (.Values.sovereignRealm.name | default "sovereign") | quote }}
+      filters:
+        - type: RequestRedirect
+          requestRedirect:
+            scheme: https
+            hostname: {{ printf "console.%s" .Values.sovereignFQDN | quote }}
+            port: 443
+            path:
+              type: ReplaceFullPath
+              replaceFullPath: {{ .Values.gateway.accountConsoleRedirect.path | default "/settings" | quote }}
+            statusCode: 302
+{{- end }}
     - matches:
         - path:
             type: PathPrefix

--- a/platform/keycloak/chart/values.yaml
+++ b/platform/keycloak/chart/values.yaml
@@ -723,6 +723,28 @@ gateway:
   bareURLAdminRedirect:
     enabled: true
     realm: sovereign
+  # accountConsoleRedirect (#6090, UAT row 109) — intercept Keycloak's built-in
+  # account console and send the User to the console surface that actually
+  # serves their profile.
+  #
+  # The account console cannot work on a Sovereign: a Keycloak-native account
+  # console cannot mint a REST token from a PIN-brokered session (#688), which
+  # is definitional and permanent. Left alone it does not refuse — it renders
+  # the branded sign-in, completes catalyst-pin SILENTLY, and then hangs
+  # forever on the literal string "Loading the Account Console" with no error
+  # text and no way out (measured hw293, held 20+ seconds against a healthy
+  # backend). Row 109 asks that reaching it directly fail loud and legibly; a
+  # silent infinite spinner is the one outcome a User cannot act on.
+  #
+  # Only the two SPA ENTRY paths are matched, and only as Exact — the account
+  # REST surface (/realms/<realm>/account/config and friends) must keep
+  # answering, so a PathPrefix here would turn a UI problem into an API outage.
+  #
+  # Requires sovereignFQDN to be set (the redirect target is
+  # console.<sovereignFQDN>). Set enabled:false to serve the stock console.
+  accountConsoleRedirect:
+    enabled: true
+    path: /settings
   # Backend Service — defaults to <release>-keycloak (bitnami subchart fullname)
   backendService: ""
   backendPort: 80

--- a/platform/keycloak/chart/values.yaml
+++ b/platform/keycloak/chart/values.yaml
@@ -40,6 +40,40 @@ catalystBlueprint:
 # Per-Sovereign bootstrap-kit HelmRelease overlay supplies this.
 sovereignFQDN: ""
 
+# catalystAPIInternalURL — the in-cluster base URL for the catalyst-pin
+# identity provider's BACKCHANNEL legs (#6087, UAT row 219).
+#
+# The catalyst-pin IdP federates Keycloak to catalyst-api's OIDC provider. Its
+# frontchannel leg is a BROWSER redirect (authorizationUrl) and must stay
+# public. Its backchannel legs — tokenUrl, userInfoUrl, jwksUrl — are dialed
+# SERVER-SIDE from inside the Keycloak pod, and configmap-sovereign-realm.yaml's
+# own flow comment names them: "KC server calls https://api.<sov-fqdn>/oidc/token
+# to exchange" and "KC validates id_token signature via
+# https://api.<sov-fqdn>/oidc/certs".
+#
+# Pointing those at the PUBLIC api.<sov-fqdn> asks the pod to hairpin out to the
+# Sovereign's own EIP and back in through the gateway. On Huawei that does not
+# work, and it is the exact defect class #3844 fixed everywhere else — see
+# platform/oidc-gate/chart/Chart.yaml 0.1.5: "on Huawei a Pod cannot dial the
+# Sovereign's own public EIP (ELB-DNAT'd, no hairpin — same class as #3241)".
+# oidc-gate, hubble-ui, gitea and the bp-agenity gate all took the
+# frontchannel-public / backchannel-internal split via a *InternalURL value.
+# The catalyst-pin IdP is the one federation seam that never got it, and the
+# result is UAT row 219: the browser reaches
+# /realms/sovereign/broker/catalyst-pin/endpoint and Keycloak answers HTTP 502
+# ("Unexpected error when authenticating with identity provider"), which is what
+# AbstractOAuth2IdentityProvider returns when the server-side token exchange
+# fails.
+#
+# `issuer` deliberately stays PUBLIC even when this is set: the id_token's `iss`
+# claim is minted from catalyst-api's own SOVEREIGN_FQDN-derived issuer, so a
+# private issuer here would turn a connectivity failure into a validation
+# failure. Same split bp-keycloak already applies by pinning KC_HOSTNAME public.
+#
+# Set to "" to restore the all-public behaviour on clusters whose EIP does
+# hairpin.
+catalystAPIInternalURL: "http://catalyst-api.catalyst-system.svc.cluster.local:8080"
+
 # G117.5b #2789 — SSO client-secret rotation knob.
 #
 # All Tier-1 / Tier-2 / Tier-3 client secrets are derived via the

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-10T21:54:13.249Z",
+  "generatedAt": "2026-08-10T23:20:57.297Z",
   "blueprints": [
     {
       "id": "bp-agenity",
@@ -2235,7 +2235,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "1.5.7",
+      "version": "1.5.8",
       "section": "pts-2-3-per-sovereign-supporting-services",
       "depends": [
         "bp-postgres"

--- a/products/catalyst/bootstrap/api/internal/handler/org_directory_scope_6081_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_directory_scope_6081_test.go
@@ -1,0 +1,269 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/auth"
+)
+
+// UAT row 218 (#6081) — the per-Org console's install wizard could not name the
+// Organization it is scoped to.
+//
+// `listOrganizations()` (ui/src/lib/organizations.api.ts) composes the PARENT
+// row from GET /api/v1/sovereign/self with the SUB-ORG rows from
+// GET /api/v1/organizations. Only the first of those is on the Org-scoped
+// allowlist, so OrgScopeGuard 403'd the second, `listOrgRecords` swallowed the
+// non-2xx into `[]` (bss.api.ts:826-828), and the wizard's org select rendered
+// with exactly one option: the Sovereign self-org. #5823's pre-select then
+// filtered that lone parent row out BY DESIGN, leaving zero candidates and an
+// unselected control — the honest outcome for the list it was handed.
+//
+// The pre-select was never the defect. The candidate list was.
+//
+// These tests pin BOTH halves of the fix, because either half alone is a new
+// defect: opening the route without confining the handler hands a customer the
+// whole Sovereign's Organization directory, and confining the handler without
+// opening the route leaves the list empty.
+
+// orgScopedClaims builds the session an Org console mints (tier=org-admin +
+// the Org slug), which is what claimsAreOrgScoped/orgScopeForRequest read.
+func orgScopedClaims(slug string) *auth.Claims {
+	return &auth.Claims{Email: "customer@" + slug, Tier: orgScopedTier, Org: slug}
+}
+
+func withDirClaims(r *http.Request, c *auth.Claims) *http.Request {
+	return r.WithContext(context.WithValue(r.Context(), auth.ClaimsKey, c))
+}
+
+// decodeOrgSlugs returns the SUBDOMAIN (slug) of every row in a directory
+// response. Asserting on the slugs rather than on the presence of the `items`
+// key is deliberate: an empty array carries that key too, so a key-presence
+// assertion passes on exactly the failure this row recorded.
+func decodeOrgSlugs(t *testing.T, body []byte) []string {
+	t.Helper()
+	var got struct {
+		Items []orgTenantResponse `json:"items"`
+	}
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("decode directory: %v (body=%s)", err, string(body))
+	}
+	out := make([]string, 0, len(got.Items))
+	for _, it := range got.Items {
+		out = append(out, it.Subdomain)
+	}
+	return out
+}
+
+func containsSlug(slugs []string, want string) bool {
+	for _, s := range slugs {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}
+
+// TestListOrganizations_OrgScopedSessionSeesItsOwnOrg is the subject.
+//
+// The expectation is DERIVED from orgScopeForRequest — the same acceptance
+// function HandleCreateInstance uses to force an Org-scoped install into the
+// caller's own Org (#4937). Deriving it here rather than hardcoding "uatwalk91"
+// is what stops the two sides drifting again: if the scope seam ever resolves a
+// different Org than the directory serves, this fails instead of quietly
+// agreeing with a literal.
+func TestListOrganizations_OrgScopedSessionSeesItsOwnOrg(t *testing.T) {
+	h, _ := newOrgHandlerWithSeededCRs(t,
+		orgReadyCR("uatwalk91", "UAT Walk 91", "omani.homes", "owner@uatwalk91.test", "Ready"),
+		orgReadyCR("otherorg", "Someone Else", "omani.homes", "owner@otherorg.test", "Ready"),
+		orgReadyCR("omantel", "Omantel", "", "admin@omantel.biz", "Ready"),
+	)
+
+	req := withDirClaims(
+		httptest.NewRequest(http.MethodGet, "/api/v1/organizations", nil),
+		orgScopedClaims("uatwalk91"),
+	)
+
+	wantSlug, scoped := h.orgScopeForRequest(req)
+	if !scoped || wantSlug == "" {
+		t.Fatalf("fixture is inert: orgScopeForRequest reported scoped=%v slug=%q — "+
+			"the request this test drives is not Org-scoped at all, so it could not "+
+			"discriminate the fix", scoped, wantSlug)
+	}
+
+	w := httptest.NewRecorder()
+	h.HandleListOrganizations(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: want 200 got %d body=%s", w.Code, w.Body.String())
+	}
+	slugs := decodeOrgSlugs(t, w.Body.Bytes())
+
+	if !containsSlug(slugs, wantSlug) {
+		t.Errorf("the Org-scoped console cannot see its OWN Organization %q — "+
+			"directory returned %v. This is UAT row 218: the install wizard's org "+
+			"select has no candidate to pre-select.", wantSlug, slugs)
+	}
+	if len(slugs) != 1 {
+		t.Errorf("an Org-scoped session must see EXACTLY its own Organization, got %v "+
+			"(%d rows) — anything more is a cross-Org directory leak", slugs, len(slugs))
+	}
+	for _, s := range slugs {
+		if s != wantSlug {
+			t.Errorf("cross-Org leak: Org-scoped session for %q was served row %q", wantSlug, s)
+		}
+	}
+}
+
+// TestOrgScopeGuard_OrgScoped_ReadsOrganizationsDirectory — the route half. The
+// handler above can be perfectly confined and the console still sees nothing if
+// the guard never lets the request through.
+func TestOrgScopeGuard_OrgScoped_ReadsOrganizationsDirectory(t *testing.T) {
+	h := &Handler{log: quietLog()}
+
+	reached := false
+	guard := h.OrgScopeGuard(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		reached = true
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := withDirClaims(
+		httptest.NewRequest(http.MethodGet, "/api/v1/organizations", nil),
+		orgScopedClaims("acme"),
+	)
+	rec := httptest.NewRecorder()
+	guard.ServeHTTP(rec, req)
+
+	if !reached {
+		t.Fatalf("the Org console's own directory read was 403'd (status %d) — "+
+			"listOrgRecords turns that into an empty array and the install wizard "+
+			"renders no candidate Organization (UAT row 218)", rec.Code)
+	}
+}
+
+// TestOrgScopeGuard_OrgScoped_StillCannotWriteOrganizations is the CONTROL that
+// holds the fix to opening a READ rather than a path.
+//
+// POST /api/v1/organizations (create) and DELETE /api/v1/organizations/{id}
+// share the read's path prefix, and pathIsOrgSafe is method-blind — so a
+// prefix entry on the existing allowlist would hand every customer session
+// org-create AND org-delete. org_scope_test.go's wipe test states the rule this
+// control enforces from the other direction: the guard "must not become
+// method-sensitive in a way that lets a write through on a path whose reads are
+// denied." Admitting a read on a path whose writes stay denied is the inverse,
+// and this test is what proves it stayed the inverse.
+func TestOrgScopeGuard_OrgScoped_StillCannotWriteOrganizations(t *testing.T) {
+	cases := []struct {
+		method string
+		path   string
+		what   string
+	}{
+		{http.MethodPost, "/api/v1/organizations", "create an Organization"},
+		{http.MethodDelete, "/api/v1/organizations/uuid-1", "delete an Organization"},
+		{http.MethodPost, "/api/v1/organizations/uuid-1/reconcile", "re-run another Org's pipeline"},
+		{http.MethodPut, "/api/v1/organizations", "overwrite the Organization directory"},
+		{http.MethodPatch, "/api/v1/organizations/uuid-1", "patch an Organization"},
+	}
+	for _, c := range cases {
+		h := &Handler{log: quietLog()}
+		reached := false
+		guard := h.OrgScopeGuard(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			reached = true
+			w.WriteHeader(http.StatusOK)
+		}))
+
+		req := withDirClaims(httptest.NewRequest(c.method, c.path, nil), orgScopedClaims("acme"))
+		rec := httptest.NewRecorder()
+		guard.ServeHTTP(rec, req)
+
+		if reached {
+			t.Errorf("%s %s: an Org-scoped customer session REACHED the handler and could %s",
+				c.method, c.path, c.what)
+		}
+		if rec.Code != http.StatusForbidden {
+			t.Errorf("%s %s: want 403 for an Org-scoped session, got %d", c.method, c.path, rec.Code)
+		}
+	}
+}
+
+// TestOrgScopeGuard_OrgScoped_SubPathReadsStayDenied is the second CONTROL on
+// the route half: only the directory COLLECTION is opened, never the
+// per-Organization detail route, which is addressed by another Org's id.
+func TestOrgScopeGuard_OrgScoped_SubPathReadsStayDenied(t *testing.T) {
+	h := &Handler{log: quietLog()}
+	reached := false
+	guard := h.OrgScopeGuard(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		reached = true
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := withDirClaims(
+		httptest.NewRequest(http.MethodGet, "/api/v1/organizations/uuid-of-another-org", nil),
+		orgScopedClaims("acme"),
+	)
+	rec := httptest.NewRecorder()
+	guard.ServeHTTP(rec, req)
+
+	if reached {
+		t.Fatalf("an Org-scoped session reached another Organization's detail route")
+	}
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("want 403 on the org-detail route, got %d", rec.Code)
+	}
+}
+
+// TestListOrganizations_SovereignAdminStillSeesEveryOrg is the CONTROL that
+// keeps the handler-side confinement from being a blanket filter. The operator
+// directory is the whole point of GET /api/v1/organizations; a fix that made
+// this test fail would have "closed" row 218 by emptying the Sovereign console.
+func TestListOrganizations_SovereignAdminStillSeesEveryOrg(t *testing.T) {
+	h, _ := newOrgHandlerWithSeededCRs(t,
+		orgReadyCR("uatwalk91", "UAT Walk 91", "omani.homes", "owner@uatwalk91.test", "Ready"),
+		orgReadyCR("otherorg", "Someone Else", "omani.homes", "owner@otherorg.test", "Ready"),
+		orgReadyCR("omantel", "Omantel", "", "admin@omantel.biz", "Ready"),
+	)
+
+	req := withDirClaims(
+		httptest.NewRequest(http.MethodGet, "/api/v1/organizations", nil),
+		&auth.Claims{Email: "operator@openova.io", Tier: "owner"},
+	)
+	if _, scoped := h.orgScopeForRequest(req); scoped {
+		t.Fatalf("control is inert: the operator request resolved as Org-scoped")
+	}
+
+	w := httptest.NewRecorder()
+	h.HandleListOrganizations(w, req)
+
+	slugs := decodeOrgSlugs(t, w.Body.Bytes())
+	for _, want := range []string{"uatwalk91", "otherorg", "omantel"} {
+		if !containsSlug(slugs, want) {
+			t.Errorf("Sovereign-admin directory lost %q — got %v", want, slugs)
+		}
+	}
+}
+
+// TestListOrganizations_OrgScopedSessionWithNoMatchingRowStaysEmpty is the
+// CONTROL against inventing a row. A confinement that SYNTHESISED the caller's
+// Org when the directory holds none would make the subject test pass while
+// telling the console an Organization exists that no CR backs.
+func TestListOrganizations_OrgScopedSessionWithNoMatchingRowStaysEmpty(t *testing.T) {
+	h, _ := newOrgHandlerWithSeededCRs(t,
+		orgReadyCR("otherorg", "Someone Else", "omani.homes", "owner@otherorg.test", "Ready"),
+	)
+
+	req := withDirClaims(
+		httptest.NewRequest(http.MethodGet, "/api/v1/organizations", nil),
+		orgScopedClaims("ghostorg"),
+	)
+	w := httptest.NewRecorder()
+	h.HandleListOrganizations(w, req)
+
+	slugs := decodeOrgSlugs(t, w.Body.Bytes())
+	if len(slugs) != 0 {
+		t.Errorf("an Org-scoped session whose Org has no record must get an EMPTY "+
+			"directory, not an invented row or someone else's: got %v", slugs)
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/org_scope.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_scope.go
@@ -303,6 +303,50 @@ func pathIsOrgSafe(p string) bool {
 	return false
 }
 
+// orgSafeExactReadPaths is the METHOD-AWARE, EXACT-PATH half of the allowlist:
+// collections whose READ is an Org-OWN surface while every WRITE on the same
+// path — and every SUB-path — stays Sovereign-only.
+//
+//   - /api/v1/organizations — the Organization directory. The console's
+//     `listOrganizations()` reads it for the SUB-ORG rows that populate the
+//     install wizard's target-Org select; without it a per-Org console cannot
+//     name the Organization it is scoped to (#6081, UAT row 218).
+//     HandleListOrganizations confines an Org-scoped caller to its own row via
+//     orgScopeForRequest, so this entry cannot span Orgs — the same
+//     server-side-confinement contract the #4937 entries above rely on.
+//
+// WHY A SEPARATE LIST INSTEAD OF A PREFIX ENTRY. orgSafePathPrefixes is
+// prefix-matched and method-blind, and this path's siblings are the most
+// destructive routes on the Organization API: POST /api/v1/organizations
+// (create), DELETE /api/v1/organizations/{id} (delete) and POST
+// .../{id}/reconcile. A prefix entry would hand every customer session all
+// three. org_scope_test.go's wipe test states the rule from the other
+// direction — the guard "must not become method-sensitive in a way that lets a
+// write through on a path whose reads are denied". Admitting a read on a path
+// whose writes stay denied is the inverse of that, and it is deliberately
+// narrow: exact path only (no {id} detail route) and read methods only.
+var orgSafeExactReadPaths = []string{
+	"/api/v1/organizations",
+}
+
+// requestIsOrgSafe is the guard's verdict for one request. The method-blind
+// prefix allowlist is consulted first and unchanged; the exact-path read
+// allowlist applies to GET/HEAD only.
+func requestIsOrgSafe(method, p string) bool {
+	if pathIsOrgSafe(p) {
+		return true
+	}
+	if method != http.MethodGet && method != http.MethodHead {
+		return false
+	}
+	for _, exact := range orgSafeExactReadPaths {
+		if p == exact {
+			return true
+		}
+	}
+	return false
+}
+
 // OrgScopeGuard is a chi-compatible middleware applied to the whole
 // RequireSession group in cmd/api/main.go. For a NON-Org-scoped session
 // (Sovereign-admin / operator) it is a transparent passthrough — zero
@@ -340,7 +384,7 @@ func (h *Handler) OrgScopeGuard(next http.Handler) http.Handler {
 			return
 		}
 		// Org-scoped customer session: deny-by-default outside the allowlist.
-		if pathIsOrgSafe(r.URL.Path) {
+		if requestIsOrgSafe(r.Method, r.URL.Path) {
 			next.ServeHTTP(w, r)
 			return
 		}

--- a/products/catalyst/bootstrap/api/internal/handler/organization_provisioning.go
+++ b/products/catalyst/bootstrap/api/internal/handler/organization_provisioning.go
@@ -926,7 +926,56 @@ func (h *Handler) HandleListOrganizations(w http.ResponseWriter, r *http.Request
 	}
 
 	out := mergeOrgResponses(local, fromCR)
+
+	// #6081 (UAT row 218) — an Org-scoped session sees its OWN row and nothing
+	// else.
+	//
+	// This directory is the SUB-ORG half of the console's `listOrganizations()`
+	// (ui/src/lib/organizations.api.ts); the parent row comes from
+	// /api/v1/sovereign/self. On a per-Org console the whole endpoint was 403'd
+	// by OrgScopeGuard, `listOrgRecords` swallowed the non-2xx into `[]`
+	// (bss.api.ts:826-828), and the bp-agenity install wizard's org select was
+	// left with exactly one option — the Sovereign self-org — which #5823's
+	// pre-select then correctly discards as a parent. The Organization the
+	// console is scoped to was not a candidate for installing into itself.
+	//
+	// The confinement is what makes opening that route safe, so the two land
+	// together: the guard admits only the GET, and this filter is why the GET
+	// cannot become a cross-Org directory read. orgScopeForRequest is reused
+	// rather than re-deriving the scope because it is the SAME acceptance
+	// function HandleCreateInstance consults to force an Org-scoped install into
+	// the caller's own Org (#4937) — the list the wizard offers is then, by
+	// construction, the set the create seam would accept. Two sides deriving the
+	// caller's Org independently is exactly how #6064's picker came to offer
+	// nothing the create handler honoured.
+	//
+	// A Sovereign-admin / operator session returns ("", false) here and keeps
+	// the full cross-Org directory with zero behaviour change.
+	if slug, scoped := h.orgScopeForRequest(r); scoped {
+		out = confineOrgResponsesToSlug(out, slug)
+	}
+
 	writeJSON(w, http.StatusOK, map[string]any{"items": out})
+}
+
+// confineOrgResponsesToSlug keeps only the rows belonging to `slug`.
+//
+// It FILTERS rather than synthesising: an Org-scoped caller whose Organization
+// has no record yet gets an empty directory, never an invented row. A fabricated
+// row would make the console render an Organization no CR backs — the
+// #5489/#5501 class of lie this endpoint has already been corrected for twice.
+func confineOrgResponsesToSlug(in []orgTenantResponse, slug string) []orgTenantResponse {
+	want := strings.ToLower(strings.TrimSpace(slug))
+	out := make([]orgTenantResponse, 0, 1)
+	if want == "" {
+		return out
+	}
+	for _, it := range in {
+		if strings.EqualFold(strings.TrimSpace(it.Subdomain), want) {
+			out = append(out, it)
+		}
+	}
+	return out
 }
 
 // HandleGetOrganization — GET /api/v1/org/tenants/{id}.

--- a/products/catalyst/bootstrap/ui/src/app/router.tsx
+++ b/products/catalyst/bootstrap/ui/src/app/router.tsx
@@ -388,7 +388,16 @@ export const SILENT_SSO_NAV_GRACE_MS = 8000
 // before falling back to the PIN wall.
 export async function attemptSilentSovereignSSO(): Promise<boolean> {
   if (typeof window === 'undefined') return false
-  const fqdn = DETECTED_MODE.sovereignFQDN
+  // #5895 / UAT row 29 — ASK for the Sovereign FQDN, never derive it from this
+  // host. `DETECTED_MODE.sovereignFQDN` strips one `console.` label, which on a
+  // per-Org console yields the ORG apex; the authorize URL then targets
+  // `auth.<orgslug>.<parent>`, where a walker measured 404 on 10/10 probes
+  // (valid wildcard cert, cookies intact — the per-Org Gateway has a
+  // `*.<slug>.<parent>` listener but no HTTPRoute for that name). The silent leg
+  // then never commits, SILENT_SSO_NAV_GRACE_MS below expires, and the visitor
+  // lands on the PIN wall this row exists to forbid.
+  const { resolveSovereignFQDN } = await import('@/shared/lib/resolveSovereignFQDN')
+  const fqdn = await resolveSovereignFQDN()
   if (!fqdn) return false
   try {
     if (sessionStorage.getItem(SILENT_SSO_GUARD_KEY) === '1') {

--- a/products/catalyst/bootstrap/ui/src/components/RequiredActionsModal.tsx
+++ b/products/catalyst/bootstrap/ui/src/components/RequiredActionsModal.tsx
@@ -11,29 +11,40 @@
  *   - CONFIGURE_TOTP      — TOTP 2FA must be configured
  *
  * This modal is shown as a blocking interstitial — the user cannot
- * dismiss it; they must complete the required action in Keycloak's
- * account-management UI (opened in a new tab) and then click
- * "I've completed the setup" to refresh their tokens. If the refresh
- * still shows required actions, the modal re-appears.
+ * dismiss it; they complete the required action from their account
+ * settings and then click "I've completed the setup" to refresh their
+ * tokens. If the refresh still shows required actions, the modal
+ * re-appears.
  *
  * Design rationale:
  *   - We do NOT embed a Keycloak account-management iframe because
  *     Keycloak's CSP and X-Frame-Options headers prevent framing in
- *     modern browsers without explicit configuration. A new-tab link to
- *     the Keycloak account console is the standard approach.
+ *     modern browsers without explicit configuration.
+ *   - #6090 (UAT row 109): the link is NOT to Keycloak's account console.
+ *     That was the standard approach and it is wrong on a Sovereign — a
+ *     Keycloak-native account console cannot mint a REST token from a
+ *     PIN-brokered session (#688), so reaching it does not refuse: it
+ *     authenticates silently and then hangs forever on "Loading the
+ *     Account Console" with no error text and no way out (measured hw293).
+ *     Row 109 requires that NO console navigation link a User there, and
+ *     sending someone into an infinite spinner to satisfy a required
+ *     action is worse than sending them nowhere. The affordance now points
+ *     at this console's own /settings — the surface that actually renders
+ *     the signed-in owner's profile, and the same destination the gateway
+ *     intercept redirects the account console to.
  *   - The "I've completed the setup" button triggers a silent token
  *     refresh; if required actions are gone, the modal closes.
  *   - If Keycloak's refresh returns new required actions, the modal
  *     re-renders with the updated list.
  *
- * Per docs/INVIOLABLE-PRINCIPLES.md #4 (never hardcode), the Keycloak
- * account URL is derived from the Sovereign FQDN at runtime.
+ * sovereignFQDN is still a prop: silentRefresh() needs it to reach the
+ * Sovereign's token endpoint. It no longer builds any account-console URL.
  *
  * Related: GitHub issue #607
  */
 
 import { useState } from 'react'
-import { ShieldCheck, Key, Lock, RefreshCw, ExternalLink } from 'lucide-react'
+import { ShieldCheck, Key, Lock, RefreshCw } from 'lucide-react'
 import { Button } from '@/shared/ui/button'
 import { silentRefresh, getRequiredActions, saveTokens } from '@/shared/lib/oidc'
 import type { TokenSet } from '@/shared/lib/oidc'
@@ -44,7 +55,7 @@ import {
 } from '@/shared/lib/oidc'
 
 interface RequiredActionsModalProps {
-  /** Sovereign FQDN — used to derive the Keycloak account URL. */
+  /** Sovereign FQDN — used by silentRefresh to reach the token endpoint. */
   sovereignFQDN: string
   /** Required actions from the current id_token. */
   requiredActions: string[]
@@ -88,7 +99,7 @@ function describeAction(code: string): ActionDescriptor {
     ACTION_DESCRIPTORS.find((a) => a.code === code) ?? {
       code,
       label: code,
-      description: 'Complete this required action in the Keycloak account console.',
+      description: 'Complete this required action from your account settings.',
       icon: <ShieldCheck className="h-5 w-5 text-[var(--color-accent)]" />,
     }
   )
@@ -103,7 +114,11 @@ export function RequiredActionsModal({
   const [error, setError] = useState<string | null>(null)
   const [currentActions, setCurrentActions] = useState<string[]>(requiredActions)
 
-  const accountUrl = `https://auth.${sovereignFQDN}/realms/sovereign/account`
+  // #6090 (UAT row 109) — this console's OWN profile surface, never
+  // `https://auth.${sovereignFQDN}/realms/sovereign/account`. That URL
+  // authenticates silently and then hangs forever on "Loading the Account
+  // Console"; the row forbids any console navigation from linking a User to it.
+  const accountUrl = '/settings'
 
   async function handleDone() {
     setRefreshing(true)
@@ -152,7 +167,7 @@ export function RequiredActionsModal({
               Account setup required
             </h2>
             <p className="mt-1 text-sm text-[var(--color-text-dim)]">
-              Complete the following steps in the Keycloak account console before accessing the Sovereign Console.
+              Complete the following steps in your account settings before accessing the Sovereign Console.
             </p>
           </div>
         </div>
@@ -181,16 +196,13 @@ export function RequiredActionsModal({
           })}
         </ul>
 
-        {/* Open Keycloak account console */}
+        {/* Open this console's own account settings (#6090) */}
         <a
           href={accountUrl}
-          target="_blank"
-          rel="noopener noreferrer"
           className="mb-4 flex w-full items-center justify-center gap-2 rounded-lg border border-[var(--color-border)] bg-[var(--color-bg)] px-4 py-2.5 text-sm font-medium text-[var(--color-text)] transition-colors hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text-strong)]"
           data-testid="ra-open-account-link"
         >
-          Open Keycloak account console
-          <ExternalLink className="h-3.5 w-3.5" />
+          Open account settings
         </a>
 
         {/* Error */}

--- a/products/catalyst/bootstrap/ui/src/pages/auth/AuthCallbackPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/auth/AuthCallbackPage.tsx
@@ -63,9 +63,14 @@ function SovereignCallbackPage() {
       try {
         // Lazy-import oidc so Catalyst-Zero builds don't pay for unused code.
         const { handleCallback, parseSilentAuthError } = await import('@/shared/lib/oidc')
-        const { DETECTED_MODE } = await import('@/shared/lib/detectMode')
+        // #5895 / UAT row 29 — the token exchange MUST target the same host the
+        // authorize leg used (attemptSilentSovereignSSO, router.tsx). Resolving
+        // through the shared cache is what guarantees that: deriving it here
+        // from the hostname would send the exchange to `auth.<orgslug>` on a
+        // per-Org console while the code was issued by the Sovereign realm.
+        const { resolveSovereignFQDN } = await import('@/shared/lib/resolveSovereignFQDN')
 
-        const sovereignFQDN = DETECTED_MODE.sovereignFQDN
+        const sovereignFQDN = await resolveSovereignFQDN()
         if (!sovereignFQDN) {
           setState({
             status: 'error',

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -2370,7 +2370,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "1.5.7",
+    "version": "1.5.8",
     "section": "pts-2-3-per-sovereign-supporting-services",
     "depends": [
       "bp-postgres"

--- a/products/catalyst/bootstrap/ui/src/shared/lib/resolveSovereignFQDN.test.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/lib/resolveSovereignFQDN.test.ts
@@ -1,0 +1,179 @@
+/**
+ * UAT row 29 / #3374, root cause #5895 — the silent re-auth host.
+ *
+ * `detectMode()` derives the Sovereign FQDN by stripping ONE leading `console.`
+ * label, which is right for the Sovereign console and wrong for a per-Org
+ * console — both match `console.*`:
+ *
+ *   console.hw293.omantel.biz       -> hw293.omantel.biz       (Sovereign, correct)
+ *   console.walkone.omani.homes     -> walkone.omani.homes     (an ORG, wrong)
+ *
+ * That value feeds buildOIDCEndpoints() -> `https://auth.${fqdn}/realms/sovereign`,
+ * so on a per-Org console the silent `prompt=none` re-auth navigates to
+ * `auth.<orgslug>.<parent>`. A walker measured 404 on 10/10 probes there with a
+ * VALID wildcard cert and realm cookies intact: the per-Org Gateway listener is
+ * `*.<slug>.<parent>` (org_console_tls.go:257) so TLS terminates, but no
+ * HTTPRoute carries that hostname — only `console.<slug>.<parent>`
+ * (tenant_route.go:147). There is no per-Org IdP by design; gitops.go:307 builds
+ * the single shared issuer at `auth.<SovereignFQDN>/realms/<realm>`.
+ *
+ * The host cannot be told apart by SHAPE, so it has to be ASKED for.
+ * GET /api/v1/sovereign/self is unauthenticated by design (sovereign_self.go:24
+ * "carries no secrets, only public identifiers ... usable on the very first
+ * browser hit before login") and is Org-scope-allowlisted (org_scope.go), which
+ * is what makes it usable on exactly the expired-session path row 29 walks.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest'
+
+async function loadResolver(
+  hostname: string,
+  viteCatalystMode?: string,
+  viteSovereignFqdn?: string,
+) {
+  vi.resetModules()
+  vi.doMock('@/shared/constants/env', () => ({
+    VITE_CATALYST_MODE: viteCatalystMode,
+    VITE_SOVEREIGN_FQDN: viteSovereignFqdn,
+    APP_MODE: 'saas',
+    IS_SAAS: true,
+    IS_SELFHOSTED: false,
+    APP_VERSION: 'dev',
+  }))
+  // pathname/host are read at module-init by shared/config/urls.ts (BASE), so
+  // a hostname-only stub would throw before the resolver ever runs.
+  Object.defineProperty(window, 'location', {
+    value: { hostname, host: hostname, pathname: '/', origin: `https://${hostname}` },
+    writable: true,
+    configurable: true,
+  })
+  return await import('./resolveSovereignFQDN')
+}
+
+afterEach(() => {
+  vi.resetModules()
+  vi.restoreAllMocks()
+})
+
+/** A /sovereign/self responder that records how many times it was called. */
+function mockSelf(sovereignFQDN: string) {
+  const fetchMock = vi.fn(async () => ({
+    ok: true,
+    status: 200,
+    json: async () => ({ deploymentId: 'dep-1', sovereignFQDN }),
+  }))
+  vi.stubGlobal('fetch', fetchMock)
+  return fetchMock
+}
+
+describe('#5895 / UAT row 29 — resolveSovereignFQDN', () => {
+  // THE SUBJECT. A per-Org console must resolve the SOVEREIGN, not its own
+  // apex, or the silent re-auth navigates to a host the gateway does not route.
+  it('on a per-Org console, resolves the Sovereign FQDN and NOT the Org apex', async () => {
+    const { resolveSovereignFQDN } = await loadResolver('console.walkone.omani.homes')
+    mockSelf('hw293.omantel.biz')
+
+    const got = await resolveSovereignFQDN()
+
+    expect(got).toBe('hw293.omantel.biz')
+    // Named explicitly: this is the value that produced auth.<org> 404s.
+    expect(got).not.toBe('walkone.omani.homes')
+  })
+
+  // The CONTROL that stops the fix from being "always ask the API": the
+  // Sovereign console must keep resolving its own FQDN. A change that broke
+  // this would have "fixed" row 29 by breaking every operator login.
+  it('on the Sovereign console, still resolves the Sovereign FQDN', async () => {
+    const { resolveSovereignFQDN } = await loadResolver('console.hw293.omantel.biz')
+    mockSelf('hw293.omantel.biz')
+
+    expect(await resolveSovereignFQDN()).toBe('hw293.omantel.biz')
+  })
+
+  // The CONTROL that keeps the API from being a hard dependency of login. If
+  // /sovereign/self is unreachable the resolver must degrade to the hostname
+  // derivation — the Sovereign console then behaves exactly as it does today
+  // rather than losing its auth host entirely.
+  it('falls back to the hostname derivation when /sovereign/self fails', async () => {
+    const { resolveSovereignFQDN } = await loadResolver('console.hw293.omantel.biz')
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new Error('network down')
+      }),
+    )
+
+    expect(await resolveSovereignFQDN()).toBe('hw293.omantel.biz')
+  })
+
+  // A non-2xx is not a source of truth either — same fallback, asserted
+  // separately because `ok:false` and a thrown error are different code paths.
+  it('falls back when /sovereign/self answers non-2xx', async () => {
+    const { resolveSovereignFQDN } = await loadResolver('console.hw293.omantel.biz')
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ ok: false, status: 503, json: async () => ({}) })),
+    )
+
+    expect(await resolveSovereignFQDN()).toBe('hw293.omantel.biz')
+  })
+
+  // An EMPTY sovereignFQDN must not be accepted as an answer — it would build
+  // `https://auth./realms/sovereign`. Asserting on the VALUE rather than on the
+  // response being present is the whole point.
+  it('falls back when /sovereign/self answers with an empty sovereignFQDN', async () => {
+    const { resolveSovereignFQDN } = await loadResolver('console.hw293.omantel.biz')
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        json: async () => ({ deploymentId: 'dep-1', sovereignFQDN: '   ' }),
+      })),
+    )
+
+    expect(await resolveSovereignFQDN()).toBe('hw293.omantel.biz')
+  })
+
+  // The build-time override must still win, and must NOT cost a request —
+  // dev/CI have no catalyst-api to answer.
+  it('honours the build-time VITE_SOVEREIGN_FQDN override without calling the API', async () => {
+    const { resolveSovereignFQDN } = await loadResolver(
+      'console.hw293.omantel.biz',
+      'sovereign',
+      'forced.example',
+    )
+    const fetchMock = mockSelf('hw293.omantel.biz')
+
+    expect(await resolveSovereignFQDN()).toBe('forced.example')
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  // catalyst-zero has no Sovereign at all; asking for one would be a wrong
+  // question, not a slow one.
+  it('returns null in catalyst-zero mode without calling the API', async () => {
+    const { resolveSovereignFQDN } = await loadResolver('console.openova.io')
+    const fetchMock = mockSelf('hw293.omantel.biz')
+
+    expect(await resolveSovereignFQDN()).toBeNull()
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  // Row 29 is a re-auth path that can fire from several places in one page
+  // load (rootBeforeLoad, the layout's expiry path, the callback). Resolving
+  // once keeps the authorize leg and the token-exchange leg on the SAME host —
+  // two different answers would break the exchange rather than fix the login.
+  it('resolves once and caches, so every leg uses the same host', async () => {
+    const { resolveSovereignFQDN } = await loadResolver('console.walkone.omani.homes')
+    const fetchMock = mockSelf('hw293.omantel.biz')
+
+    const [a, b, c] = await Promise.all([
+      resolveSovereignFQDN(),
+      resolveSovereignFQDN(),
+      resolveSovereignFQDN(),
+    ])
+
+    expect([a, b, c]).toEqual(['hw293.omantel.biz', 'hw293.omantel.biz', 'hw293.omantel.biz'])
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/shared/lib/resolveSovereignFQDN.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/lib/resolveSovereignFQDN.ts
@@ -1,0 +1,112 @@
+/**
+ * resolveSovereignFQDN — the AUTHORITATIVE Sovereign FQDN for auth URLs.
+ *
+ * #5895 / UAT row 29 (#3374). `detectMode()` derives the Sovereign FQDN by
+ * stripping one leading `console.` label. That is correct for the Sovereign
+ * console and WRONG for a per-Organization console, because a per-Org console
+ * satisfies the `console.*` pattern without being a Sovereign:
+ *
+ *   console.hw293.omantel.biz    -> hw293.omantel.biz    (Sovereign, correct)
+ *   console.walkone.omani.homes  -> walkone.omani.homes  (an ORG, wrong)
+ *
+ * The derived value feeds `buildOIDCEndpoints()` (oidc.ts:56) →
+ * `https://auth.${sovereignFQDN}/realms/sovereign`, so on a per-Org console the
+ * silent `prompt=none` re-auth navigates to `auth.<orgslug>.<parent>`. A walker
+ * measured **404 on 10/10 parallel probes** there, with a VALID wildcard cert
+ * and realm cookies preserved — which is precisely the signature of a routing
+ * gap rather than a TLS or session one: the per-Org Gateway carries a listener
+ * for `*.<slug>.<parent>` (org_console_tls.go:257) so TLS terminates against the
+ * wildcard, but the only HTTPRoute minted for an Org is `console.<slug>.<parent>`
+ * (tenant_route.go:147). Nothing serves `auth.<slug>.<parent>`, and nothing
+ * should: there is no per-Org IdP by design. gitops.go:289-307 says so directly —
+ * "the per-Org `keycloak.<slug>.<parent>` host is NXDOMAIN there ... The shared
+ * realm at auth.<fqdn> is the SAME issuer the console + every other Sovereign
+ * app resolves".
+ *
+ * The two host shapes are INDISTINGUISHABLE by inspection — `console.` plus
+ * three labels either way — so the answer cannot be derived, it has to be asked
+ * for. GET /api/v1/sovereign/self is the right source and the only one that
+ * works on this path: it is unauthenticated by design (sovereign_self.go:24-28,
+ * "carries no secrets, only public identifiers ... Bypassing the session gate
+ * keeps the SovereignConsoleRedirect helper usable on the very first browser hit
+ * before login") and it is on the Org-scoped allowlist (org_scope.go). Row 29 is
+ * by definition an EXPIRED-session walk, so a session-gated source such as
+ * /whoami — which also carries sovereignFQDN — cannot answer it.
+ *
+ * WHY THIS IS A SEPARATE MODULE RATHER THAN A CHANGE TO detectMode().
+ * `DETECTED_MODE` is a synchronous module-level singleton resolved at import
+ * time; this answer is necessarily async. detectMode() keeps deriving the MODE
+ * from the hostname, which is correct — the per-Org console really is served by
+ * the Sovereign bundle (tenant_route.go:127-133). What it cannot do is VERIFY
+ * the FQDN, so every auth-URL caller resolves through here instead.
+ */
+
+import { VITE_SOVEREIGN_FQDN } from '@/shared/constants/env'
+import { API_BASE } from '@/shared/config/urls'
+import { DETECTED_MODE } from './detectMode'
+
+/**
+ * In-flight/settled promise, so concurrent callers share ONE answer.
+ *
+ * Caching is not an optimisation here, it is a correctness requirement: a page
+ * load can enter the re-auth path from `rootBeforeLoad`, from
+ * SovereignConsoleLayout's cookie-expiry branch (#5460) and from the OIDC
+ * callback. If those legs resolved different hosts, the authorize request and
+ * the token exchange would target different Keycloaks and the login would fail
+ * in a NEW way rather than being fixed.
+ */
+let inFlight: Promise<string | null> | null = null
+
+/**
+ * resolveSovereignFQDN — the Sovereign FQDN to build auth URLs against.
+ *
+ * Returns null in catalyst-zero mode (there is no Sovereign to authenticate
+ * against). Never rejects: on any failure it degrades to the hostname
+ * derivation, which is exactly today's behaviour and is correct on the
+ * Sovereign console itself.
+ */
+export function resolveSovereignFQDN(): Promise<string | null> {
+  if (!inFlight) inFlight = resolveOnce()
+  return inFlight
+}
+
+/** Test-only cache reset; production code resolves once per page load. */
+export function resetSovereignFQDNCache(): void {
+  inFlight = null
+}
+
+async function resolveOnce(): Promise<string | null> {
+  // catalyst-zero has no Sovereign — asking would be a wrong question, not a
+  // slow one.
+  if (DETECTED_MODE.mode !== 'sovereign') return null
+
+  // Build-time override wins and costs no request: dev/CI have no catalyst-api
+  // to answer, and VITE_SOVEREIGN_FQDN exists precisely to stand in for one.
+  const forced = (VITE_SOVEREIGN_FQDN ?? '').trim()
+  if (forced) return forced
+
+  // The hostname derivation is the FALLBACK, not the answer. It is right on the
+  // Sovereign console and wrong on a per-Org console; using it only when the
+  // authoritative source is unreachable keeps this module from making login
+  // strictly more fragile than it was.
+  const derived = DETECTED_MODE.sovereignFQDN
+
+  try {
+    const res = await fetch(`${API_BASE}/v1/sovereign/self`, {
+      headers: { Accept: 'application/json' },
+    })
+    if (res.ok) {
+      const body = (await res.json()) as { sovereignFQDN?: unknown } | null
+      const fqdn =
+        typeof body?.sovereignFQDN === 'string' ? body.sovereignFQDN.trim() : ''
+      // Assert on the VALUE. An empty string is a present key with no answer,
+      // and accepting it would build `https://auth./realms/sovereign` — a worse
+      // failure than the one being fixed.
+      if (fqdn) return fqdn
+    }
+  } catch {
+    // Network failure / offline / jsdom without a fetch stub — fall through.
+  }
+
+  return derived
+}

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3775,7 +3775,7 @@ name: bp-catalyst-platform
 #   138s later under a new uid. A ClusterRole is delivered only by the
 #   published umbrella, so the grant reaches a Sovereign only once this
 #   version advances. Lockstep w/ slot-13 pin.
-version: 1.4.1350
+version: 1.4.1351
 # 1.4.1229 — #5389: catalog-seed bp-newapi declares its `ui` endpoint
 #   (newapi.<fqdn>, ssoEnabled, launchDefault, ssoInitPath "/") instead of
 #   `endpoints: []`. The empty list made userUIGatePasses fail closed, which
@@ -3930,7 +3930,7 @@ version: 1.4.1350
 # scripts/check-chart-version-forward.sh (#5743) fails unless the two match —
 # main was carrying a pre-existing 1.4.1330/1.4.1329 split, so this bump heals
 # it in the same commit, exactly as the documented self-heal contract does.
-appVersion: 1.4.1350
+appVersion: 1.4.1351
 # 1.4.239 — Wave 3 / Issue #2140 (2026-05-23): Huawei provider
 # implementation lands behind the Wave 2 CloudProvider interface.
 # Adds the OpenTofu module at infra/providers/huawei/ (VPC + Subnet +

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -592,7 +592,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "1.5.7"
+  version: "1.5.8"
   visibility: listed
   card:
     title: "Keycloak"
@@ -620,7 +620,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-keycloak
-    version: "1.5.7"
+    version: "1.5.8"
   # G117.1+G117.4+G117.6 #2744-followup (2026-06-03): bp-keycloak
   # catalog-seed needs topology + endpoints + sso so application-
   # controller can fan out HRs and operator console can mint silent-SSO

--- a/tests/e2e/bootstrap-kit/account_console_intercept_6090_test.go
+++ b/tests/e2e/bootstrap-kit/account_console_intercept_6090_test.go
@@ -1,0 +1,267 @@
+// Render guards for the Keycloak account-console intercept.
+//
+// UAT row 109 clause (b): "if the Keycloak account console is reached directly
+// it fails loud and legibly, and NO console navigation links a User to it."
+//
+// The no-link half passed on hw293. The loud-and-legible half failed in the
+// opposite direction from a refusal: reaching
+// https://auth.<fqdn>/realms/sovereign/account/ rendered the branded sign-in,
+// the catalyst-pin IdP completed SILENTLY with no PIN prompt, and the browser
+// landed on a page whose entire body text was "Loading the Account Console" —
+// held 20+ seconds, document.title "Account Management", zero h1/h2 elements,
+// no error text, no diagnosis, no way out. Not a backend fault:
+// /realms/sovereign/account/config on that same page answered 200 with
+// x-envoy-upstream-service-time 12.
+//
+// That the console cannot work here is definitional, not a defect — a
+// Keycloak-native account console cannot mint a REST token from a PIN-brokered
+// session (#688). The defect is that it hangs instead of saying so.
+package bootstrapkit
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// renderKeycloakRoute renders the chart's HTTPRoute template offline.
+func renderKeycloakRoute(t *testing.T, extraArgs ...string) map[string]any {
+	t.Helper()
+
+	helmBin := os.Getenv("HELM_BIN")
+	if helmBin == "" {
+		helmBin = "helm"
+	}
+	if _, err := exec.LookPath(helmBin); err != nil {
+		t.Skipf("helm not on PATH (%v)", err)
+	}
+
+	src := filepath.Join(repoRoot(t), "platform", "keycloak", "chart")
+	dir := t.TempDir()
+
+	rawChart, err := os.ReadFile(filepath.Join(src, "Chart.yaml"))
+	if err != nil {
+		t.Fatalf("read Chart.yaml: %v", err)
+	}
+	var chart map[string]any
+	if uerr := yaml.Unmarshal(rawChart, &chart); uerr != nil {
+		t.Fatalf("parse Chart.yaml: %v", uerr)
+	}
+	delete(chart, "dependencies")
+	outChart, _ := yaml.Marshal(chart)
+	if werr := os.WriteFile(filepath.Join(dir, "Chart.yaml"), outChart, 0o644); werr != nil {
+		t.Fatalf("write Chart.yaml: %v", werr)
+	}
+	rawValues, err := os.ReadFile(filepath.Join(src, "values.yaml"))
+	if err != nil {
+		t.Fatalf("read values.yaml: %v", err)
+	}
+	if werr := os.WriteFile(filepath.Join(dir, "values.yaml"), rawValues, 0o644); werr != nil {
+		t.Fatalf("write values.yaml: %v", werr)
+	}
+	if merr := os.MkdirAll(filepath.Join(dir, "templates"), 0o755); merr != nil {
+		t.Fatalf("mkdir: %v", merr)
+	}
+	for _, name := range []string{"_helpers.tpl", "httproute.yaml"} {
+		raw, rerr := os.ReadFile(filepath.Join(src, "templates", name))
+		if rerr != nil {
+			t.Fatalf("read templates/%s: %v", name, rerr)
+		}
+		if werr := os.WriteFile(filepath.Join(dir, "templates", name), raw, 0o644); werr != nil {
+			t.Fatalf("write templates/%s: %v", name, werr)
+		}
+	}
+
+	args := []string{
+		"template", "kc", ".",
+		"--set", "sovereignFQDN=" + testFQDN,
+		"--set", "gateway.enabled=true",
+		"--set", "gateway.host=auth." + testFQDN,
+	}
+	args = append(args, extraArgs...)
+
+	cmd := exec.Command(helmBin, args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("helm template httproute: %v\noutput:\n%s", err, out)
+	}
+
+	dec := yaml.NewDecoder(strings.NewReader(string(out)))
+	for {
+		var doc map[string]any
+		if derr := dec.Decode(&doc); derr != nil {
+			break
+		}
+		if doc == nil {
+			continue
+		}
+		if kind, _ := doc["kind"].(string); kind == "HTTPRoute" {
+			return doc
+		}
+	}
+	t.Fatalf("chart rendered NO HTTPRoute — the guard would be vacuous\nrendered:\n%s", out)
+	return nil
+}
+
+// routeRules returns spec.rules, failing loudly when the shape is not what the
+// rest of this file assumes.
+func routeRules(t *testing.T, route map[string]any) []any {
+	t.Helper()
+	spec, _ := route["spec"].(map[string]any)
+	rules, _ := spec["rules"].([]any)
+	if len(rules) == 0 {
+		t.Fatal("HTTPRoute rendered ZERO rules — vacuous")
+	}
+	return rules
+}
+
+// findExactPathRule returns the rule whose matches include an Exact path equal
+// to want, or nil.
+func findExactPathRule(rules []any, want string) map[string]any {
+	for _, raw := range rules {
+		rule, _ := raw.(map[string]any)
+		matches, _ := rule["matches"].([]any)
+		for _, mraw := range matches {
+			m, _ := mraw.(map[string]any)
+			p, _ := m["path"].(map[string]any)
+			if pt, _ := p["type"].(string); pt != "Exact" {
+				continue
+			}
+			if pv, _ := p["value"].(string); pv == want {
+				return rule
+			}
+		}
+	}
+	return nil
+}
+
+// TestAccountConsole_EntryPathsAreIntercepted is the SUBJECT.
+func TestAccountConsole_EntryPathsAreIntercepted(t *testing.T) {
+	rules := routeRules(t, renderKeycloakRoute(t))
+
+	for _, want := range []string{"/realms/sovereign/account", "/realms/sovereign/account/"} {
+		rule := findExactPathRule(rules, want)
+		if rule == nil {
+			t.Errorf("no rule matches Exact %q — the account-console SPA still boots and "+
+				"hangs forever on 'Loading the Account Console' with no error text (UAT row 109)", want)
+			continue
+		}
+		filters, _ := rule["filters"].([]any)
+		if len(filters) == 0 {
+			t.Errorf("rule for %q has no filters — it would proxy to Keycloak, not intercept", want)
+			continue
+		}
+		f, _ := filters[0].(map[string]any)
+		if ft, _ := f["type"].(string); ft != "RequestRedirect" {
+			t.Errorf("rule for %q filter type = %q, want RequestRedirect", want, ft)
+			continue
+		}
+		rr, _ := f["requestRedirect"].(map[string]any)
+		if got, _ := rr["hostname"].(string); got != "console."+testFQDN {
+			t.Errorf("rule for %q redirect hostname = %q, want %q — the User must land on "+
+				"the console surface that actually serves their profile", want, got, "console."+testFQDN)
+		}
+		// Port is asserted as a VALUE because omitting it is the #3310 class:
+		// Gateway API copies the cilium listener port into Location.
+		if got, _ := rr["port"].(int); got != 443 {
+			t.Errorf("rule for %q redirect port = %v, want 443 (#3310 — an omitted port "+
+				"leaks the cilium listener port into Location)", want, rr["port"])
+		}
+		path, _ := rr["path"].(map[string]any)
+		if got, _ := path["replaceFullPath"].(string); got != "/settings" {
+			t.Errorf("rule for %q redirect path = %q, want /settings", want, got)
+		}
+	}
+}
+
+// TestAccountConsole_RestSurfaceIsNotIntercepted is the CONTROL that holds the
+// intercept to Exact matches.
+//
+// A PathPrefix on /realms/<realm>/account would also capture
+// /realms/<realm>/account/config and the rest of the account REST API, turning
+// a UI hang into an API outage — and /account/config is precisely the endpoint
+// that answered 200 during the walk, proving the backend healthy.
+func TestAccountConsole_RestSurfaceIsNotIntercepted(t *testing.T) {
+	rules := routeRules(t, renderKeycloakRoute(t))
+
+	for _, rule := range rules {
+		r, _ := rule.(map[string]any)
+		filters, _ := r["filters"].([]any)
+		if len(filters) == 0 {
+			continue // the proxy rule
+		}
+		matches, _ := r["matches"].([]any)
+		for _, mraw := range matches {
+			m, _ := mraw.(map[string]any)
+			p, _ := m["path"].(map[string]any)
+			pt, _ := p["type"].(string)
+			pv, _ := p["value"].(string)
+			if pt == "PathPrefix" && strings.Contains(pv, "account") {
+				t.Errorf("a REDIRECT rule uses PathPrefix %q — this captures "+
+					"/realms/sovereign/account/config and the whole account REST surface", pv)
+			}
+		}
+	}
+}
+
+// TestAccountConsole_ProxyCatchAllSurvives is the CONTROL that the intercept did
+// not eat the route. Every other path on auth.<fqdn> — the realm endpoints, the
+// admin console, the broker legs row 219 depends on — must still reach Keycloak.
+func TestAccountConsole_ProxyCatchAllSurvives(t *testing.T) {
+	rules := routeRules(t, renderKeycloakRoute(t))
+
+	found := false
+	for _, raw := range rules {
+		rule, _ := raw.(map[string]any)
+		backends, _ := rule["backendRefs"].([]any)
+		if len(backends) == 0 {
+			continue
+		}
+		matches, _ := rule["matches"].([]any)
+		for _, mraw := range matches {
+			m, _ := mraw.(map[string]any)
+			p, _ := m["path"].(map[string]any)
+			if pt, _ := p["type"].(string); pt != "PathPrefix" {
+				continue
+			}
+			if pv, _ := p["value"].(string); pv == "/" {
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Fatal("the PathPrefix / → keycloak backend rule is gone — every realm, broker " +
+			"and admin-console path on the auth host would stop resolving")
+	}
+}
+
+// TestAccountConsole_InterceptIsDisableable is the CONTROL that keeps the knob a
+// knob: an operator who wants the stock console back must be able to have it.
+func TestAccountConsole_InterceptIsDisableable(t *testing.T) {
+	rules := routeRules(t, renderKeycloakRoute(t,
+		"--set", "gateway.accountConsoleRedirect.enabled=false"))
+
+	if rule := findExactPathRule(rules, "/realms/sovereign/account"); rule != nil {
+		t.Error("intercept still rendered with gateway.accountConsoleRedirect.enabled=false")
+	}
+}
+
+// TestAccountConsole_InterceptFollowsTheRealmName proves the path is built from
+// the configured realm rather than a hardcoded "sovereign". A Sovereign whose
+// realm is its tenant short-name would otherwise be silently unprotected.
+func TestAccountConsole_InterceptFollowsTheRealmName(t *testing.T) {
+	rules := routeRules(t, renderKeycloakRoute(t, "--set", "sovereignRealm.name=omantel"))
+
+	if rule := findExactPathRule(rules, "/realms/omantel/account"); rule == nil {
+		t.Error("with sovereignRealm.name=omantel, no rule matches /realms/omantel/account — " +
+			"the intercept is pinned to a hardcoded realm and misses every renamed realm")
+	}
+	if rule := findExactPathRule(rules, "/realms/sovereign/account"); rule != nil {
+		t.Error("the intercept still matches /realms/sovereign/account on a realm named omantel")
+	}
+}

--- a/tests/e2e/bootstrap-kit/catalyst_pin_backchannel_6087_test.go
+++ b/tests/e2e/bootstrap-kit/catalyst_pin_backchannel_6087_test.go
@@ -1,0 +1,317 @@
+// Render guards for platform/keycloak/chart.
+//
+// UAT row 219 (#6087) — the catalyst-pin IdP's backchannel legs.
+//
+// The row's failing clause is "chepherd console reachable in his Org". Two
+// walkers agreed the Application converges (HelmRelease Ready, pod Ready,
+// route + gate healthy) and disagreed only on the last hop: following the
+// gate's redirect to completion in a real browser terminates at
+// https://auth.<fqdn>/realms/sovereign/broker/catalyst-pin/endpoint?code=...
+// with HTTP 502, rendering Keycloak's own error page ("Unexpected error when
+// authenticating with identity provider"). Not the region-B transport artifact:
+// a sibling asset on the SAME page load answered 200 with an
+// x-envoy-upstream-service-time header, so the origin was reached.
+//
+// /broker/<alias>/endpoint is the token-exchange callback. Keycloak's
+// AbstractOAuth2IdentityProvider answers 502 there when its own SERVER-SIDE
+// call to the upstream fails — which is exactly what the realm config asked for
+// by pointing tokenUrl / userInfoUrl / jwksUrl at the PUBLIC api.<sov-fqdn>.
+package bootstrapkit
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+const testFQDN = "hw293.omantel.biz"
+
+// miniChart builds an offline, dependency-free copy of this wrapper chart
+// containing only the realm ConfigMap template and the helpers it includes.
+func miniChart(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	src := filepath.Join(repoRoot(t), "platform", "keycloak", "chart")
+
+	rawChart, err := os.ReadFile(filepath.Join(src, "Chart.yaml"))
+	if err != nil {
+		t.Fatalf("read Chart.yaml: %v", err)
+	}
+	var chart map[string]any
+	if uerr := yaml.Unmarshal(rawChart, &chart); uerr != nil {
+		t.Fatalf("parse Chart.yaml: %v", uerr)
+	}
+	delete(chart, "dependencies")
+	outChart, err := yaml.Marshal(chart)
+	if err != nil {
+		t.Fatalf("marshal Chart.yaml: %v", err)
+	}
+	if werr := os.WriteFile(filepath.Join(dir, "Chart.yaml"), outChart, 0o644); werr != nil {
+		t.Fatalf("write Chart.yaml: %v", werr)
+	}
+
+	rawValues, err := os.ReadFile(filepath.Join(src, "values.yaml"))
+	if err != nil {
+		t.Fatalf("read values.yaml: %v", err)
+	}
+	if werr := os.WriteFile(filepath.Join(dir, "values.yaml"), rawValues, 0o644); werr != nil {
+		t.Fatalf("write values.yaml: %v", werr)
+	}
+
+	if merr := os.MkdirAll(filepath.Join(dir, "templates"), 0o755); merr != nil {
+		t.Fatalf("mkdir templates: %v", merr)
+	}
+	for _, name := range []string{"_helpers.tpl", "configmap-sovereign-realm.yaml"} {
+		raw, rerr := os.ReadFile(filepath.Join(src, "templates", name))
+		if rerr != nil {
+			t.Fatalf("read templates/%s: %v", name, rerr)
+		}
+		if werr := os.WriteFile(filepath.Join(dir, "templates", name), raw, 0o644); werr != nil {
+			t.Fatalf("write templates/%s: %v", name, werr)
+		}
+	}
+	return dir
+}
+
+// renderRealm runs `helm template` and returns the decoded sovereign realm JSON.
+func renderRealm(t *testing.T, extraArgs ...string) map[string]any {
+	t.Helper()
+
+	helmBin := os.Getenv("HELM_BIN")
+	if helmBin == "" {
+		helmBin = "helm"
+	}
+	if _, err := exec.LookPath(helmBin); err != nil {
+		t.Skipf("helm not on PATH (%v)", err)
+	}
+
+	// Render from a MINIMAL offline copy: the wrapper's realm ConfigMap plus
+	// the helpers it includes, with the upstream bitnami/keycloak dependency
+	// stripped from Chart.yaml. The realm JSON is authored entirely by this
+	// wrapper template, so nothing under test is lost — and the guard then
+	// needs no `helm dependency build` and no network.
+	chartDir := miniChart(t)
+
+	args := []string{
+		"template", "kc", ".",
+		"--set", "sovereignFQDN=" + testFQDN,
+		"--set", "sovereignRealm.enabled=true",
+	}
+	args = append(args, extraArgs...)
+
+	cmd := exec.Command(helmBin, args...)
+	cmd.Dir = chartDir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("helm template: %v\noutput:\n%s", err, out)
+	}
+
+	dec := yaml.NewDecoder(strings.NewReader(string(out)))
+	for {
+		var doc map[string]any
+		if derr := dec.Decode(&doc); derr != nil {
+			break
+		}
+		if doc == nil {
+			continue
+		}
+		if kind, _ := doc["kind"].(string); kind != "ConfigMap" {
+			continue
+		}
+		data, _ := doc["data"].(map[string]any)
+		for key, v := range data {
+			if !strings.Contains(key, "realm") {
+				continue
+			}
+			raw, ok := v.(string)
+			if !ok {
+				continue
+			}
+			var realm map[string]any
+			if jerr := json.Unmarshal([]byte(raw), &realm); jerr != nil {
+				continue
+			}
+			if _, has := realm["identityProviders"]; has {
+				return realm
+			}
+		}
+	}
+	t.Fatalf("no ConfigMap carried a realm JSON with identityProviders\nrendered:\n%s", out)
+	return nil
+}
+
+// catalystPinConfig digs out the catalyst-pin IdP's config block.
+//
+// It FAILS rather than skipping when the provider is absent: a guard that
+// silently finds nothing to check is the "tested a surface that cannot fail"
+// shape, and this test's whole value is that it renders a real provider.
+func catalystPinConfig(t *testing.T, realm map[string]any) map[string]any {
+	t.Helper()
+	idps, _ := realm["identityProviders"].([]any)
+	if len(idps) == 0 {
+		t.Fatalf("realm rendered ZERO identityProviders — the fixture is inert and this guard could not fail")
+	}
+	for _, raw := range idps {
+		idp, _ := raw.(map[string]any)
+		if alias, _ := idp["alias"].(string); alias != "catalyst-pin" {
+			continue
+		}
+		cfg, _ := idp["config"].(map[string]any)
+		if len(cfg) == 0 {
+			t.Fatalf("catalyst-pin rendered an EMPTY config block")
+		}
+		return cfg
+	}
+	t.Fatalf("catalyst-pin identity provider not found among %d providers", len(idps))
+	return nil
+}
+
+func mustString(t *testing.T, cfg map[string]any, key string) string {
+	t.Helper()
+	v, ok := cfg[key].(string)
+	if !ok {
+		t.Fatalf("catalyst-pin config.%s is absent or not a string (got %#v) — "+
+			"asserting on the KEY alone would have passed here", key, cfg[key])
+	}
+	if strings.TrimSpace(v) == "" {
+		t.Fatalf("catalyst-pin config.%s rendered EMPTY", key)
+	}
+	return v
+}
+
+// TestCatalystPin_BackchannelLegsAreInCluster is the SUBJECT.
+//
+// tokenUrl, userInfoUrl and jwksUrl are dialed server-side from the Keycloak
+// Pod. They must not name the Sovereign's own public host.
+func TestCatalystPin_BackchannelLegsAreInCluster(t *testing.T) {
+	cfg := catalystPinConfig(t, renderRealm(t))
+
+	publicHost := "api." + testFQDN
+	for _, key := range []string{"tokenUrl", "userInfoUrl", "jwksUrl"} {
+		got := mustString(t, cfg, key)
+		if strings.Contains(got, publicHost) {
+			t.Errorf("catalyst-pin config.%s = %q — this leg is dialed SERVER-SIDE from "+
+				"inside the Keycloak Pod, and %q is the Sovereign's own public EIP. The "+
+				"hairpin does not work on Huawei (#3241/#3844), which is the HTTP 502 at "+
+				"/broker/catalyst-pin/endpoint recorded in UAT row 219.", key, got, publicHost)
+		}
+		if !strings.HasPrefix(got, "http://catalyst-api.catalyst-system.svc") {
+			t.Errorf("catalyst-pin config.%s = %q — want the in-cluster catalyst-api "+
+				"Service, the same seam openova-mcp and bp-self-sovereign-cutover already use", key, got)
+		}
+		if !strings.HasSuffix(got, oidcPath(key)) {
+			t.Errorf("catalyst-pin config.%s = %q — lost its %q path in the rewrite", key, got, oidcPath(key))
+		}
+	}
+}
+
+func oidcPath(key string) string {
+	switch key {
+	case "tokenUrl":
+		return "/oidc/token"
+	case "userInfoUrl":
+		return "/oidc/userinfo"
+	case "jwksUrl":
+		return "/oidc/certs"
+	}
+	return ""
+}
+
+// TestCatalystPin_FrontchannelAndIssuerStayPublic is the CONTROL that stops the
+// fix from being "rewrite every URL inward".
+//
+// authorizationUrl is a BROWSER redirect — an in-cluster host there would send
+// the user's browser to a name it cannot resolve, breaking login outright.
+// issuer is compared against the `iss` claim catalyst-api mints from its own
+// SOVEREIGN_FQDN, so an internal issuer trades a connectivity failure for a
+// signature-validation failure. Both must stay public.
+func TestCatalystPin_FrontchannelAndIssuerStayPublic(t *testing.T) {
+	cfg := catalystPinConfig(t, renderRealm(t))
+
+	wantAuthorize := "https://api." + testFQDN + "/oidc/auth"
+	if got := mustString(t, cfg, "authorizationUrl"); got != wantAuthorize {
+		t.Errorf("catalyst-pin config.authorizationUrl = %q, want %q — the browser "+
+			"resolves this one; an in-cluster host here breaks login for every User", got, wantAuthorize)
+	}
+	wantIssuer := "https://api." + testFQDN
+	if got := mustString(t, cfg, "issuer"); got != wantIssuer {
+		t.Errorf("catalyst-pin config.issuer = %q, want %q — this is matched against "+
+			"the id_token `iss` catalyst-api mints from SOVEREIGN_FQDN", got, wantIssuer)
+	}
+}
+
+// TestCatalystPin_SignatureValidationStaysOn is the CONTROL against the
+// tempting wrong fix.
+//
+// Turning validateSignature/useJwksUrl off would ALSO stop the 502, by removing
+// the jwks fetch that was failing — and it would silently accept unverified
+// id_tokens from the broker. A fix that made the subject pass by weakening this
+// is strictly worse than the defect.
+func TestCatalystPin_SignatureValidationStaysOn(t *testing.T) {
+	cfg := catalystPinConfig(t, renderRealm(t))
+
+	for key, want := range map[string]string{"validateSignature": "true", "useJwksUrl": "true"} {
+		if got := mustString(t, cfg, key); got != want {
+			t.Errorf("catalyst-pin config.%s = %q, want %q — the backchannel fix must not "+
+				"buy its green by disabling signature verification", key, got, want)
+		}
+	}
+}
+
+// TestCatalystPin_EmptyInternalURLRestoresPublicLegs is the CONTROL that keeps
+// the knob a knob. A cluster whose EIP does hairpin must be able to opt out and
+// get exactly the pre-fix render back.
+func TestCatalystPin_EmptyInternalURLRestoresPublicLegs(t *testing.T) {
+	cfg := catalystPinConfig(t, renderRealm(t, "--set", "catalystAPIInternalURL="))
+
+	for _, key := range []string{"tokenUrl", "userInfoUrl", "jwksUrl"} {
+		got := mustString(t, cfg, key)
+		if !strings.HasPrefix(got, "https://api."+testFQDN) {
+			t.Errorf("with catalystAPIInternalURL empty, config.%s = %q — want the public "+
+				"leg restored; the knob must be able to turn the behaviour OFF", key, got)
+		}
+	}
+}
+
+// TestCatalystPin_HonoursAnOperatorSuppliedInternalURL proves the value is
+// really read, rather than the template having hardcoded the Service name.
+func TestCatalystPin_HonoursAnOperatorSuppliedInternalURL(t *testing.T) {
+	cfg := catalystPinConfig(t, renderRealm(t,
+		"--set", "catalystAPIInternalURL=http://elsewhere.example:9090/"))
+
+	// The trailing slash is deliberate: it proves the join does not produce
+	// `//oidc/token`.
+	want := map[string]string{
+		"tokenUrl":    "http://elsewhere.example:9090/oidc/token",
+		"userInfoUrl": "http://elsewhere.example:9090/oidc/userinfo",
+		"jwksUrl":     "http://elsewhere.example:9090/oidc/certs",
+	}
+	for key, exp := range want {
+		if got := mustString(t, cfg, key); got != exp {
+			t.Errorf("config.%s = %q, want %q", key, got, exp)
+		}
+	}
+}
+
+// TestRealmRendersTheProviderAtAll is the VACUITY CHECK.
+//
+// Every assertion above is reached through catalystPinConfig. If the realm ever
+// stopped rendering the provider — a values rename, a guard clause, a broken
+// template — those tests would t.Fatal rather than pass, but this names the
+// precondition explicitly so a reader can see the guard has something to bite.
+func TestRealmRendersTheProviderAtAll(t *testing.T) {
+	realm := renderRealm(t)
+	idps, _ := realm["identityProviders"].([]any)
+	if len(idps) == 0 {
+		t.Fatal("realm rendered ZERO identityProviders — every other test here is vacuous")
+	}
+	cfg := catalystPinConfig(t, realm)
+	if _, ok := cfg["tokenUrl"]; !ok {
+		t.Fatal("catalyst-pin config has no tokenUrl key at all — the guard is vacuous")
+	}
+}


### PR DESCRIPTION
Four UAT auth/session rows, each fixed at its producer, each with the failing test watched red first.

## Row 218 — the per-Org install wizard had no Organization to target (#6081)

`bp-agenity`'s wizard now opens, but `select-instance-org` sits at `value=""` and its only option is the Sovereign self-org. The Organization the console is scoped to is not a candidate at all.

The pre-select was never the defect. `listOrganizations()` composes the parent row from `/api/v1/sovereign/self` with the sub-org rows from `/api/v1/organizations`; only the first is Org-scope-allowlisted, so OrgScopeGuard 403s the second, `listOrgRecords` swallows the non-2xx into `[]`, and #5823's `soleOrgSlug` then correctly discards the lone parent row. The comment at that edit site was right and is untouched.

Allowlisting the prefix would have been wrong twice: `pathIsOrgSafe` is prefix-matched and method-blind, so `POST /organizations` and `DELETE /organizations/{id}` would have come with it — and the read itself served every Organization on the Sovereign. Both halves therefore land together: `HandleListOrganizations` confines an Org-scoped caller via `orgScopeForRequest` (the same acceptance function `HandleCreateInstance` uses to force an install into the caller's own Org), and a new method-aware exact-path list admits GET/HEAD only.

RED: `got [omantel otherorg uatwalk91] (3 rows)` cross-Org leak; directory read `403`; ghost-org `got [otherorg]`. GREEN: all 6, plus the whole handler package (`ok ... 288.396s`).

Needs a **catalyst-api image roll**.

## Row 29 — silent re-auth asked the wrong host for the Sovereign (#6084)

Measured: `auth.<orgslug>.omani.homes` 404 on 10/10 probes, valid wildcard cert, cookies intact. Not a missing route — a wrong URL, already diagnosed in-tree by the `it.fails` tripwire at `detectMode.test.ts:120-172` (#5895).

`detectMode()` strips one `console.` label, which on a per-Org console yields the Org apex. The per-Org Gateway has a `*.<slug>.<parent>` listener so TLS terminates, but the only HTTPRoute minted for an Org is `console.<slug>.<parent>`. There is no per-Org IdP by design.

Worth naming: #5909 fixed the marker-staleness half correctly, and that is precisely what made this the next hop — the gate now reliably *reaches* a silent leg that navigates nowhere, so the 8s grace timer fires and the visitor lands on the PIN wall the row forbids.

The two host shapes are indistinguishable by inspection, so the FQDN is now **asked for** via `GET /api/v1/sovereign/self` — unauthenticated by design and Org-scope-allowlisted, which is what lets it answer on an expired-session path. `/whoami` also carries it but is session-gated. `detectMode()` and its tripwire are deliberately left alone: the *mode* it derives is correct, only the FQDN is unverifiable.

RED (pre-fix derivation): `expected 'walkone.omani.homes' to be 'hw293.omantel.biz'`, twice. GREEN: 8 passed; 24 files / 288 passed suite-wide; `tsc --noEmit` clean.

Rides the next **catalyst-ui build**.

## Row 219 — the catalyst-pin broker dialed catalyst-api over the Sovereign's own EIP (#6087)

Both walkers were right about different hops. The chain terminates at `/realms/sovereign/broker/catalyst-pin/endpoint` with **502** — the token-exchange callback, which `AbstractOAuth2IdentityProvider` returns when Keycloak's own server-side call fails.

The realm config asked for it: `tokenUrl`/`userInfoUrl`/`jwksUrl` named the public `api.<sovereignFQDN>`, and the template's own flow comment already describes them as server-side legs. That asks the Keycloak Pod to hairpin out to the Sovereign's public EIP and back — the #3241/#3844 class, stated verbatim in `oidc-gate/chart/Chart.yaml` 0.1.5. oidc-gate, hubble-ui, gitea and the bp-agenity gate all took the frontchannel-public/backchannel-internal split; the catalyst-pin IdP is the one federation seam that never did.

Ruled out rather than left open: an upstream client allow-list (the broker always presents `client_id=catalyst-pin`, never `agenity-*`) and NetworkPolicy (keycloak is in the catalyst-system baseline CNP's allowed list).

RED: the three legs render `https://api.hw293.omantel.biz/oidc/{token,userinfo,certs}`. GREEN: all 6 + full bootstrap-kit e2e.

Chart change — bp-keycloak 1.5.7 to 1.5.8 across **all five lockstep sites**; the e2e display-drift guard caught the catalog-seed `spec.version`/`source.version` pair the shell gates cannot see, which in turn required the umbrella bump to 1.4.1350 (1.4.1349 is claimed by open PR #6068). Delivered by the bp-keycloak HR upgrade's config-cli post-upgrade hook — **no catalyst-api roll**.

## Row 109 — the account console hung forever instead of refusing (#6090)

Clause (a) passes. Clause (b) failed in the opposite direction from a refusal: the account console authenticates **silently** and then hangs indefinitely on `Loading the Account Console` — 20+ seconds, no h1/h2, no error text, no way out, against a healthy backend (`/account/config` answered 200).

Four wrong fixes were ruled out first. Nothing in the repo disables the console, and #3934's `browser-no-idp` binding is working exactly as designed. There is **no custom Keycloak theme anywhere in the repo** (zero `.ftl`, zero `theme.properties`, zero `accountTheme`), so a broken theme cannot be the cause — this is the stock `keycloak.v2` SPA swallowing a failed bootstrap. And that it *cannot* work is definitional, already recorded in `uat-retirements.csv`: a Keycloak-native account console cannot mint a REST token from a PIN-brokered session (#688). The string `Loading the Account Console` appears exactly once in the repo — in the ledger evidence. Nothing handled this clause.

So the console is unfixable by design and the honest posture is to stop serving it. Gateway API v1 has no direct-response filter, so the intercept is a 302 to `console.<fqdn>/settings` — the surface clause (a) already passes on. **Exact matches only**: a PathPrefix would swallow `/realms/<realm>/account/config` and the whole account REST surface, turning a UI hang into an API outage.

Second half, which passed the walk only by accident: `RequiredActionsModal` built that exact URL and rendered it as "Open Keycloak account console". The walk counted 0 anchors only because the modal is conditional on a `requiredActions` claim. The comment at that site justified the link as "the standard approach" — a rationale that predates #688 — so it is replaced, not deleted, and the affordance now points at the console's own `/settings`.

RED: `no rule matches Exact "/realms/sovereign/account"`, and the realm-name test caught a hardcoded `sovereign`. GREEN: all 5 + full e2e.

Rides the **already-bumped, unpublished bp-keycloak 1.5.8** together with row 219; the modal half rides the next **catalyst-ui build**.

## Controls

Every fix ships controls that stay green so it discriminates rather than disables:

- 218: five write methods still 403 **without entering** the handler; the `{id}` detail route stays denied; a Sovereign-admin still sees every Org; a scoped session with no record gets an empty list, not a fabricated row. `TestPathIsOrgSafe` — which asserts `/api/v1/organizations` is *not* prefix-safe — is untouched and still green.
- 29: the Sovereign console still resolves its own FQDN; a thrown fetch, a non-2xx and an **empty** `sovereignFQDN` each fall back rather than building `https://auth./realms/sovereign`; the build-time override still wins at zero requests.
- 219: `authorizationUrl` and `issuer` must stay public (an inward issuer would trade a connectivity failure for a validation failure); `validateSignature`/`useJwksUrl` must stay on, so the green cannot be bought by deleting the jwks fetch that was failing; the empty knob restores the old behaviour; a vacuity check names the precondition.
- 109: the account REST surface must not be captured by any redirect rule; the `PathPrefix /` backend rule must survive, or every realm, broker and admin-console path on the auth host stops resolving — **including the catalyst-pin broker legs row 219 depends on**; the knob still disables the whole thing; and the path is built from `sovereignRealm.name`, so a renamed realm is not silently unprotected.

## Not in this PR

**Row G7** was investigated but needs no code from me, and saying why matters more than shipping something. Its terminal failure — `BYO CNAME validation failed: resolve CNAME for console.g7doora.omani.rest: no such host` — is **correct behaviour** on an apex the caller does not control, not a defect. Its free-subdomain path is the row's own `NEEDS-CODE` partition and is already fixed by the merged #6064.

The brief suspected the #4539 label-vs-backing divergence at `organization_provisioning.go:390-395`. That divergence is **real but is not what killed G7**, and it is not where the brief placed it: that site deliberately lets an explicit `isolation` override the tier gate, and the site that ignores it is `org_list_from_cr.go:136`, which is *correct* — `isolationForTier(planSlug)` mirrors the authoritative `boundaryIsVcluster(planSlug)`, which never reads any isolation field. So a door-A create posting `isolation: vcluster` on a default `s` plan gets `vcluster_name` stamped while the controller authors a **host namespace** — consistent with the walker finding namespace `g7doora` left behind. I did **not** change it: the override is pinned by a deliberate test (`TestIsolationForTier_ExplicitOverrideStillWins`, "the advanced-operator escape hatch"), and the console half is already authored on an unmerged sibling branch whose commit message argues the same conclusion — "a field no renderer reads is not an override". Flipping a pinned contract that another branch is mid-change on would collide. Worth a follow-up on the **server** side, since the console fix does not close it for MCP/CLI callers.

Refs #6081 #6084 #6087 #3988 #5823 #4937 #4110 #5895 #5909 #3374 #4180 #4553 #3844 #3241
