### PR TITLE
fix(scripts): bump-chart-version consults open PR heads before choosing a version

### DIFF
--- a/.github/workflows/catalyst-build.yaml
+++ b/.github/workflows/catalyst-build.yaml
@@ -530,6 +530,13 @@ jobs:
       # blueprint-release was never dispatched, leaving Sovereigns
       # provisioned afterwards on the pre-fix chart.
       actions: write
+      # pull-requests: read — #5583. scripts/bump-chart-version.sh enumerates
+      # OPEN PRs so it never hands this deploy commit a version an open branch
+      # already claims (whichever lands first publishes the artifact; the other
+      # then merges different content under a taken version and ships nothing).
+      # Without this scope `gh pr list` 403s and the bump step FAILS LOUDLY
+      # rather than quietly falling back to the colliding main-only answer.
+      pull-requests: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -921,6 +928,14 @@ jobs:
       #     scripts/tests/test-chart-version-forward.sh (T5).
       - name: "Atomically bump products/catalyst/chart/Chart.yaml version"
         id: bump_chart_version
+        env:
+          # #5583 — bump-chart-version.sh calls `gh pr list` (via
+          # scripts/check-chart-version-not-claimed-by-open-pr.py) to skip any
+          # version an open PR head already claims. `gh` reads GH_TOKEN; with
+          # no token the step fails loudly instead of computing the colliding
+          # main-only number. A shallow single-branch checkout is fine — the
+          # enumerator fetches PR heads by explicit refspec.
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           git config user.name  "hatiyildiz"

--- a/.github/workflows/check-chart-version-forward.yaml
+++ b/.github/workflows/check-chart-version-forward.yaml
@@ -40,6 +40,8 @@ on:
       - 'scripts/bump-chart-version.sh'
       - 'scripts/push-chart-version-bump.sh'
       - 'scripts/tests/test-chart-version-forward.sh'
+      - 'scripts/tests/test-bump-chart-version-open-pr-claims.sh'
+      - 'scripts/check-chart-version-not-claimed-by-open-pr.py'
       - '.github/workflows/catalyst-build.yaml'
       - '.github/workflows/services-build.yaml'
       - '.github/workflows/check-chart-version-forward.yaml'
@@ -51,6 +53,8 @@ on:
       - 'scripts/bump-chart-version.sh'
       - 'scripts/push-chart-version-bump.sh'
       - 'scripts/tests/test-chart-version-forward.sh'
+      - 'scripts/tests/test-bump-chart-version-open-pr-claims.sh'
+      - 'scripts/check-chart-version-not-claimed-by-open-pr.py'
       - '.github/workflows/catalyst-build.yaml'
       - '.github/workflows/services-build.yaml'
       - '.github/workflows/check-chart-version-forward.yaml'
@@ -76,3 +80,10 @@ jobs:
 
       - name: Prove the guard goes RED for the real incident and GREEN once fixed
         run: bash scripts/tests/test-chart-version-forward.sh
+
+      # #5583 — the writer must step OVER versions open PR heads already claim,
+      # and must refuse rather than silently answer from origin/main alone when
+      # it cannot see them. Hermetic: the fixture supplies its own gh, so this
+      # needs no token and asserts nothing about the live repo's PRs.
+      - name: Prove the writer cannot hand two open PRs the same version
+        run: bash scripts/tests/test-bump-chart-version-open-pr-claims.sh

--- a/.github/workflows/services-build.yaml
+++ b/.github/workflows/services-build.yaml
@@ -62,6 +62,12 @@ jobs:
       # for deploy commits (issues #872, #712 — same root cause as the
       # catalyst-build dispatch fix in PR #720).
       actions: write
+      # pull-requests: read — #5583. scripts/bump-chart-version.sh enumerates
+      # OPEN PRs so it never hands this deploy commit a version an open branch
+      # already claims. Without this scope `gh pr list` 403s and the bump step
+      # FAILS LOUDLY rather than quietly falling back to the colliding
+      # main-only answer. See the matching note in catalyst-build.yaml.
+      pull-requests: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -265,6 +271,11 @@ jobs:
       # field.
       - name: "Atomically bump products/catalyst/chart/Chart.yaml version"
         id: bump_chart_version
+        env:
+          # #5583 — see the matching note in catalyst-build.yaml. `gh` reads
+          # GH_TOKEN; without it bump-chart-version.sh cannot enumerate open PR
+          # claims and fails loudly rather than picking a colliding version.
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           git config user.name "github-actions[bot]"

--- a/scripts/bump-chart-version.sh
+++ b/scripts/bump-chart-version.sh
@@ -25,11 +25,47 @@
 #     `git show`, so a stale checkout can never poison the computed number —
 #     the read half of the read-modify-write is pinned to the moment of the
 #     call, not the moment the job started.
-#   - next_version = bump_patch(max(baseline_version, baseline_appVersion)).
-#     Taking the MAX of both fields (not just `version:`) means the very
-#     first call after this fix lands SELF-HEALS the existing 1.4.1327 /
-#     1.4.1325 drift instead of perpetuating it, and a bump can never regress
-#     either field.
+#   - next_version = bump_patch(max(baseline_version, baseline_appVersion,
+#     every version this same chart carries on an OPEN PR head)).
+#     Taking the MAX of both baseline fields (not just `version:`) means the
+#     very first call after that fix landed SELF-HEALS the 1.4.1327 / 1.4.1325
+#     drift instead of perpetuating it, and a bump can never regress either
+#     field. Taking the max over open PR heads too is the #5583 half — see
+#     below.
+#
+# WHY IT ALSO READS OPEN PR HEADS (Refs #5583 #5734, added 2026-08-11)
+# --------------------------------------------------------------------
+# Reading the baseline from origin/main ONLY gave this script no view of what
+# other open branches already claim, so ANY TWO PRs rebased in the same window
+# landed on the SAME version, deterministically. On 2026-08-10 that happened
+# five times in one night — #6059/#6068 twice, #6089/#6068, and a three-way
+# #6099/#6096/#6068 all computing 1.4.1353 — each needing manual separation.
+#
+# The annoyance is not the point. Whichever of two same-version PRs merges
+# first publishes that artifact to ghcr; the second then merges carrying
+# DIFFERENT content under a version already published, the registry keeps the
+# first push, and the second PR's change renders clean, passes every gate, and
+# ships NOTHING. Same hollow-pin class as a partial lockstep bump.
+#
+# scripts/check-chart-version-not-claimed-by-open-pr.py already detects that
+# collision — but only at CI time, after the rebase, the push and a full check
+# cycle. The writer that CREATES the collision could not see what the checker
+# can. So the writer now asks that same script (`--claimed-versions`) for the
+# sibling claims: ONE enumerator, two consumers, no chance of the reader and
+# the writer disagreeing about what "an open PR claims version X" means.
+#
+#   - The number may now SKIP values: if main is at 1.4.1352 and an open PR
+#     head carries 1.4.1400, the next bump is 1.4.1401, not 1.4.1353. That is
+#     deliberate. The version is a claim on a shared registry namespace, not a
+#     dense counter, and a gap costs nothing while a reuse costs a silently
+#     un-shipped fix.
+#   - If the sibling claims cannot be established — no `gh`, no token, the
+#     enumeration errors, a fork PR's head is unreadable — this script EXITS
+#     NON-ZERO and writes nothing. It never quietly falls back to the
+#     main-only answer. A version writer that silently degrades to the
+#     colliding behaviour is worse than one that stops, because the caller
+#     believes it consulted its siblings. The single escape hatch is the
+#     explicit `--allow-unchecked-siblings` flag, which warns loudly.
 #   - Before writing anything it calls check-chart-version-forward.sh as a
 #     self-check on its own arithmetic — belt-and-braces against a bug in
 #     this very script shipping the same class of defect it exists to kill.
@@ -42,24 +78,50 @@
 #     to fall back on.
 #
 # Usage:
