### PR TITLE
fix(jobs,openbao): the cutover tree was ordered by the alphabet, and openbao's DR witness could never take a lease

### DIFF
--- a/clusters/_template/bootstrap-kit/08-openbao.yaml
+++ b/clusters/_template/bootstrap-kit/08-openbao.yaml
@@ -180,7 +180,7 @@ spec:
       #   trusting it into /ui/vault/secrets, instead of trusting a
       #   client-side-only tokenExpirationEpoch that can't see a server-side
       #   revoke — closes the "no login form but 403 on mounts" gap.
-      version: 1.2.66
+      version: 1.2.67
       sourceRef:
         kind: HelmRepository
         name: bp-openbao

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1374,7 +1374,7 @@ spec:
       #   provisioned. Env injection ships inside this umbrella, so the
       #   witness reaches the controller only once this pin advances. Lockstep
       #   w/ products/catalyst/chart/Chart.yaml.
-      version: 1.4.1358
+      version: 1.4.1359
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/platform/openbao/blueprint.yaml
+++ b/platform/openbao/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.2.66  # lockstep with chart/Chart.yaml (#5829: both sso-configure ACL-policy writes now GATE the tick — a swallowed policy failure left auth/oidc/role/operator naming a policy that does not exist, so every token 403'd incl. sys/internal/ui/mounts — UAT row 183)
+  version: 1.2.67  # lockstep with chart/Chart.yaml (#5829: both sso-configure ACL-policy writes now GATE the tick — a swallowed policy failure left auth/oidc/role/operator naming a policy that does not exist, so every token 403'd incl. sys/internal/ui/mounts — UAT row 183)
   card:
     title: openbao
     summary: OpenBao secret backend. 3-node Raft per region (independent quorum, async perf-replication across regions). MPL 2.0 — drop-in Vault replacement.

--- a/platform/openbao/chart/Chart.yaml
+++ b/platform/openbao/chart/Chart.yaml
@@ -256,7 +256,7 @@ name: bp-openbao
 #   The landing page now calls auth/token/lookup-self BEFORE trusting a
 #   cached token; a non-200 clears it and falls through to a fresh OIDC
 #   round-trip instead of dead-ending on a silent 403.
-version: 1.2.66
+version: 1.2.67
 # 1.2.51 (#3888, Refs #3847): prov-time openbao KV-seed mechanism — the
 # auth-bootstrap Job reads a one-shot cloud-init `openbao-bootstrap-seed`
 # Secret + writes its keys into KV at secret/<prefix>/* with the still-valid

--- a/platform/openbao/chart/values.yaml
+++ b/platform/openbao/chart/values.yaml
@@ -711,17 +711,39 @@ continuum:
   # one-directional, so it is an operator-confirmed action (DoD-8 step 8.6),
   # not an automatic lag-breach flip.
   autoFailover: false
-  # Lease witness — dns-quorum by default (the same fallback bp-cnpg-pair
-  # uses). Per-Sovereign overlay may switch to cloudflare-kv.
+  # Lease witness — k8s-lease (#3829) is the air-gappable DEFAULT: a
+  # native coordination.k8s.io/v1 Lease in the control-plane cluster,
+  # durable etcd-backed CAS, zero external dependency (so it survives
+  # the Pillar-5 air-gap). The continuum-controller ClusterRole already
+  # grants coordination.k8s.io/leases, so no RBAC change is needed.
+  #
+  # This default used to read `kind: dns-quorum` with resolvers
+  # 10.43.0.10/.11/.12, and every Continuum it rendered was born dead —
+  # the same defect #6074 removed from the per-Org GitOps writer, whose
+  # comment then claimed that writer "was the last producer still
+  # selecting the dead backend". This chart was the counter-example.
+  # Three independent reasons re-pointing the resolvers would not have
+  # helped, all measured rather than assumed:
+  #
+  #  1. dns-quorum's registered factory builds its client with a nil
+  #     TXTWriter unconditionally (internal/witness/dnsquorum/client.go),
+  #     so Acquire can never take the lease whatever resolvers it gets.
+  #  2. kube-dns is not authoritative for the lease zone, so the read
+  #     side finds no TXT record to reach a majority either.
+  #  3. kube-dns is REGION-LOCAL (measured on hw293: region A serves
+  #     10.96.0.10, region B serves 10.97.0.10). A witness exists so two
+  #     regions can arbitrate ONE slot; per-region resolver sets can
+  #     never form the shared quorum that requires.
+  #
+  # 10.43.0.0/16 is k3s's DEFAULT service CIDR and these Sovereigns
+  # allocate from 10.96.0.0/12, so .11 and .12 were never anything at
+  # all. Matches the shipped defaults of bp-cnpg-pair and bp-postgres.
+  # Per-Sovereign overlay may still switch to cloudflare-kv.
   leaseClient:
