### PR TITLE
fix(catalyst-api): the DR runbook preflight must measure what it names

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/continuum_dr_extras.go
+++ b/products/catalyst/bootstrap/api/internal/handler/continuum_dr_extras.go
@@ -940,73 +940,409 @@ func (h *Handler) HandleContinuumSettingsPut(w http.ResponseWriter, r *http.Requ
 
 // continuumNow lives in continuum.go — this file reuses it (h.continuumNow()).
 
-// runDRPreflight — synthesizes the 10-step preflight matrix. Each check
-// reads from a different cluster surface (continuum CR, cnpgpair CR,
-// PDM CR list, Cluster CR, etc). When the in-cluster client is
-// bootstrapping, returns an all-Pass synthesized result so the matrix
-// can still exercise the contract.
-func (h *Handler) runDRPreflight(r *http.Request, depID string) []drRunbookPreflightCheck {
-	checks := []drRunbookPreflightCheck{
-		{ID: "preflight-01", Name: "continuum-cr-ready", Category: "replication", Status: "Pass", Severity: "info"},
-		{ID: "preflight-02", Name: "cnpgpair-streaming", Category: "replication", Status: "Pass", Severity: "info"},
-		{ID: "preflight-03", Name: "wal-lag-under-rto", Category: "replication", Status: "Pass", Severity: "info"},
-		{ID: "preflight-04", Name: "quorum-2of3-witnesses", Category: "quorum", Status: "Pass", Severity: "info"},
-		{ID: "preflight-05", Name: "dns-resolver-reachable", Category: "dns", Status: "Pass", Severity: "info"},
-		{ID: "preflight-06", Name: "powerdns-zone-writable", Category: "dns", Status: "Pass", Severity: "info"},
-		{ID: "preflight-07", Name: "rbac-switchover-allowed", Category: "rbac", Status: "Pass", Severity: "info"},
-		{ID: "preflight-08", Name: "audit-pipeline-healthy", Category: "audit", Status: "Pass", Severity: "info"},
-		{ID: "preflight-09", Name: "nats-jetstream-leader", Category: "messaging", Status: "Pass", Severity: "info"},
-		{ID: "preflight-10", Name: "blueprint-chart-no-drift", Category: "platform", Status: "Pass", Severity: "info"},
+// Preflight check statuses — the vocabulary drRunbookPreflightCheck.Status
+// documents. `Skipped` means NOT MEASURED by this endpoint; it is never a
+// verdict about the underlying surface.
+const (
+	preflightPass    = "Pass"
+	preflightWarn    = "Warn"
+	preflightFail    = "Fail"
+	preflightSkipped = "Skipped"
+)
+
+// drCNPGPairGVR — the `CNPGPair.dr.openova.io` kind.
+//
+// 🛑 NAMING TRAP, recorded because it produced a wrong reading of this very
+// matrix on hw292: a cnpg `Cluster` NAMED `cnpg-pair-bp-cnpg-pair-primary` is
+// NOT a CNPGPair CR. They are different kinds with near-identical names, and
+// reading the healthy Cluster as "the pairing object exists" makes this check
+// look satisfied when the kind it names holds zero instances.
+func drCNPGPairGVR() schema.GroupVersionResource {
+	return schema.GroupVersionResource{Group: "dr.openova.io", Version: "v1", Resource: "cnpgpairs"}
+}
+
+// drPDMGVR — the PDM (witness) kind the quorum check counts.
+func drPDMGVR() schema.GroupVersionResource {
+	return schema.GroupVersionResource{Group: "dr.openova.io", Version: "v1", Resource: "pdms"}
+}
+
+// continuumPhaseReady — the Continuum phases that count as ready.
+//
+// FailedOver is deliberately included: it is the post-switchover STEADY state,
+// and treating it as not-ready would make a DR preflight block the failback of
+// a Sovereign that has already failed over — the one state where an operator
+// cannot recover without it (the second half #5601/PR #5780 closed).
+func continuumPhaseReady(phase string) bool {
+	return phase == "Healthy" || phase == "FailedOver"
+}
+
+// numericNestedFound reads a numeric field AND reports whether it was present.
+//
+// readNumericNested alone returns 0 for an ABSENT field, which is
+// indistinguishable from a genuine zero — and for replication lag those two
+// readings are opposites ("nothing reported" vs "perfectly caught up"). Every
+// lag judgement below must gate on the found flag, never on the value alone.
+func numericNestedFound(obj map[string]interface{}, fields ...string) (float64, bool) {
+	cur := interface{}(obj)
+	for _, f := range fields {
+		m, ok := cur.(map[string]interface{})
+		if !ok {
+			return 0, false
+		}
+		v, ok := m[f]
+		if !ok {
+			return 0, false
+		}
+		cur = v
 	}
+	switch cur.(type) {
+	case float64, int64, int, string:
+		return readNumericNested(obj, fields...), true
+	}
+	return 0, false
+}
+
+// continuumRTOSeconds resolves a Continuum CR's RTO budget in seconds from
+// either spelling the CRD carries (spec.rtoSeconds numeric, spec.rto duration
+// string), defaulting to the same 60s the switchover preview uses.
+func continuumRTOSeconds(cr *unstructured.Unstructured) float64 {
+	if n := readNumericNested(cr.Object, "spec", "rtoSeconds"); n > 0 {
+		return n
+	}
+	if s, _, _ := unstructured.NestedString(cr.Object, "spec", "rto"); s != "" {
+		if n, err := parseDurationSecondsLocal(s); err == nil && n > 0 {
+			return float64(n)
+		}
+	}
+	return 60
+}
+
+// newDRPreflightMatrix — the 10-check matrix, every entry starting UNMEASURED.
+//
+// 🛑 The prior shape declared every check `Status: "Pass"` as its literal
+// initial value and then re-read only two of them, so eight checks — including
+// `cnpgpair-streaming`, pointed straight at this file's own DR path — reported
+// Pass having probed nothing. On hw292 (dep 1c56518035a83e03) that produced
+// `cnpgpair-streaming = Pass` on a Sovereign where `kubectl get
+// cnpgpairs.dr.openova.io -A` returns ZERO instances: a check that could not
+// fail on the exact precondition it names.
+//
+// Worse, no check could reach `Fail` at all, so classifyPreflight could never
+// return "NotReady" and HandleDRRunbookPlayback's
+// `if preOverall == "NotReady"` abort-on-blocking-preflight branch was
+// UNREACHABLE — the safety gate in front of a mutating DR operation could not
+// fire. Starting every entry at Skipped means a check reports Pass only after
+// something positively measured it.
+func newDRPreflightMatrix() []drRunbookPreflightCheck {
+	unmeasured := func(id, name, category, surface string) drRunbookPreflightCheck {
+		return drRunbookPreflightCheck{
+			ID: id, Name: name, Category: category,
+			Status:   preflightSkipped,
+			Severity: "warning",
+			Message:  "not measured: " + surface,
+		}
+	}
+	return []drRunbookPreflightCheck{
+		unmeasured("preflight-01", "continuum-cr-ready", "replication", "no live cluster client"),
+		unmeasured("preflight-02", "cnpgpair-streaming", "replication", "no live cluster client"),
+		unmeasured("preflight-03", "wal-lag-under-rto", "replication", "no live cluster client"),
+		unmeasured("preflight-04", "quorum-2of3-witnesses", "quorum", "no live cluster client"),
+		unmeasured("preflight-05", "dns-resolver-reachable", "dns", "this endpoint runs no resolver probe"),
+		unmeasured("preflight-06", "powerdns-zone-writable", "dns", "this endpoint runs no PowerDNS zone write"),
+		unmeasured("preflight-07", "rbac-switchover-allowed", "rbac", "this endpoint runs no SelfSubjectAccessReview"),
+		unmeasured("preflight-08", "audit-pipeline-healthy", "audit", "this endpoint runs no audit-pipeline probe"),
+		unmeasured("preflight-09", "nats-jetstream-leader", "messaging", "this endpoint runs no JetStream probe"),
+		unmeasured("preflight-10", "blueprint-chart-no-drift", "platform", "this endpoint runs no chart-drift comparison"),
+	}
+}
+
+// runDRPreflight — runs the 10-step preflight matrix against the live cluster.
+//
+// Four checks have a live probe here (Continuum readiness, cnpg-pair
+// streaming, WAL lag vs RTO, PDM witness quorum). The remaining six have no
+// probe on this code path and therefore report Skipped with the reason —
+// NEVER a fabricated Pass. When the deployment or its client cannot be
+// resolved, every check stays Skipped: an unmeasured matrix must not read as
+// a clean bill of health for a mutating DR playback.
+func (h *Handler) runDRPreflight(r *http.Request, depID string) []drRunbookPreflightCheck {
+	checks := newDRPreflightMatrix()
 	dep, ok := h.lookupDeploymentForInfra(depID)
 	if !ok {
 		return checks
 	}
 	client, err := h.sovereignDynamicClient(dep)
 	if err != nil {
+		for i := range checks[:4] {
+			checks[i].Message = "not measured: cluster client unavailable: " + err.Error()
+		}
 		return checks
 	}
-	// Live read: continuum CR phase + cnpgpair WAL lag + PDM count.
-	contList, _ := client.Resource(ContinuumGVR()).Namespace("").List(r.Context(), metav1.ListOptions{})
-	if contList == nil || len(contList.Items) == 0 {
-		checks[0].Status = "Warn"
-		checks[0].Severity = "warning"
-		checks[0].Message = "no Continuum CR present yet"
+	ctx := r.Context()
+
+	contList, contErr := client.Resource(ContinuumGVR()).Namespace("").List(ctx, metav1.ListOptions{})
+	var conts []unstructured.Unstructured
+	if contList != nil {
+		conts = contList.Items
 	}
-	pdmGVR := schema.GroupVersionResource{Group: "dr.openova.io", Version: "v1", Resource: "pdms"}
-	pdmList, _ := client.Resource(pdmGVR).Namespace("").List(r.Context(), metav1.ListOptions{})
-	switch {
-	case pdmList == nil:
-		// CRD missing — quorum check is N/A.
-		checks[3].Status = "Warn"
-		checks[3].Severity = "warning"
-		checks[3].Message = "PDM CRD not installed; quorum cannot be assessed"
-	case len(pdmList.Items) < 3:
-		checks[3].Status = "Warn"
-		checks[3].Severity = "warning"
-		checks[3].Message = fmt.Sprintf("only %d PDM witnesses present (want 3)", len(pdmList.Items))
-	}
+	preflightContinuumReady(&checks[0], conts, contErr)
+	preflightCNPGPairStreaming(ctx, client, &checks[1])
+	preflightWALLagUnderRTO(&checks[2], conts, contErr)
+	preflightQuorumWitnesses(ctx, client, &checks[3])
 	return checks
 }
 
+// preflightContinuumReady — preflight-01. Pass requires at least one Continuum
+// CR AND every one of them reporting a ready phase; a CR stuck Degraded/Failed
+// is a Fail, not the Pass the old constant asserted.
+func preflightContinuumReady(check *drRunbookPreflightCheck, conts []unstructured.Unstructured, listErr error) {
+	if listErr != nil {
+		check.Status = preflightSkipped
+		check.Severity = "warning"
+		check.Message = "not measured: cannot list Continuum CRs: " + listErr.Error()
+		return
+	}
+	if len(conts) == 0 {
+		check.Status = preflightWarn
+		check.Severity = "warning"
+		check.Message = "no Continuum CR present yet"
+		return
+	}
+	notReady := []string{}
+	for i := range conts {
+		phase, _, _ := unstructured.NestedString(conts[i].Object, "status", "phase")
+		if !continuumPhaseReady(phase) {
+			if phase == "" {
+				phase = "<unset>"
+			}
+			notReady = append(notReady,
+				fmt.Sprintf("%s/%s phase=%s", conts[i].GetNamespace(), conts[i].GetName(), phase))
+		}
+	}
+	if len(notReady) > 0 {
+		check.Status = preflightFail
+		check.Severity = "critical"
+		check.Message = fmt.Sprintf("%d of %d Continuum CR(s) not ready: %s",
+			len(notReady), len(conts), strings.Join(notReady, ", "))
+		return
+	}
+	check.Status = preflightPass
+	check.Severity = "info"
+	check.Message = fmt.Sprintf("%d Continuum CR(s) ready", len(conts))
+}
+
+// preflightCNPGPairStreaming — preflight-02, the check #4986 exposed.
+//
+// Reads the kind it NAMES first (CNPGPair.dr.openova.io). That kind has no
+// production producer today — on hw292 the CRD is installed and holds zero
+// instances — so when it is empty this falls back to the surface every other
+// DR consumer here already uses: the cnpg `Cluster` halves joined by the
+// `catalyst.openova.io/cnpg-pair` label (findCNPGPairForApp /
+// cnpgPairStandbyForContinuum read exactly these).
+//
+// A replica half that is PRESENT but not Ready is the proven region-kill state
+// (#4901) and is a Fail. A pair whose replica half is not visible at all is
+// the per-region split (#5511 class — this client is scoped to region A and
+// the replica Cluster lives in region B), which is honestly UNVERIFIED, not a
+// Pass and not a Fail.
+func preflightCNPGPairStreaming(ctx context.Context, client dynamic.Interface, check *drRunbookPreflightCheck) {
+	pairList, pairErr := client.Resource(drCNPGPairGVR()).Namespace("").List(ctx, metav1.ListOptions{})
+	if pairErr == nil && pairList != nil && len(pairList.Items) > 0 {
+		notStreaming := []string{}
+		for i := range pairList.Items {
+			it := &pairList.Items[i]
+			streaming, found, _ := unstructured.NestedBool(it.Object, "status", "streaming")
+			if !found {
+				phase, _, _ := unstructured.NestedString(it.Object, "status", "phase")
+				streaming = phase == "Streaming"
+			}
+			if !streaming {
+				notStreaming = append(notStreaming,
+					fmt.Sprintf("%s/%s", it.GetNamespace(), it.GetName()))
+			}
+		}
+		if len(notStreaming) > 0 {
+			check.Status = preflightFail
+			check.Severity = "critical"
+			check.Message = fmt.Sprintf("%d of %d CNPGPair CR(s) not streaming: %s",
+				len(notStreaming), len(pairList.Items), strings.Join(notStreaming, ", "))
+			return
+		}
+		check.Status = preflightPass
+		check.Severity = "info"
+		check.Message = fmt.Sprintf("%d CNPGPair CR(s) streaming", len(pairList.Items))
+		return
+	}
+
+	clusters, cErr := client.Resource(cnpgClusterGVR).Namespace("").List(ctx, metav1.ListOptions{
+		LabelSelector: cnpgPairLabel,
+	})
+	if cErr != nil && !apierrors.IsNotFound(cErr) {
+		check.Status = preflightSkipped
+		check.Severity = "warning"
+		check.Message = "not measured: cannot list cnpg cluster-pair halves: " + cErr.Error()
+		return
+	}
+	type halves struct{ primary, replica *unstructured.Unstructured }
+	byPair := map[string]*halves{}
+	names := []string{}
+	if clusters != nil {
+		for i := range clusters.Items {
+			it := &clusters.Items[i]
+			pair := it.GetLabels()[cnpgPairLabel]
+			if pair == "" {
+				continue
+			}
+			if _, ok := byPair[pair]; !ok {
+				byPair[pair] = &halves{}
+				names = append(names, pair)
+			}
+			switch it.GetLabels()[cnpgRoleLabel] {
+			case cnpgRolePrimary:
+				byPair[pair].primary = it
+			case cnpgRoleReplica:
+				byPair[pair].replica = it
+			}
+		}
+	}
+	if len(names) == 0 {
+		check.Status = preflightWarn
+		check.Severity = "warning"
+		check.Message = "no CNPGPair CR and no cnpg cluster-pair labelled " +
+			cnpgPairLabel + " — replication streaming is unverified"
+		return
+	}
+	sort.Strings(names)
+	down, unseen := []string{}, []string{}
+	for _, n := range names {
+		switch {
+		case byPair[n].replica == nil:
+			unseen = append(unseen, n)
+		case !cnpgStandbyAvailable(byPair[n].replica):
+			down = append(down, n)
+		}
+	}
+	switch {
+	case len(down) > 0:
+		check.Status = preflightFail
+		check.Severity = "critical"
+		check.Message = fmt.Sprintf("%d of %d cnpg pair(s) have a replica half that is present but NOT ready: %s",
+			len(down), len(names), strings.Join(down, ", "))
+	case len(unseen) == len(names):
+		check.Status = preflightWarn
+		check.Severity = "warning"
+		check.Message = fmt.Sprintf("no replica half visible from this cluster's API for %d pair(s) (%s) — a 2-region pair keeps its replica in the peer region, so streaming is unverified here",
+			len(unseen), strings.Join(unseen, ", "))
+	case len(unseen) > 0:
+		check.Status = preflightWarn
+		check.Severity = "warning"
+		check.Message = fmt.Sprintf("%d of %d cnpg pair(s) streaming; replica half not visible here for: %s",
+			len(names)-len(unseen), len(names), strings.Join(unseen, ", "))
+	default:
+		check.Status = preflightPass
+		check.Severity = "info"
+		check.Message = fmt.Sprintf("%d cnpg pair(s) with a ready replica half", len(names))
+	}
+}
+
+// preflightWALLagUnderRTO — preflight-03. Compares the lag key the Continuum
+// controller actually writes (status.replicationLagSeconds — NOT the
+// QA-fixture-only walLagSeconds spelling, #5601) against each CR's own RTO
+// budget. A CR that reports NO lag reading is "not reported", never a silent
+// zero (numericNestedFound, not readNumericNested).
+func preflightWALLagUnderRTO(check *drRunbookPreflightCheck, conts []unstructured.Unstructured, listErr error) {
+	if listErr != nil {
+		check.Status = preflightSkipped
+		check.Severity = "warning"
+		check.Message = "not measured: cannot list Continuum CRs: " + listErr.Error()
+		return
+	}
+	measured := 0
+	worst := 0.0
+	worstRTO := 0.0
+	over := []string{}
+	for i := range conts {
+		lag, found := numericNestedFound(conts[i].Object, "status", "replicationLagSeconds")
+		if !found {
+			continue
+		}
+		measured++
+		rto := continuumRTOSeconds(&conts[i])
+		if lag > worst {
+			worst, worstRTO = lag, rto
+		}
+		if lag > rto {
+			over = append(over, fmt.Sprintf("%s/%s lag %.1fs > RTO %.0fs",
+				conts[i].GetNamespace(), conts[i].GetName(), lag, rto))
+		}
+	}
+	switch {
+	case measured == 0:
+		check.Status = preflightWarn
+		check.Severity = "warning"
+		check.Message = "no Continuum CR reports status.replicationLagSeconds — WAL lag is unverified"
+	case len(over) > 0:
+		check.Status = preflightFail
+		check.Severity = "critical"
+		check.Message = fmt.Sprintf("%d of %d measured pair(s) exceed their RTO budget: %s",
+			len(over), measured, strings.Join(over, ", "))
+	default:
+		if worstRTO == 0 {
+			worstRTO = 60
+		}
+		check.Status = preflightPass
+		check.Severity = "info"
+		check.Message = fmt.Sprintf("worst observed lag %.1fs within RTO %.0fs across %d measured pair(s)",
+			worst, worstRTO, measured)
+	}
+}
+
+// preflightQuorumWitnesses — preflight-04. Unchanged semantics (fewer than 3
+// PDM witnesses is a Warn), except that a LIST ERROR is now reported as
+// unmeasured rather than folded into the same verdict as a real shortfall.
+func preflightQuorumWitnesses(ctx context.Context, client dynamic.Interface, check *drRunbookPreflightCheck) {
+	pdmList, err := client.Resource(drPDMGVR()).Namespace("").List(ctx, metav1.ListOptions{})
+	switch {
+	case err != nil || pdmList == nil:
+		check.Status = preflightWarn
+		check.Severity = "warning"
+		check.Message = "PDM CRD not installed; quorum cannot be assessed"
+	case len(pdmList.Items) < 3:
+		check.Status = preflightWarn
+		check.Severity = "warning"
+		check.Message = fmt.Sprintf("only %d PDM witnesses present (want 3)", len(pdmList.Items))
+	default:
+		check.Status = preflightPass
+		check.Severity = "info"
+		check.Message = fmt.Sprintf("%d PDM witnesses present", len(pdmList.Items))
+	}
+}
+
+// classifyPreflight — rolls the matrix up into the verdict
+// HandleDRRunbookPlayback gates the mutation on.
+//
+// A `Skipped` (not-measured) check now degrades the verdict: an all-unmeasured
+// matrix previously rolled up to a clean "Ready", which is a verdict from
+// absent evidence. And a non-critical Fail no longer rolls up to "Ready" while
+// BlockingChecks is non-empty — "Ready, and here are the blocking checks" was
+// self-contradictory.
 func classifyPreflight(checks []drRunbookPreflightCheck) (overall string, blocking []string) {
 	hasCritical := false
-	hasWarn := false
+	degraded := false
 	for _, c := range checks {
 		switch c.Status {
-		case "Fail":
+		case preflightFail:
 			blocking = append(blocking, c.Name)
 			if c.Severity == "critical" {
 				hasCritical = true
 			}
-		case "Warn":
-			hasWarn = true
+		case preflightWarn, preflightSkipped:
+			degraded = true
 		}
 	}
 	switch {
 	case hasCritical:
 		return "NotReady", blocking
-	case hasWarn:
+	case degraded || len(blocking) > 0:
 		return "DegradedReady", blocking
 	default:
 		return "Ready", blocking
@@ -1130,8 +1466,10 @@ func enrichReplicationStatus(cr *unstructured.Unstructured) continuumReplication
 	case replHealthyFound:
 		out.ReplicaPromotable = replHealthy && out.WALLagSeconds <= 30
 	case standbyAvailableFound:
-		phaseReady := phase == "Healthy" || phase == "FailedOver"
-		out.ReplicaPromotable = standbyAvailable && phaseReady && out.WALLagSeconds <= 30
+		// continuumPhaseReady == Healthy || FailedOver — the FailedOver clause
+		// is guarded by continuum_dr_extras_5601_test.go, which fails if it is
+		// dropped (deleting it used to leave every test green).
+		out.ReplicaPromotable = standbyAvailable && continuumPhaseReady(phase) && out.WALLagSeconds <= 30
 	}
 	// #4923 — health gates DERIVED from the observed CR status, never a
 	// hardcoded all-Pass wall (the prior shape reported "streaming-replication

--- a/products/catalyst/bootstrap/api/internal/handler/continuum_dr_preflight_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/continuum_dr_preflight_test.go
@@ -1,0 +1,367 @@
+// continuum_dr_preflight_test.go — regression coverage for the DR runbook
+// preflight matrix (POST /api/v1/sovereigns/{id}/dr/runbook/preflight, and the
+// same matrix run as step 1 of .../dr/runbook/playback).
+//
+// WHY THIS FILE EXISTS. runDRPreflight had ZERO tests. It declared all ten
+// checks `Status: "Pass"` as their literal initial value and then re-read only
+// two of them, so eight checks reported Pass having probed nothing. Measured on
+// hw292 (dep 1c56518035a83e03, 2026-08-10): `kubectl get cnpgpairs.dr.openova.io
+// -A` returns ZERO instances while the matrix reported
+// `preflight-02 cnpgpair-streaming = Pass` — a check that could not fail on the
+// exact precondition it names, pointed at the DR path.
+//
+// The systemic half: no check could ever reach "Fail", so classifyPreflight
+// could never return "NotReady", so HandleDRRunbookPlayback's
+// `if preOverall == "NotReady" { abort }` branch was UNREACHABLE. The safety
+// gate in front of a mutating DR operation could not fire.
+//
+// Every test below is written to FAIL against that prior implementation:
+//   - the Fail cases got "Pass" from the constant;
+//   - the zero-CNPGPair case got "Pass" from the constant;
+//   - the unmeasured checks got "Pass" from the constant;
+//   - NotReady/blockingChecks were unreachable.
+//
+// TestDRPreflight_HealthyMatrixStillPasses is the vacuity control: it proves
+// the probes can still return Pass on a genuinely healthy Sovereign, so this
+// file is not simply hardwiring the matrix to Fail.
+package handler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+)
+
+// preflightListKinds — every resource runDRPreflight LISTs. The fake dynamic
+// client panics on a LIST whose list-kind it does not know, so cnpgpairs and
+// pdms must be registered here even (especially) for the zero-instance cases:
+// a panic would otherwise be indistinguishable from the defect under test.
+func preflightListKinds() map[schema.GroupVersionResource]string {
+	return map[schema.GroupVersionResource]string{
+		ContinuumGVR():  "ContinuumList",
+		cnpgClusterGVR:  "ClusterList",
+		drCNPGPairGVR(): "CNPGPairList",
+		drPDMGVR():      "PDMList",
+	}
+}
+
+func fakePreflightHandler(t *testing.T, id string, seed ...runtime.Object) (*Handler, string) {
+	t.Helper()
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(), preflightListKinds(), seed...)
+	h.dynamicFactory = func(_ string) (dynamic.Interface, error) { return client, nil }
+	dep := installUserAccessDeployment(t, h, id)
+	return h, dep.ID
+}
+
+func runPreflight(t *testing.T, h *Handler, depID string) []drRunbookPreflightCheck {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost,
+		"/api/v1/sovereigns/"+depID+"/dr/runbook/preflight", nil)
+	return h.runDRPreflight(req, depID)
+}
+
+func checkByID(t *testing.T, checks []drRunbookPreflightCheck, id string) drRunbookPreflightCheck {
+	t.Helper()
+	for _, c := range checks {
+		if c.ID == id {
+			return c
+		}
+	}
+	t.Fatalf("preflight check %q not found in matrix of %d", id, len(checks))
+	return drRunbookPreflightCheck{}
+}
+
+// newCNPGPairCRFixture — a CNPGPair.dr.openova.io CR (the kind preflight-02
+// NAMES). NOT to be confused with a cnpg Cluster named `cnpg-pair-*`.
+func newCNPGPairCRFixture(name, namespace string, streaming bool) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{}
+	u.SetAPIVersion("dr.openova.io/v1")
+	u.SetKind("CNPGPair")
+	u.SetName(name)
+	u.SetNamespace(namespace)
+	_ = unstructured.SetNestedMap(u.Object, map[string]interface{}{
+		"primaryCluster": name + "-primary",
+		"replicaCluster": name + "-replica",
+		"topology":       "active-hot-standby",
+	}, "spec")
+	_ = unstructured.SetNestedMap(u.Object, map[string]interface{}{
+		"streaming": streaming,
+	}, "status")
+	return u
+}
+
+func newPDMFixture(name string) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{}
+	u.SetAPIVersion("dr.openova.io/v1")
+	u.SetKind("PDM")
+	u.SetName(name)
+	u.SetNamespace("catalyst")
+	return u
+}
+
+// markCNPGClusterNotReady flips a cnpg Cluster half to the proven region-kill
+// shape (#4901): the Cluster is PRESENT but reports Ready=False.
+func markCNPGClusterNotReady(c *unstructured.Unstructured) {
+	_ = unstructured.SetNestedSlice(c.Object, []interface{}{
+		map[string]interface{}{"type": "Ready", "status": "False"},
+	}, "status", "conditions")
+	_ = unstructured.SetNestedField(c.Object, int64(0), "status", "readyInstances")
+}
+
+func withContinuumStatus(cr *unstructured.Unstructured, phase string, lagSeconds interface{}) *unstructured.Unstructured {
+	_ = unstructured.SetNestedField(cr.Object, phase, "status", "phase")
+	if lagSeconds != nil {
+		_ = unstructured.SetNestedField(cr.Object, lagSeconds, "status", "replicationLagSeconds")
+	}
+	return cr
+}
+
+// ── preflight-02: the #4986 shape ────────────────────────────────────
+
+// THE hw292 CASE. The CNPGPair CRD is installed and holds ZERO instances, and
+// no cnpg Cluster carries the pair label. `cnpgpair-streaming` must NOT report
+// Pass — there is nothing to have observed streaming.
+func TestDRPreflight_CNPGPairStreamingIsNotPassWhenNoPairExists(t *testing.T) {
+	cr := newContinuumUnstructured("dr-shared-pg", "shared-data", "shared-pg",
+		"me-east-215-a", []string{"me-east-215-b"})
+	h, depID := fakePreflightHandler(t, "dep-preflight-nopair", cr)
+
+	c := checkByID(t, runPreflight(t, h, depID), "preflight-02")
+
+	if c.Status == preflightPass {
+		t.Errorf("cnpgpair-streaming: got Pass with ZERO CNPGPair CRs and ZERO labelled cnpg pairs — "+
+			"that is the hw292 #4986 reading: a check that cannot fail on the precondition it names (msg=%q)", c.Message)
+	}
+	if c.Message == "" {
+		t.Error("cnpgpair-streaming: a non-Pass verdict must say what was (not) measured")
+	}
+}
+
+// A CNPGPair CR that exists and reports streaming=false is a hard Fail, not a
+// Warn and certainly not the Pass the constant asserted.
+func TestDRPreflight_CNPGPairNotStreamingIsCriticalFail(t *testing.T) {
+	h, depID := fakePreflightHandler(t, "dep-preflight-pair-down",
+		newCNPGPairCRFixture("shared-pg", "shared-data", false))
+
+	c := checkByID(t, runPreflight(t, h, depID), "preflight-02")
+
+	if c.Status != preflightFail {
+		t.Errorf("cnpgpair-streaming: got %q want Fail — the CNPGPair CR reports status.streaming=false (msg=%q)",
+			c.Status, c.Message)
+	}
+	if c.Severity != "critical" {
+		t.Errorf("cnpgpair-streaming severity: got %q want critical — a non-streaming DR pair must block a playback", c.Severity)
+	}
+}
+
+// The region-kill shape (#4901): no CNPGPair CR, but the cnpg Cluster halves
+// are labelled and the REPLICA half is present-but-not-Ready.
+func TestDRPreflight_ReplicaHalfPresentButNotReadyIsFail(t *testing.T) {
+	primary, replica := newCNPGPairFixture("shared-pg", "shared-data", "me-east-215-a", "me-east-215-b")
+	markCNPGClusterNotReady(replica)
+	h, depID := fakePreflightHandler(t, "dep-preflight-replica-down", primary, replica)
+
+	c := checkByID(t, runPreflight(t, h, depID), "preflight-02")
+
+	if c.Status != preflightFail {
+		t.Errorf("cnpgpair-streaming: got %q want Fail — the replica half is present and NOT ready, "+
+			"which is the proven region-kill state (msg=%q)", c.Status, c.Message)
+	}
+}
+
+// The per-region split (#5511 class): this client sees only the primary half
+// because the replica Cluster lives in the peer region. Honest verdict is
+// UNVERIFIED — neither a Pass nor a Fail.
+func TestDRPreflight_ReplicaHalfInvisibleIsWarnNotPass(t *testing.T) {
+	primary, _ := newCNPGPairFixture("shared-pg", "shared-data", "me-east-215-a", "me-east-215-b")
+	h, depID := fakePreflightHandler(t, "dep-preflight-split", primary)
+
+	c := checkByID(t, runPreflight(t, h, depID), "preflight-02")
+
+	if c.Status != preflightWarn {
+		t.Errorf("cnpgpair-streaming: got %q want Warn — only the primary half is visible from this "+
+			"cluster's API, so streaming cannot be observed here (msg=%q)", c.Status, c.Message)
+	}
+}
+
+// ── preflight-01 + preflight-03 ──────────────────────────────────────
+
+func TestDRPreflight_DegradedContinuumIsCriticalFail(t *testing.T) {
+	healthy := withContinuumStatus(newContinuumUnstructured(
+		"dr-spine-gitea", "catalyst", "spine-gitea", "me-east-215-a", []string{"me-east-215-b"}),
+		"Healthy", int64(0))
+	degraded := withContinuumStatus(newContinuumUnstructured(
+		"dr-shared-pg", "shared-data", "shared-pg", "me-east-215-a", []string{"me-east-215-b"}),
+		"Degraded", int64(0))
+	h, depID := fakePreflightHandler(t, "dep-preflight-degraded", healthy, degraded)
+
+	c := checkByID(t, runPreflight(t, h, depID), "preflight-01")
+
+	if c.Status != preflightFail {
+		t.Errorf("continuum-cr-ready: got %q want Fail — dr-shared-pg reports phase=Degraded (msg=%q)",
+			c.Status, c.Message)
+	}
+}
+
+// FailedOver is the post-switchover STEADY state and must stay ready, or the
+// preflight would block the failback of an already-failed-over Sovereign.
+func TestDRPreflight_FailedOverPhaseIsStillReady(t *testing.T) {
+	cr := withContinuumStatus(newContinuumUnstructured(
+		"dr-shared-pg", "shared-data", "shared-pg", "me-east-215-a", []string{"me-east-215-b"}),
+		"FailedOver", int64(0))
+	h, depID := fakePreflightHandler(t, "dep-preflight-failedover", cr)
+
+	c := checkByID(t, runPreflight(t, h, depID), "preflight-01")
+
+	if c.Status != preflightPass {
+		t.Errorf("continuum-cr-ready: got %q want Pass — FailedOver is the post-switchover steady state "+
+			"and blocking it strands the failback (msg=%q)", c.Status, c.Message)
+	}
+}
+
+func TestDRPreflight_WALLagOverRTOIsCriticalFail(t *testing.T) {
+	cr := withContinuumStatus(newContinuumUnstructured(
+		"dr-shared-pg", "shared-data", "shared-pg", "me-east-215-a", []string{"me-east-215-b"}),
+		"Healthy", int64(320))
+	_ = unstructured.SetNestedField(cr.Object, "30s", "spec", "rto")
+	h, depID := fakePreflightHandler(t, "dep-preflight-lag", cr)
+
+	c := checkByID(t, runPreflight(t, h, depID), "preflight-03")
+
+	if c.Status != preflightFail {
+		t.Errorf("wal-lag-under-rto: got %q want Fail — 320s lag against a 30s RTO budget (msg=%q)",
+			c.Status, c.Message)
+	}
+}
+
+// THE VACUITY TRAP THIS GUARDS. A CR that omits status.replicationLagSeconds
+// must read "not reported", never a silent zero that passes the RTO
+// comparison — absent evidence and a perfectly caught-up standby are opposite
+// readings of the same field.
+func TestDRPreflight_AbsentLagKeyIsNotAMeasuredZero(t *testing.T) {
+	cr := newContinuumUnstructured("dr-spine-openbao", "catalyst", "spine-openbao",
+		"me-east-215-a", []string{"me-east-215-b"})
+	// deliberately no status.replicationLagSeconds
+	h, depID := fakePreflightHandler(t, "dep-preflight-nolag", cr)
+
+	c := checkByID(t, runPreflight(t, h, depID), "preflight-03")
+
+	if c.Status == preflightPass {
+		t.Errorf("wal-lag-under-rto: got Pass from a CR that reports NO lag key — an absent field was "+
+			"read as a measured 0s (msg=%q)", c.Message)
+	}
+}
+
+// ── the six checks with no probe on this path ────────────────────────
+
+func TestDRPreflight_UnprobedChecksDoNotReportPass(t *testing.T) {
+	cr := withContinuumStatus(newContinuumUnstructured(
+		"dr-shared-pg", "shared-data", "shared-pg", "me-east-215-a", []string{"me-east-215-b"}),
+		"Healthy", int64(0))
+	h, depID := fakePreflightHandler(t, "dep-preflight-unprobed", cr)
+	checks := runPreflight(t, h, depID)
+
+	for _, id := range []string{"preflight-05", "preflight-06", "preflight-07",
+		"preflight-08", "preflight-09", "preflight-10"} {
+		c := checkByID(t, checks, id)
+		if c.Status == preflightPass {
+			t.Errorf("%s (%s): got Pass, but this endpoint runs no probe for it — "+
+				"a verdict from absent evidence", c.ID, c.Name)
+		}
+		if c.Message == "" {
+			t.Errorf("%s (%s): an unmeasured check must name what was not measured", c.ID, c.Name)
+		}
+	}
+}
+
+// An unresolvable deployment must not yield a clean matrix — nothing was read.
+func TestDRPreflight_UnknownDeploymentIsAllUnmeasured(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sovereigns/nope/dr/runbook/preflight", nil)
+
+	checks := h.runDRPreflight(req, "nope")
+
+	for _, c := range checks {
+		if c.Status == preflightPass {
+			t.Errorf("%s (%s): got Pass with no deployment and no cluster client at all", c.ID, c.Name)
+		}
+	}
+	if overall, _ := classifyPreflight(checks); overall == "Ready" {
+		t.Error("classifyPreflight: an all-unmeasured matrix rolled up to Ready — a clean bill of health from zero evidence")
+	}
+}
+
+// ── the rollup: the playback abort branch must be reachable ──────────
+
+// HandleDRRunbookPlayback aborts only on overall == "NotReady". Before this
+// change no check could reach Fail, so that branch was dead code: the safety
+// gate in front of a mutating DR operation could never fire.
+func TestDRPreflight_CriticalFailReachesNotReadyAndBlocks(t *testing.T) {
+	degraded := withContinuumStatus(newContinuumUnstructured(
+		"dr-shared-pg", "shared-data", "shared-pg", "me-east-215-a", []string{"me-east-215-b"}),
+		"Degraded", int64(0))
+	h, depID := fakePreflightHandler(t, "dep-preflight-notready", degraded)
+
+	overall, blocking := classifyPreflight(runPreflight(t, h, depID))
+
+	if overall != "NotReady" {
+		t.Errorf("overall: got %q want NotReady — a Degraded Continuum must abort the runbook playback", overall)
+	}
+	if len(blocking) == 0 {
+		t.Error("blockingChecks: empty on a NotReady matrix — the operator is told to abort without being told why")
+	}
+}
+
+// classifyPreflight must never report Ready while blockingChecks is non-empty.
+func TestClassifyPreflight_NonCriticalFailIsNotReadyVerdict(t *testing.T) {
+	checks := []drRunbookPreflightCheck{
+		{ID: "preflight-01", Name: "continuum-cr-ready", Status: preflightPass, Severity: "info"},
+		{ID: "preflight-02", Name: "cnpgpair-streaming", Status: preflightFail, Severity: "warning"},
+	}
+
+	overall, blocking := classifyPreflight(checks)
+
+	if len(blocking) != 1 {
+		t.Fatalf("blockingChecks: got %v want 1 entry", blocking)
+	}
+	if overall == "Ready" {
+		t.Errorf("overall: got Ready with %d blocking check(s) — self-contradictory", len(blocking))
+	}
+}
+
+// ── vacuity control ──────────────────────────────────────────────────
+
+// The probes must still be able to say Pass. A genuinely healthy Sovereign —
+// Continuum CRs Healthy and caught up, both cnpg pair halves visible and
+// Ready, three PDM witnesses — must report the four probed checks Pass and
+// must NOT roll up to NotReady. Without this, every assertion above could be
+// satisfied by hardwiring the matrix to Fail.
+func TestDRPreflight_HealthyMatrixStillPasses(t *testing.T) {
+	cr := withContinuumStatus(newContinuumUnstructured(
+		"dr-shared-pg", "shared-data", "shared-pg", "me-east-215-a", []string{"me-east-215-b"}),
+		"Healthy", int64(0))
+	primary, replica := newCNPGPairFixture("shared-pg", "shared-data", "me-east-215-a", "me-east-215-b")
+	h, depID := fakePreflightHandler(t, "dep-preflight-healthy",
+		cr, primary, replica,
+		newPDMFixture("pdm-a"), newPDMFixture("pdm-b"), newPDMFixture("pdm-c"))
+
+	checks := runPreflight(t, h, depID)
+
+	for _, id := range []string{"preflight-01", "preflight-02", "preflight-03", "preflight-04"} {
+		if c := checkByID(t, checks, id); c.Status != preflightPass {
+			t.Errorf("%s (%s): got %q want Pass on a genuinely healthy Sovereign (msg=%q)",
+				c.ID, c.Name, c.Status, c.Message)
+		}
+	}
+	if overall, blocking := classifyPreflight(checks); overall == "NotReady" {
+		t.Errorf("overall: got NotReady on a healthy Sovereign (blocking=%v)", blocking)
+	}
+}