-#   bump-chart-version.sh <path/to/Chart.yaml>
+#   bump-chart-version.sh [--allow-unchecked-siblings] <path/to/Chart.yaml>
+#
+# Flags:
+#   --allow-unchecked-siblings
+#         Skip the open-PR claim consult and compute from origin/main alone —
+#         i.e. the pre-#5583 behaviour, which CAN hand two branches the same
+#         version. For callers that genuinely have no way to enumerate PRs.
+#         It is a flag and not an automatic fallback on purpose: the degraded
+#         mode has to be chosen out loud by the caller, and it prints a
+#         WARNING banner on every run.
 #
 # Contract:
 #   - All diagnostics go to stderr.
 #   - The ONLY thing printed to stdout is the final next_version, so callers
 #     can do `NEXT=$(bump-chart-version.sh path/to/Chart.yaml)`.
 #
+# Requires (unless --allow-unchecked-siblings): `python3`, and an authenticated
+# `gh` — in Actions that means `GH_TOKEN` on the step and `pull-requests: read`
+# on the job. A shallow, single-branch `actions/checkout@v4` is fine; the
+# enumerator fetches PR heads by explicit refspec.
+#
 # Exit 0: bumped; next_version on stdout.
 # Exit 1: any failure — missing file, unparseable baseline, guard rejection,
-#         or the post-write read-back not matching what was intended.
+#         the sibling claims not being establishable, or the post-write
+#         read-back not matching what was intended.
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 GUARD="${SCRIPT_DIR}/check-chart-version-forward.sh"
+CLAIMS="${SCRIPT_DIR}/check-chart-version-not-claimed-by-open-pr.py"
+
+ALLOW_UNCHECKED_SIBLINGS=0
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --allow-unchecked-siblings) ALLOW_UNCHECKED_SIBLINGS=1; shift ;;
+    --) shift; break ;;
+    -*) echo "::error title=bump-chart-version::unknown flag '$1'." >&2; exit 1 ;;
+    *) break ;;
+  esac
+done
 
 if [ "$#" -lt 1 ]; then
-  echo "Usage: $0 <path/to/Chart.yaml>" >&2
+  echo "Usage: $0 [--allow-unchecked-siblings] <path/to/Chart.yaml>" >&2
   exit 1
 fi
 CHART_YAML="$1"
@@ -71,6 +133,11 @@ fi
 
 if [ ! -x "${GUARD}" ] && [ ! -r "${GUARD}" ]; then
   echo "::error title=bump-chart-version::guard script not found at ${GUARD}." >&2
+  exit 1
+fi
+
+if [ "${ALLOW_UNCHECKED_SIBLINGS}" -eq 0 ] && [ ! -r "${CLAIMS}" ]; then
+  echo "::error title=bump-chart-version::open-PR claim enumerator not found at ${CLAIMS}." >&2
   exit 1
 fi
 
@@ -98,8 +165,10 @@ git fetch --quiet origin main
 #
 # Reading from a file removes the pipe, so `exit` costs nothing and the
 # byte-size of the chart stops being load-bearing. Regression coverage:
-# scripts/tests/test-bump-chart-version.sh builds a chart with >64 KiB
-# after `version:` and asserts this script still exits 0.
+# scripts/tests/test-chart-version-forward.sh T6 builds a chart with >64 KiB
+# after `version:` and asserts this script still exits 0. (That line used to
+# name scripts/tests/test-bump-chart-version.sh, a file that has never
+# existed — a reader chasing the regression coverage found nothing.)
 BASELINE_FILE="$(mktemp)"
 trap 'rm -f "${BASELINE_FILE}"' EXIT
 git show "origin/main:${CHART_YAML}" > "${BASELINE_FILE}"
@@ -137,9 +206,47 @@ semver_max() {
 }
 
 BASE_MAX="$(semver_max "${BASE_VERSION}" "${BASE_APPVERSION}")"
-MAJOR="$(echo "${BASE_MAX}" | cut -d. -f1)"
-MINOR="$(echo "${BASE_MAX}" | cut -d. -f2)"
-PATCH="$(echo "${BASE_MAX}" | cut -d. -f3)"
+
+# ── the #5583 half: step over every version an OPEN PR head already claims ──
+#
+# `--claimed-versions` prints one `<pr> <version>` line per open PR head that
+# carries this chart, and exits 2 if it could not establish the sibling set.
+# We take its verdict as-is: exit non-zero here rather than compute the
+# main-only number, which is the number that collides.
+CEILING="${BASE_MAX}"
+CEILING_SOURCE="origin/main baseline"
+CLAIMANTS=""
+
+if [ "${ALLOW_UNCHECKED_SIBLINGS}" -eq 1 ]; then
+  echo "::warning title=bump-chart-version::WARNING — --allow-unchecked-siblings: computing ${CHART_YAML}'s next version from origin/main ALONE, without consulting open PR heads. Two branches bumped in this window can land on the SAME version; whichever merges first publishes it and the other ships nothing (#5583)." >&2
+else
+  CLAIMS_FILE="$(mktemp)"
+  trap 'rm -f "${BASELINE_FILE}" "${CLAIMS_FILE}"' EXIT
+  if ! python3 "${CLAIMS}" --claimed-versions "${CHART_YAML}" > "${CLAIMS_FILE}"; then
+    echo "::error title=bump-chart-version::could not establish which versions of ${CHART_YAML} are already claimed by OPEN pull requests (see the INCONCLUSIVE reason above). Refusing to compute a version from origin/main alone — that is precisely the #5583 collision this consult exists to prevent. Needs an authenticated \`gh\` (GH_TOKEN + pull-requests: read). If this caller genuinely cannot enumerate PRs, pass --allow-unchecked-siblings explicitly." >&2
+    exit 1
+  fi
+  # No pipe into the loop: the claim list is read from the file directly, for
+  # the same reason the baseline is (see the SIGPIPE note above) and so the
+  # CEILING assignments land in THIS shell rather than a subshell's.
+  while read -r CLAIM_PR CLAIM_VER; do
+    [ -n "${CLAIM_VER:-}" ] || continue
+    if ! [[ "${CLAIM_VER}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+      echo "bump-chart-version: open PR #${CLAIM_PR} carries a non-MAJOR.MINOR.PATCH ${CHART_YAML} version '${CLAIM_VER}' — this script only ever writes MAJOR.MINOR.PATCH, so it cannot collide with that claim; skipping it." >&2
+      continue
+    fi
+    CLAIMANTS="${CLAIMANTS}#${CLAIM_PR}=${CLAIM_VER} "
+    NEW_CEILING="$(semver_max "${CEILING}" "${CLAIM_VER}")"
+    if [ "${NEW_CEILING}" != "${CEILING}" ]; then
+      CEILING="${NEW_CEILING}"
+      CEILING_SOURCE="open PR #${CLAIM_PR}"
+    fi
+  done < "${CLAIMS_FILE}"
+fi
+
+MAJOR="$(echo "${CEILING}" | cut -d. -f1)"
+MINOR="$(echo "${CEILING}" | cut -d. -f2)"
+PATCH="$(echo "${CEILING}" | cut -d. -f3)"
 NEXT_VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))"
 
 # Self-check before touching the working tree — never trust this script's