-    kind: dns-quorum
+    kind: k8s-lease
     config:
       ttlSeconds: 30
       renewSeconds: 10
-      resolvers:
-        - "10.43.0.10"
-        - "10.43.0.11"
-        - "10.43.0.12"
   # PowerDNS zone the lua-record probe target is flipped in (the Sovereign
   # FQDN). Per-Sovereign overlay sets it.
   pdmZone: ""

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-10T23:20:57.297Z",
+  "generatedAt": "2026-08-10T23:57:47.871Z",
   "blueprints": [
     {
       "id": "bp-agenity",
@@ -3620,7 +3620,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "1.2.66",
+      "version": "1.2.67",
       "section": "pts-2-3-per-sovereign-supporting-services",
       "depends": [],
       "shareable": false,

--- a/products/catalyst/bootstrap/api/internal/handler/cutover_activity_bridge.go
+++ b/products/catalyst/bootstrap/api/internal/handler/cutover_activity_bridge.go
@@ -270,3 +270,57 @@ func parseCutoverStatusTime(s string) time.Time {
 	}
 	return time.Now().UTC()
 }
+
+// mergeCutoverStepOrder returns the slug sequence the cutover steps are
+// projected in — and therefore, via projectCutoverResumeSeed's
+// Order: i+1 and ActivityBridge.dependsOnForStepLocked, the dependency
+// edges the execution tree renders (issue #6093).
+//
+// The two arguments are the platform's two step sources, and they are
+// NOT interchangeable:
+//
+//   - ordered — from listCutoverSteps, sorted by the
+//     `bp.openova.io/cutover-order` label on each cutover-step-NN-<slug>
+//     ConfigMap. This is the ONLY source that knows the real execution
+//     sequence.
+//   - fromStatus — from listStepNamesFromStatus, i.e. the durable
+//     self-sovereign-cutover-status ConfigMap. A ConfigMap's data is an
+//     unordered map, so this source CANNOT carry a sequence; it ends in
+//     sort.Strings and is therefore alphabetical by construction.
+//
+// Reading the sequence off fromStatus produced a plausible-looking tree
+// in which every one of the eleven steps was in the wrong slot, with the
+// step-08 deny-egress sovereignty proof rendered third (measured on
+// hw293, 2026-08-11). So order comes from `ordered`, always.
+//
+// They are unioned rather than chosen between, because each covers a
+// case the other misses. `ordered` misses a step whose ConfigMap is gone
+// after a completed cutover — precisely the durability case #3646 built
+// the status replay for. `fromStatus` misses nothing but knows no order.
+// A step known only to the durable record has no order label to claim a
+// position with, so it trails the order-bearing steps in the
+// deterministic order it arrived in, rather than being interleaved into
+// a slot it cannot justify.
+//
+// Blank slugs are dropped: ActivityBridge skips them anyway, and letting
+// one occupy a slot would shift every edge after it.
+func mergeCutoverStepOrder(ordered, fromStatus []string) []string {
+	out := make([]string, 0, len(ordered)+len(fromStatus))
+	seen := make(map[string]struct{}, len(ordered)+len(fromStatus))
+	appendUnique := func(names []string) {
+		for _, n := range names {
+			n = strings.TrimSpace(n)
+			if n == "" {
+				continue
+			}
+			if _, dup := seen[n]; dup {
+				continue
+			}
+			seen[n] = struct{}{}
+			out = append(out, n)
+		}
+	}
+	appendUnique(ordered)
+	appendUnique(fromStatus)
+	return out
+}

--- a/products/catalyst/bootstrap/api/internal/handler/jobs.go
+++ b/products/catalyst/bootstrap/api/internal/handler/jobs.go
@@ -481,15 +481,32 @@ func (h *Handler) chrootSeedCutoverActivity(ctx context.Context, dep *Deployment
 		return
 	}
 	// Nothing to project until the cutover has at least been discovered.
-	// Prefer the durable per-step keys; fall back to live step discovery
-	// so a cutover that's installed-but-never-run still shows its pending
-	// steps (the honest "tethered, 0/N" picture).
-	stepNames := listStepNamesFromStatus(status)
-	if len(stepNames) == 0 {
-		if steps, derr := listCutoverSteps(ctx, deps); derr == nil {
-			stepNames = stepNamesFromSteps(steps)
-		}
+	// UNION the two step sources, order-bearing one FIRST (issue #6093).
+	//
+	// This used to prefer listStepNamesFromStatus and reach
+	// listCutoverSteps only when that came back empty. It never did: the
+	// chart pre-seeds all eleven `step.<name>.result` keys at install
+	// (09-cutover-status-configmap.yaml), so on any Sovereign where the
+	// chart landed the status map is non-empty from the first second and
+	// the order-bearing branch was unreachable. What shipped instead was
+	// listStepNamesFromStatus's sort.Strings output — a ConfigMap's data
+	// is an unordered map, so that source cannot carry a sequence — which
+	// made every projected dependsOn edge alphabetical. On hw293 that put
+	// the step-08 deny-egress sovereignty proof third in the tree.
+	//
+	// mergeCutoverStepOrder takes the sequence from the ConfigMap order
+	// labels and still surfaces any step present only in the durable
+	// record (a completed cutover whose step ConfigMaps were reaped — the
+	// #3646 case), so an installed-but-never-run chain still shows the
+	// honest "tethered, 0/N" picture in the right order.
+	var orderedNames []string
+	if steps, derr := listCutoverSteps(ctx, deps); derr == nil {
+		orderedNames = stepNamesFromSteps(steps)
+	} else {
+		h.log.Debug("chroot seed: ordered cutover step discovery failed; falling back to the durable record's order",
+			"depId", dep.ID, "err", derr)
 	}
+	stepNames := mergeCutoverStepOrder(orderedNames, listStepNamesFromStatus(status))
 	if len(stepNames) == 0 {
 		// Cutover chart not installed / no steps — nothing to surface.
 		return

--- a/products/catalyst/bootstrap/api/internal/handler/jobs_cutover_step_order_6093_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/jobs_cutover_step_order_6093_test.go
@@ -1,0 +1,206 @@
+// jobs_cutover_step_order_6093_test.go — pins the ORDER the `/jobs`
+// read path projects the eleven self-sovereign cutover steps in, and
+// therefore the dependency edges the execution tree renders (issue
+// #6093).
+//
+// # What went wrong
+//
+// chrootSeedCutoverActivity preferred listStepNamesFromStatus() — which
+// reads the durable `self-sovereign-cutover-status` ConfigMap and ends
+// in sort.Strings, because a ConfigMap's data map carries no sequence —
+// and only fell back to the order-bearing listCutoverSteps() when that
+// returned EMPTY. The chart pre-seeds all eleven `step.<name>.result`
+// keys at install (09-cutover-status-configmap.yaml), so the empty case
+// never happens on a Sovereign where the chart installed: the
+// correctly-ordered branch was unreachable and the alphabetical one was
+// permanently in charge.
+//
+// Measured on hw293.omantel.biz (dep a0077ba47e3720e5, 2026-08-11), with
+// the chart Ready at 0.1.179 and no cutover ever run, the projected rows
+// chained catalyst-api-env-patch -> crossplane-provider-pivot ->
+// egress-block-test -> ... — pure lexicographic order, with the step-08
+// deny-egress sovereignty proof rendered third. All eleven positions
+// were wrong.
+//
+// # What these tests hold
+//
+// The assertions are on the ORDERED SLUG VALUES, never on the count: a
+// length check passes on any permutation, which is exactly the mistake
+// that let the scramble ship. Each test names the sequence it demands.
+package handler
+
+import (
+	"strings"
+	"testing"
+)
+
+// theElevenStepsInChartOrder is the declared execution order carried by
+// the `bp.openova.io/cutover-order` label on the cutover-step-NN-<slug>
+// ConfigMaps — read live off hw293 and identical to the ADR-0002 /
+// CLAUDE.md eleven-step chain.
+var theElevenStepsInChartOrder = []string{
+	"gitea-mirror",              // 01
+	"harbor-projects",           // 02
+	"harbor-prewarm",            // 03
+	"registry-pivot",            // 04
+	"flux-gitrepository-patch",  // 05
+	"helmrepository-patches",    // 06
+	"catalyst-api-env-patch",    // 07
+	"egress-block-test",         // 08 — the deny-egress sovereignty proof
+	"gitea-token-mint",          // 09
+	"vcluster-registry-pivot",   // 10
+	"crossplane-provider-pivot", // 11
+}
+
+// statusKeysFor builds the durable status map the chart pre-seeds at
+// install: one empty `step.<name>.result` per declared step, and nothing
+// that encodes order. Returned as a Go map precisely because a map has
+// no iteration order — the same property the real ConfigMap has.
+func statusKeysFor(names []string) map[string]string {
+	out := map[string]string{
+		"cutoverComplete": "false",
+		"progressPercent": "0",
+		"totalSteps":      "11",
+	}
+	for _, n := range names {
+		out["step."+n+".result"] = ""
+		out["step."+n+".startedAt"] = ""
+		out["step."+n+".finishedAt"] = ""
+		out["step."+n+".jobName"] = ""
+	}
+	return out
+}
+
+// TestMergeCutoverStepOrder_ChartOrderWins is the headline: when the
+// order-bearing step ConfigMaps are readable, the projection order is
+// the CHART's, not the alphabet's.
+func TestMergeCutoverStepOrder_ChartOrderWins(t *testing.T) {
+	status := listStepNamesFromStatus(statusKeysFor(theElevenStepsInChartOrder))
+
+	// Control on the INPUT, so this test cannot pass by accident: the
+	// status-derived list must genuinely be the scrambled one. If
+	// listStepNamesFromStatus ever started preserving order, the
+	// assertion below would be vacuous and we want to know.
+	if equalSlugs(status, theElevenStepsInChartOrder) {
+		t.Fatalf("control failed: the status-derived order is ALREADY the chart order, so this test proves nothing.\n got %v", status)
+	}
+	if got, want := strings.Join(status, ","), "catalyst-api-env-patch,crossplane-provider-pivot,egress-block-test,flux-gitrepository-patch,gitea-mirror,gitea-token-mint,harbor-prewarm,harbor-projects,helmrepository-patches,registry-pivot,vcluster-registry-pivot"; got != want {
+		t.Fatalf("control failed: expected listStepNamesFromStatus to return the alphabetical order.\n got  %s\n want %s", got, want)
+	}
+
+	got := mergeCutoverStepOrder(theElevenStepsInChartOrder, status)
+	if !equalSlugs(got, theElevenStepsInChartOrder) {
+		t.Errorf("projection order is not the chart's execution order.\n got  %v\n want %v", got, theElevenStepsInChartOrder)
+	}
+
+	// Name the single most misleading consequence explicitly, so a
+	// regression reads as what it is rather than as a diff of two lists.
+	if idx := indexOfSlug(got, "egress-block-test"); idx != 7 {
+		t.Errorf("egress-block-test is the step-08 deny-egress sovereignty proof; projected at position %d, want position 8", idx+1)
+	}
+}
+
+// TestMergeCutoverStepOrder_DurableOnlyStepSurvives holds law 3: a step
+// that exists only in the durable record — its ConfigMap reaped after a
+// completed cutover, which is the whole reason the status-derived path
+// exists (#3646) — must still project, and must land AFTER every
+// order-bearing step rather than being interleaved into a position it
+// cannot claim (law 4).
+func TestMergeCutoverStepOrder_DurableOnlyStepSurvives(t *testing.T) {
+	// The live ConfigMaps have lost two steps; the durable record still
+	// names all eleven. "aaa-reaped" is deliberately alphabetically
+	// FIRST so an accidental re-sort would move it to the front and be
+	// caught here.
+	ordered := []string{"gitea-mirror", "harbor-projects"}
+	durable := listStepNamesFromStatus(statusKeysFor([]string{
+		"gitea-mirror", "harbor-projects", "aaa-reaped", "zzz-reaped",
+	}))
+
+	got := mergeCutoverStepOrder(ordered, durable)
+	want := []string{"gitea-mirror", "harbor-projects", "aaa-reaped", "zzz-reaped"}
+	if !equalSlugs(got, want) {
+		t.Fatalf("durable-only steps must survive and trail the order-bearing ones.\n got  %v\n want %v", got, want)
+	}
+}
+
+// TestMergeCutoverStepOrder_NoOrderBearingSourceStillProjects holds the
+// vacuity case: when listCutoverSteps yields nothing (step ConfigMaps
+// unreadable, or none carries the order label), the projection must
+// still surface every step the durable record names. Returning an empty
+// slice here would silently erase the Cutover group from /jobs — a
+// worse failure than the wrong order.
+func TestMergeCutoverStepOrder_NoOrderBearingSourceStillProjects(t *testing.T) {
+	durable := listStepNamesFromStatus(statusKeysFor(theElevenStepsInChartOrder))
+
+	got := mergeCutoverStepOrder(nil, durable)
+	if len(got) != len(theElevenStepsInChartOrder) {
+		t.Fatalf("with no order-bearing source the projection must still surface every durable step.\n got  %v (%d)\n want %d steps", got, len(got), len(theElevenStepsInChartOrder))
+	}
+	if !equalSlugs(got, durable) {
+		t.Errorf("with no order-bearing source the durable order must pass through unchanged.\n got  %v\n want %v", got, durable)
+	}
+}
+
+// TestMergeCutoverStepOrder_NoDurableRecordStillProjects is the mirror:
+// a chart installed but never run whose status ConfigMap has not been
+// written yet must still project its steps, in chart order.
+func TestMergeCutoverStepOrder_NoDurableRecordStillProjects(t *testing.T) {
+	got := mergeCutoverStepOrder(theElevenStepsInChartOrder, nil)
+	if !equalSlugs(got, theElevenStepsInChartOrder) {
+		t.Errorf("with no durable record the chart order must pass through unchanged.\n got  %v\n want %v", got, theElevenStepsInChartOrder)
+	}
+}
+
+// TestMergeCutoverStepOrder_NoDuplicatesWhenBothSourcesAgree is the
+// idempotency floor: the union of two sources naming the same eleven
+// steps is eleven rows, not twenty-two. A duplicated slug would mint a
+// second leaf Job per step on every /jobs read.
+func TestMergeCutoverStepOrder_NoDuplicatesWhenBothSourcesAgree(t *testing.T) {
+	durable := listStepNamesFromStatus(statusKeysFor(theElevenStepsInChartOrder))
+	got := mergeCutoverStepOrder(theElevenStepsInChartOrder, durable)
+
+	seen := map[string]int{}
+	for _, s := range got {
+		seen[s]++
+	}
+	for slug, n := range seen {
+		if n != 1 {
+			t.Errorf("step %q projected %d times; each step must appear exactly once", slug, n)
+		}
+	}
+	if len(got) != 11 {
+		t.Errorf("union of two sources naming the same 11 steps must be 11 rows, got %d: %v", len(got), got)
+	}
+}
+
+// TestMergeCutoverStepOrder_BlanksDropped defends the downstream
+// contract: ActivityBridge skips an empty slug, so a blank must never
+// occupy a projection slot and shift the chain.
+func TestMergeCutoverStepOrder_BlanksDropped(t *testing.T) {
+	got := mergeCutoverStepOrder([]string{"gitea-mirror", "  ", ""}, []string{"", "harbor-projects"})
+	want := []string{"gitea-mirror", "harbor-projects"}
+	if !equalSlugs(got, want) {
+		t.Errorf("blank slugs must be dropped, not projected.\n got  %v\n want %v", got, want)
+	}
+}
+
+func equalSlugs(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func indexOfSlug(in []string, want string) int {
+	for i, s := range in {
+		if s == want {
+			return i
+		}
+	}
+	return -1
+}

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -3755,7 +3755,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "1.2.66",
+    "version": "1.2.67",
     "section": "pts-2-3-per-sovereign-supporting-services",
     "depends": [],
     "shareable": false,

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3802,7 +3802,7 @@ name: bp-catalyst-platform
 #   rule: the controller must read Secrets cluster-wide (controller-runtime's
 #   cache is cluster-scoped) but must not be able to DELETE any Secret in the
 #   cluster to clean up its own. Lockstep w/ slot-13 pin.
-version: 1.4.1358
+version: 1.4.1359
 # 1.4.1229 — #5389: catalog-seed bp-newapi declares its `ui` endpoint
 #   (newapi.<fqdn>, ssoEnabled, launchDefault, ssoInitPath "/") instead of
 #   `endpoints: []`. The empty list made userUIGatePasses fail closed, which
@@ -3957,7 +3957,7 @@ version: 1.4.1358
 # scripts/check-chart-version-forward.sh (#5743) fails unless the two match —
 # main was carrying a pre-existing 1.4.1330/1.4.1329 split, so this bump heals
 # it in the same commit, exactly as the documented self-heal contract does.
-appVersion: 1.4.1358
+appVersion: 1.4.1359
 # 1.4.239 — Wave 3 / Issue #2140 (2026-05-23): Huawei provider
 # implementation lands behind the Wave 2 CloudProvider interface.
 # Adds the OpenTofu module at infra/providers/huawei/ (VPC + Subnet +

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -3485,7 +3485,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "1.2.66"
+  version: "1.2.67"
   visibility: unlisted
   card:
     title: "OpenBao"
@@ -3510,7 +3510,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-openbao
-    version: "1.2.66"
+    version: "1.2.67"
   topology:
     supported:
     - active-passive


### PR DESCRIPTION
Two defects in the same class, both found while walking the `cutover` and `dr` UAT rows on hw293.omantel.biz (dep `a0077ba47e3720e5`): a code path that looks correct, is exercised on every Sovereign, and produces a plausible-looking wrong answer that nothing was asserting on.

## 1. The cutover execution tree was ordered alphabetically

`/jobs` projected the eleven self-sovereign cutover steps in lexicographic order, so every `dependsOn` edge the canvas draws was fabricated. Read straight out of the live jobs store on hw293:

```
cutover-step-catalyst-api-env-patch      dependsOn []
cutover-step-crossplane-provider-pivot   dependsOn [cutover-step-catalyst-api-env-patch]
cutover-step-egress-block-test           dependsOn [cutover-step-crossplane-provider-pivot]
...
```

That is `sort.Strings` output. The step-08 deny-egress sovereignty proof renders third, the real first step `gitea-mirror` renders fifth, and not one of the eleven lands in its true slot.

**Why the good branch never ran.** `chrootSeedCutoverActivity` preferred `listStepNamesFromStatus` and reached the order-bearing `listCutoverSteps` only when that returned empty. It never did: the chart pre-seeds all eleven `step.<name>.result` keys at install (`09-cutover-status-configmap.yaml:86-126`), so on any Sovereign where the chart landed the status map is non-empty from the first second. The correctly-ordered branch was unreachable and the alphabetical one was permanently in charge.

A ConfigMap's `data` is an unordered map, so the durable status record cannot carry a sequence at all. `listStepNamesFromStatus` ends in `sort.Strings` for determinism, and that determinism was being read as execution order.

**The fix** takes the sequence from the `bp.openova.io/cutover-order` label via `listCutoverSteps`, and UNIONs rather than chooses. A step present only in the durable record still projects — that replay is the entire point of the #3646 durability path, an operator opening `/jobs` long after a completed cutover whose step ConfigMaps were reaped. Such a step has no order label to claim a position with, so it trails the order-bearing ones rather than being interleaved into a slot it cannot justify.

The engine-driven call site (`cutover.go:1567`) already passed ordered steps; only the read-path seed was wrong. But `mergeJob` lets a non-empty incoming `DependsOn` overwrite the stored one, so every `/jobs` read re-applied the scramble rather than the first write winning.

## 2. bp-openbao defaulted its Continuum lease witness to a backend that cannot take a lease

`platform/openbao/chart/values.yaml` shipped `kind: dns-quorum` with resolvers `10.43.0.10/.11/.12`. #6074 removed exactly this from the per-Org GitOps writer, and its comment then claimed that writer "was the last producer still selecting the dead backend" — this chart was the counter-example.

Re-pointing the resolvers would not have helped, for three reasons: dns-quorum's factory builds its client with a nil `TXTWriter` unconditionally so `Acquire` fails whatever it is given; kube-dns is not authoritative for the lease zone; and kube-dns is region-local (hw293 serves 10.96.0.10 in region A and 10.97.0.10 in region B), so per-region resolver sets can never form the shared quorum a witness exists to provide. `10.43.0.0/16` is k3s's default service CIDR while these Sovereigns allocate from `10.96.0.0/12`, so `.11` and `.12` were never anything at all.

Switched to `k8s-lease`, matching the shipped defaults of bp-cnpg-pair and bp-postgres. Chart `1.2.66 -> 1.2.67` in lockstep across `Chart.yaml`, `blueprint.yaml` and `clusters/_template/bootstrap-kit/08-openbao.yaml`.

## Evidence discipline

Every guard here was watched fail before it was watched pass.

- The six new Go tests assert **ordered slug values**, never a count — a length check passes on any permutation, which is exactly how this shipped. Run first against a stub reproducing current behaviour, they reported `egress-block-test` at position 3, matching the live store exactly.
- The headline test carries a control on its own **input**: it fails loudly if `listStepNamesFromStatus` ever stops being alphabetical, so it cannot go vacuously green.
- Three further tests pin the cases the union exists for — a durable-only step surviving and trailing, no order-bearing source still projecting every step rather than erasing the group, and no duplicate rows when both sources agree.
- The openbao change is proved **by render**, with a control: the CR now emits `kind: "k8s-lease"` and no resolvers block, and an explicit `--set` back to dns-quorum still renders resolvers — so the absence is a real absence, not a template that never emits them.
- `scripts/check-bootstrap-kit-pin-sync.sh` watched RED on a deliberate one-digit pin drift (`DRIFT bp-openbao: chart=1.2.67 pin=1.2.66`, exit 1) before being watched green.
- `go test -race -count=1` green in `internal/handler` (301s) and `internal/jobs` (30s).

## Live state this was measured against

catalyst-api `c50f2a5`, `flux-system/bp-self-sovereign-cutover` `Ready=True` at chart `0.1.179`, cutover never run (`cutoverComplete=false`, `progressPercent=0`, all eleven `step.<name>.result` empty). `git merge-base --is-ancestor e5178488d c50f2a5` passes with the reverse direction failing as a control, so the projection code under discussion is the code that is running.

No live-cluster writes were made and the cutover chain was not fired.

Refs #6093 #3646 #3379 #4486 #6074 #3829

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Appendix — the lockstep chain this bump actually needed

Recorded because the shell guards were green the whole way down and every one of these was found by a Go/CI gate instead. A `platform/<x>/chart` bump touching a catalog-seed pin moves **seven** sites, not three:

| site | found green by | caught red by |
|---|---|---|
| `platform/openbao/chart/Chart.yaml` | — | — |
| `platform/openbao/blueprint.yaml` | — | — |
| `clusters/_template/bootstrap-kit/08-openbao.yaml` | `check-bootstrap-kit-pin-sync.sh` | (watched red on a deliberate 1-digit drift) |
| `catalog.generated.ts` + `blueprints.json` | both shell guards | `check — generated catalog is in sync (#5520)` |
| catalog-seed `spec.version` | `check-catalog-seed-lockstep.sh` | `#5583` release-lockstep-writer Go guard |
| catalog-seed `source.version` | `check-catalog-seed-lockstep.sh` | same |
| `products/catalyst/chart/Chart.yaml` + slot-13 pin | `check-bootstrap-kit-pin-sync.sh` | hollow-pin guard + `#5734` umbrella-republish gate |

`check-catalog-seed-lockstep.sh` compares topology, endpoints and sso fields — not versions — so it cannot see a version drift at all. `check-bootstrap-kit-pin-sync.sh` compares a pin against its chart, so it stays green when both sides are equally stale. Only the gates that read the RENDERED surface catch that.

One local-verification trap worth naming: the first local run of the `#5583` guard came back green **from cache**, and stayed green after I reverted one of the two seed lines. With `-count=1` it fails correctly. Every guard result quoted above is uncached.

The umbrella number moved twice — `1.4.1353` against main at `1.4.1352`, then rebased to `1.4.1357` once main's deploy-bot reached `1.4.1356`. `check-chart-version-not-claimed-by-open-pr.py --pr 6099` reports no collision across the 32 open PRs carrying these charts.
