### PR TITLE
fix(catalyst-api): census the converged-late rescue over the platform, not the tenants

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/phase1_converged_late.go
+++ b/products/catalyst/bootstrap/api/internal/handler/phase1_converged_late.go
@@ -242,9 +242,43 @@ func notRecoveredFailedComponents(dep *Deployment, readyIDs map[string]bool) []s
 	return stillFailed
 }
 
-// censusHelmReleases counts Ready=True vs total HelmReleases on the
+// censusHelmReleases counts Ready=True vs total PLATFORM HelmReleases on the
 // cluster behind the given kubeconfig file, and returns the SET of
 // component ids observed Ready=True. Pure helper, test-seamed.
+//
+// SCOPED TO helmwatch.FluxNamespace (#6091), because that is the population
+// Phase-1 itself watched — helmwatch.go:1396 and :2682 both list
+// `Namespace(FluxNamespace)` — and therefore the only population
+// Result.ComponentStates was ever derived from. This read `Namespace("")` and
+// censused every namespace on the cluster, which asks a different question of
+// a different set of objects and breaks the census two ways.
+//
+// 1. The ratio gate in runConvergedLateRescue is `ready*10 < total*9`, so every
+// per-Org TENANT application HelmRelease landed in the denominator. Measured
+// read-only on hw293 (dep a0077ba47e3720e5, region A), minutes apart, with no
+// platform change in between: cluster-wide read 76/84 = 0.9048, then 72/78 =
+// 0.9231 — the ratio moved 0.018 on tenant churn alone (an Org namespace being
+// torn down). At 0.9048 the rescue was ONE non-Ready tenant release from
+// declining: 75/84 = 0.8929, 750 < 756, "cluster not (yet) converged; record
+// stays failed" — forever, for a platform that had fully converged. The
+// flux-system population read 63/67 = 0.9403 throughout. Customer installs fail
+// for reasons that are not the platform's: an Org whose plan-quota limits.cpu is
+// exhausted gets `Helm install failed ... context deadline exceeded`, and a
+// customer exhausting their own quota must not be able to freeze the Sovereign's
+// handover.
+//
+// 2. readyIDs is keyed by NAME alone, so a tenant release could forge the
+// per-component recovery proof for a platform component that happens to share
+// its id. On hw293 `newapi` is both a platform ComponentStates key and a
+// tenant-installable Blueprint, and a `bp-newapi` HelmRelease existed in an Org
+// namespace while `flux-system/bp-newapi` existed too. The comment below is
+// exactly right that absence never reads as recovery — but that contract was
+// only ever proof against a MISSING object, never against a same-named object
+// somewhere else. Scoping the list restores it.
+//
+// The 45-entry floor and the 0.90 ratio were calibrated against the
+// bootstrap-kit population, not against the kit plus whatever Organizations
+// have bought since.
 //
 // readyIDs is keyed by the Sovereign-Admin component id
 // (helmwatch.ComponentIDFromHelmRelease — "bp-cilium" → "cilium"), which is