@@ -156,5 +263,5 @@ if [ "${WROTE_VERSION}" != "${NEXT_VERSION}" ] || [ "${WROTE_APPVERSION}" != "${
   exit 1
 fi
 
-echo "bump-chart-version: origin/main's ${CHART_YAML} was version=${BASE_VERSION} appVersion=${BASE_APPVERSION} -> writing ${NEXT_VERSION}/${NEXT_VERSION} (Refs #5743)" >&2
+echo "bump-chart-version: origin/main's ${CHART_YAML} was version=${BASE_VERSION} appVersion=${BASE_APPVERSION}; open-PR claims: ${CLAIMANTS:-none}; ceiling ${CEILING} from ${CEILING_SOURCE} -> writing ${NEXT_VERSION}/${NEXT_VERSION} (Refs #5743 #5583)" >&2
 echo "${NEXT_VERSION}"

--- a/scripts/check-chart-version-not-claimed-by-open-pr.py
+++ b/scripts/check-chart-version-not-claimed-by-open-pr.py
@@ -1,5 +1,16 @@
 #!/usr/bin/env python3
-"""Fail a PR that claims a chart version another OPEN pull request already claims.
+"""Chart-version claims across every OPEN pull request.
+
+Two consumers, ONE enumerator (this file):
+
+  * the CHECKER — `--pr N` — fails a PR that claims a chart version another open
+    PR already claims. Wired into .github/workflows/check-chart-version-claim.yaml.
+  * the WRITER  — `--claimed-versions <Chart.yaml>` — lets
+    scripts/bump-chart-version.sh pick a version no open branch has taken, so the
+    collision is never created in the first place.
+
+They must never disagree about what "an open PR claims version X" means, which is
+why the writer calls this file instead of growing a second reader of the same fact.
 
 Why this exists (2026-08-10).
 
@@ -21,16 +32,23 @@ a partial lockstep bump — a chart that looks released and delivers no change.
 A version number is a claim on a namespace shared across every open branch. It is
 the one thing in a PR that cannot be validated by looking at that PR alone.
 
-Root cause is dispatch, not code: two agents were each handed work that required an
-agenity chart release, and neither could see the other's claim. So the check belongs
-at PR time, where both claims are visible.
+The check alone was not enough (2026-08-11). It fires at CI time, after the rebase
+and the push — the WRITER that creates the collision still could not see what the
+checker can, so `scripts/bump-chart-version.sh` kept handing the same number to
+whichever two PRs rebased in the same window. That happened five more times in one
+night (#6059/#6068 twice, #6089/#6068, and a three-way #6099/#6096/#6068, all
+computing 1.4.1353). Hence `--claimed-versions`: the writer consults these same
+claims before it chooses.
 
     python3 scripts/check-chart-version-not-claimed-by-open-pr.py --self-test
     python3 scripts/check-chart-version-not-claimed-by-open-pr.py --pr 5964
+    python3 scripts/check-chart-version-not-claimed-by-open-pr.py \
+        --claimed-versions products/catalyst/chart/Chart.yaml
 
-Needs `gh` authenticated. Exit 0 = no collision. Exit 1 = collision. Exit 2 =
-INCONCLUSIVE, could not enumerate open PRs (never a pass — a check that saw no
-siblings has asserted nothing).
+Needs `gh` authenticated. Exit 0 = no collision / claims listed. Exit 1 = collision.
+Exit 2 = INCONCLUSIVE, the set of sibling claims could not be established (never a
+pass, and never a silent empty answer — a reader that saw no siblings has asserted
+nothing).
 """
 import argparse
 import json
@@ -40,6 +58,27 @@ import sys
 
 VERSION_LINE = re.compile(r"^version:\s*(\S+)\s*$", re.M)
 
+# `gh pr list` caps at --limit; a listing that comes back exactly full may be
+# TRUNCATED, and a truncated sibling set is an unknown sibling set, not an empty one.
+PR_LIST_LIMIT = 500
+
+# Open PR heads are fetched into a private ref namespace with an EXPLICIT refspec
+# rather than relied upon at `origin/<branch>`.
+#
+# `actions/checkout@v4` defaults to a shallow, single-branch clone whose
+# remote.origin.fetch maps ONLY the checked-out branch. In such a clone
+# `git fetch origin <other-branch>` exits 0 and creates NO `origin/<other-branch>`
+# ref at all — measured 2026-08-11: the following `git show origin/pr-a:...` dies
+# with "fatal: invalid object name". A reader that resolves siblings through
+# `origin/<branch>` therefore sees every sibling as "claims nothing" and passes by
+# comparing nothing. `+refs/heads/<b>:refs/prclaims/<n>` works in that same clone,
+# leaves it shallow (2 extra objects for the fixture measured), and does not depend
+# on how the caller configured its remote — which is what lets the deploy-bots call
+# this without a full-history checkout. Numbering the ref by PR rather than by
+# branch name also avoids the `refs/x` vs `refs/x/y` directory/file clash that
+# branch names like `fix/a` and `fix/a/b` would produce.
+CLAIM_REF_NS = "refs/prclaims"
+
 
 def gh(*args):
     """Run gh and return stdout, or None if it failed."""
@@ -48,6 +87,15 @@ def gh(*args):
     except (OSError, subprocess.TimeoutExpired):
         return None
     return r.stdout if r.returncode == 0 else None
+
+
+def git(args, timeout=180):
+    """Run git and return the CompletedProcess, or None if it could not run."""
+    try:
+        return subprocess.run(["git"] + args, capture_output=True, text=True,
+                              timeout=timeout)
+    except (OSError, subprocess.TimeoutExpired):
+        return None
 
 
 def chart_files_touched(pr):
@@ -67,17 +115,126 @@ def chart_files_touched(pr):
 
 def version_at(ref, path):
     """The `version:` value of a Chart.yaml at a git ref, or None."""
-    try:
-        r = subprocess.run(["git", "show", "%s:%s" % (ref, path)],
-                           capture_output=True, text=True, timeout=60)
-    except (OSError, subprocess.TimeoutExpired):
-        return None
-    if r.returncode != 0:
+    r = git(["show", "%s:%s" % (ref, path)], timeout=60)
+    if r is None or r.returncode != 0:
         return None
     found = VERSION_LINE.findall(r.stdout)
     # a Chart.yaml may carry commentary containing the word version; the real key
     # is the last bare `version:` at column 0, which is what helm reads.
     return found[-1] if found else None
+
+
+def open_prs():
+    """[{number, headRefName, isCrossRepository}] for every open PR, or None."""
+    out = gh("pr", "list", "--state", "open", "--limit", str(PR_LIST_LIMIT),
+             "--json", "number,headRefName,isCrossRepository")
+    if out is None:
+        return None
+    try:
+        prs = json.loads(out)
+    except ValueError:
+        return None
+    if len(prs) >= PR_LIST_LIMIT:
+        return None  # possibly truncated — an unknown sibling set, not an empty one
+    return prs
+
+
+def origin_branches():
+    """Branch names that exist on origin right now, or None if it could not be read."""
+    r = git(["ls-remote", "--heads", "origin"], timeout=120)
+    if r is None or r.returncode != 0:
+        return None
+    names = set()
+    for line in r.stdout.splitlines():
+        parts = line.split("\t")
+        if len(parts) == 2 and parts[1].startswith("refs/heads/"):
+            names.add(parts[1][len("refs/heads/"):])
+    return names
+
+
+def classify_heads(prs, branch_names):
+    """Split open PRs into (readable, holes, voids). Pure, so the self-test drives it.
+
+    readable — head branch lives on origin, so its claim can be read.
+    holes    — head cannot be read from origin (a fork PR). Its claim is UNKNOWN,
+               which is not the same as absent and must never be treated as one.
+    voids    — head branch no longer exists on origin. Such a PR cannot merge, so
+               whatever version it once claimed can never be published; treating it
+               as a hole would wedge the deploy-bots every time somebody deletes a
+               branch out from under an open PR.
+    """
+    readable, holes, voids = [], [], []
+    for pr in prs:
+        if pr.get("isCrossRepository"):
+            holes.append((pr["number"],
+                          "head branch '%s' lives in a fork — origin cannot read it"
+                          % pr.get("headRefName")))
+        elif pr.get("headRefName") not in branch_names:
+            voids.append((pr["number"],
+                          "head branch '%s' no longer exists on origin — unmergeable"
+                          % pr.get("headRefName")))
+        else:
+            readable.append(pr)
+    return readable, holes, voids
+
+
+def fetch_heads(prs):
+    """Fetch each PR head into CLAIM_REF_NS/<number>. Returns the PRs still missing."""
+    specs = ["+refs/heads/%s:%s/%s" % (p["headRefName"], CLAIM_REF_NS, p["number"])
+             for p in prs]
+    for i in range(0, len(specs), 50):
+        chunk = specs[i:i + 50]
+        r = git(["fetch", "-q", "--no-tags", "origin"] + chunk, timeout=600)
+        if r is None or r.returncode != 0:
+            # one bad refspec fails the whole batch — fall back to per-branch so a
+            # single unfetchable head cannot hide the other 49.
+            for spec in chunk:
+                git(["fetch", "-q", "--no-tags", "origin", spec], timeout=120)
+    missing = []
+    for p in prs:
+        ref = "%s/%s" % (CLAIM_REF_NS, p["number"])
+        r = git(["rev-parse", "--verify", "-q", ref + "^{commit}"], timeout=30)
+        if r is None or r.returncode != 0:
+            missing.append(p)
+    return missing
+
+
+def collect_claims(paths, log=sys.stderr):
+    """({pr_number: {path: version_or_None}}, None), or (None, why-it-is-unknown).
+
+    There is deliberately no third outcome: an empty dict means "there are
+    genuinely no open PRs", never "I could not look".
+    """
+    prs = open_prs()
+    if prs is None:
+        return None, ("could not enumerate open PRs. `gh pr list --state open` "
+                      "failed, returned unparseable JSON, or came back at the "
+                      "%d-row limit (possibly truncated)." % PR_LIST_LIMIT)
+
+    branches = origin_branches()
+    if branches is None:
+        return None, "could not read origin's branches via `git ls-remote --heads origin`."
+
+    readable, holes, voids = classify_heads(prs, branches)
+    for number, why in voids:
+        print("  note: PR #%s ignored — %s" % (number, why), file=log)
+    if holes:
+        detail = "; ".join("#%s (%s)" % (n, w) for n, w in holes)
+        return None, ("the version claimed by %d open PR(s) cannot be read from "
+                      "origin: %s" % (len(holes), detail))
+
+    unfetched = fetch_heads(readable)
+    if unfetched:
+        detail = ", ".join("#%s (%s)" % (p["number"], p["headRefName"])
+                           for p in unfetched)
+        return None, ("could not fetch the head of %d open PR(s): %s"
+                      % (len(unfetched), detail))
+
+    claims = {}
+    for pr in readable:
+        ref = "%s/%s" % (CLAIM_REF_NS, pr["number"])
+        claims[int(pr["number"])] = {p: version_at(ref, p) for p in paths}
+    return claims, None
 
 
 def collisions(mine, others):
@@ -124,12 +281,103 @@ def self_test():
         print("  %s  self-test: %s (want %d, got %d)"
               % ("PASS" if ok else "FAIL", label, want, len(got)))
         bad += 0 if ok else 1
+
+    # The head classifier decides what counts as an UNKNOWN claim. Getting it wrong
+    # in the permissive direction reintroduces the silent hole this whole file
+    # exists to close, so it is pinned here too.
+    head_cases = [
+        ([{"number": 1, "headRefName": "fix/a", "isCrossRepository": False}],
+         {"fix/a"}, (1, 0, 0), "same-repo head that exists is readable"),
+        ([{"number": 2, "headRefName": "fix/gone", "isCrossRepository": False}],
+         {"fix/a"}, (0, 0, 1), "deleted head branch is a VOID claim, not a hole"),
+        ([{"number": 3, "headRefName": "patch-1", "isCrossRepository": True}],
+         {"patch-1"}, (0, 1, 0),
+         "fork head is a HOLE even when a same-named branch exists on origin"),
+        ([], set(), (0, 0, 0), "no open PRs"),
+    ]
+    for prs, branches, want, label in head_cases:
+        r, h, v = classify_heads(prs, branches)
+        got = (len(r), len(h), len(v))
+        ok = got == want
+        print("  %s  self-test: %s (want %s, got %s)"
+              % ("PASS" if ok else "FAIL", label, want, got))
+        bad += 0 if ok else 1
     return bad
+
+
+def cmd_claimed_versions(path):
+    """Print `<pr> <version>` for every open PR head carrying `path`."""
+    claims, why = collect_claims([path])
+    if claims is None:
+        print("INCONCLUSIVE: %s" % why, file=sys.stderr)
+        print("Refusing to report an empty claim set — a caller that reads "
+              "'no siblings seen' as 'no siblings exist' will pick a version "
+              "another open branch already owns.", file=sys.stderr)
+        return 2
+    carried = 0
+    for pr in sorted(claims):
+        ver = claims[pr].get(path)
+        if ver:
+            print("%s %s" % (pr, ver))
+            carried += 1
+    print("claimed-versions: %s is carried by %d of %d open PR head(s)."
+          % (path, carried, len(claims)), file=sys.stderr)
+    return 0
+
+
+def cmd_check_pr(pr):
+    mine_paths = chart_files_touched(pr)
+    if mine_paths is None:
+        print("INCONCLUSIVE: could not read PR #%s's changed files via gh." % pr,
+              file=sys.stderr)
+        return 2
+    if not mine_paths:
+        print("PR #%s modifies no Chart.yaml — nothing to claim." % pr)
+        return 0
+
+    claims, why = collect_claims(mine_paths)
+    if claims is None:
+        print("INCONCLUSIVE: %s" % why, file=sys.stderr)
+        print("Nothing was compared. This is NOT a pass.", file=sys.stderr)
+        return 2
+
+    mine = claims.pop(int(pr), None)
+    if mine is None:
+        print("INCONCLUSIVE: PR #%s is not among the readable open PRs." % pr,
+              file=sys.stderr)
+        return 2
+
+    print("PR #%s claims:" % pr)
+    for p, v in sorted(mine.items()):
+        print("   %-58s %s" % (p, v or "(unreadable)"))
+
+    others = {n: c for n, c in claims.items() if any(v for v in c.values())}
+    hits = collisions(mine, others)
+    print("\ncompared against %d open PR(s) that carry these charts" % len(others))
+
+    if hits:
+        print()
+        for path, ver, other in hits:
+            print("FAIL: PR #%s claims %s version %s — so does OPEN PR #%s."
+                  % (pr, path, ver, other), file=sys.stderr)
+        print("\nA version is a claim on a namespace shared by every branch. Whichever "
+              "of these merges first publishes that artifact; the other then ships its "
+              "OWN content under a version already taken, renders clean, passes every "
+              "lockstep gate, and delivers nothing.", file=sys.stderr)
+        print("Fix: serialize. Rebase this PR after the other lands and re-run the "
+              "release writer so it takes the next free version.", file=sys.stderr)
+        return 1
+
+    print("OK — no open PR claims any of these versions.")
+    return 0
 
 
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--pr", help="PR number to check")
+    ap.add_argument("--claimed-versions", metavar="CHART_YAML",
+                    help="list `<pr> <version>` for every open PR head carrying "
+                         "this Chart.yaml (used by scripts/bump-chart-version.sh)")
     ap.add_argument("--self-test", action="store_true")
     a = ap.parse_args()
 
@@ -143,74 +391,15 @@ def main():
               "quiet on the safe cases.")
         return 0
 
+    if a.claimed_versions:
+        return cmd_claimed_versions(a.claimed_versions)
+
     if not a.pr:
-        print("INCONCLUSIVE: --pr is required outside --self-test", file=sys.stderr)
+        print("INCONCLUSIVE: --pr or --claimed-versions is required outside "
+              "--self-test", file=sys.stderr)
         return 2
 
-    mine_paths = chart_files_touched(a.pr)
-    if mine_paths is None:
-        print("INCONCLUSIVE: could not read PR #%s's changed files via gh." % a.pr,
-              file=sys.stderr)
-        return 2
-    if not mine_paths:
-        print("PR #%s modifies no Chart.yaml — nothing to claim." % a.pr)
-        return 0
-
-    listing = gh("pr", "list", "--state", "open", "--limit", "100",
-                 "--json", "number,headRefName")
-    if listing is None:
-        print("INCONCLUSIVE: could not enumerate open PRs. A check that saw no "
-              "siblings has asserted nothing — this is NOT a pass.", file=sys.stderr)
-        return 2
-    open_prs = json.loads(listing)
-
-    me = [p for p in open_prs if str(p["number"]) == str(a.pr)]
-    if not me:
-        print("INCONCLUSIVE: PR #%s is not in the open list." % a.pr, file=sys.stderr)
-        return 2
-    my_ref = "origin/" + me[0]["headRefName"]
-
-    mine = {p: version_at(my_ref, p) for p in mine_paths}
-    print("PR #%s claims:" % a.pr)
-    for p, v in sorted(mine.items()):
-        print("   %-58s %s" % (p, v or "(unreadable)"))
-
-    others, examined = {}, 0
-    for pr in open_prs:
-        if str(pr["number"]) == str(a.pr):
-            continue
-        ref = "origin/" + pr["headRefName"]
-        subprocess.run(["git", "fetch", "-q", "origin", pr["headRefName"]],
-                       capture_output=True, timeout=180)
-        claims = {p: version_at(ref, p) for p in mine_paths}
-        if any(v for v in claims.values()):
-            others[pr["number"]] = claims
-            examined += 1
-
-    if examined == 0:
-        print("\nINCONCLUSIVE: none of the %d other open PR(s) could be read for "
-              "these chart files." % (len(open_prs) - 1), file=sys.stderr)
-        print("Nothing was compared. This is NOT a pass.", file=sys.stderr)
-        return 2
-
-    hits = collisions(mine, others)
-    print("\ncompared against %d open PR(s) that carry these charts" % examined)
-
-    if hits:
-        print()
-        for path, ver, other in hits:
-            print("FAIL: PR #%s claims %s version %s — so does OPEN PR #%s."
-                  % (a.pr, path, ver, other), file=sys.stderr)
-        print("\nA version is a claim on a namespace shared by every branch. Whichever "
-              "of these merges first publishes that artifact; the other then ships its "
-              "OWN content under a version already taken, renders clean, passes every "
-              "lockstep gate, and delivers nothing.", file=sys.stderr)
-        print("Fix: serialize. Rebase this PR after the other lands and re-run the "
-              "release writer so it takes the next free version.", file=sys.stderr)
-        return 1
-
-    print("OK — no open PR claims any of these versions.")
-    return 0
+    return cmd_check_pr(a.pr)
 
 
 if __name__ == "__main__":

--- a/scripts/push-chart-version-bump.sh
+++ b/scripts/push-chart-version-bump.sh
@@ -22,7 +22,15 @@
 # other bot already pushed.
 #
 # Usage:
-#   push-chart-version-bump.sh <path/to/Chart.yaml> [commit-message-prefix] [max-attempts]
+#   push-chart-version-bump.sh [--allow-unchecked-siblings] \
+#       <path/to/Chart.yaml> [commit-message-prefix] [max-attempts]
+#
+# --allow-unchecked-siblings is forwarded verbatim to bump-chart-version.sh; see
+# its header. It disables the open-PR claim consult (#5583), so two branches
+# bumped in the same window can land on the same version and the later merge
+# ships nothing. It exists only for a caller that genuinely cannot enumerate
+# PRs, and it must be chosen explicitly — there is deliberately no automatic
+# fallback to it.
 #
 # Requires: a working tree already checked out with an `origin` remote and
 # `git config user.name`/`user.email` already set by the caller.
@@ -47,7 +55,17 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BUMP="${SCRIPT_DIR}/bump-chart-version.sh"
 
-CHART_YAML="${1:?Usage: $0 <path/to/Chart.yaml> [commit-message-prefix] [max-attempts]}"
+BUMP_FLAGS=()
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --allow-unchecked-siblings) BUMP_FLAGS+=("$1"); shift ;;
+    --) shift; break ;;
+    -*) echo "::error title=push-chart-version-bump::unknown flag '$1'." >&2; exit 1 ;;
+    *) break ;;
+  esac
+done
+
+CHART_YAML="${1:?Usage: $0 [--allow-unchecked-siblings] <path/to/Chart.yaml> [commit-message-prefix] [max-attempts]}"
 MSG_PREFIX="${2:-deploy(bp-catalyst-platform): bump chart version}"
 MAX_ATTEMPTS="${3:-5}"
 SLEEP_SCALE="${SLEEP_SCALE:-1}"
@@ -56,7 +74,7 @@ git fetch --quiet origin main
 git reset --hard --quiet origin/main
 
 for i in $(seq 1 "${MAX_ATTEMPTS}"); do
-  NEXT="$("${BUMP}" "${CHART_YAML}")"
+  NEXT="$("${BUMP}" ${BUMP_FLAGS[@]+"${BUMP_FLAGS[@]}"} "${CHART_YAML}")"
   git add "${CHART_YAML}"
   if git diff --staged --quiet; then
     echo "push-chart-version-bump: no-op — ${CHART_YAML} already at target on origin/main." >&2

--- a/scripts/tests/test-bump-chart-version-open-pr-claims.sh
+++ b/scripts/tests/test-bump-chart-version-open-pr-claims.sh
@@ -1,0 +1,359 @@
+#!/usr/bin/env bash
+# test-bump-chart-version-open-pr-claims.sh — non-vacuity proof for #5583/#5734
+#
+# WHAT THIS PINS
+# --------------
+# scripts/bump-chart-version.sh used to compute
+#
+#     next = bump_patch(max(origin/main version, origin/main appVersion))
+#
+# reading the baseline from origin/main ONLY. It had no view of what other open
+# branches already claim, so ANY TWO PRs rebased in the same window land on the
+# SAME version, deterministically. That happened five times on 2026-08-10:
+# #6059/#6068 twice, #6089/#6068, and a three-way #6099/#6096/#6068 all
+# computing 1.4.1353.
+#
+# The damage is not the merge conflict. Whichever PR merges first publishes that
+# artifact to ghcr; the second then merges carrying DIFFERENT content under a
+# version already published, the registry keeps the first push, and the second
+# PR's change renders clean, passes every gate, and ships nothing.
+#
+# scripts/check-chart-version-not-claimed-by-open-pr.py already detects that —
+# but only at CI time, after the rebase and the push. The writer that CREATES
+# the collision could not see what the checker can. This test pins the fix:
+# the writer now consults the same enumerator the checker uses.
+#
+#   W1  THE DECISIVE CASE. origin/main at 1.4.1352; two OPEN PRs both carry
+#       1.4.1353 on their heads. Pre-fix the writer returns 1.4.1353 — the
+#       collision it is supposed to prevent. Post-fix it must return 1.4.1354.
+#   W2  CONTROL — no open PRs at all: the answer must be UNCHANGED from the
+#       pre-fix arithmetic (1.4.1353). The fix adds a constraint; it must not
+#       change the arithmetic.
+#   W3  CONTROL — an open PR exists but never bumped this chart (its head
+#       carries main's own 1.4.1352): still 1.4.1353. A sibling only binds
+#       when it actually claims ahead.
+#   W4  FAIL LOUD — PR enumeration fails: non-zero exit AND the working copy
+#       must be left untouched. Never a silent fall back to the main-only
+#       answer, which is exactly the colliding behaviour.
+#   W5  FAIL LOUD — `gh` not on PATH at all: same.
+#   W6  OPT-OUT — --allow-unchecked-siblings with enumeration broken: exit 0,
+#       the main-only answer, and a loud warning on stderr.
+#   W7  An open PR whose head branch was DELETED from origin is unmergeable,
+#       so its version claim is void — not a hole. Must not wedge the writer.
+#   W8  A cross-repository (fork) PR head cannot be read from origin, so its
+#       claim is UNKNOWN — that IS a hole. Must fail loud.
+#   W9  A shallow, single-branch clone — what actions/checkout@v4 produces by
+#       default — must still read sibling claims. `git fetch origin <branch>`
+#       exits 0 there but leaves NO origin/<branch> ref, which would resolve
+#       every sibling to "no claim" and pass by comparing nothing.
+#   W10 The existing write contract survives: both `version:` and
+#       `appVersion:` are written, in lockstep, to the computed value.
+#
+# Usage: bash scripts/tests/test-bump-chart-version-open-pr-claims.sh
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/../.." && pwd)"
+BUMP="${REPO_ROOT}/scripts/bump-chart-version.sh"
+CLAIMS="${REPO_ROOT}/scripts/check-chart-version-not-claimed-by-open-pr.py"
+
+for f in "${BUMP}"; do
+  [ -x "${f}" ] || chmod +x "${f}"
+done
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "${WORK}"' EXIT
+
+FAILED=0
+fail() { echo "FAIL: $*" >&2; FAILED=1; }
+pass() { echo "PASS: $*"; }
+
+CHART_PATH="products/catalyst/chart/Chart.yaml"
+
+# ── fixture: a bare "origin" with main at 1.4.1352 and three branches ────────
+UPSTREAM="${WORK}/upstream.git"
+git init -q -b main --bare "${UPSTREAM}"
+
+SEED="${WORK}/seed"
+git clone -q "${UPSTREAM}" "${SEED}" 2>/dev/null
+mkdir -p "${SEED}/$(dirname "${CHART_PATH}")"
+write_chart() {
+  # $1 = repo dir, $2 = version
+  cat > "$1/${CHART_PATH}" <<YAML
+apiVersion: v2
+name: bp-catalyst-platform
+version: $2
+appVersion: $2
+YAML
+}
+gitc() { git -C "$1" -c user.name=seed -c user.email=seed@test.local "${@:2}"; }
+
+write_chart "${SEED}" 1.4.1352
+gitc "${SEED}" add -A
+gitc "${SEED}" commit -qm "seed: 1.4.1352/1.4.1352"
+gitc "${SEED}" push -q -u origin main
+
+# two sibling branches that BOTH claim 1.4.1353 — the real 2026-08-10 shape
+for b in pr-a pr-b; do
+  gitc "${SEED}" checkout -q -b "${b}" main
+  write_chart "${SEED}" 1.4.1353
+  gitc "${SEED}" commit -qam "${b}: claim 1.4.1353"
+  gitc "${SEED}" push -q origin "${b}"
+done
+# a branch that touches something else and never bumps the chart
+gitc "${SEED}" checkout -q -b pr-nochart main
+echo "docs" > "${SEED}/NOTES.md"
+gitc "${SEED}" add -A
+gitc "${SEED}" commit -qm "pr-nochart: no chart change"
+gitc "${SEED}" push -q origin pr-nochart
+gitc "${SEED}" checkout -q main
+
+# ── stub gh: answers `gh pr list ... --json ...` from a file ─────────────────
+BIN="${WORK}/bin"
+mkdir -p "${BIN}"
+cat > "${BIN}/gh" <<EOF
+#!/usr/bin/env bash
+# stub gh for the fixture — the fixture's "origin" is a local bare repo, so the
+# real gh (which would answer about openova-io/openova) is meaningless here.
+RC_FILE="${WORK}/gh.rc"
+if [ -f "\${RC_FILE}" ]; then
+  echo "stub gh: forced failure (enumeration unavailable)" >&2
+  exit "\$(cat "\${RC_FILE}")"
+fi
+if [ "\${1:-}" = "pr" ] && [ "\${2:-}" = "list" ]; then
+  cat "${WORK}/pr-list.json"
+  exit 0
+fi
+echo "stub gh: unexpected invocation: \$*" >&2
+exit 1
+EOF
+chmod +x "${BIN}/gh"
+
+set_prs() { printf '%s\n' "$1" > "${WORK}/pr-list.json"; rm -f "${WORK}/gh.rc"; }
+break_gh() { printf '%s\n' "$1" > "${WORK}/gh.rc"; }
+
+# ── harness ─────────────────────────────────────────────────────────────────
+# Each case gets a FRESH clone, because bump-chart-version.sh writes into the
+# working tree it is handed.
+CASE_N=0
+run_bump() {
+  # $1 = clone flags ("" or "shallow"), rest = extra args to bump
+  CASE_N=$((CASE_N + 1))
+  RUN_DIR="${WORK}/run${CASE_N}"
+  if [ "$1" = "shallow" ]; then
+    git clone -q --depth=1 --single-branch --branch main "file://${UPSTREAM}" "${RUN_DIR}"
+  else
+    git clone -q "${UPSTREAM}" "${RUN_DIR}"
+  fi
+  shift
+  ( cd "${RUN_DIR}" && PATH="${BIN}:${PATH}" "${BUMP}" "$@" "${CHART_PATH}" ) \
+    > "${RUN_DIR}.stdout" 2> "${RUN_DIR}.stderr"
+  RUN_RC=$?
+  RUN_OUT="$(cat "${RUN_DIR}.stdout")"
+  return 0
+}
+
+file_version() { awk '/^version:/{print $2; exit}' "$1/${CHART_PATH}"; }
+file_appversion() { awk '/^appVersion:/{print $2; exit}' "$1/${CHART_PATH}"; }
+
+echo "=============================================================="
+echo "W1 — DECISIVE: two OPEN PRs both already claim 1.4.1353"
+echo "     origin/main is 1.4.1352. Pre-fix answer: 1.4.1353 (collision)."
+echo "=============================================================="
+set_prs '[{"number":9001,"headRefName":"pr-a","isCrossRepository":false},
+          {"number":9002,"headRefName":"pr-b","isCrossRepository":false}]'
+run_bump full
+echo "--- stderr ---"; cat "${RUN_DIR}.stderr"
+echo "--- exit=${RUN_RC} next=${RUN_OUT} ---"
+if [ "${RUN_RC}" -ne 0 ]; then
+  fail "W1 — writer exited ${RUN_RC}; it must produce a free version, not refuse."
+elif [ "${RUN_OUT}" = "1.4.1353" ]; then
+  fail "W1 — writer returned 1.4.1353, the version BOTH open PRs already claim. This is the #5583 collision: whichever merges first publishes it, the second ships nothing."
+elif [ "${RUN_OUT}" != "1.4.1354" ]; then
+  fail "W1 — expected 1.4.1354 (next patch above the highest open-PR claim 1.4.1353), got '${RUN_OUT}'."
+else
+  pass "W1 — writer stepped over both open claims: 1.4.1352 baseline + claims{1.4.1353} -> 1.4.1354."
+fi
+echo
+
+echo "=============================================================="
+echo "W10 — the existing write contract still holds on that run"
+echo "=============================================================="
+W1_DIR="${WORK}/run1"
+GOT_V="$(file_version "${W1_DIR}")"; GOT_A="$(file_appversion "${W1_DIR}")"
+echo "written: version=${GOT_V} appVersion=${GOT_A}"
+if [ "${GOT_V}" != "${RUN_OUT}" ] || [ "${GOT_A}" != "${RUN_OUT}" ]; then
+  fail "W10 — both fields must be written in lockstep to ${RUN_OUT}; got version=${GOT_V} appVersion=${GOT_A}."
+else
+  pass "W10 — version and appVersion both written to ${RUN_OUT}, in lockstep."
+fi
+echo
+
+echo "=============================================================="
+echo "W2 — CONTROL: no open PRs. The arithmetic must be UNCHANGED."
+echo "=============================================================="
+set_prs '[]'
+run_bump full
+echo "--- exit=${RUN_RC} next=${RUN_OUT} ---"
+if [ "${RUN_RC}" -ne 0 ] || [ "${RUN_OUT}" != "1.4.1353" ]; then
+  echo "--- stderr ---"; cat "${RUN_DIR}.stderr"
+  fail "W2 — with no siblings the answer must stay exactly today's 1.4.1353 (exit ${RUN_RC}, got '${RUN_OUT}'). The fix must ADD a constraint, not change the arithmetic."
+else
+  pass "W2 — no open PRs: 1.4.1352 -> 1.4.1353, identical to the pre-fix behaviour."
+fi
+echo
+
+echo "=============================================================="
+echo "W3 — CONTROL: an open PR that never bumped this chart"
+echo "=============================================================="
+set_prs '[{"number":9003,"headRefName":"pr-nochart","isCrossRepository":false}]'
+run_bump full
+echo "--- exit=${RUN_RC} next=${RUN_OUT} ---"
+if [ "${RUN_RC}" -ne 0 ] || [ "${RUN_OUT}" != "1.4.1353" ]; then
+  echo "--- stderr ---"; cat "${RUN_DIR}.stderr"
+  fail "W3 — a sibling carrying main's own version claims nothing ahead; the answer must stay 1.4.1353 (exit ${RUN_RC}, got '${RUN_OUT}')."
+else
+  pass "W3 — sibling at main's version does not inflate the bump."
+fi
+echo
+
+echo "=============================================================="
+echo "W4 — FAIL LOUD: enumeration fails -> non-zero, nothing written"
+echo "=============================================================="
+break_gh 1
+run_bump full
+echo "--- stderr ---"; cat "${RUN_DIR}.stderr"
+echo "--- exit=${RUN_RC} stdout='${RUN_OUT}' ---"
+LEFT_V="$(file_version "${RUN_DIR}")"
+if [ "${RUN_RC}" -eq 0 ]; then
+  fail "W4 — writer exited 0 with the enumeration broken. It returned '${RUN_OUT}' having consulted nothing: a version writer that silently degrades to the colliding behaviour is worse than one that stops."
+elif [ "${LEFT_V}" != "1.4.1352" ]; then
+  fail "W4 — writer refused but still wrote ${LEFT_V} into the working copy; it must leave the tree untouched."
+else
+  pass "W4 — enumeration failure is fatal (exit ${RUN_RC}) and the working copy is untouched."
+fi
+echo
+
+echo "=============================================================="
+echo "W5 — FAIL LOUD: gh not on PATH at all"
+echo "=============================================================="
+# A PATH built from symlinks to exactly the tools the writer needs, and no gh.
+# Hardcoding /usr/bin:/bin would not do: on a GitHub runner gh sits in /usr/bin
+# next to git, so the case would silently test nothing.
+NOGH_BIN="${WORK}/nogh-bin"
+mkdir -p "${NOGH_BIN}"
+for t in bash env git awk sed tr cut cat rm mktemp dirname; do
+  SRC="$(command -v "${t}" 2>/dev/null || true)"
+  [ -n "${SRC}" ] && ln -sf "${SRC}" "${NOGH_BIN}/${t}"
+done
+SRC="$(command -v python3 2>/dev/null || true)"
+[ -n "${SRC}" ] && ln -sf "${SRC}" "${NOGH_BIN}/python3"
+if PATH="${NOGH_BIN}" command -v gh >/dev/null 2>&1; then
+  fail "W5 VACUITY — gh is still reachable under the stripped PATH; this case cannot test the absence it exists to test."
+else
+  echo "vacuity check: gh is NOT reachable under the stripped PATH."
+fi
+CASE_N=$((CASE_N + 1))
+RUN_DIR="${WORK}/run${CASE_N}"
+git clone -q "${UPSTREAM}" "${RUN_DIR}"
+( cd "${RUN_DIR}" && PATH="${NOGH_BIN}" "${BUMP}" "${CHART_PATH}" ) \
+  > "${RUN_DIR}.stdout" 2> "${RUN_DIR}.stderr"
+RC5=$?
+echo "--- stderr ---"; cat "${RUN_DIR}.stderr"
+echo "--- exit=${RC5} ---"
+if [ "${RC5}" -eq 0 ]; then
+  fail "W5 — writer exited 0 with no gh available; absence of the enumerator must be fatal, not a silent main-only answer."
+else
+  pass "W5 — missing gh is fatal (exit ${RC5})."
+fi
+echo
+
+echo "=============================================================="
+echo "W6 — OPT-OUT: --allow-unchecked-siblings, loudly"
+echo "=============================================================="
+break_gh 1
+run_bump full --allow-unchecked-siblings
+echo "--- stderr ---"; cat "${RUN_DIR}.stderr"
+echo "--- exit=${RUN_RC} next=${RUN_OUT} ---"
+if [ "${RUN_RC}" -ne 0 ] || [ "${RUN_OUT}" != "1.4.1353" ]; then
+  fail "W6 — the explicit opt-out must still produce the main-only answer 1.4.1353 (exit ${RUN_RC}, got '${RUN_OUT}')."
+elif ! grep -qi "warning" "${RUN_DIR}.stderr"; then
+  fail "W6 — the opt-out took effect with no loud warning on stderr. An unchecked bump must announce itself."
+else
+  pass "W6 — opt-out produces the main-only answer AND warns loudly."
+fi
+rm -f "${WORK}/gh.rc"
+echo
+
+echo "=============================================================="
+echo "W7 — an open PR whose head branch was DELETED from origin"
+echo "     (unmergeable -> its claim is void, not an unknown)"
+echo "=============================================================="
+set_prs '[{"number":9004,"headRefName":"branch-deleted-from-origin","isCrossRepository":false}]'
+run_bump full
+echo "--- exit=${RUN_RC} next=${RUN_OUT} ---"
+if [ "${RUN_RC}" -ne 0 ] || [ "${RUN_OUT}" != "1.4.1353" ]; then
+  echo "--- stderr ---"; cat "${RUN_DIR}.stderr"
+  fail "W7 — a PR whose head no longer exists on origin can never merge, so it claims nothing. The writer must not wedge on it (exit ${RUN_RC}, got '${RUN_OUT}')."
+else
+  pass "W7 — deleted head branch treated as a void claim, writer proceeds."
+fi
+echo
+
+echo "=============================================================="
+echo "W8 — a CROSS-REPOSITORY (fork) PR head is unreadable from"
+echo "     origin, so its claim is UNKNOWN -> fail loud"
+echo "=============================================================="
+set_prs '[{"number":9005,"headRefName":"some-fork-branch","isCrossRepository":true}]'
+run_bump full
+echo "--- stderr ---"; cat "${RUN_DIR}.stderr"
+echo "--- exit=${RUN_RC} stdout='${RUN_OUT}' ---"
+if [ "${RUN_RC}" -eq 0 ]; then
+  fail "W8 — a fork PR's claim cannot be read from origin. Proceeding as if it claimed nothing is the silent-hole shape; this must be fatal."
+else
+  pass "W8 — an unreadable fork head is reported as an unknown claim and is fatal (exit ${RUN_RC})."
+fi
+echo
+
+echo "=============================================================="
+echo "W9 — shallow, single-branch clone (actions/checkout@v4 default)"
+echo "     must STILL see the sibling claims"
+echo "=============================================================="
+# `git fetch origin pr-a` exits 0 in such a clone but creates NO origin/pr-a,
+# because remote.origin.fetch only maps main. A reader that resolves siblings
+# through origin/<branch> silently sees no claims and passes on nothing.
+set_prs '[{"number":9001,"headRefName":"pr-a","isCrossRepository":false},
+          {"number":9002,"headRefName":"pr-b","isCrossRepository":false}]'
+run_bump shallow
+echo "--- stderr ---"; cat "${RUN_DIR}.stderr"
+echo "--- exit=${RUN_RC} next=${RUN_OUT} ---"
+if [ "${RUN_RC}" -ne 0 ]; then
+  fail "W9 — writer exited ${RUN_RC} on a shallow single-branch clone; that is the default CI checkout shape."
+elif [ "${RUN_OUT}" != "1.4.1354" ]; then
+  fail "W9 — on a shallow single-branch clone the writer returned '${RUN_OUT}'; 1.4.1353 here means the sibling heads resolved to nothing and the constraint was vacuous."
+else
+  pass "W9 — sibling claims are read correctly from a shallow single-branch clone."
+fi
+echo
+
+echo "=============================================================="
+echo "W11 — the enumerator's own self-test still passes"
+echo "=============================================================="
+python3 "${CLAIMS}" --self-test
+RC11=$?
+if [ "${RC11}" -ne 0 ]; then
+  fail "W11 — check-chart-version-not-claimed-by-open-pr.py --self-test exited ${RC11}."
+else
+  pass "W11 — enumerator self-test green."
+fi
+echo
+
+if [ "${FAILED}" -ne 0 ]; then
+  echo "=============================================================="
+  echo "RESULT: FAILED"
+  echo "=============================================================="
+  exit 1
+fi
+echo "=============================================================="
+echo "RESULT: all cases passed"
+echo "=============================================================="

--- a/scripts/tests/test-chart-version-forward.sh
+++ b/scripts/tests/test-chart-version-forward.sh
@@ -42,6 +42,29 @@ done
 WORK="$(mktemp -d)"
 trap 'rm -rf "${WORK}"' EXIT
 
+# bump-chart-version.sh consults open PR heads before it picks a version
+# (#5583), and it fails LOUDLY rather than silently degrading when it cannot.
+# Every fixture below has a local bare repo as its "origin", where the real gh
+# has no repository to answer about — so the fixture supplies its own gh that
+# reports the truth for that origin: it has no pull requests at all. Using this
+# rather than --allow-unchecked-siblings keeps T5/T6 exercising the REAL consult
+# path (enumerate -> zero siblings -> main-only ceiling) instead of the opt-out.
+# The sibling-claim arithmetic itself is pinned in
+# scripts/tests/test-bump-chart-version-open-pr-claims.sh.
+STUB_BIN="${WORK}/stub-bin"
+mkdir -p "${STUB_BIN}"
+cat > "${STUB_BIN}/gh" <<'EOF'
+#!/usr/bin/env bash
+if [ "${1:-}" = "pr" ] && [ "${2:-}" = "list" ]; then
+  echo "[]"
+  exit 0
+fi
+echo "fixture gh stub: unexpected invocation: $*" >&2
+exit 1
+EOF
+chmod +x "${STUB_BIN}/gh"
+export PATH="${STUB_BIN}:${PATH}"
+
 FAILED=0
 fail() { echo "FAIL: $*" >&2; FAILED=1; }
 pass() { echo "PASS: $*"; }


### PR DESCRIPTION
Refs #5583 #5734

## The defect, measured five times in one night

`scripts/bump-chart-version.sh` computed

```
next = bump_patch(max(baseline.version, baseline.appVersion))
```

reading the baseline from `origin/main` **only**. It had no view of what other open branches already claim, so **any two PRs rebased in the same window land on the same version, deterministically** — #6059/#6068 twice, #6089/#6068, and a three-way #6099/#6096/#6068 all computing `1.4.1353`.

The manual separation is not the cost. Whichever of two same-version PRs merges first publishes that artifact to ghcr. The second then merges carrying **different content under a version already published**, the registry keeps the first push, and the second PR's change renders clean, passes every gate, and **ships nothing**.

`scripts/check-chart-version-not-claimed-by-open-pr.py` already detects exactly this — but only at CI time, after the rebase, the push and a full check cycle. **The writer that creates the collision could not see what the checker can.**

## The change

The writer now asks the checker's own enumerator, through a new `--claimed-versions` mode. One enumerator, two consumers — the reader and the writer cannot disagree about what "an open PR claims version X" means.

```
next = bump_patch(max(origin/main baseline, every version this chart carries on an open PR head))
```

Numbers may be skipped. A version is a claim on a shared registry namespace, not a dense counter: a gap costs nothing, a reuse costs a silently un-shipped fix.

**Fails loudly, never silently.** If the sibling set cannot be established — no `gh`, no token, enumeration error, an unreadable fork head — the script exits non-zero and writes nothing rather than computing the main-only number that collides. The single escape hatch is an explicit `--allow-unchecked-siblings` flag that prints a warning banner on every run. There is deliberately no automatic fallback: a version writer that quietly degrades to the colliding behaviour is worse than one that stops, because the caller believes it consulted its siblings.

Preserved unchanged: both `version:` and `appVersion:` are still written in lockstep, the `check-chart-version-forward.sh` self-check still runs before any write, and the baseline is still read through a temp file rather than a pipe (the `77a47f167` SIGPIPE that failed 53 consecutive runs).

## A silent hole fixed in the shared enumerator

Measured 2026-08-11 on a `--depth=1 --single-branch` clone, which is what `actions/checkout@v4` produces by default:

```
$ git fetch -q origin pr-a ; echo "fetch rc=$?"
fetch rc=0
$ git show origin/pr-a:products/catalyst/chart/Chart.yaml
fatal: invalid object name 'origin/pr-a'.
```

The fetch reports success and creates **no** `origin/pr-a` ref, because `remote.origin.fetch` maps only the checked-out branch. A reader resolving siblings through `origin/<branch>` therefore sees every sibling as claiming nothing and passes by comparing nothing — the checker was relying on its workflow's `fetch-depth: 0` to avoid it. Heads are now fetched by explicit refspec into `refs/prclaims/<pr-number>`, which works in that same clone, leaves it shallow (2 extra objects), and does not depend on how the caller configured its remote. That is what lets the deploy-bots call this without a full-history checkout.

Two head states are now distinguished instead of both silently reading as "claims nothing":

- a **fork** head cannot be read from origin, so its claim is **unknown** — fatal.
- a head branch **deleted** from origin belongs to a PR that can never merge, so its claim is **void** — ignored with a note, and it does not wedge the deploy-bots.

## Red, then green

The decisive fixture: `origin/main` at `1.4.1352`, two open PR heads both carrying `1.4.1353`.

**Against the pre-fix script:**

```
W1 — DECISIVE: two OPEN PRs both already claim 1.4.1353
bump-chart-version: origin/main's .../Chart.yaml was version=1.4.1352 appVersion=1.4.1352 -> writing 1.4.1353/1.4.1353
--- exit=0 next=1.4.1353 ---
FAIL: W1 — writer returned 1.4.1353, the version BOTH open PRs already claim.
FAIL: W4 — writer exited 0 with the enumeration broken.
FAIL: W5 — writer exited 0 with no gh available.
FAIL: W8 — a fork PR's claim cannot be read from origin.
FAIL: W9 — on a shallow single-branch clone the writer returned '1.4.1353'.
RESULT: FAILED
```

**Post-fix:**

```
W1 open-PR claims: #9001=1.4.1353 #9002=1.4.1353 ; ceiling 1.4.1353 from open PR #9001 -> writing 1.4.1354/1.4.1354
--- exit=0 next=1.4.1354 ---
PASS: W1 — writer stepped over both open claims: 1.4.1352 baseline + claims{1.4.1353} -> 1.4.1354.
RESULT: all cases passed
```

**Controls — green on BOTH scripts**, so the fix is shown to add a constraint rather than change the arithmetic:

- `W2` no open PRs at all: `1.4.1352 -> 1.4.1353`, byte-identical to today's answer.
- `W3` an open PR that never bumped this chart (its head carries main's own `1.4.1352`): still `1.4.1353`. A sibling only binds when it claims ahead.
- `W7` a PR whose head branch was deleted from origin: still `1.4.1353`, no wedge.
- `W10` both fields written in lockstep to the computed value.
- `W11` the enumerator's own self-test.

**Fail-loud paths**, each red pre-fix (the old script exited 0 and answered `1.4.1353`):

- `W4` enumeration returns non-zero: exit 1, and the working copy is left at `1.4.1352` — nothing written.
- `W5` `gh` absent from `PATH` entirely. The case builds a `PATH` of symlinks to exactly the tools the writer needs and asserts `gh` is unreachable under it before running, because hardcoding `/usr/bin:/bin` would leave `gh` reachable on a runner and test nothing.
- `W8` an unreadable fork head: exit 1.
- `W6` the opt-out: `--allow-unchecked-siblings` with enumeration broken returns the main-only `1.4.1353`, exit 0, and the case asserts a warning actually reached stderr.

`scripts/tests/test-chart-version-forward.sh` (T1-T6, including the production-sized-chart SIGPIPE case) still passes. Its fixtures use a local bare repo as origin, where the real `gh` has no repository to answer about, so they now supply their own `gh` reporting zero open PRs — truthful for that origin, and it keeps T5/T6 on the real consult path rather than the opt-out.

## Live verification against this repository

```
$ python3 scripts/check-chart-version-not-claimed-by-open-pr.py --claimed-versions products/catalyst/chart/Chart.yaml
claimed-versions: products/catalyst/chart/Chart.yaml is carried by 33 of 33 open PR head(s).
...
5964 1.4.1332
5968 1.4.1332
6068 1.4.1355
6094 1.4.1349
6096 1.4.1354
6099 1.4.1353
real 0m3.153s
```

3.1 s for 33 open PRs. The checker still fires on real data — `--pr 5964` reports the collision with #5968 on both `products/agenity/chart` `0.5.23` and `products/catalyst/chart` `1.4.1332` (exit 1), and `--pr 6099` is clean (exit 0).

## Workflow wiring

Both deploy-bot bump steps get `GH_TOKEN: ${{ github.token }}` and `pull-requests: read` on the job. Neither had a token on that step, so without this the enumeration would 403 and the bump would fail loudly on every run. No checkout-depth change is needed. The new test is hermetic (it supplies its own `gh`) and runs in `check-chart-version-forward.yaml` alongside the existing one.

`scripts/` only — no chart touched, so no version bump and no lockstep pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