### PR DESCRIPTION
## What this is

The code half of PR #5985, unchanged, on a branch that can actually merge.

#5985 is green on 24 checks and has sat open since 2026-08-10T11:37Z. Its only
conflict is `docs/ledger/UAT.md` — a file a 15-minute cron rewrites, so the
conflict re-forms faster than resolving it. Test-merged locally against today's
`origin/main`: `docs/ledger/UAT.md` is the sole `diff-filter=U` path; both Go
files merge clean. The ledger hunk is dropped here and left to the walkers who
own that file. #5985 can then be retired in favour of this PR.

## The defect

`runDRPreflight` built its 10-check matrix with every entry hardcoded
`Status: "Pass"`, and only two were ever corrected by a live read —
`preflight-01` from the Continuum CR list, `preflight-04` from the PDM list.

`preflight-02 cnpgpair-streaming` is touched by no code path at all. On hw293
(dep `a0077ba47e3720e5`) the DR preflight therefore reports
`cnpgpair-streaming = Pass` while there is no pair to stream: measured
read-only in both regions tonight, subject verified by node name before any
count was believed —

| surface | region A | region B |
|---|---|---|
| `cnpgpairs.dr.openova.io` CRD | installed `2026-08-10T13:04:38Z` | not served |
| CnpgPair CRs | 0 | n/a |
| `kube-system/cilium-clustermesh` | absent | absent |

