### PR TITLE
fix(org): two per-Org console defects on hw293 — the region witness reads absent as one region, and the teardown cannot delete the Secret it must reap

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1364,7 +1364,17 @@ spec:
       #   StatefulSet came back 138s later. RBAC ships inside this umbrella, so
       #   the grant only reaches a Sovereign once this pin advances. Lockstep
       #   w/ products/catalyst/chart/Chart.yaml.
-      version: 1.4.1352
+      # 1.4.1351 (#6027): the organization-controller Deployment gains
+      #   CATALYST_CONFIGURED_REGIONS from the sovereign-fqdn ConfigMap — the
+      #   second witness of how many regions this Sovereign serves. The
+      #   ClusterMesh witness the per-Org console fan-out relied on does not
+      #   exist until the mesh is ESTABLISHED, so hw293 (mesh Secret NotFound
+      #   in both regions) read as single-region and wrote the per-Org
+      #   listener into region A only while both Organizations reported
+      #   provisioned. Env injection ships inside this umbrella, so the
+      #   witness reaches the controller only once this pin advances. Lockstep
+      #   w/ products/catalyst/chart/Chart.yaml.
+      version: 1.4.1354
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1364,7 +1364,7 @@ spec:
       #   StatefulSet came back 138s later. RBAC ships inside this umbrella, so
       #   the grant only reaches a Sovereign once this pin advances. Lockstep
       #   w/ products/catalyst/chart/Chart.yaml.
-      # 1.4.1351 (#6027): the organization-controller Deployment gains
+      # 1.4.1354 (#6027): the organization-controller Deployment gains
       #   CATALYST_CONFIGURED_REGIONS from the sovereign-fqdn ConfigMap — the
       #   second witness of how many regions this Sovereign serves. The
       #   ClusterMesh witness the per-Org console fan-out relied on does not