@@ -254,22 +288,33 @@ func notRecoveredFailedComponents(dep *Deployment, readyIDs map[string]bool) []s
 // set, so "not recovered" is the default and a missing observation can never
 // be mistaken for a recovery.
 var censusHelmReleases = func(kubeconfigPath string) (ready, total int, readyIDs map[string]bool, err error) {
-	readyIDs = map[string]bool{}
 	raw, err := os.ReadFile(kubeconfigPath)
 	if err != nil {
-		return 0, 0, readyIDs, err
+		return 0, 0, map[string]bool{}, err
 	}
 	cfg, err := clientcmd.RESTConfigFromKubeConfig(raw)
 	if err != nil {
-		return 0, 0, readyIDs, err
+		return 0, 0, map[string]bool{}, err
 	}
 	dyn, err := dynamic.NewForConfig(cfg)
 	if err != nil {
-		return 0, 0, readyIDs, err
+		return 0, 0, map[string]bool{}, err
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
-	list, err := dyn.Resource(helmReleaseGVR).Namespace("").List(ctx, metav1.ListOptions{})
+	return censusHelmReleasesWithClient(ctx, dyn)
+}
+
+// censusHelmReleasesWithClient is the client-taking half of the census, split
+// out so a test can drive it with a seeded fake dynamic client and OBSERVE the
+// namespace scope rather than assert a constant. Every existing test of the
+// rescue seams `censusHelmReleases` out wholesale
+// (phase1_converged_late_test.go, phase1_converged_late_failed_recovered_6082_test.go),
+// which left the real lister's namespace — the thing #6091 was about — the one
+// part of it nothing exercised.
+func censusHelmReleasesWithClient(ctx context.Context, dyn dynamic.Interface) (ready, total int, readyIDs map[string]bool, err error) {
+	readyIDs = map[string]bool{}
+	list, err := dyn.Resource(helmReleaseGVR).Namespace(helmwatch.FluxNamespace).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return 0, 0, readyIDs, err
 	}

--- a/products/catalyst/bootstrap/api/internal/handler/phase1_converged_late_census_scope_6091_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/phase1_converged_late_census_scope_6091_test.go
@@ -1,0 +1,205 @@
+// phase1_converged_late_census_scope_6091_test.go — #6091.
+//
+// WHAT WAS WRONG. censusHelmReleases listed `Namespace("")` — every namespace
+// on the cluster — while Phase-1 itself watches only `Namespace(FluxNamespace)`
+// (helmwatch.go:1396 and :2682). The census that decides whether a `failed`
+// record may be rescued therefore counted a DIFFERENT population from the one
+// Result.ComponentStates was derived from, and per-Org tenant application
+// HelmReleases rode into both halves of the decision:
+//
+//   - into `total`, where the ratio gate is `ready*10 < total*9`. Measured
+//     read-only on hw293 (dep a0077ba47e3720e5) minutes apart with no platform
+//     change: 76/84 = 0.9048, then 72/78 = 0.9231 — pure tenant churn. At
+//     0.9048 the rescue was ONE non-Ready tenant release from declining
+//     (75/84 = 0.8929). The flux-system population read 63/67 = 0.9403.
+//
+//   - into `readyIDs`, which is keyed by NAME with no namespace
+//     discrimination, so a tenant release could satisfy the #6082
+//     per-component recovery proof for a platform component sharing its id.
+//     `newapi` is exactly such an id on hw293.
+//
+// WHY THIS TEST EXISTS AT ALL. Every other test of the rescue seams
+// `censusHelmReleases` out wholesale (phase1_converged_late_test.go:96,
+// phase1_converged_late_failed_recovered_6082_test.go:80 and its siblings), so
+// the real lister — and specifically its namespace — was the one part of the
+// census nothing exercised. The suite was fully green with the bug in it.
+//
+// It asserts on the OBSERVED counts from a seeded fake apiserver, not on a
+// constant: a test that read `helmwatch.FluxNamespace` back out of the source
+// would pass against a census that named the constant and then ignored it.
+package handler
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/helmwatch"
+)
+
+// hr builds one HelmRelease with the given Ready condition status. A status of
+// "" means the object carries no conditions at all — the shape a freshly
+// created, not-yet-reconciled release has.
+func hr(ns, name, ready string) *unstructured.Unstructured {
+	o := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "helm.toolkit.fluxcd.io/v2",
+		"kind":       "HelmRelease",
+		"metadata":   map[string]interface{}{"name": name, "namespace": ns},
+	}}
+	if ready != "" {
+		_ = unstructured.SetNestedSlice(o.Object, []interface{}{
+			map[string]interface{}{"type": "Ready", "status": ready},
+		}, "status", "conditions")
+	}
+	return o
+}
+
+func censusFakeClient(objs ...runtime.Object) *dynamicfake.FakeDynamicClient {
+	scheme := runtime.NewScheme()
+	gvk := schema.GroupVersionKind{Group: "helm.toolkit.fluxcd.io", Version: "v2", Kind: "HelmRelease"}
+	scheme.AddKnownTypeWithName(gvk, &unstructured.Unstructured{})
+	scheme.AddKnownTypeWithName(gvk.GroupVersion().WithKind("HelmReleaseList"), &unstructured.UnstructuredList{})
+	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+		map[schema.GroupVersionResource]string{helmReleaseGVR: "HelmReleaseList"}, objs...)
+}
+
+// TestCensusHelmReleases_CountsOnlyFluxNamespace6091 is the hw293 shape with
+// the numbers scaled down: a platform population that has converged, plus
+// tenant releases whose failures have nothing to do with it.
+//
+// The seed reproduces the hw293 disagreement in miniature. Scoped to
+// flux-system it reads 9 Ready of 10 = 0.90 and the rescue PROCEEDS — the one
+// non-Ready platform entry is `bp-velero`, a by-design hcloud no-op on a Huawei
+// prov, exactly the kind of entry the 0.90 tolerance was sized for. Censused
+// cluster-wide the same instant it reads 10 of 14 = 0.714 and the rescue
+// DECLINES, purely on customer application state.
+func TestCensusHelmReleases_CountsOnlyFluxNamespace6091(t *testing.T) {
+	dyn := censusFakeClient(
+		// The platform population Phase-1 watched.
+		hr(helmwatch.FluxNamespace, "bp-cilium", "True"),
+		hr(helmwatch.FluxNamespace, "bp-keycloak", "True"),
+		hr(helmwatch.FluxNamespace, "bp-self-sovereign-cutover", "True"),
+		hr(helmwatch.FluxNamespace, "bp-newapi", "True"),
+		hr(helmwatch.FluxNamespace, "bp-flux", "True"),
+		hr(helmwatch.FluxNamespace, "bp-gitea", "True"),
+		hr(helmwatch.FluxNamespace, "bp-harbor", "True"),
+		hr(helmwatch.FluxNamespace, "bp-openbao", "True"),
+		hr(helmwatch.FluxNamespace, "bp-cnpg", "True"),
+		hr(helmwatch.FluxNamespace, "bp-velero", "False"), // by-design hcloud no-op on a Huawei prov
+		// Tenant application releases. Two failed on the plan-quota ceiling
+		// ("Helm install failed ... context deadline exceeded"); one is mid-install.
+		hr("hw293walkone", "uat174-wp-rtz-a", "False"),
+		hr("hw293walkone", "uat224-openclaw-mgmt-a", ""),
+		hr("g7doora", "bp-wordpress-tenant", "False"),
+		hr("hw293walktwo", "uatm4-agenity-rtz-a", "True"),
+	)
+
+	ready, total, readyIDs, err := censusHelmReleasesWithClient(context.Background(), dyn)
+	if err != nil {
+		t.Fatalf("census: %v", err)
+	}
+
+	if total != 10 {
+		t.Errorf("total = %d, want 10 (the flux-system population only). "+
+			"A total of 14 means the census is still listing every namespace and "+
+			"tenant application releases are in the ratio denominator — #6091.", total)
+	}
+	if ready != 9 {
+		t.Errorf("ready = %d, want 9", ready)
+	}
+
+	// THE CONTROL that makes the scoping matter rather than merely differ: the
+	// SAME seeded cluster, censused across all namespaces the way #6091 did,
+	// reaches the OPPOSITE verdict under runConvergedLateRescue's own ratio
+	// gate. If both populations agreed, this test would be pinning a
+	// distinction without a consequence.
+	wideList, err := dyn.Resource(helmReleaseGVR).Namespace("").List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("cluster-wide control list: %v", err)
+	}
+	wideTotal := len(wideList.Items)
+	wideReady := 0
+	for i := range wideList.Items {
+		conds, _, _ := unstructured.NestedSlice(wideList.Items[i].Object, "status", "conditions")
+		for _, c := range conds {
+			if cm, ok := c.(map[string]interface{}); ok && cm["type"] == "Ready" && cm["status"] == "True" {
+				wideReady++
+				break
+			}
+		}
+	}
+	scopedDeclines := ready*10 < total*9
+	wideDeclines := wideReady*10 < wideTotal*9
+	if scopedDeclines {
+		t.Errorf("scoped census %d/%d DECLINES the rescue — the platform population "+
+			"converged and must not read as unconverged", ready, total)
+	}
+	if !wideDeclines {
+		t.Errorf("cluster-wide census %d/%d does not decline, so this seed does not "+
+			"reproduce #6091 and the scoped assertion above proves nothing",
+			wideReady, wideTotal)
+	}
+
+	// readyIDs must not carry tenant-derived ids: they are what
+	// notRecoveredFailedComponents consults as positive recovery evidence.
+	for _, id := range []string{"uatm4-agenity-rtz-a", "uat174-wp-rtz-a", "uat224-openclaw-mgmt-a", "wordpress-tenant"} {
+		if readyIDs[id] {
+			t.Errorf("readyIDs carries tenant-derived id %q — a per-Org release can "+
+				"reach the #6082 per-component recovery proof", id)
+		}
+	}
+	for _, id := range []string{"cilium", "keycloak", "self-sovereign-cutover", "newapi"} {
+		if !readyIDs[id] {
+			t.Errorf("readyIDs is missing platform id %q — the census stopped seeing "+
+				"the population the recovery proof needs", id)
+		}
+	}
+	if readyIDs["velero"] {
+		t.Errorf("readyIDs carries %q, whose release is Ready=False — membership must "+
+			"stay POSITIVE evidence only", "velero")
+	}
+}
+
+// TestCensusHelmReleases_TenantReleaseCannotForgeRecovery6091 is defect 2 on
+// its own, with the id collision that exists for real.
+//
+// `newapi` is simultaneously a platform ComponentStates key and a
+// tenant-installable Blueprint. Here the PLATFORM flux-system/bp-newapi is
+// still failing and a tenant Org's bp-newapi is healthy. A namespace-blind
+// census reports newapi as recovered on the strength of the tenant's copy,
+// which is precisely the evidence notRecoveredFailedComponents treats as proof
+// that the component whose failure latched the record has healed.
+func TestCensusHelmReleases_TenantReleaseCannotForgeRecovery6091(t *testing.T) {
+	dyn := censusFakeClient(
+		hr(helmwatch.FluxNamespace, "bp-newapi", "False"), // the platform component: still failed
+		hr("someorg", "bp-newapi", "True"),                // a customer's own install: healthy
+	)
+
+	_, _, readyIDs, err := censusHelmReleasesWithClient(context.Background(), dyn)
+	if err != nil {
+		t.Fatalf("census: %v", err)
+	}
+	if readyIDs["newapi"] {
+		t.Errorf("readyIDs[\"newapi\"] is true while the PLATFORM flux-system/bp-newapi " +
+			"is Ready=False — a tenant release in another namespace forged the " +
+			"per-component recovery proof (#6091)")
+	}
+
+	// The control, in the same call: with the platform release healthy the id
+	// MUST appear, so the assertion above is not passing merely because the
+	// census stopped reporting anything.
+	dyn = censusFakeClient(hr(helmwatch.FluxNamespace, "bp-newapi", "True"))
+	_, _, readyIDs, err = censusHelmReleasesWithClient(context.Background(), dyn)
+	if err != nil {
+		t.Fatalf("census (control): %v", err)
+	}
+	if !readyIDs["newapi"] {
+		t.Fatalf("control failed: a Ready platform bp-newapi did not register, so the " +
+			"negative assertion above proves nothing")
+	}
+}