The CRD presence is quoted explicitly because an empty listing alone cannot
tell "no instances" from "unknown kind".

The second half is why the first stayed invisible: no check could reach `Fail`,
so `classifyPreflight` could never return `NotReady` and the
abort-on-blocking-preflight branch of the runbook playback was unreachable.

## The change

Every check starts UNMEASURED (`Skipped`, `not measured: <surface>`) and only a
real probe moves it. The replication checks read the Continuum and CnpgPair CRs.
The six with no producer in this endpoint say so rather than claiming a pass.

## Guard watched failing before it passed

Mutation applied to the fixed tree — `unmeasured()` returns `Pass` instead of
`Skipped`:

```
--- FAIL: TestDRPreflight_UnprobedChecksDoNotReportPass
    preflight-05 (dns-resolver-reachable): got Pass, but this endpoint runs no
    probe for it — a verdict from absent evidence
    ... preflight-06..10 likewise
--- FAIL: TestDRPreflight_UnknownDeploymentIsAllUnmeasured
    preflight-01..10: got Pass with no deployment and no cluster client at all
```

Unmutated, full package, today's `origin/main`:

```
ok  github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/handler  294.791s
```

`scripts/check-no-banned-words.sh` — OK.

## What this does NOT do

It does not move UAT row 57 to green. Row 57 needs a live 2-region cnpg-pair,
and no pair exists on hw293 because ClusterMesh has never been established
there. This removes the signal that was hiding that fact from an operator
reading the DR preflight.

Refs #5982 #5985 #3375 #4986