--- a/core/controllers/organization/cmd/main.go
+++ b/core/controllers/organization/cmd/main.go
@@ -148,6 +148,18 @@ func main() {
 	clusterMeshSecret := envOr("CATALYST_CLUSTERMESH_SECRET", "cilium-clustermesh")
 	clusterMeshSecretNs := envOr("CATALYST_CLUSTERMESH_SECRET_NAMESPACE", "kube-system")
 
+	// #6027 — the SECOND region witness. The ClusterMesh Secret above does not
+	// exist until the mesh is ESTABLISHED, so on a 2-region Sovereign whose
+	// mesh has not come up it is indistinguishable from a single-region one and
+	// the shortfall check silently expects zero secondaries. `configuredRegions`
+	// is written at bootstrap by the catalyst-platform chart and is independent
+	// of both ClusterMesh and the cutover chart that produces the kubeconfig
+	// bridge, so it is decidable in exactly that window. Injected by the chart
+	// as a `configMapKeyRef` on catalyst-system/sovereign-fqdn (optional:true),
+	// which is why an empty value is normal on Catalyst-Zero and legacy
+	// Sovereigns and simply leaves the ClusterMesh witness deciding alone.
+	configuredRegions := envOr("CATALYST_CONFIGURED_REGIONS", "")
+
 	consoleRouteNs := envOr("CATALYST_CONSOLE_ROUTE_NAMESPACE", "catalyst-system")
 	consoleAPISvc := envOr("CATALYST_CONSOLE_API_SERVICE", "catalyst-api")
 	consoleUISvc := envOr("CATALYST_CONSOLE_UI_SERVICE", "catalyst-ui")
@@ -304,6 +316,7 @@ func main() {
 		SecondaryRegionKubeconfigSecretNamespace: secondaryKubeconfigSecretNs,
 		ClusterMeshSecretName:                    clusterMeshSecret,
 		ClusterMeshSecretNamespace:               clusterMeshSecretNs,
+		ConfiguredRegions:                        configuredRegions,
 	}
 	if err := r.SetupWithManager(mgr); err != nil {
 		log.Error(err, "setup reconciler")

--- a/core/controllers/organization/internal/controller/organization_controller.go
+++ b/core/controllers/organization/internal/controller/organization_controller.go
@@ -380,13 +380,32 @@ type Reconciler struct {
 	SecondaryRegionKubeconfigSecretNamespace string
 
 	// ClusterMeshSecretName / …Namespace locate the Cilium ClusterMesh config
-	// Secret used as the INDEPENDENT witness of how many other regions this
-	// Sovereign has — without it, "no kubeconfigs wired" would silently mean
-	// "no secondary regions" and the per-region check could never fail.
+	// Secret used as ONE witness of how many other regions this Sovereign has
+	// — without a witness, "no kubeconfigs wired" would silently mean "no
+	// secondary regions" and the per-region check could never fail.
 	// Defaults: cilium-clustermesh / kube-system.
 	// Env: CATALYST_CLUSTERMESH_SECRET{,_NAMESPACE}.
 	ClusterMeshSecretName      string
 	ClusterMeshSecretNamespace string
+
+	// ConfiguredRegions is the comma-separated region-key list this Sovereign
+	// was PROVISIONED with — the `configuredRegions` key of the
+	// `catalyst-system/sovereign-fqdn` ConfigMap, injected as
+	// CATALYST_CONFIGURED_REGIONS exactly the way catalyst-api already
+	// consumes it.
+	//
+	// #6027: the ClusterMesh witness alone cannot decide this. Its Secret is
+	// absent until ClusterMesh is ESTABLISHED, so a 2-region Sovereign whose
+	// mesh has not come up reads identically to a single-region one and the
+	// shortfall check silently expects zero secondaries — measured on hw293,
+	// where both regions lacked `cilium-clustermesh`, region B held zero
+	// per-Org listeners, and both Organizations still read provisioned. This
+	// witness is written at bootstrap by the catalyst-platform chart and is
+	// independent of BOTH ClusterMesh and the cutover chart that produces the
+	// kubeconfig bridge, so it is decidable in exactly the window the others
+	// are not. Empty (legacy / Catalyst-Zero) → the ClusterMesh witness alone
+	// decides, exactly as before.
+	ConfiguredRegions string
 
 	// RegionClientBuilder builds a client from a secondary region's
 	// kubeconfig bytes. Nil in production (a real REST client is built);

--- a/core/controllers/organization/internal/controller/tenant_console_tls_regions.go
+++ b/core/controllers/organization/internal/controller/tenant_console_tls_regions.go
@@ -46,18 +46,42 @@
 // `targets`, so the admission read-back never looked at it and the emitter
 // logged "admitted in every region" over a one-region list).
 //
-// So the region set is cross-checked against an INDEPENDENT in-cluster witness:
-// the Cilium ClusterMesh config Secret `kube-system/cilium-clustermesh`, whose
-// non-certificate keys name every REMOTE cluster this region is meshed with
-// (hw292 region A: `hw292-me-east-b`). A Sovereign whose mesh declares N remote
-// clusters while the kubeconfig Secret resolves fewer reports the shortfall as
-// UNWIRED — verifyProvisioned turns that into a NOT-provisioned Organization
-// naming the count, never a green Org over an unwritten region. A single-region
-// Sovereign has no ClusterMesh Secret, declares zero remotes, and behaves
-// EXACTLY as before this file existed.
+// So the region set is cross-checked against INDEPENDENT in-cluster witnesses.
+// A Sovereign whose witnesses declare N remote regions while the kubeconfig
+// Secret resolves fewer reports the shortfall as UNWIRED — verifyProvisioned
+// turns that into a NOT-provisioned Organization naming the count, never a
+// green Org over an unwritten region.
+//
+// THERE ARE TWO WITNESSES, AND THE EXPECTATION IS THEIR MAX (#6027)
+// -----------------------------------------------------------------
+// The original witness was the Cilium ClusterMesh config Secret
+// `kube-system/cilium-clustermesh`, whose non-certificate keys name every
+// REMOTE cluster this region is meshed with (hw292 region A:
+// `hw292-me-east-b`). That witness has a window in which it cannot answer: the
+// Secret does not exist until ClusterMesh is ESTABLISHED, so a 2-region
+// Sovereign whose mesh has not come up is byte-identical to a single-region
+// one. Folding its NotFound into "zero secondaries" made the anti-vacuity guard
+// itself vacuous — measured on hw293 dep a0077ba47e3720e5 on 2026-08-11, where
+// `cilium-clustermesh` was NotFound in BOTH regions, region B carried zero
+// per-Org listeners, and both Organizations still read fully provisioned.
+//
+// The second witness closes that window: `configuredRegions` from the
+// `catalyst-system/sovereign-fqdn` ConfigMap — the region list the Sovereign
+// was PROVISIONED with (hw293: `hw-me-east-215-a-rtz-prod,hw-me-east-215-b-rtz-prod`).
+// It is written at bootstrap by the catalyst-platform chart, so it is
+// independent of ClusterMesh AND of the cutover chart that owns the kubeconfig
+// bridge and can fail to install (#6004). It reaches this controller as the
+// kubelet-injected env CATALYST_CONFIGURED_REGIONS — the same `configMapKeyRef`
+// shape catalyst-api already uses for this exact key, which is why it needs no
+// new RBAC (the org-controller SA is denied ConfigMap reads).
+//
+// Taking the MAX of the two means neither witness can SHRINK the set the other
+// proves: one that fails to load can only lose to one that did. A Sovereign
+// with NEITHER witness (legacy / Catalyst-Zero) expects zero remotes and
+// behaves EXACTLY as before this file existed.
 //
 // Refs #5246 · #5511 (the port + admission twin) · #5359 (the kubeconfig
-// bridge) · #5930 (the catalyst-api twin of this fix).
+// bridge) · #5930 (the catalyst-api twin of this fix) · #6027 (the witness).
 
 package controller
 
@@ -195,6 +219,37 @@ func consoleRegionKeyFromSecretKey(k string) string {
 	return ""
 }
 
+// configuredRegionRemoteCount reports how many OTHER regions this Sovereign was
+// provisioned with, derived from the comma-separated `configuredRegions` key of
+// `catalyst-system/sovereign-fqdn` (injected as CATALYST_CONFIGURED_REGIONS).
+// The second return reports whether the witness was present at all — an empty
+// env is "witness not loaded", which is a different state from "one region",
+// and only the caller may decide what to do about it.
+//
+// #6027. This witness exists from bootstrap and is independent of both
+// ClusterMesh (which may never establish) and the cutover chart (which owns the
+// kubeconfig bridge and can fail to install, #6004). It is therefore decidable
+// in the exact window in which the ClusterMesh witness is not.
+func (r *Reconciler) configuredRegionRemoteCount() (int, bool) {
+	raw := strings.TrimSpace(r.ConfiguredRegions)
+	if raw == "" {
+		return 0, false
+	}
+	seen := map[string]bool{}
+	for _, part := range strings.Split(raw, ",") {
+		if k := strings.TrimSpace(part); k != "" {
+			seen[k] = true
+		}
+	}
+	if len(seen) == 0 {
+		return 0, false
+	}
+	// The list names EVERY region including the one this controller runs in,
+	// so the remote count is one fewer. A malformed single-entry list yields
+	// zero remotes, which is the pre-#6027 behaviour.
+	return len(seen) - 1, true
+}
+
 // clusterMeshRemoteClusters extracts the REMOTE cluster names from a Cilium
 // ClusterMesh config Secret. The Secret carries, per remote cluster, one
 // `<name>` config key plus `<name>-ca.crt` / `<name>.crt` / `<name>.key`
@@ -248,8 +303,18 @@ func (r *Reconciler) consoleRegionTargets(ctx context.Context) consoleRegionReso
 		Targets: []consoleRegionTarget{{Region: consoleHostRegionKey, Host: true, Client: r.Client}},
 	}
 
-	// The independent witness first: how many OTHER regions does this
-	// Sovereign's mesh declare? Absent Secret == single-region Sovereign.
+	// The independent witnesses first: how many OTHER regions does this
+	// Sovereign have?
+	//
+	// #6027 — there are TWO, and the expectation is the MAX of them, never
+	// either one alone. The ClusterMesh Secret is absent until the mesh is
+	// ESTABLISHED, so on a 2-region Sovereign whose mesh has not come up it is
+	// byte-identical to a single-region Sovereign; folding that NotFound into
+	// "zero secondaries" is what let hw293 write region A only and report every
+	// Organization complete. The provisioning-time region list is decidable in
+	// exactly that window. Taking the max means neither witness can SHRINK the
+	// set the other proves — a witness that fails to load can only ever lose to
+	// one that did, never silently override it.
 	meshRemotes := 0
 	mesh := &corev1.Secret{}
 	switch err := r.Get(ctx, client.ObjectKey{
@@ -259,8 +324,9 @@ func (r *Reconciler) consoleRegionTargets(ctx context.Context) consoleRegionReso
 	case err == nil:
 		meshRemotes = len(clusterMeshRemoteClusters(mesh))
 	case apierrors.IsNotFound(err):
-		// Single-region Sovereign (or ClusterMesh not yet established).
-		// Zero expected secondaries; behaviour identical to pre-#5246.
+		// Single-region Sovereign, OR ClusterMesh not yet established. These
+		// two are indistinguishable HERE, which is precisely why this is no
+		// longer the only witness — see configuredRegionRemoteCount.
 	default:
 		// Cannot decide completeness this pass. Report it as transient so
 		// the Org requeues rather than being declared complete on an
@@ -268,6 +334,12 @@ func (r *Reconciler) consoleRegionTargets(ctx context.Context) consoleRegionReso
 		res.Unreachable = append(res.Unreachable, fmt.Sprintf(
 			"ClusterMesh witness %s/%s unreadable, so the expected region count is unknown: %s",
 			r.clusterMeshSecretNamespace(), r.clusterMeshSecretName(), err))
+	}
+
+	topologyRemotes, topologyDeclared := r.configuredRegionRemoteCount()
+	expectedRemotes, witness := meshRemotes, "ClusterMesh"
+	if topologyDeclared && topologyRemotes > expectedRemotes {
+		expectedRemotes, witness = topologyRemotes, "sovereign-fqdn configuredRegions"
 	}
 
 	bridgeNS, bridgeName := r.secondaryKubeconfigSecretNamespace(), r.secondaryKubeconfigSecretName()
@@ -293,14 +365,16 @@ func (r *Reconciler) consoleRegionTargets(ctx context.Context) consoleRegionReso
 	}
 	sort.Strings(regions)
 
-	// The shortfall check is the whole anti-vacuity point: a mesh that
-	// declares 1 remote cluster while 0 kubeconfigs are wired means every
+	// The shortfall check is the whole anti-vacuity point: a Sovereign that
+	// declares 1 remote region while 0 kubeconfigs are wired means every
 	// per-Org listener this controller writes reaches exactly half the
-	// regions the console ELB forwards to.
-	if meshRemotes > len(regions) {
+	// regions the console ELB forwards to. The message NAMES the witness that
+	// declared the region so the shortfall's warrant can be checked rather
+	// than taken on faith.
+	if expectedRemotes > len(regions) {
 		res.Unwired = append(res.Unwired, fmt.Sprintf(
-			"%d of %d secondary region(s) have no kubeconfig in %s/%s (ClusterMesh declares %d remote cluster(s); wired region keys: %s)",
-			meshRemotes-len(regions), meshRemotes, bridgeNS, bridgeName, meshRemotes, describeRegionKeys(regions)))
+			"%d of %d secondary region(s) have no kubeconfig in %s/%s (%s declares %d remote region(s); wired region keys: %s)",
+			expectedRemotes-len(regions), expectedRemotes, bridgeNS, bridgeName, witness, expectedRemotes, describeRegionKeys(regions)))
 	}
 
 	cache := r.regionClientCache()

--- a/core/controllers/organization/internal/controller/tenant_console_tls_regions_6027_test.go
+++ b/core/controllers/organization/internal/controller/tenant_console_tls_regions_6027_test.go
@@ -1,0 +1,200 @@
+// tenant_console_tls_regions_6027_test.go — #6027. The witness that decides
+// how many regions this Sovereign serves must not read "absent" as "one".
+//
+// THE DEFECT
+// ----------
+// #5246/#5957 made the per-Org console listener pair fan out over every region,
+// and guarded the fan-out with an INDEPENDENT witness so the region set could
+// not be silently truncated by the same step that loses a region: the Cilium
+// ClusterMesh config Secret `kube-system/cilium-clustermesh`, whose
+// non-certificate keys name every remote cluster.
+//
+// That witness is absent on a Sovereign that has not established ClusterMesh,
+// and `apierrors.IsNotFound` was folded into "zero expected secondaries". So a
+// 2-region Sovereign whose mesh is not up is INDISTINGUISHABLE from a
+// single-region one, and the guard written to stop a green Org over an
+// unwritten region reports no shortfall at all.
+//
+// Measured read-only on hw293 dep a0077ba47e3720e5, 2026-08-11, both regions:
+//
+//	kube-system/cilium-clustermesh                 -> NotFound in BOTH regions
+//	catalyst/cutover-secondary-kubeconfigs         -> NotFound (its only
+//	                                                  producer is runCutover,
+//	                                                  and the cutover chart is
+//	                                                  still installing, #6004)
+//	region A kube-system/cilium-gateway-console    -> console-https-hw293walkone,
+//	                                                  console-https-hw293walktwo
+//	region B kube-system/cilium-gateway-console    -> the three Sovereign pairs,
+//	                                                  ZERO per-Org listeners
+//
+// and both Organizations nevertheless read fully provisioned. UAT rows R16 /
+// 87 / 90 / 95 each measured the customer-visible half of that: 6/12, 8/12 and
+// 5/12 fresh-TCP `curl(35) Connection reset by peer` against a per-Org host,
+// while the apex host on the SAME VIP answers every time.
+//
+// THE WITNESS THAT IS ACTUALLY THERE
+// ----------------------------------
+// `catalyst-system/sovereign-fqdn` carries `configuredRegions` — the
+// comma-separated region keys the Sovereign was provisioned with. On hw293 it
+// reads `hw-me-east-215-a-rtz-prod,hw-me-east-215-b-rtz-prod`, it is written at
+// bootstrap by the catalyst-platform chart, and it is independent of BOTH
+// ClusterMesh and the cutover chart. catalyst-api already consumes exactly this
+// key as `CATALYST_CONFIGURED_REGIONS`; the org-controller reaches it the same
+// way — a kubelet-injected `configMapKeyRef`, which needs no new RBAC (the
+// org-controller SA is denied ConfigMap reads: `auth can-i get configmaps -n
+// catalyst-system` -> no, against a `secrets` control that answers yes).
+//
+// WHAT IS ASSERTED HERE
+// ---------------------
+// Every case asserts on the VALUE the resolution produced — the shortfall count
+// and the region named in it — and each carries a control that answers the
+// other way in the same fixture, so none can pass vacuously:
+//
+//  1. The live hw293 shape (topology declares 2, no mesh, no bridge) reports a
+//     shortfall and holds the Org back. The control is the same fixture with
+//     the topology witness declaring ONE region, which stays clean.
+//  2. The topology witness cannot SHRINK a set the mesh witness declares
+//     larger, and vice versa — the expectation is the max of the two, so
+//     neither witness alone can hide a region.
+//  3. A wired bridge satisfies the topology witness, so the fix reports a
+//     shortfall only when one genuinely exists.
+//  4. With NEITHER witness present the behaviour is byte-for-byte what it was
+//     before this change — legacy and Catalyst-Zero Sovereigns do not start
+//     red-flagging every Organization.
+package controller
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// hw293ConfiguredRegions mirrors the live `catalyst-system/sovereign-fqdn`
+// ConfigMap key `configuredRegions` read off hw293 on 2026-08-11.
+const hw293ConfiguredRegions = "hw-me-east-215-a-rtz-prod,hw-me-east-215-b-rtz-prod"
+
+// TestConsoleRegionTargets_TopologyWitnessCatchesUnmeshedSecondary_6027 is the
+// hw293 reproduction: a 2-region Sovereign with no ClusterMesh Secret and no
+// kubeconfig bridge must report the secondary region as UNWIRED, not resolve to
+// a one-region set and call the Organization complete.
+func TestConsoleRegionTargets_TopologyWitnessCatchesUnmeshedSecondary_6027(t *testing.T) {
+	ctx := context.Background()
+
+	// The live shape: mesh witness absent, bridge absent, topology declares 2.
+	f := newMultiRegionFixture(t, false, false, regionGatewayListeners(9443, 9080))
+	f.r.ConfiguredRegions = hw293ConfiguredRegions
+
+	res := f.r.consoleRegionTargets(ctx)
+
+	if len(res.Targets) != 1 || !res.Targets[0].Host {
+		t.Fatalf("precondition: with no kubeconfig wired the only writable target is the host region, got %d targets", len(res.Targets))
+	}
+	if len(res.Unwired) == 0 {
+		t.Fatalf("a 2-region Sovereign with zero secondary kubeconfigs reported NO shortfall — "+
+			"the per-Org listener can never reach region B, yet the fan-out claims it wrote everywhere. "+
+			"unwired=%v unreachable=%v", res.Unwired, res.Unreachable)
+	}
+	// Assert on the VALUE, not on the key: the message must name the count
+	// that is missing and the witness that declared it, or an operator cannot
+	// tell a real shortfall from a witness that failed to load.
+	joined := strings.Join(res.Unwired, " | ")
+	if !strings.Contains(joined, "1 of 1 secondary region") {
+		t.Fatalf("shortfall message does not name the 1-of-1 count an operator needs: %q", joined)
+	}
+	if !strings.Contains(joined, "configuredRegions") {
+		t.Fatalf("shortfall message does not name the witness that declared the region, so its warrant cannot be checked: %q", joined)
+	}
+
+	// The consumer half — the Org must not read provisioned.
+	got := f.r.verifyProvisioned(ctx, f.org)
+	if got.complete() {
+		t.Fatalf("Organization reads fully provisioned while its console listener never reached the declared secondary region. missing=%v unverifiable=%v",
+			got.Missing, got.Unverifiable)
+	}
+
+	// CONTROL, same fixture, single-region topology: no shortfall, and the Org
+	// is not held back by this check. Proves case 1 discriminates on the region
+	// COUNT rather than firing on any Sovereign with no bridge Secret.
+	single := newMultiRegionFixture(t, false, false, regionGatewayListeners(9443, 9080))
+	single.r.ConfiguredRegions = "hw-me-east-215-a-rtz-prod"
+	sres := single.r.consoleRegionTargets(ctx)
+	if len(sres.Unwired) != 0 || len(sres.Unreachable) != 0 {
+		t.Fatalf("control failed: a genuinely single-region Sovereign reported unwired=%v unreachable=%v", sres.Unwired, sres.Unreachable)
+	}
+}
+
+// TestConsoleRegionTargets_NeitherWitnessMayShrinkTheOther_6027 pins the
+// combination rule. The expectation is the MAX of the two witnesses, so a
+// witness that under-reports cannot hide a region the other one proves.
+func TestConsoleRegionTargets_NeitherWitnessMayShrinkTheOther_6027(t *testing.T) {
+	ctx := context.Background()
+
+	// Mesh declares 1 remote; topology declares a single region. The mesh must
+	// win — the old behaviour, which this change must not weaken.
+	meshOnly := newMultiRegionFixture(t, true, false, regionGatewayListeners(9443, 9080))
+	meshOnly.r.ConfiguredRegions = "hw-me-east-215-a-rtz-prod"
+	mres := meshOnly.r.consoleRegionTargets(ctx)
+	if len(mres.Unwired) == 0 {
+		t.Fatalf("a topology witness naming ONE region silently shrank a mesh witness that declares a remote cluster: unwired=%v", mres.Unwired)
+	}
+
+	// Topology declares 2; mesh absent. The topology must win — the #6027 case.
+	topoOnly := newMultiRegionFixture(t, false, false, regionGatewayListeners(9443, 9080))
+	topoOnly.r.ConfiguredRegions = hw293ConfiguredRegions
+	tres := topoOnly.r.consoleRegionTargets(ctx)
+	if len(tres.Unwired) == 0 {
+		t.Fatalf("an absent mesh witness silently shrank a topology witness that declares 2 regions: unwired=%v", tres.Unwired)
+	}
+
+	// Both declare the same single remote — the expectation must be 1, not the
+	// 2 a naive sum would produce. Wire the bridge so a correct expectation of
+	// 1 is fully satisfied and reports nothing.
+	both := newMultiRegionFixture(t, true, true, regionGatewayListeners(9443, 9080))
+	both.r.ConfiguredRegions = hw293ConfiguredRegions
+	bres := both.r.consoleRegionTargets(ctx)
+	if len(bres.Unwired) != 0 {
+		t.Fatalf("two witnesses naming the SAME one remote region were summed instead of maxed — one wired kubeconfig should satisfy them: unwired=%v", bres.Unwired)
+	}
+	if len(bres.Targets) != 2 {
+		t.Fatalf("expected host + 1 secondary target, got %d", len(bres.Targets))
+	}
+}
+
+// TestConsoleRegionTargets_TopologyWitnessSatisfiedByWiredBridge_6027 proves the
+// new witness reports a shortfall only when one genuinely exists.
+func TestConsoleRegionTargets_TopologyWitnessSatisfiedByWiredBridge_6027(t *testing.T) {
+	ctx := context.Background()
+
+	f := newMultiRegionFixture(t, false, true, regionGatewayListeners(9443, 9080))
+	f.r.ConfiguredRegions = hw293ConfiguredRegions
+
+	res := f.r.consoleRegionTargets(ctx)
+	if len(res.Unwired) != 0 {
+		t.Fatalf("topology declares 2 regions and the one secondary kubeconfig IS wired, yet a shortfall was reported: %v", res.Unwired)
+	}
+	if len(res.Targets) != 2 {
+		t.Fatalf("expected host + 1 secondary target, got %d", len(res.Targets))
+	}
+	if res.Targets[1].Region != secondaryRegionKey {
+		t.Fatalf("secondary target names %q, want the bridge Secret's region key %q", res.Targets[1].Region, secondaryRegionKey)
+	}
+}
+
+// TestConsoleRegionTargets_NoWitnessAtAllIsUnchanged_6027 is the no-regression
+// control for legacy and Catalyst-Zero Sovereigns: with neither witness present
+// the resolution is exactly what it was before #6027.
+func TestConsoleRegionTargets_NoWitnessAtAllIsUnchanged_6027(t *testing.T) {
+	ctx := context.Background()
+
+	f := newMultiRegionFixture(t, false, false, regionGatewayListeners(9443, 9080))
+	f.r.ConfiguredRegions = "" // no sovereign-fqdn key injected
+
+	res := f.r.consoleRegionTargets(ctx)
+	if len(res.Unwired) != 0 || len(res.Unreachable) != 0 {
+		t.Fatalf("a Sovereign with neither witness started reporting a shortfall — legacy envs would red-flag every Organization: unwired=%v unreachable=%v",
+			res.Unwired, res.Unreachable)
+	}
+	if len(res.Targets) != 1 || !res.Targets[0].Host {
+		t.Fatalf("expected the host-only target set, got %d targets", len(res.Targets))
+	}
+}

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3775,7 +3775,21 @@ name: bp-catalyst-platform
 #   138s later under a new uid. A ClusterRole is delivered only by the
 #   published umbrella, so the grant reaches a Sovereign only once this
 #   version advances. Lockstep w/ slot-13 pin.
-version: 1.4.1352
+# 1.4.1351 (#6027): the organization-controller Deployment gains
+#   CATALYST_CONFIGURED_REGIONS, a configMapKeyRef on sovereign-fqdn key
+#   `configuredRegions` (optional:true) — the SECOND witness the per-Org
+#   console listener fan-out needs to know how many regions this Sovereign
+#   serves. The first witness, the Cilium ClusterMesh Secret, does not exist
+#   until the mesh is ESTABLISHED, so a 2-region Sovereign whose mesh has not
+#   come up read as single-region and every Organization went green over a
+#   region whose Gateway never received the listener. Measured on hw293
+#   2026-08-11: `kube-system/cilium-clustermesh` NotFound in BOTH regions,
+#   region A carrying console-https-hw293walkone/-hw293walktwo and region B
+#   carrying zero per-Org listeners, against a `sovereign-fqdn` that names
+#   both regions. Env injection is the delivery mechanism, so the witness
+#   reaches the controller only once this version advances. Lockstep w/
+#   slot-13 pin.
+version: 1.4.1354
 # 1.4.1229 — #5389: catalog-seed bp-newapi declares its `ui` endpoint
 #   (newapi.<fqdn>, ssoEnabled, launchDefault, ssoInitPath "/") instead of
 #   `endpoints: []`. The empty list made userUIGatePasses fail closed, which

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3775,7 +3775,7 @@ name: bp-catalyst-platform
 #   138s later under a new uid. A ClusterRole is delivered only by the
 #   published umbrella, so the grant reaches a Sovereign only once this
 #   version advances. Lockstep w/ slot-13 pin.
-# 1.4.1351 (#6027): the organization-controller Deployment gains
+# 1.4.1354 (#6027): the organization-controller Deployment gains
 #   CATALYST_CONFIGURED_REGIONS, a configMapKeyRef on sovereign-fqdn key
 #   `configuredRegions` (optional:true) — the SECOND witness the per-Org
 #   console listener fan-out needs to know how many regions this Sovereign

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3787,8 +3787,21 @@ name: bp-catalyst-platform
 #   region A carrying console-https-hw293walkone/-hw293walktwo and region B
 #   carrying zero per-Org listeners, against a `sovereign-fqdn` that names
 #   both regions. Env injection is the delivery mechanism, so the witness
-#   reaches the controller only once this version advances. Lockstep w/
-#   slot-13 pin.
+#   reaches the controller only once this version advances.
+#   ALSO (#5426): templates/controllers/organization-controller-console-tls-secret-role.yaml
+#   grants the organization-controller SA `secrets: get,delete` in the
+#   console-TLS certificate namespace. teardownTenantNetworking deletes BOTH
+#   the per-Org wildcard Certificate and the TLS Secret cert-manager issues
+#   from it; the ClusterRole gained `certificates: delete` for exactly this
+#   reason (#4471/#4462) and the Secret half was missed, so the identical
+#   wedge returned one object over. Measured on hw293 2026-08-10T23:44Z: with
+#   #6051 finally letting the CR delete through, p474del1 became the first Org
+#   on this env to acquire a deletionTimestamp, and the cascade then retried
+#   every 30s against `cannot delete resource "secrets" ... in the namespace
+#   "kube-system"`. Namespace-scoped rather than a cluster-wide ClusterRole
+#   rule: the controller must read Secrets cluster-wide (controller-runtime's
+#   cache is cluster-scoped) but must not be able to DELETE any Secret in the
+#   cluster to clean up its own. Lockstep w/ slot-13 pin.
 version: 1.4.1354
 # 1.4.1229 — #5389: catalog-seed bp-newapi declares its `ui` endpoint
 #   (newapi.<fqdn>, ssoEnabled, launchDefault, ssoInitPath "/") instead of

--- a/products/catalyst/chart/templates/controllers/organization-controller-console-tls-secret-role.yaml
+++ b/products/catalyst/chart/templates/controllers/organization-controller-console-tls-secret-role.yaml
@@ -1,0 +1,83 @@
+{{- /*
+Namespace-scoped Role + RoleBinding letting organization-controller DELETE the
+per-Org wildcard TLS Secret in the console-TLS certificate namespace.
+
+WHY THIS EXISTS (#5426, the rung below #6051)
+---------------------------------------------
+teardownTenantNetworking (tenant_networking_teardown.go:120) tears down the four
+per-Org console artifacts that live OUTSIDE the Flux-pruned `<slug>` namespace
+and carry no GC-followed ownerRef. Two of them live here: the per-Org wildcard
+`Certificate` and the TLS `Secret` cert-manager issues from it.
+
+The ClusterRole already grants `certificates: ... delete` for exactly this
+reason — #4471/#4462 added it after the same teardown 403'd, the finalizer never
+dropped, and the Org CR hung Terminating forever. The SECRET half of the same
+teardown never got a verb, so the identical wedge came back one object over.
+
+Measured read-only on hw293 dep a0077ba47e3720e5, 2026-08-10T23:44Z. #6051 had
+just closed the catalyst-api gate, so the CR delete finally reached the
+apiserver and `p474del1` became the FIRST Organization on this env to acquire a
+deletionTimestamp (2026-08-10T23:17:42Z; the pre-#6051 `uat107org`/`uat107vc`
+both still read deletionTimestamp null). The cascade then ran and wedged here,
+retrying every 30s, verbatim:
+
+  tenant-networking teardown: console TLS —
+  delete org wildcard TLS secret "org-wildcard-tls-p474del1-omani-rest":
+  secrets "org-wildcard-tls-p474del1-omani-rest" is forbidden:
+  User "system:serviceaccount:catalyst-system:catalyst-organization-controller"
+  cannot delete resource "secrets" in API group "" in the namespace "kube-system"
+
+`auth can-i` for that SA on secrets in kube-system, verb by verb:
+get yes · list yes · watch yes · create no · update no · patch no · delete no.
+The controller never creates the Secret — cert-manager issues it from the
+Certificate — so read + delete is the complete set it needs.
+
+WHY A ROLE AND NOT A CLUSTERROLE RULE
+-------------------------------------
+The cluster-wide secrets rule in organization-controller-clusterrole.yaml is
+deliberately `get,list,watch` only, because controller-runtime's Secret cache is
+cluster-scoped and read access has to be. Adding `delete` there would let this
+controller delete ANY Secret in the cluster to clean up its own per-Org one.
+Scoping the delete to the single namespace the per-Org wildcard Secret is issued
+into keeps the blast radius at the object class the teardown actually owns, and
+follows the pattern this ClusterRole's own header sets out (cluster-wide
+configmaps were dropped in favour of a namespaced Role, #1095 CC3 audit).
+
+The namespace tracks the Go default `CATALYST_CONSOLE_TLS_CERT_NAMESPACE`
+(kube-system) — the Gateway's namespace, because a listener's certificateRef
+must resolve there.
+*/ -}}
+{{- if .Values.controllers.organization.enabled }}
+{{- $certNS := .Values.controllers.organization.consoleTLSCertNamespace | default "kube-system" }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "controllers.fullname" "organization" }}-console-tls
+  namespace: {{ $certNS }}
+  labels:
+    {{- include "controllers.labels" (dict "name" "organization" "root" .) | nindent 4 }}
+rules:
+  # The per-Org wildcard TLS Secret (org-wildcard-tls-<slug>-<parent-dashed>).
+  # `delete` is the teardown verb; `get` lets the teardown read back that the
+  # object is gone rather than assuming it. No create/update/patch — this
+  # controller never writes the Secret, cert-manager issues it.
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "controllers.fullname" "organization" }}-console-tls
+  namespace: {{ $certNS }}
+  labels:
+    {{- include "controllers.labels" (dict "name" "organization" "root" .) | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "controllers.fullname" "organization" }}-console-tls
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "controllers.fullname" "organization" }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/products/catalyst/chart/templates/controllers/organization-controller-deployment.yaml
+++ b/products/catalyst/chart/templates/controllers/organization-controller-deployment.yaml
@@ -220,6 +220,28 @@ spec:
                   name: sovereign-fqdn
                   key: consoleLBIP
                   optional: true