### PR DESCRIPTION
## What this changes

`censusHelmReleases` — the live-cluster census the converged-late rescue uses to
decide whether a `failed` deployment record may be flipped to `ready` and the
whole handover chain fired — listed `Namespace("")`, every namespace on the
cluster. Phase-1 itself watches only `Namespace(FluxNamespace)`
(`helmwatch.go:1396`, `helmwatch.go:2682`; `FluxNamespace = "flux-system"` at
`helmwatch.go:86`).

So the census answered a question about a population Phase-1 never watched and
`Result.ComponentStates` was never derived from. Per-Org tenant application
HelmReleases rode into both halves of the decision.

### Into the ratio denominator

The gate in `runConvergedLateRescue` is `ready < convergedLateMinReady || ready*10 < total*9`.

Measured read-only on hw293 (dep `a0077ba47e3720e5`, region A), minutes apart,
with no platform change in between:

| population | Ready | total | ratio | verdict at the 0.90 gate |
|---|--:|--:|--:|---|
| cluster-wide (what the census counted) | 76 | 84 | **0.9048** | proceeds, by one HelmRelease |
| cluster-wide, minutes later | 72 | 78 | 0.9231 | proceeds |
| `flux-system` (what Phase-1 watched) | 63 | 67 | 0.9403 | proceeds |