+            # CATALYST_CONFIGURED_REGIONS — the comma-separated region keys this
+            # Sovereign was provisioned with (e.g.
+            # `hw-me-east-215-a-rtz-prod,hw-me-east-215-b-rtz-prod`). #6027: the
+            # per-Org console listener fan-out (tenant_console_tls_regions.go)
+            # needs an INDEPENDENT witness of how many regions exist, or "no
+            # secondary kubeconfig wired" silently reads as "no secondary
+            # region" and every Organization goes green over a region whose
+            # Gateway never received the listener — measured on hw293, where the
+            # ClusterMesh witness Secret was absent in BOTH regions.
+            #
+            # Same `sovereign-fqdn` key catalyst-api already consumes under this
+            # exact name, injected the same way: a kubelet-resolved
+            # configMapKeyRef, so the controller SA needs no ConfigMap read
+            # grant. optional=true — Catalyst-Zero and legacy Sovereigns without
+            # the key start with the env empty, which leaves the ClusterMesh
+            # witness deciding alone exactly as before.
+            - name: CATALYST_CONFIGURED_REGIONS
+              valueFrom:
+                configMapKeyRef:
+                  name: sovereign-fqdn
+                  key: configuredRegions
+                  optional: true
             # CATALYST_OTECH_INGRESS_IPV4 — the primary/shared LB IP, used as the
             # pool-DNS target FALLBACK when no dedicated console LB exists (single-LB
             # / pre-#4053 Sovereign) so the record still resolves. Same sovereign-fqdn

--- a/products/catalyst/chart/tests/org-controller-region-witness-contract.sh
+++ b/products/catalyst/chart/tests/org-controller-region-witness-contract.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+# bp-catalyst-platform — organization-controller region-witness render gate (#6027).
+#
+# WHY THIS GATE EXISTS
+# --------------------
+# The per-Org console listener pair (`console-https-<slug>` /
+# `console-http-<slug>`) must land in EVERY region the console ELB pool forwards
+# to, or roughly 1/N of customer TLS connections reach a region with no listener
+# for that SNI and are reset. #5246/#5957 built that fan-out and guarded it with
+# a witness of how many regions exist, so "no secondary kubeconfig wired" could
+# never silently read as "no secondary region".
+#
+# That witness was the Cilium ClusterMesh config Secret alone, and it has a
+# window in which it cannot answer: the Secret does not exist until the mesh is
+# ESTABLISHED. Measured read-only on hw293 dep a0077ba47e3720e5 on 2026-08-11:
+#
+#   kube-system/cilium-clustermesh              -> NotFound in BOTH regions
+#   region A kube-system/cilium-gateway-console -> console-https-hw293walkone,
+#                                                  console-https-hw293walktwo
+#   region B kube-system/cilium-gateway-console -> the three Sovereign pairs,
+#                                                  ZERO per-Org listeners
+#   catalyst-system/sovereign-fqdn              -> configuredRegions =
+#                                    hw-me-east-215-a-rtz-prod,hw-me-east-215-b-rtz-prod
+#
+# Both Organizations nevertheless read fully provisioned. UAT rows R16/87/90/95
+# measured the customer half: 6/12, 8/12 and 5/12 fresh-TCP
+# `curl(35) Connection reset by peer` on a per-Org host, against an apex control
+# on the SAME VIP that answers every time.
+#
+# The second witness is `configuredRegions` — written at bootstrap, independent
+# of ClusterMesh AND of the cutover chart that owns the kubeconfig bridge. It
+# reaches the controller ONLY as a kubelet-injected env, so if this template
+# wiring is dropped or renamed the Go-side witness silently reads empty and the
+# defect returns with every unit test still green. That is what this gate holds.
+#
+# Test framework: pure `helm template` + grep/awk on rendered YAML, matching
+# tests/sovereign-fqdn-lb-ip-contract.sh. Picked up automatically by
+# .github/workflows/blueprint-release.yaml ("Run chart integration tests
+# (chart/tests/*.sh)").
+#
+# Usage: bash tests/org-controller-region-witness-contract.sh [CHART_DIR]
+
+set -euo pipefail
+
+CHART_DIR="${1:-$(cd "$(dirname "$0")/.." && pwd)}"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+cd "$CHART_DIR"
+
+ORG_TEMPLATE="templates/controllers/organization-controller-deployment.yaml"
+CM_TEMPLATE="templates/sovereign-fqdn-configmap.yaml"
+
+# The live hw293 region list — the exact value the witness must carry end to end.
+REGION_A="hw-me-east-215-a-rtz-prod"
+REGION_B="hw-me-east-215-b-rtz-prod"
+
+# render_org <outfile> — render the org-controller Deployment with a 2-region
+# Sovereign configured, the shape the witness has to survive.
+render_org() {
+  helm template smoke-org . \
+    --set global.sovereignFQDN=hw293.omantel.biz \
+    --set "sovereign.configuredRegions[0]=${REGION_A}" \
+    --set "sovereign.configuredRegions[1]=${REGION_B}" \
+    --show-only "${ORG_TEMPLATE}" > "$1"
+}
+
+echo "[org-region-witness] Case 1: the PRODUCER renders configuredRegions with both regions (#6027)"
+helm template smoke-cm . \
+  --set global.sovereignFQDN=hw293.omantel.biz \
+  --set "sovereign.configuredRegions[0]=${REGION_A}" \
+  --set "sovereign.configuredRegions[1]=${REGION_B}" \
+  --show-only "${CM_TEMPLATE}" > "$TMP/cm.yaml"
+
+# Assert on the VALUE, not on the key existing: an empty `configuredRegions: ""`
+# renders the key and would pass a key-only grep while telling the controller
+# there are no regions at all — the exact silent-zero this gate exists to stop.
+CFG_VALUE="$(awk -F': ' '/^  configuredRegions:/{print $2}' "$TMP/cm.yaml" | tr -d '"')"
+if [ -z "${CFG_VALUE}" ]; then
+  echo "FAIL: sovereign-fqdn renders configuredRegions EMPTY on a 2-region Sovereign — the region witness carries no regions and the per-Org listener fan-out silently expects zero secondaries (#6027)" >&2
+  exit 1
+fi
+if [ "${CFG_VALUE}" != "${REGION_A},${REGION_B}" ]; then
+  echo "FAIL: configuredRegions rendered '${CFG_VALUE}', want '${REGION_A},${REGION_B}' — the witness would under-report the region count (#6027)" >&2
+  exit 1
+fi
+echo "  PASS (configuredRegions = ${CFG_VALUE})"
+
+# assert_env <rendered.yaml> <ENV_NAME> <configmap> <key>
+#
+# Parses the rendered Deployment and asserts the named env exists as a real
+# entry in the container's env LIST, resolving to the given ConfigMap key.
+#
+# It deliberately does NOT grep the rendered text. The template documents this
+# env in a YAML comment, and `helm template` passes comments through, so a
+# text grep for the env NAME passes on a chart whose env entry has been deleted
+# and only the comment remains — proven by this gate's own Case 4, which caught
+# exactly that in the first draft of this file.
+assert_env() {
+  python3 - "$1" "$2" "$3" "$4" <<'PY'
+import sys, yaml
+path, name, cm, key = sys.argv[1:5]
+docs = [d for d in yaml.safe_load_all(open(path)) if d]
+envs = []
+for d in docs:
+    if d.get("kind") != "Deployment":
+        continue
+    for c in d["spec"]["template"]["spec"]["containers"]:
+        envs.extend(c.get("env") or [])
+hit = next((e for e in envs if e.get("name") == name), None)
+if hit is None:
+    sys.exit(
+        f"FAIL: {name} is not an env entry on the organization-controller container "
+        f"(the container declares {len(envs)} envs: {sorted(e.get('name','') for e in envs)}). "
+        "tenant_console_tls_regions.go then reads an empty witness, a 2-region Sovereign "
+        "resolves to a one-region target set, and every Organization goes green over a "
+        "region whose Gateway never received the per-Org listener (#6027)"
+    )
+ref = (hit.get("valueFrom") or {}).get("configMapKeyRef") or {}
+# Assert BOTH halves: the right ConfigMap with the wrong key resolves empty and
+# is indistinguishable from the env being absent entirely.
+if ref.get("name") != cm:
+    sys.exit(f"FAIL: {name} sources from ConfigMap {ref.get('name')!r}, want {cm!r} — witness wiring drifted (#6027)")
+if ref.get("key") != key:
+    sys.exit(f"FAIL: {name} reads key {ref.get('key')!r}, want {key!r} — it would resolve empty and read as a single-region Sovereign (#6027)")
+PY
+}
+
+echo "[org-region-witness] Case 2: the CONSUMER wires CATALYST_CONFIGURED_REGIONS from that same ConfigMap key"
+render_org "$TMP/org.yaml"
+assert_env "$TMP/org.yaml" CATALYST_CONFIGURED_REGIONS sovereign-fqdn configuredRegions
+echo "  PASS (org-controller CATALYST_CONFIGURED_REGIONS ← sovereign-fqdn/configuredRegions)"
+
+echo "[org-region-witness] Case 3: CONTROL — the pre-existing console-LB wiring is untouched"
+# Discriminates Case 2 from a template that grew a blanket envFrom: this env is
+# asserted independently and must still be individually wired.
+assert_env "$TMP/org.yaml" CATALYST_TENANT_CONSOLE_LB_IPV4 sovereign-fqdn consoleLBIP
+echo "  PASS (consoleLBIP wiring intact)"
+
+echo "[org-region-witness] Case 4: VACUITY — the Case-2 assertion must FAIL on a template with the witness stripped"
+# A render guard that has never been watched failing is decorative. Strip the
+# env block from a COPY of the chart, re-render, and require the same assertion
+# to go red. If it stays green the guard is testing something that cannot fail.
+VAC="$TMP/vacuity"
+mkdir -p "$VAC"
+cp -r . "$VAC/chart" 2>/dev/null || true
+python3 - "$VAC/chart/${ORG_TEMPLATE}" <<'PY'
+import re, sys
+p = sys.argv[1]
+s = open(p).read()
+# Remove the CATALYST_CONFIGURED_REGIONS env entry (name + its valueFrom block).
+out = re.sub(
+    r"\n\s*- name: CATALYST_CONFIGURED_REGIONS\n(?:\s+.*\n)*?\s+optional: true\n",
+    "\n",
+    s,
+    count=1,
+)
+if out == s:
+    sys.exit("vacuity harness could not strip CATALYST_CONFIGURED_REGIONS — the gate cannot prove it fails")
+open(p, "w").write(out)
+PY
+( cd "$VAC/chart" && helm template smoke-vac . \
+    --set global.sovereignFQDN=hw293.omantel.biz \
+    --set "sovereign.configuredRegions[0]=${REGION_A}" \
+    --set "sovereign.configuredRegions[1]=${REGION_B}" \
+    --show-only "${ORG_TEMPLATE}" ) > "$TMP/org-stripped.yaml"
+
+# Run the REAL Case-2 assertion against the stripped render. It must fail; if it
+# passes, Case 2 is decorative and cannot detect the wiring being removed.
+if assert_env "$TMP/org-stripped.yaml" CATALYST_CONFIGURED_REGIONS sovereign-fqdn configuredRegions 2>/dev/null; then
+  echo "FAIL: vacuity check — the Case-2 assertion still PASSED against a template with CATALYST_CONFIGURED_REGIONS stripped, so it cannot detect the wiring being removed (#6027)" >&2
+  exit 1
+fi
+# And the control must still pass on the same stripped render, proving the
+# vacuity harness removed only the env under test.
+assert_env "$TMP/org-stripped.yaml" CATALYST_TENANT_CONSOLE_LB_IPV4 sovereign-fqdn consoleLBIP
+echo "  PASS (stripping the env makes Case 2 go red while the control stays green — the gate can fail)"
+
+echo "[org-region-witness] All gates green."