The cluster-wide ratio moved 0.018 in minutes purely on tenant churn — an Org
namespace being torn down, not a platform event. At the 0.9048 reading, one more
non-Ready tenant release takes it to 75/84 = 0.8929, `750 < 756`, and the rescue
logs `cluster not (yet) converged; record stays failed` — permanently, for a
platform that had fully converged.

The tenant releases doing this are ordinary customer installs, and some fail for
reasons that have nothing to do with the platform: an Org whose `plan-quota`
`limits.cpu` is exhausted gets `Helm install failed ... context deadline
exceeded`. A customer exhausting their own plan quota must not be able to freeze
the Sovereign's handover.

The four genuinely non-Ready `flux-system` entries on hw293 are the known
by-design hcloud no-ops on a Huawei prov (`bp-cluster-autoscaler-hcloud`,
`bp-hcloud-ccm`, `bp-velero`) plus `bp-catalyst-secondary-edge` — the population
the 45-entry floor and the 0.90 ratio were calibrated against.

### Into `readyIDs`

`readyIDs[helmwatch.ComponentIDFromHelmRelease(name)] = true` keys off the
HelmRelease **name** with no namespace discrimination, and
`notRecoveredFailedComponents` consults exactly that set as the per-component
recovery proof. The existing comment states the contract:

> Membership is POSITIVE evidence only: an absent or non-Ready HelmRelease simply
> never enters the set, so "not recovered" is the default and a missing
> observation can never be mistaken for a recovery.

That holds against *absence*. It does not hold against a *different object with
the same name in another namespace*. `newapi` is simultaneously a platform
`ComponentStates` key on hw293 (`state=installed`) and a tenant-installable
Blueprint; a `bp-newapi` HelmRelease existed in an Org namespace while
`flux-system/bp-newapi` existed too. A tenant copy reaching Ready=True writes
`readyIDs["newapi"]=true` and satisfies the recovery proof for the platform
component of that name whatever the platform's own release is doing — and that
proof exists precisely because the floor+ratio is wide enough to hide the
component whose failure latched the record.

Scoping the list to `helmwatch.FluxNamespace` closes both.

## The test, and why there wasn't one

Every existing test of the rescue seams `censusHelmReleases` out wholesale
(`phase1_converged_late_test.go:96`,
`phase1_converged_late_failed_recovered_6082_test.go:80` and its siblings), so
the real lister's namespace — the thing this PR changes — was the one part of
the census nothing exercised. The suite was fully green with the defect in it.

`censusHelmReleasesWithClient` splits the client-taking half out so a test can
drive it with a seeded fake dynamic client and **observe** the scope rather than
read the constant back out of the source (a constant-assertion would pass
against a census that named `FluxNamespace` and then ignored it).

It carries the control that makes the scoping consequential rather than merely
different: the SAME seed, censused cluster-wide, reaches the OPPOSITE verdict
under the rescue's own ratio gate — 9/10 = 0.90 proceeds, 10/14 = 0.714
declines. If both populations agreed the test would pin a distinction with no
consequence, and it fails loudly in that case.

Watched fail before it passes, with the namespace reverted to `""`:

```
--- FAIL: TestCensusHelmReleases_CountsOnlyFluxNamespace6091
    total = 14, want 10 (the flux-system population only). A total of 14 means the
      census is still listing every namespace and tenant application releases are
      in the ratio denominator — #6091.
    ready = 10, want 9
    scoped census 10/14 DECLINES the rescue — the platform population converged
      and must not read as unconverged
    readyIDs carries tenant-derived id "uatm4-agenity-rtz-a" — a per-Org release
      can reach the per-component recovery proof
--- FAIL: TestCensusHelmReleases_TenantReleaseCannotForgeRecovery6091
    readyIDs["newapi"] is true while the PLATFORM flux-system/bp-newapi is
      Ready=False — a tenant release in another namespace forged the
      per-component recovery proof (#6091)
```

and green with the fix. The second test carries its own control in the same
call: with the platform release healthy the id MUST register, so the negative
assertion is not passing because the census went silent.

`go test ./internal/handler/ -count=1` is green over the whole package (292s).

## Live state this bears on

hw293's record is `status: failed`, `phase1Outcome: failed`,
`handoverFiredAt: null`, with exactly one component recorded failed
(`self-sovereign-cutover`), and `bp-self-sovereign-cutover` now reads
`Ready=True InstallSucceeded` at chart `0.1.179` — so the per-component recovery
proof is satisfied and the rescue's preconditions are met today. The census
scope was the remaining margin-of-error on whether it fires.

Refs #6091
Refs #6082