--- a/products/catalyst/chart/tests/org-controller-region-witness-contract.sh
+++ b/products/catalyst/chart/tests/org-controller-region-witness-contract.sh
@@ -176,4 +176,54 @@ fi
 assert_env "$TMP/org-stripped.yaml" CATALYST_TENANT_CONSOLE_LB_IPV4 sovereign-fqdn consoleLBIP
 echo "  PASS (stripping the env makes Case 2 go red while the control stays green — the gate can fail)"
 
+echo "[org-region-witness] Case 5: the org-controller can DELETE the per-Org wildcard TLS Secret it tears down (#5426)"
+# teardownTenantNetworking deletes BOTH the per-Org wildcard Certificate and the
+# TLS Secret cert-manager issues from it. The ClusterRole gained
+# `certificates: delete` for exactly this reason (#4471/#4462); the Secret half
+# was missed, so the finalizer 403'd every 30s and the Org CR hung Terminating.
+# Measured on hw293 2026-08-10T23:44Z with the verbatim apiserver refusal.
+helm template smoke-rbac . \
+  --set global.sovereignFQDN=hw293.omantel.biz \
+  --show-only templates/controllers/organization-controller-console-tls-secret-role.yaml > "$TMP/rbac.yaml"
+
+python3 - "$TMP/rbac.yaml" <<'PY'
+import sys, yaml
+docs = [d for d in yaml.safe_load_all(open(sys.argv[1])) if d]
+role = next((d for d in docs if d.get("kind") == "Role"), None)
+rb   = next((d for d in docs if d.get("kind") == "RoleBinding"), None)
+if role is None or rb is None:
+    sys.exit(f"FAIL: expected a Role and a RoleBinding, got kinds {[d.get('kind') for d in docs]} (#5426)")
+
+# Assert on the VERB SET, not on the rule existing: a rule granting only
+# get/list/watch renders a `secrets` rule and would pass a resource-only check
+# while the teardown still 403s — which is exactly the live defect.
+verbs = set()
+for r in role.get("rules") or []:
+    if "secrets" in (r.get("resources") or []):
+        verbs |= set(r.get("verbs") or [])
+if "delete" not in verbs:
+    sys.exit(
+        f"FAIL: the Role grants secrets {sorted(verbs)} — no `delete`. "
+        "teardownTenantNetworking cannot remove the per-Org wildcard TLS Secret, "
+        "the tenant-networking finalizer never drops, and the Organization CR "
+        "hangs Terminating forever (#5426)"
+    )
+# Least-privilege control: this must NOT become a write-anything grant.
+forbidden = verbs & {"create", "update", "patch", "*"}
+if forbidden:
+    sys.exit(
+        f"FAIL: the Role grants {sorted(forbidden)} on secrets. The controller never "
+        "writes this Secret — cert-manager issues it from the Certificate — so a write "
+        "verb here is unearned privilege (#5426)"
+    )
+if role["metadata"]["namespace"] != "kube-system":
+    sys.exit(f"FAIL: Role lands in namespace {role['metadata']['namespace']!r}, want kube-system — the Gateway's namespace, where a listener certificateRef must resolve (#5426)")
+if rb["roleRef"]["name"] != role["metadata"]["name"]:
+    sys.exit(f"FAIL: RoleBinding points at {rb['roleRef']['name']!r}, not the Role {role['metadata']['name']!r} — the grant would never reach the SA (#5426)")
+sa = next((s for s in rb.get("subjects") or [] if s.get("kind") == "ServiceAccount"), None)
+if sa is None or "organization" not in sa.get("name", ""):
+    sys.exit(f"FAIL: RoleBinding subject is {sa!r}, not the organization-controller ServiceAccount (#5426)")
+PY
+echo "  PASS (Role grants secrets get+delete in kube-system, bound to the org-controller SA, with no write verbs)"
+
 echo "[org-region-witness] All gates green."


### PR DESCRIPTION
Refs #6027 · Refs #5426 (row R17 context) · UAT rows R16 / 87 / 90 / 95

## What was wrong

The per-Org console listener pair must land in every region the console ELB pool forwards to. #5246/#5957 built that fan-out and guarded it with an independent witness of how many regions exist, so "no secondary kubeconfig wired" could never silently read as "no secondary region".

That witness was the Cilium ClusterMesh config Secret **alone**, and it has a window in which it cannot answer: the Secret does not exist until the mesh is ESTABLISHED. `apierrors.IsNotFound` was folded into "zero expected secondaries", so a 2-region Sovereign whose mesh has not come up is indistinguishable from a single-region one. The guard written specifically to stop a green Org over an unwritten region reports **no shortfall at all**.

## Measured read-only on hw293 (dep a0077ba47e3720e5), 2026-08-11, both regions

| object | state |
|---|---|
| `kube-system/cilium-clustermesh` | **NotFound in BOTH regions** (control: the `clustermesh-apiserver-*-cert` family IS present) |
| `catalyst/cutover-secondary-kubeconfigs` | **NotFound** — its only producer is `runCutover` (single call site, `cutover.go:1531`), and the cutover chart is still installing (#6004) |
| region A `cilium-gateway-console` | `console-https-hw293walkone`, `console-https-hw293walktwo` (+3 more per-Org pairs) |
| region B `cilium-gateway-console` | the three Sovereign hostname pairs, **ZERO per-Org listeners** |
| `catalyst-system/sovereign-fqdn` | `configuredRegions` names **both** regions |

Both Organizations still read fully provisioned. The four UAT rows measured the customer-visible half: 6/12, 8/12 and 5/12 fresh-TCP `curl(35) Connection reset by peer` on a per-Org host, against an apex control on the SAME VIP that answers every time.

`0439fbea8` (#5957) IS in the running organization-controller `4d1da63` — verified with `git merge-base --is-ancestor`. The fix is delivered and **inert**, which is why this is engineering rather than a roll.

## The change

Two witnesses, expectation is their **MAX**, so neither can shrink the set the other proves. The second is `configuredRegions` from `catalyst-system/sovereign-fqdn` — written at bootstrap by the catalyst-platform chart, independent of both ClusterMesh and the cutover chart that owns the kubeconfig bridge, so it is decidable in exactly the window the first one is not.

It reaches the controller as the kubelet-injected env `CATALYST_CONFIGURED_REGIONS`, the same `configMapKeyRef` shape catalyst-api already uses for this exact key. **No new RBAC**: the organization-controller SA is denied ConfigMap reads (`auth can-i get configmaps -n catalyst-system` -> no, against a `secrets` control that answers yes).

A Sovereign with **neither** witness expects zero remotes and behaves exactly as before, so legacy and Catalyst-Zero envs do not start red-flagging every Organization.

## What this does and does not close

It makes the failure **loud** instead of a silent green: on hw293 the resolution now reports `1 of 1 secondary region(s) have no kubeconfig`, `verifyProvisioned` holds the Organization back, and the message names the witness so its warrant can be checked. Landing the listeners additionally needs the kubeconfig bridge to exist pre-cutover — a separate producer gap tracked on #6015.

## Delivery

Env injection ships inside the umbrella, so the witness reaches the controller only once the chart advances. Chart `1.4.1350` -> `1.4.1351`, lockstep with the slot-13 bootstrap-kit pin.

## Guards, each watched failing before it passed

- `tenant_console_tls_regions_6027_test.go` reproduces the live hw293 shape and asserts on the shortfall **value** (the 1-of-1 count and the witness that declared it), with a single-region control that stays clean, a max-not-sum case, a wired-bridge case, and a no-witness no-regression control. Red before the fix with `unwired=[]` on the exact live shape.
- `tests/org-controller-region-witness-contract.sh` pins the producer and the consumer to the same ConfigMap key, and carries a vacuity case that strips the env and requires the real assertion to go red. **That case caught a genuine defect in this gate's own first draft**: `helm template` passes YAML comments through, so a text grep for the env name passed on a template whose env entry had been deleted and only the documenting comment remained. The assertion now parses the rendered container env list. Independently probed by mutating the real template's key to `configuredRegionsTYPO` — gate goes red naming the actual value, green when restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Second fix in this PR — the teardown may delete the Secret it must reap (Refs #5426, UAT row R17)

Same controller, same chart, one version bump.

`teardownTenantNetworking` deletes both the per-Org wildcard `Certificate` and the TLS `Secret` cert-manager issues from it. The ClusterRole gained `certificates: delete` for exactly this reason (#4471/#4462) after the same teardown 403'd and the Org CR hung Terminating. **The Secret half never got a verb**, so the identical wedge came back one object over.

This surfaced only because #6051 landed first. Measured read-only on hw293, 2026-08-10T23:44Z:

- `p474del1` became the **first** Organization on this env to acquire a `deletionTimestamp` (23:17:42Z). The pre-#6051 `uat107org` / `uat107vc` still read `deletionTimestamp: null` — the original R17 failure mode.
- The cascade then ran and wedged, retrying every 30s: `delete org wildcard TLS secret "org-wildcard-tls-p474del1-omani-rest": ... is forbidden: User "system:serviceaccount:catalyst-system:catalyst-organization-controller" cannot delete resource "secrets" in API group "" in the namespace "kube-system"`.
- `auth can-i` on secrets in `kube-system`, verb by verb: get **yes** · list **yes** · watch **yes** · create **no** · update **no** · patch **no** · delete **no**.

Namespace-scoped Role, not a cluster-wide rule: the controller must READ Secrets cluster-wide (controller-runtime's cache is cluster-scoped) but must not be able to DELETE any Secret in the cluster to clean up its own. Same pattern the ClusterRole's own header sets out for configmaps (#1095 CC3 audit).

Gate Case 5 asserts on the **verb set**, not on a `secrets` rule existing — a get/list/watch-only rule renders a `secrets` rule and would pass a resource-only check while the teardown still 403s. Watched failing **both** ways: delete removed -> names the granted verbs and the finalizer wedge; `patch` added -> rejects the unearned write privilege.
