### PR TITLE
fix(catalyst-api): the peer-region credential Secret must not wait on a cutover

### DIFF
--- a/products/catalyst/bootstrap/api/cmd/api/main.go
+++ b/products/catalyst/bootstrap/api/cmd/api/main.go
@@ -1101,6 +1101,23 @@ func main() {
 	// is idempotent, so a healthy Sovereign sees zero object churn.
 	go h.ReconcileOrgConsoleTLSFromOrgCRs(context.Background())
 
+	// #6027 — the CREDENTIAL half of the loop above. Both that emitter and the
+	// organization-controller can only write into a peer region if a kubeconfig
+	// for it exists in-cluster, as
+	// `<cutover-ns>/cutover-secondary-kubeconfigs`. Until this loop existed the
+	// only thing that ever wrote that Secret was runCutover — one call site, in
+	// one file — so a 2-region Sovereign that had not run the operator-gated
+	// self-sovereignty cutover held no credential for its own peer region, and
+	// every per-Org console host answered only the share of the shared EIP's
+	// round-robin that landed in region A. Measured on hw293: the Secret
+	// NotFound in both regions, region B carrying zero per-Org listeners
+	// against five pairs in region A. Same shape as #6015 one layer down, and
+	// the same remedy: give the step its own level-triggered owner instead of
+	// hanging it off an unrelated milestone. Chroot-only, no-op on a
+	// single-region Sovereign, and idempotent to the point of writing nothing
+	// once converged.
+	go h.RunSecondaryKubeconfigSecretMaterializer(context.Background())
+
 	// #4877 — level-triggered self-heal for the three OpenBao seed seams
 	// (newapi-admin-token / anthropic / per-Org mcp-bearer). Those seeds fire
 	// from EXACTLY ONE place (runOrganizationPipeline, once per HTTP Org-create,

--- a/products/catalyst/bootstrap/api/internal/handler/cutover_secondary_kubeconfigs.go
+++ b/products/catalyst/bootstrap/api/internal/handler/cutover_secondary_kubeconfigs.go
@@ -56,6 +56,26 @@
 // ACTUAL condition (empty record id / ambiguous on-disk prefixes / no
 // candidate paths resolved / genuinely missing files) instead of
 // folding everything into "0 readable".
+//
+// #6027 addendum — the Secret stopped being a cutover-only artifact.
+//
+// The organization-controller reads THIS Secret to write the per-Org console
+// listener pair into every region (tenant_console_tls_regions.go). While
+// runCutover was the only caller, that credential existed only on a Sovereign
+// that had already fired the operator-gated cutover — so on hw293 the Secret
+// was NotFound in both regions and half of every customer TLS connection to
+// `console.<slug>.<parent>` reset. Three things changed here; the write itself
+// did not move, so there is still exactly one producer:
+//
+//   - A level-triggered caller (secondary_kubeconfig_secret_materializer.go)
+//     runs the same function on an interval and on delivery.
+//   - USABILITY replaced presence. A file, or a Secret value, that cannot
+//     build a client counts as absent — the 95-byte hw293 stub satisfied every
+//     non-empty check and could not authenticate.
+//   - The region COUNT is max(record, CATALYST_CONFIGURED_REGIONS) and the
+//     record may be nil. hw293's chroot restored 0 deployment records, so a
+//     record-only denominator made the completeness check unable to fail on
+//     the one Sovereign that needed it.
 package handler
 
 import (
@@ -156,6 +176,21 @@ type secondaryKubeconfigResolution struct {
 	// resolution refuses to guess between them (silently picking one
 	// could feed a FOREIGN cluster's kubeconfig to the pivot legs).
 	ambiguousPrefixes []string
+	// regionsDeclared is len(dep.Request.Regions) — the SPEC's own count,
+	// kept separately from `expected` because zero declared regions and
+	// one declared region both yield expected == 0 and mean opposite
+	// things (see specAuthoritative).
+	regionsDeclared int
+}
+
+// specAuthoritative reports whether SOMETHING credible declared how many
+// regions this Sovereign has — either the deployment record's own list or
+// the chart-baked CATALYST_CONFIGURED_REGIONS. When neither speaks, an
+// expected count of 0 means "nobody knows", not "this Sovereign is
+// single-region", and acting on that zero would reap a correct Secret a
+// prior pass materialized (the #5488 failure mode inverted).
+func (r secondaryKubeconfigResolution) specAuthoritative() bool {
+	return r.regionsDeclared > 0
 }
 
 // secondaryKubeconfigsForCutover resolves regionKey → on-disk path for
@@ -171,20 +206,57 @@ type secondaryKubeconfigResolution struct {
 // one candidate prefix → adopt it; multiple → record the ambiguity and
 // resolve nothing (the caller prefers the already-materialized Secret
 // and otherwise fails naming the candidates).
+// #6027 — the region COUNT is the max of the record's own list and the
+// chart-baked CATALYST_CONFIGURED_REGIONS, and `dep` may be nil.
+//
+// Measured on hw293 dep a0077ba47e3720e5: the chroot's catalyst-api logs
+// `restored deployments from PVC count=0` — handover never fired, so no
+// record was ever imported and resolveCutoverDeployment returns nil. Taking
+// the record as the sole authority there hands the completeness check a
+// denominator of zero, i.e. a guard that cannot fail: a 2-region Sovereign
+// reads as single-region and the producer decides, correctly by its own
+// arithmetic, that there is nothing to materialize.
+//
+// `sovereign-fqdn`'s `configuredRegions` is written by the IaC at provision
+// time and is independent of both the deployment store and the k8scache — on
+// hw293 it reads `hw-me-east-215-a-rtz-prod,hw-me-east-215-b-rtz-prod` while
+// the store held nothing. It is the same witness placementDeploymentIdentity
+// (#6015) and the org-controller's own region resolver (#6097) take the max
+// against, so no new contract is invented.
+//
+// It supplies a COUNT only. Its region names are cloud regions
+// (`hw-me-east-215-b-rtz-prod`) while the kubeconfig files are keyed by the
+// secondary CP's own regionKey (`me-east-215-b-1`), so the KEYS still come
+// from disk — the count says how many must be found, the disk says which.
 func secondaryKubeconfigsForCutover(dep *Deployment) secondaryKubeconfigResolution {
-	dep.mu.Lock()
-	expected := 0
-	if len(dep.Request.Regions) > 1 {
-		expected = len(dep.Request.Regions) - 1
+	envDeclared := len(regionsFromEnv())
+	expected, regionsDeclared, depID := 0, envDeclared, ""
+	paths := map[string]string{}
+	if envDeclared > 1 {
+		expected = envDeclared - 1
 	}
-	paths := make(map[string]string, len(dep.secondaryKubeconfigPaths))
-	for k, v := range dep.secondaryKubeconfigPaths {
-		paths[k] = v
+	if dep != nil {
+		dep.mu.Lock()
+		if n := len(dep.Request.Regions); n > 1 && n-1 > expected {
+			expected = n - 1
+		}
+		if n := len(dep.Request.Regions); n > regionsDeclared {
+			regionsDeclared = n
+		}
+		paths = make(map[string]string, len(dep.secondaryKubeconfigPaths))
+		for k, v := range dep.secondaryKubeconfigPaths {
+			paths[k] = v
+		}
+		depID = strings.TrimSpace(dep.ID)
+		dep.mu.Unlock()
 	}
-	depID := strings.TrimSpace(dep.ID)
-	dep.mu.Unlock()
 
-	res := secondaryKubeconfigResolution{paths: paths, expected: expected, depID: depID}
+	res := secondaryKubeconfigResolution{
+		paths:           paths,
+		expected:        expected,
+		depID:           depID,
+		regionsDeclared: regionsDeclared,
+	}
 	dir := secondaryKubeconfigsDir()
 
 	prefix := depID
@@ -300,28 +372,99 @@ func sanitizeSecondaryRegionKey(key string) string {
 func (h *Handler) materializeSecondaryKubeconfigsSecret(ctx context.Context, deps *cutoverDeps) (int, error) {
 	name := cutoverSecondaryKubeconfigsSecretName()
 
+	// A record-less process is NOT a single-region one (#6027). The mothership
+	// has no record because it never runs the cutover; a chroot can have none
+	// because handover never fired — hw293's catalyst-api logs `restored
+	// deployments from PVC count=0` while its `sovereign-fqdn` ConfigMap
+	// declares two regions. Returning 0 here, as this function used to, meant
+	// the exact Sovereign that most needs the peer-region credential is the one
+	// guaranteed not to get it. secondaryKubeconfigsForCutover now tolerates a
+	// nil record and falls back to CATALYST_CONFIGURED_REGIONS for the count
+	// and to the on-disk `<prefix>-<regionKey>.yaml` files for the keys; when
+	// NEITHER speaks, specAuthoritative is false below and nothing is touched.
 	dep := h.resolveCutoverDeployment()
-	if dep == nil {
-		// No deployment record on this process (mothership never runs the
-		// cutover; a record-less chroot cannot know its region topology).
-		// Do NOT delete an existing Secret — a prior run with a live record
-		// may have materialized it and the files it points at are still the
-		// truth. Loud in the log so a record-less 2-region chroot is
-		// diagnosable rather than silently single-region.
-		h.log.Warn("cutover: no deployment record matches SOVEREIGN_FQDN — secondary-region detection unavailable; proceeding with any previously-materialized secondary kubeconfigs (#5359)",
-			"secret", name)
-		return 0, nil
-	}
 
 	res := secondaryKubeconfigsForCutover(dep)
 	paths, expected := res.paths, res.expected
+
+	// annotationDepID identifies which deployment the Secret was materialized
+	// for. Empty when the record is absent or degraded AND no single on-disk
+	// prefix could be derived — the annotation is then omitted rather than
+	// written blank, so acceptMaterializedSecondaryKubeconfigsSecret's
+	// foreign-Secret check keeps a meaningful "" == unknown reading.
+	annotationDepID := res.depID
+	if annotationDepID == "" {
+		annotationDepID = res.derivedPrefix
+	}
+
+	// THE SPEC DECIDES SINGLE-REGION, NOT THE DISK (#6027).
+	//
+	// secondaryKubeconfigsForCutover unions the in-memory path map with every
+	// `<depID>-<regionKey>.yaml` it finds on disk, and that union is not
+	// bounded by the declared region count. So a ONE-region deployment that
+	// still carried a file from a prior topology fell straight past the
+	// `expected > len(data)` check (0 > 1 is false) and materialized a Secret
+	// naming a region the Sovereign does not have. Under the cutover's single
+	// call that was a narrow window; under a level-triggered loop it would be
+	// the steady state, and the control that a single-region Sovereign produces
+	// no Secret — the one control that distinguishes this fix from a producer
+	// that always writes — would be false.
+	//
+	// The `expected == 0` arm is split in two because zero has two meanings:
+	//   - a record that DECLARES one region is authoritative; there are no
+	//     secondaries, so any Secret is stale and is reaped;
+	//   - a DEGRADED record (#5488: empty id, no declared regions) knows
+	//     nothing. Reaping on that would delete the correct Secret a prior
+	//     pass materialized, which is the #5488 failure mode inverted. Leave
+	//     the object exactly as it is and say so.
+	if expected == 0 {
+		if !res.specAuthoritative() {
+			h.log.Warn("secondary-kubeconfigs: NOBODY declares a region count — no deployment record and CATALYST_CONFIGURED_REGIONS empty; leaving any already-materialized Secret untouched rather than reaping it on an unknown topology (#5488 inverted). Recovery: check the `sovereign-fqdn` ConfigMap key `configuredRegions`, or re-import the record (POST /api/v1/internal/deployments/import)",
+				"secret", deps.ns+"/"+name)
+			return 0, nil
+		}
+		// Single-region: guarantee the mount stays empty so the chart legs
+		// no-op — reap a stale Secret from a prior multi-region life.
+		//
+		// Get-before-Delete: this function is now also driven by a
+		// level-triggered loop, so an unconditional Delete would issue one
+		// apiserver write every tick, forever, to remove an object that has
+		// never existed. Reading first makes the steady state a single cheap
+		// Get and keeps the reap.
+		if _, gerr := deps.core.CoreV1().Secrets(deps.ns).Get(ctx, name, metav1.GetOptions{}); apierrors.IsNotFound(gerr) {
+			return 0, nil
+		}
+		if derr := deps.core.CoreV1().Secrets(deps.ns).Delete(ctx, name, metav1.DeleteOptions{}); derr != nil && !apierrors.IsNotFound(derr) {
+			return 0, fmt.Errorf("cutover: delete stale %s/%s: %w", deps.ns, name, derr)
+		}
+		return 0, nil
+	}
 
 	data := make(map[string][]byte, len(paths))
 	var missing []string
 	for key, path := range paths {
 		raw, err := os.ReadFile(path)
 		if err != nil || len(raw) == 0 {
-			missing = append(missing, fmt.Sprintf("%s (%s)", key, path))
+			missing = append(missing, fmt.Sprintf("%s (%s: unreadable or empty)", key, path))
+			continue
+		}
+		// USABILITY, not presence (#6027). Until this check existed the only
+		// bar a file had to clear was len(raw) != 0, so the 95-byte hw293
+		// stub — clusters+server and nothing else — was materialized into
+		// the Secret and returned n=1. Every consumer then read region B as
+		// CREDENTIALLED: the org-controller's newRegionClient failed at
+		// clientcmd, logged the region as Unreachable, and the per-Org
+		// console listener was never written there while the Secret sat in
+		// the namespace looking complete. A key whose value cannot build a
+		// client is worth exactly as much as an absent key, so it is counted
+		// as one — the same fail-loud arm, naming the byte count and the
+		// missing sections. See secondary_kubeconfig_completeness.go for the
+		// measured artefact; this is the READ-side twin of the #6054
+		// write-side gate, and it is what disqualifies a stub that landed on
+		// disk BEFORE that gate shipped.
+		if defects := secondaryKubeconfigDefects(string(raw)); len(defects) > 0 {
+			missing = append(missing, fmt.Sprintf("%s (%s: %d bytes, cannot build a client — missing %s)",
+				key, path, len(raw), strings.Join(defects, "+")))
 			continue
 		}
 		data[sanitizeSecondaryRegionKey(key)+".yaml"] = raw
@@ -366,23 +509,19 @@ func (h *Handler) materializeSecondaryKubeconfigsSecret(ctx context.Context, dep
 				res.depID, expected, res.depID, secondaryKubeconfigsDir(), secretRef)
 		default:
 			// Original #5359 contract: candidate paths existed but the
-			// files are genuinely missing/unreadable — name each one.
+			// files are genuinely missing/unreadable/unusable — name each.
 			return 0, fmt.Errorf(
-				"cutover: deployment %s expects %d secondary region(s) but only %d kubeconfig(s) are readable (missing/unreadable: %s) — refusing to start a cutover whose region-B pivot legs would silently no-op (#5359)",
+				"cutover: deployment %s expects %d secondary region(s) but only %d kubeconfig(s) are USABLE (rejected: %s) — refusing to start a cutover whose region-B pivot legs would silently no-op (#5359)",
 				res.depID, expected, len(data), strings.Join(missing, ", "))
 		}
 	}
 
-	if len(data) == 0 {
-		// Single-region: guarantee the mount stays empty so the chart legs
-		// no-op — delete any stale Secret from a prior multi-region life.
-		err := deps.core.CoreV1().Secrets(deps.ns).Delete(ctx, name, metav1.DeleteOptions{})
-		if err != nil && !apierrors.IsNotFound(err) {
-			return 0, fmt.Errorf("cutover: delete stale %s/%s: %w", deps.ns, name, err)
-		}
-		return 0, nil
+	annotations := map[string]string{
+		"catalyst.openova.io/materialized": time.Now().UTC().Format(time.RFC3339),
 	}
-
+	if annotationDepID != "" {
+		annotations["catalyst.openova.io/deployment-id"] = annotationDepID
+	}
 	desired := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -392,10 +531,7 @@ func (h *Handler) materializeSecondaryKubeconfigsSecret(ctx context.Context, dep
 				"app.kubernetes.io/managed-by": "catalyst-api",
 				"app.kubernetes.io/component":  "cutover-secondary-kubeconfigs",
 			},
-			Annotations: map[string]string{
-				"catalyst.openova.io/deployment-id": dep.ID,
-				"catalyst.openova.io/materialized":  time.Now().UTC().Format(time.RFC3339),
-			},
+			Annotations: annotations,
 		},
 		Type: corev1.SecretTypeOpaque,
 		Data: data,
@@ -410,6 +546,25 @@ func (h *Handler) materializeSecondaryKubeconfigsSecret(ctx context.Context, dep
 	case err != nil:
 		return 0, fmt.Errorf("cutover: get %s/%s: %w", deps.ns, name, err)
 	default:
+		// Converged? Then write NOTHING (#6027). The `materialized`
+		// annotation is a timestamp, so an unconditional Update rewrites the
+		// object on every pass and bumps its resourceVersion. That is not
+		// merely wasteful: the org-controller keys its per-region client
+		// cache on exactly this Secret's resourceVersion
+		// (tenant_console_tls_regions.go regionClientCache), so a churning
+		// object throws away every secondary-region client and re-runs
+		// discovery against the peer apiserver once per Org per tick. Under
+		// the cutover's single call this was invisible; under a
+		// level-triggered loop it would be a standing load. Measured on the
+		// fake clientset: 3 identical passes produced 3 writes before this
+		// check, 1 after.
+		if secretDataEqualBytes(existing.Data, desired.Data) &&
+			existing.Type == desired.Type &&
+			len(existing.StringData) == 0 &&
+			existing.Labels["app.kubernetes.io/component"] == desired.Labels["app.kubernetes.io/component"] &&
+			existing.Annotations["catalyst.openova.io/deployment-id"] == desired.Annotations["catalyst.openova.io/deployment-id"] {
+			return len(data), nil
+		}
 		// Full data replace (stale region keys must not linger); keep the
 		// live object's resourceVersion for a conflict-safe update.
 		updated := existing.DeepCopy()
@@ -430,7 +585,7 @@ func (h *Handler) materializeSecondaryKubeconfigsSecret(ctx context.Context, dep
 	h.log.Info("cutover: secondary-region kubeconfigs materialized for the step Jobs (#5359)",
 		"secret", deps.ns+"/"+name,
 		"regions", strings.Join(keys, ","),
-		"deploymentID", dep.ID)
+		"deploymentID", annotationDepID)
 	return len(data), nil
 }
 
@@ -466,9 +621,14 @@ func (h *Handler) acceptMaterializedSecondaryKubeconfigsSecret(ctx context.Conte
 			return 0, false // materialized for a different deployment.
 		}
 	}
+	// USABILITY, not presence (#6027). `len(v) > 0` accepted the 95-byte
+	// hw293 stub here exactly as it did on the read path — and this arm is
+	// the one that runs when the process cannot re-derive its own on-disk
+	// paths, i.e. precisely when nothing else would catch it. A key that
+	// cannot build a client does not count toward the expected total.
 	n := 0
 	for _, v := range existing.Data {
-		if len(v) > 0 {
+		if len(v) > 0 && secondaryKubeconfigUsable(string(v)) {
 			n++
 		}
 	}

--- a/products/catalyst/bootstrap/api/internal/handler/cutover_secondary_kubeconfigs_5488_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/cutover_secondary_kubeconfigs_5488_test.go
@@ -84,9 +84,16 @@ func newFixture5488(t *testing.T, depID string, regions int) (*Handler, *cutover
 
 func seedMaterializedSecret5488(t *testing.T, deps *cutoverDeps, annotationDepID string, keys ...string) {
 	t.Helper()
+	// The seeded value must be a COMPLETE kubeconfig. These tests are about
+	// path resolution and the post-restart recovery arm, not about content —
+	// but the placeholder they used to carry (`clusters: []`, 41 bytes) could
+	// not build a client, and the recovery check counted it toward the
+	// expected total anyway. That is the hw293 stub's defect in miniature, so
+	// the fixture now uses a document that actually authenticates and the
+	// count means what it says (#6027).
 	data := map[string][]byte{}
 	for _, k := range keys {
-		data[k] = []byte("apiVersion: v1\nkind: Config\nclusters: []\n")
+		data[k] = []byte(completeKubeconfigSameCluster)
 	}
 	sec := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -106,7 +113,8 @@ func seedMaterializedSecret5488(t *testing.T, deps *cutoverDeps, annotationDepID
 func writeKubeconfigFile5488(t *testing.T, dir, stem string) {
 	t.Helper()
 	path := filepath.Join(dir, stem+".yaml")
-	if err := os.WriteFile(path, []byte("apiVersion: v1\nkind: Config\nclusters: []\n"), 0o600); err != nil {
+	// Complete document — see seedMaterializedSecret5488 (#6027).
+	if err := os.WriteFile(path, []byte(completeKubeconfigSameCluster), 0o600); err != nil {
 		t.Fatalf("write %s: %v", path, err)
 	}
 }
@@ -267,7 +275,11 @@ func TestMaterializeSecondaryKubeconfigs_5488_AbortMessages(t *testing.T) {
 			},
 			wantSubstrs: []string{
 				"deployment dep5488",
-				"missing/unreadable",
+				// #6027 renamed this arm's verb: the list now covers files
+				// that are unreadable AND files that are readable but cannot
+				// build a client, so each entry names its own condition
+				// instead of sharing one "missing/unreadable" label.
+				"unreadable or empty",
 				"me-east-215-b-1",
 				"does-not-exist.yaml",
 				"#5359",

--- a/products/catalyst/bootstrap/api/internal/handler/cutover_secondary_kubeconfigs_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/cutover_secondary_kubeconfigs_test.go
@@ -60,7 +60,11 @@ func newSecondaryKubeconfigFixture(t *testing.T, regions int) (*Handler, *cutove
 func writeSecondaryKubeconfig(t *testing.T, dir, depID, region string) {
 	t.Helper()
 	path := filepath.Join(dir, depID+"-"+region+".yaml")
-	if err := os.WriteFile(path, []byte("apiVersion: v1\nkind: Config\nclusters: []\n"), 0o600); err != nil {
+	// A COMPLETE kubeconfig (#6027). The placeholder this used to write —
+	// `clusters: []`, 41 bytes — cannot build a client, so these tests were
+	// asserting that a Secret gets a KEY, never that the key is a usable
+	// credential. That is the same gap the 95-byte hw293 stub walked through.
+	if err := os.WriteFile(path, []byte(completeKubeconfigSameCluster), 0o600); err != nil {
 		t.Fatalf("write %s: %v", path, err)
 	}
 }

--- a/products/catalyst/bootstrap/api/internal/handler/handler.go
+++ b/products/catalyst/bootstrap/api/internal/handler/handler.go
@@ -81,6 +81,25 @@ type Handler struct {
 	// zero.
 	secondaryKubeconfigDeliveryInterval time.Duration
 
+	// secondaryKubeconfigSecretKick / …Once (#6027) — the coalescing kick the
+	// delivery endpoint uses to ask RunSecondaryKubeconfigSecretMaterializer
+	// for an immediate pass, so a freshly-delivered peer-region kubeconfig
+	// becomes the in-cluster credential Secret in about a second instead of on
+	// the next tick. Capacity 1; a burst of POSTs collapses into one pass.
+	secondaryKubeconfigSecretKick     chan struct{}
+	secondaryKubeconfigSecretKickOnce sync.Once
+
+	// secondaryKubeconfigSecretInterval (#6027) — cadence of that loop. Zero
+	// falls back to secondaryKubeconfigSecretIntervalDefault; tests inject a
+	// sub-second value.
+	secondaryKubeconfigSecretInterval time.Duration
+
+	// secondaryKubeconfigSecretState / …Mu — the last outcome the materializer
+	// reported, so a converged Sovereign stays quiet and every TRANSITION is
+	// logged. The loop is the only writer, but a test may read it.
+	secondaryKubeconfigSecretState   string
+	secondaryKubeconfigSecretStateMu sync.Mutex
+
 	// orphanReleaseWG tracks the releaseOrphanedReservation goroutines that
 	// restoreFromStore fires (#489). Those goroutines outlive the call that
 	// spawned them: after pdm.Release returns they clear the dep's PDM

--- a/products/catalyst/bootstrap/api/internal/handler/secondary_kubeconfig_secret_materializer.go
+++ b/products/catalyst/bootstrap/api/internal/handler/secondary_kubeconfig_secret_materializer.go
@@ -1,0 +1,216 @@
+// secondary_kubeconfig_secret_materializer.go — give the secondary-region
+// credential Secret a producer that does not require a cutover.
+//
+// THE DEFECT (measured on hw293, dep a0077ba47e3720e5, both regions)
+// ------------------------------------------------------------------
+// The per-Org console surface answered roughly half of all fresh TCP
+// connections. `console.<slug>.<parent>` resolves to one shared EIP whose
+// ELB round-robins every region's envoy, so a host only region A can serve
+// resets whatever share the pool sends to region B. Region B's
+// `kube-system/cilium-gateway-console` carried ZERO per-Org listeners against
+// five pairs in region A.
+//
+// The organization-controller writes those listeners into every region it can
+// reach, and it reaches a secondary region through exactly one artefact:
+//
+//	Secret catalyst/cutover-secondary-kubeconfigs
+//	  data: "<regionKey>.yaml" -> kubeconfig bytes
+//
+// On hw293 that Secret was NotFound in both regions. The controls prove the
+// query was live: `catalyst` held 11 other Secrets, `kube-system` held the
+// whole `clustermesh-apiserver-*-cert` family. It was that one object, absent.
+//
+// WHY IT WAS ABSENT — a structural property, not a failure
+// --------------------------------------------------------
+// materializeSecondaryKubeconfigsSecret had exactly ONE production call site:
+// cutover.go, inside runCutover. Counted, not assumed — one, in one file. So
+// the Secret came into existence only on a Sovereign that had already run the
+// self-sovereignty cutover, and bp-self-sovereign-cutover installs DORMANT at
+// bootstrap-kit slot 06a and is operator-gated by design. A 2-region Sovereign
+// that has never cut over — which is every Sovereign, until an operator
+// decides otherwise — therefore could not hold the credential for its own peer
+// region. Nothing was broken; nothing had ever been asked to write it.
+//
+// That is the same shape as #6015 one layer down. There, both producers of the
+// chroot's on-disk kubeconfigs were gated behind `finalStatus == "ready"`, so
+// one dormant HelmRelease blinded the Sovereign to region B. #6015 gave
+// DELIVERY its own level-triggered loop. This file does the same for the step
+// that turns a delivered file into the in-cluster credential the controllers
+// consume: a Sovereign that has a peer region gets a usable Secret for it as
+// soon as the file lands, and keeps having one.
+//
+// ONE PRODUCER, TWO TRIGGERS
+// --------------------------
+// The Secret is still written by exactly one function — materializeSecondary-
+// KubeconfigsSecret. Two producers of one object generate drift by
+// construction, so nothing here re-implements the write: runCutover keeps its
+// pre-flight call (with its fail-loud abort), and this loop calls the same
+// function on an interval plus on a kick from the delivery endpoint. Every
+// write stays idempotent and, since #6027's convergence check, a no-op once
+// the object matches.
+//
+// WHAT SINGLE-REGION DOES
+// -----------------------
+// Nothing, loudly enough to be checkable. When the declared region count is 1,
+// the shared function takes its `expected == 0` arm BEFORE it reads anything
+// off disk: it reaps a stale Secret if one exists and otherwise writes nothing
+// and returns (0, nil). Reading the spec first rather than the disk is what
+// makes that arm reachable — a stray kubeconfig left over from a prior
+// topology used to walk straight past the completeness check and materialize a
+// region the Sovereign does not have. The loop reports "no secondary regions"
+// and keeps ticking. A fix that always writes a Secret would be
+// indistinguishable from the defect it claims to fix, so this is pinned by its
+// own test.
+//
+// Refs #6015 #6027.
+package handler
+
+import (
+	"context"
+	"strconv"
+	"time"
+)
+
+// secondaryKubeconfigSecretIntervalDefault — cadence of the level-triggered
+// materializer. Faster than the 5-minute delivery loop because this side is a
+// local read plus (in the converged case) a single Get: the cost of a pass is
+// negligible and the reward is that a Sovereign converges soon after the
+// delivery loop lands a file, even if the kick is missed across a restart.
+const secondaryKubeconfigSecretIntervalDefault = 60 * time.Second
+
+// secondaryKubeconfigSecretKickChan returns the coalescing kick channel,
+// allocating it on first use. Capacity 1: a burst of deliveries collapses into
+// one extra pass instead of queueing one pass per POST.
+func (h *Handler) secondaryKubeconfigSecretKickChan() chan struct{} {
+	h.secondaryKubeconfigSecretKickOnce.Do(func() {
+		h.secondaryKubeconfigSecretKick = make(chan struct{}, 1)
+	})
+	return h.secondaryKubeconfigSecretKick
+}
+
+// kickSecondaryKubeconfigSecret asks the materializer for an immediate pass.
+// Non-blocking and safe to call when no loop is running (the buffered slot
+// simply stays full until one starts).
+func (h *Handler) kickSecondaryKubeconfigSecret() {
+	select {
+	case h.secondaryKubeconfigSecretKickChan() <- struct{}{}:
+	default:
+	}
+}
+
+// RunSecondaryKubeconfigSecretMaterializer is the level-triggered producer of
+// the secondary-region credential Secret. It runs on the chroot Sovereign only
+// — the mothership holds no cutover namespace and serves no deployment record
+// of its own — and returns when ctx is cancelled.
+//
+// Every pass delegates to materializeSecondaryKubeconfigsSecret, so the
+// contract is that function's: a complete set of USABLE secondary kubeconfigs
+// produces the Secret, an incomplete set produces nothing and says which
+// region fell short, and a single-region Sovereign produces nothing at all.
+// The difference here is only WHEN it is asked — every tick and on delivery,
+// rather than once, if and when an operator fires a cutover.
+//
+// A shortfall is logged and retried, never fatal: the region-B file may simply
+// not have been delivered yet, and this loop is the thing that notices when it
+// arrives. runCutover keeps the hard abort, because starting the 11-step chain
+// against a half-known topology is the #5359 false positive.
+func (h *Handler) RunSecondaryKubeconfigSecretMaterializer(ctx context.Context) {
+	if !isChroot() {
+		h.log.Debug("secondary-kubeconfig-secret: materializer not started — SOVEREIGN_FQDN unset (mothership mode)")
+		return
+	}
+	interval := h.secondaryKubeconfigSecretInterval
+	if interval <= 0 {
+		interval = secondaryKubeconfigSecretIntervalDefault
+	}
+	kick := h.secondaryKubeconfigSecretKickChan()
+
+	h.log.Info("secondary-kubeconfig-secret: level-triggered materializer started — the per-Org console credential for a peer region no longer waits on a cutover (#6027)",
+		"secret", cutoverSecondaryKubeconfigsSecretName(),
+		"interval", interval.String(),
+	)
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		h.reconcileSecondaryKubeconfigsSecret(ctx)
+		select {
+		case <-ctx.Done():
+			return
+		case <-kick:
+		case <-ticker.C:
+		}
+	}
+}
+
+// reconcileSecondaryKubeconfigsSecret runs one pass. Exported only to the
+// package so a test can drive a single pass deterministically instead of
+// racing the loop's timer.
+func (h *Handler) reconcileSecondaryKubeconfigsSecret(ctx context.Context) {
+	deps, err := h.cutoverDepsFor()
+	if err != nil || deps == nil {
+		h.logSecondaryKubeconfigSecretState("deps-unavailable",
+			func() {
+				h.log.Warn("secondary-kubeconfig-secret: cannot build an in-cluster client this pass; retrying", "err", err)
+			})
+		return
+	}
+	n, merr := h.materializeSecondaryKubeconfigsSecret(ctx, deps)
+	switch {
+	case merr != nil:
+		// Not fatal here. The most common cause is the one this loop exists
+		// to wait out: the peer region's kubeconfig has not been delivered
+		// (or is the credential-less shell #6054 now refuses at the door and
+		// the read path now refuses off disk). Say which, once per change of
+		// state, and try again next tick.
+		h.logSecondaryKubeconfigSecretState("incomplete:"+merr.Error(),
+			func() {
+				h.log.Warn("secondary-kubeconfig-secret: the peer region(s) have no usable kubeconfig yet — the per-Org console listener cannot be written there until one lands; retrying",
+					"secret", deps.ns+"/"+cutoverSecondaryKubeconfigsSecretName(),
+					"detail", merr.Error())
+			})
+	case n == 0:
+		h.logSecondaryKubeconfigSecretState("single-region",
+			func() {
+				h.log.Info("secondary-kubeconfig-secret: no secondary regions — no Secret is produced (single-region Sovereign; behaviour identical to before this loop existed)",
+					"secret", deps.ns+"/"+cutoverSecondaryKubeconfigsSecretName())
+			})
+	default:
+		h.logSecondaryKubeconfigSecretState("materialized:"+strconv.Itoa(n),
+			func() {
+				h.log.Info("secondary-kubeconfig-secret: peer-region credential materialized — the organization-controller can now write the per-Org console listener pair into every region (#6027)",
+					"secret", deps.ns+"/"+cutoverSecondaryKubeconfigsSecretName(),
+					"regions", n)
+			})
+	}
+}
+
+// logSecondaryKubeconfigSecretState emits `emit` only when the outcome differs
+// from the previous pass. A converged Sovereign is quiet; a state change is
+// always on the record. Without this a 60-second loop would print the same
+// line 1440 times a day and bury the transition that matters.
+func (h *Handler) logSecondaryKubeconfigSecretState(state string, emit func()) {
+	h.secondaryKubeconfigSecretStateMu.Lock()
+	changed := h.secondaryKubeconfigSecretState != state
+	h.secondaryKubeconfigSecretState = state
+	h.secondaryKubeconfigSecretStateMu.Unlock()
+	if changed {
+		emit()
+	}
+}
+
+// secretDataEqualBytes compares two Secret data maps byte-for-byte. Used by
+// the convergence check that keeps a level-triggered pass from rewriting an
+// already-correct object.
+func secretDataEqualBytes(a, b map[string][]byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, av := range a {
+		bv, ok := b[k]
+		if !ok || string(av) != string(bv) {
+			return false
+		}
+	}
+	return true
+}

--- a/products/catalyst/bootstrap/api/internal/handler/secondary_kubeconfig_secret_materializer_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/secondary_kubeconfig_secret_materializer_test.go
@@ -1,0 +1,505 @@
+// secondary_kubeconfig_secret_materializer_test.go — #6027.
+//
+// What these pin, in the order a reader should judge them:
+//
+//  1. THE PRODUCER EXISTS OUTSIDE runCutover. Before this change
+//     materializeSecondaryKubeconfigsSecret had exactly one production call
+//     site, in cutover.go — counted by TestSecondaryKubeconfigSecret_HasA-
+//     ProducerOutsideCutover, which is the guard that fails if someone later
+//     folds the loop back into the cutover path.
+//
+//  2. THE VALUE, NOT THE PRESENCE. A Secret carrying the 95-byte hw293 stub
+//     is worth nothing: the organization-controller's newRegionClient runs
+//     clientcmd on it, fails, and records the region Unreachable — while the
+//     Secret sits there looking complete. So the acceptance test parses the
+//     delivered bytes back into a rest.Config, and a second test proves the
+//     stub is REFUSED rather than materialized.
+//
+//  3. THE DECISIVE CONTROL. A genuinely single-region Sovereign must produce
+//     no Secret and must not error. A producer that always writes one would
+//     pass every test above and still be wrong.
+//
+// Refs #6015 #6027.
+
+package handler
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	fakek8s "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// materializerFixture wires the chroot-shaped fixture used by the #5359 suite
+// to a Handler whose cutoverDeps factory returns ONE stable fake clientset, so
+// a test can drive the production loop and then inspect what it wrote.
+func materializerFixture(t *testing.T, regions int) (*Handler, *fakek8s.Clientset, string) {
+	t.Helper()
+	h, deps, dir := newSecondaryKubeconfigFixture(t, regions)
+	fake := deps.core.(*fakek8s.Clientset)
+	h.SetCutoverDepsFactory(func() (*cutoverDeps, error) { return deps, nil })
+	h.secondaryKubeconfigSecretInterval = 5 * time.Millisecond
+	return h, fake, dir
+}
+
+func writeKubeconfigFile(t *testing.T, dir, depID, region, body string) {
+	t.Helper()
+	path := filepath.Join(dir, depID+"-"+region+".yaml")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func getBridgeSecret(t *testing.T, fake *fakek8s.Clientset) (*corev1.Secret, error) {
+	t.Helper()
+	return fake.CoreV1().Secrets(cutoverTestNS).Get(context.Background(),
+		cutoverSecondaryKubeconfigsSecretName(), metav1.GetOptions{})
+}
+
+func waitForBridgeSecret(t *testing.T, fake *fakek8s.Clientset, d time.Duration) *corev1.Secret {
+	t.Helper()
+	deadline := time.Now().Add(d)
+	for time.Now().Before(deadline) {
+		if sec, err := getBridgeSecret(t, fake); err == nil {
+			return sec
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// 1. The producer exists outside runCutover.
+// ---------------------------------------------------------------------------
+
+// TestSecondaryKubeconfigSecret_HasAProducerOutsideCutover states the root
+// cause as a number. With one production call site — cutover.go's — the Secret
+// could only ever exist on a Sovereign that had already run the operator-gated
+// cutover, which is why hw293 held none in either region while its peer
+// region's apiserver was healthy the whole time.
+func TestSecondaryKubeconfigSecret_HasAProducerOutsideCutover(t *testing.T) {
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("read package dir: %v", err)
+	}
+	const call = "h.materializeSecondaryKubeconfigsSecret("
+	sites := map[string]int{}
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		raw, rerr := os.ReadFile(name)
+		if rerr != nil {
+			continue
+		}
+		if n := strings.Count(string(raw), call); n > 0 {
+			sites[name] = n
+		}
+	}
+	if len(sites) == 0 {
+		t.Fatalf("no production call site of materializeSecondaryKubeconfigsSecret at all — the Secret has no producer")
+	}
+	outside := 0
+	for file, n := range sites {
+		if file != "cutover.go" {
+			outside += n
+		}
+	}
+	if outside == 0 {
+		t.Fatalf("materializeSecondaryKubeconfigsSecret is called ONLY from cutover.go (%v) — "+
+			"the peer-region credential Secret exists only after an operator fires the cutover, "+
+			"so a 2-region Sovereign that has not cut over cannot write per-Org console listeners "+
+			"into its own region B (#6027)", sites)
+	}
+}
+
+// TestSecondaryKubeconfigSecret_IsStartedByMain is the wiring guard. Every
+// other test here calls RunSecondaryKubeconfigSecretMaterializer directly, so
+// all of them stay green if the `go h.Run…` line is deleted from main() and
+// the loop never runs in production — the exact "guard that cannot fail"
+// shape. main() is package main and is not drivable from here, so the spawn is
+// asserted at the source level.
+func TestSecondaryKubeconfigSecret_IsStartedByMain(t *testing.T) {
+	const mainPath = "../../cmd/api/main.go"
+	raw, err := os.ReadFile(mainPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", mainPath, err)
+	}
+	const spawn = "go h.RunSecondaryKubeconfigSecretMaterializer("
+	if !strings.Contains(string(raw), spawn) {
+		t.Fatalf("%s does not spawn the secondary-kubeconfig Secret materializer (%q) — "+
+			"the loop exists but nothing starts it, so the Secret still has no producer "+
+			"outside runCutover on a real Sovereign (#6027)", mainPath, spawn)
+	}
+	// Vacuity arm: the same read must be able to MISS something, or a typo in
+	// the needle above would make this test pass against any file at all.
+	if strings.Contains(string(raw), "go h.RunSecondaryKubeconfigSecretMaterializerThatDoesNotExist(") {
+		t.Fatal("control needle matched — the containment check is not discriminating")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 2. The value, not the presence.
+// ---------------------------------------------------------------------------
+
+// TestSecondaryKubeconfigSecret_MaterializesPreCutover is the acceptance unit:
+// a 2-region Sovereign that has NEVER run a cutover ends up holding a peer-
+// region credential that actually builds a client.
+func TestSecondaryKubeconfigSecret_MaterializesPreCutover(t *testing.T) {
+	h, fake, dir := materializerFixture(t, 2)
+	writeKubeconfigFile(t, dir, "dep5359", "me-east-215-b", completeKubeconfigSameCluster)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go h.RunSecondaryKubeconfigSecretMaterializer(ctx)
+
+	sec := waitForBridgeSecret(t, fake, 3*time.Second)
+	if sec == nil {
+		t.Fatalf("no %s Secret after a level-triggered pass on a 2-region Sovereign — "+
+			"the organization-controller still has no credential for region B and its per-Org "+
+			"console listener pair can only ever land in region A (#6027)",
+			cutoverSecondaryKubeconfigsSecretName())
+	}
+
+	// ASSERT ON THE VALUE. A key is not a credential: the 95-byte hw293 stub
+	// satisfied every presence check ever applied to this object and still
+	// could not produce a client.
+	raw, ok := sec.Data["me-east-215-b.yaml"]
+	if !ok {
+		t.Fatalf("Secret carries no key for region me-east-215-b; keys=%v", secretDataKeys(sec))
+	}
+	cfg, err := clientcmd.RESTConfigFromKubeConfig(raw)
+	if err != nil {
+		t.Fatalf("the materialized %d-byte value cannot build a client: %v — presence without usability is the defect, not the fix", len(raw), err)
+	}
+	if strings.TrimSpace(cfg.Host) == "" {
+		t.Fatalf("materialized kubeconfig built a rest.Config with no Host")
+	}
+	if len(cfg.BearerToken) == 0 && cfg.CertData == nil && cfg.AuthProvider == nil && cfg.ExecProvider == nil {
+		t.Fatalf("materialized kubeconfig carries no credential at all — Host alone cannot authenticate")
+	}
+}
+
+// TestSecondaryKubeconfigSecret_StubIsRefused is the read-side twin of #6054.
+// #6054 stops a credential-less document at the delivery endpoint, but hw293's
+// 95-byte stub was already on the PVC when that gate shipped, and the
+// materializer's only content check was len(raw) != 0. Measured before this
+// change: n=1, err=nil, and a 95-byte value in the Secret that
+// clientcmd.RESTConfigFromKubeConfig rejects.
+func TestSecondaryKubeconfigSecret_StubIsRefused(t *testing.T) {
+	h, fake, dir := materializerFixture(t, 2)
+	writeKubeconfigFile(t, dir, "dep5359", "me-east-215-b", hw293StubKubeconfig)
+
+	n, err := h.materializeSecondaryKubeconfigsSecret(context.Background(), &cutoverDeps{core: fake, ns: cutoverTestNS})
+	if err == nil {
+		t.Fatalf("a %d-byte credential-less kubeconfig was ACCEPTED (n=%d) — every consumer would then read region B as credentialled while no client can be built from it", len(hw293StubKubeconfig), n)
+	}
+	for _, want := range []string{"contexts", "users", "current-context", "95 bytes"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("rejection message does not name %q, so an operator cannot tell WHAT is missing: %s", want, err)
+		}
+	}
+	if _, gerr := getBridgeSecret(t, fake); gerr == nil {
+		t.Fatalf("the unusable document was still written to the Secret — a refusal that persists its own reject is not a refusal")
+	}
+
+	// VACUITY ARM — the same fixture with the same cluster block, complete,
+	// must be accepted. A gate that cannot pass is as useless as one that
+	// cannot fail.
+	writeKubeconfigFile(t, dir, "dep5359", "me-east-215-b", completeKubeconfigSameCluster)
+	if n, err := h.materializeSecondaryKubeconfigsSecret(context.Background(), &cutoverDeps{core: fake, ns: cutoverTestNS}); err != nil || n != 1 {
+		t.Fatalf("the complete control was refused: n=%d err=%v", n, err)
+	}
+}
+
+// TestSecondaryKubeconfigSecret_StubInSecretIsNotAcceptedAsRecovery covers the
+// #5488 recovery arm, which is the one that runs when the process cannot
+// re-derive its on-disk paths — i.e. exactly when nothing else would catch a
+// bad value. It counted any non-empty key toward the expected total.
+func TestSecondaryKubeconfigSecret_StubInSecretIsNotAcceptedAsRecovery(t *testing.T) {
+	h, fake, _ := materializerFixture(t, 2) // 2 regions expected, NOTHING on disk
+	deps := &cutoverDeps{core: fake, ns: cutoverTestNS}
+
+	if _, err := fake.CoreV1().Secrets(cutoverTestNS).Create(context.Background(), &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: cutoverSecondaryKubeconfigsSecretName(), Namespace: cutoverTestNS},
+		Data:       map[string][]byte{"me-east-215-b.yaml": []byte(hw293StubKubeconfig)},
+	}, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	if n, ok := h.acceptMaterializedSecondaryKubeconfigsSecret(context.Background(), deps,
+		cutoverSecondaryKubeconfigsSecretName(), 1, "dep5359"); ok {
+		t.Fatalf("a Secret whose only key is the 95-byte stub satisfied the recovery check (n=%d) — the count was of keys, not of credentials", n)
+	}
+
+	// Vacuity arm: the same Secret carrying a COMPLETE document is accepted.
+	sec, _ := getBridgeSecret(t, fake)
+	sec.Data["me-east-215-b.yaml"] = []byte(completeKubeconfigSameCluster)
+	if _, err := fake.CoreV1().Secrets(cutoverTestNS).Update(context.Background(), sec, metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	if n, ok := h.acceptMaterializedSecondaryKubeconfigsSecret(context.Background(), deps,
+		cutoverSecondaryKubeconfigsSecretName(), 1, "dep5359"); !ok || n != 1 {
+		t.Fatalf("the complete control was refused by the recovery check: n=%d ok=%v", n, ok)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 2b. The hw293 state: a chroot with NO deployment record.
+// ---------------------------------------------------------------------------
+
+// recordlessChrootFixture reproduces hw293 dep a0077ba47e3720e5 as measured:
+// `restored deployments from PVC count=0` (handover never fired, so no record
+// was ever imported) while the `sovereign-fqdn` ConfigMap declares two regions
+// via CATALYST_CONFIGURED_REGIONS. The primary kubeconfig is on disk beside the
+// secondary, which is what lets the on-disk prefix derivation name the region.
+func recordlessChrootFixture(t *testing.T) (*Handler, *fakek8s.Clientset, string) {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("CATALYST_K8SCACHE_KUBECONFIGS_DIR", dir)
+	t.Setenv("SOVEREIGN_FQDN", "hw293.omantel.biz")
+	t.Setenv("CATALYST_CONFIGURED_REGIONS", "hw-me-east-215-a-rtz-prod,hw-me-east-215-b-rtz-prod")
+
+	h := NewWithPDM(silentLogger(), &fakePDM{}) // deployments map deliberately EMPTY
+	fake := fakek8s.NewSimpleClientset()
+	deps := &cutoverDeps{core: fake, ns: cutoverTestNS}
+	h.SetCutoverDepsFactory(func() (*cutoverDeps, error) { return deps, nil })
+	h.secondaryKubeconfigSecretInterval = 5 * time.Millisecond
+
+	if err := os.WriteFile(filepath.Join(dir, "a0077ba47e3720e5.yaml"),
+		[]byte(completeKubeconfigSameCluster), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return h, fake, dir
+}
+
+// TestSecondaryKubeconfigSecret_RecordlessChrootStillMaterializes is the test
+// that decides whether this change reaches hw293 at all.
+//
+// resolveCutoverDeployment returns nil there. Deriving the expected region
+// count from the record alone would hand the completeness check a denominator
+// of zero — a guard that cannot fail — and the producer would conclude,
+// correctly by its own arithmetic, that a 2-region Sovereign has nothing to
+// materialize. The count therefore comes from CATALYST_CONFIGURED_REGIONS,
+// which the IaC writes at provision time and which is independent of both the
+// deployment store and the k8scache.
+func TestSecondaryKubeconfigSecret_RecordlessChrootStillMaterializes(t *testing.T) {
+	h, fake, dir := recordlessChrootFixture(t)
+	if h.resolveCutoverDeployment() != nil {
+		t.Fatalf("fixture is not record-less")
+	}
+	writeKubeconfigFile(t, dir, "a0077ba47e3720e5", "me-east-215-b-1", completeKubeconfigSameCluster)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go h.RunSecondaryKubeconfigSecretMaterializer(ctx)
+
+	sec := waitForBridgeSecret(t, fake, 3*time.Second)
+	if sec == nil {
+		t.Fatalf("a chroot with NO deployment record and CATALYST_CONFIGURED_REGIONS declaring 2 regions "+
+			"produced no %s Secret — the region count was taken from the record, which is the one source "+
+			"that is blank on exactly the Sovereign that needs this (#6027)",
+			cutoverSecondaryKubeconfigsSecretName())
+	}
+	raw, ok := sec.Data["me-east-215-b-1.yaml"]
+	if !ok {
+		t.Fatalf("Secret carries no key for the derived region; keys=%v", secretDataKeys(sec))
+	}
+	if _, err := clientcmd.RESTConfigFromKubeConfig(raw); err != nil {
+		t.Fatalf("materialized value cannot build a client: %v", err)
+	}
+	if got := sec.Annotations["catalyst.openova.io/deployment-id"]; got != "a0077ba47e3720e5" {
+		t.Errorf("deployment-id annotation = %q, want the prefix derived from disk", got)
+	}
+}
+
+// TestSecondaryKubeconfigSecret_RecordlessChrootWithNoUsableFileWritesNothing
+// is the same fixture minus a usable peer kubeconfig — the hw293 state as it
+// stands today, where the only region-B document ever delivered was the
+// 95-byte stub. The pass must produce nothing and must not reap an existing
+// Secret, because "I cannot see the credential" is not "the credential is
+// wrong".
+func TestSecondaryKubeconfigSecret_RecordlessChrootWithNoUsableFileWritesNothing(t *testing.T) {
+	h, fake, dir := recordlessChrootFixture(t)
+	writeKubeconfigFile(t, dir, "a0077ba47e3720e5", "me-east-215-b-1", hw293StubKubeconfig)
+
+	if _, err := fake.CoreV1().Secrets(cutoverTestNS).Create(context.Background(), &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: cutoverSecondaryKubeconfigsSecretName(), Namespace: cutoverTestNS},
+		Data:       map[string][]byte{"me-east-215-b-1.yaml": []byte(completeKubeconfigSameCluster)},
+	}, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("seed a GOOD Secret from a prior pass: %v", err)
+	}
+
+	h.reconcileSecondaryKubeconfigsSecret(context.Background())
+
+	sec, err := getBridgeSecret(t, fake)
+	if err != nil {
+		t.Fatalf("a pass that could not read a usable kubeconfig DELETED the good Secret a prior pass "+
+			"had materialized: %v — an unreadable peer is a wait, not a teardown", err)
+	}
+	if !strings.Contains(string(sec.Data["me-east-215-b-1.yaml"]), "fake-token") {
+		t.Fatalf("the good Secret value was overwritten by the stub")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 3. The decisive control.
+// ---------------------------------------------------------------------------
+
+// TestSecondaryKubeconfigSecret_SingleRegionProducesNothing is the control that
+// makes every test above mean something. A producer that always writes a Secret
+// would satisfy the acceptance case and be indistinguishable from the defect.
+// A one-region Sovereign must end the pass with NO Secret and NO error, and the
+// loop must stay alive rather than wedging on the absence.
+func TestSecondaryKubeconfigSecret_SingleRegionProducesNothing(t *testing.T) {
+	h, fake, dir := materializerFixture(t, 1)
+
+	// A stray file on disk must not conjure a secondary region either: the
+	// expected count comes from the deployment SPEC.
+	writeKubeconfigFile(t, dir, "dep5359", "me-east-215-b", completeKubeconfigSameCluster)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go h.RunSecondaryKubeconfigSecretMaterializer(ctx)
+	time.Sleep(120 * time.Millisecond) // ~24 ticks at the 5ms test interval
+
+	if sec, err := getBridgeSecret(t, fake); err == nil {
+		t.Fatalf("a SINGLE-region Sovereign produced a secondary-kubeconfig Secret (keys=%v) — "+
+			"a producer that always writes one is not a fix", secretDataKeys(sec))
+	}
+
+	// …and it did not fail, either: the state the loop settled in is the
+	// single-region one, not an error.
+	h.secondaryKubeconfigSecretStateMu.Lock()
+	state := h.secondaryKubeconfigSecretState
+	h.secondaryKubeconfigSecretStateMu.Unlock()
+	if state != "single-region" {
+		t.Fatalf("single-region loop settled in state %q, want %q — the absence of a peer region is a normal outcome, not a failure", state, "single-region")
+	}
+}
+
+// TestSecondaryKubeconfigSecret_SingleRegionReapsStaleSecret keeps the #5359
+// reap: a Sovereign that USED to be multi-region must lose the Secret, or the
+// cutover chart's region-B legs would fire against a region that is gone.
+func TestSecondaryKubeconfigSecret_SingleRegionReapsStaleSecret(t *testing.T) {
+	h, fake, _ := materializerFixture(t, 1)
+	if _, err := fake.CoreV1().Secrets(cutoverTestNS).Create(context.Background(), &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: cutoverSecondaryKubeconfigsSecretName(), Namespace: cutoverTestNS},
+		Data:       map[string][]byte{"gone-region.yaml": []byte(completeKubeconfigSameCluster)},
+	}, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	h.reconcileSecondaryKubeconfigsSecret(context.Background())
+	if _, err := getBridgeSecret(t, fake); err == nil {
+		t.Fatalf("stale Secret survived a single-region pass")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Steady state.
+// ---------------------------------------------------------------------------
+
+// TestSecondaryKubeconfigSecret_ConvergedPassWritesNothing protects the
+// consumer this whole change exists to serve. The organization-controller keys
+// its per-region client cache on this Secret's resourceVersion, so an
+// unconditional Update on every pass would discard every secondary-region
+// client and re-run discovery against the peer apiserver once per Org per
+// tick. Measured before the convergence check: 3 identical passes → 3 writes.
+func TestSecondaryKubeconfigSecret_ConvergedPassWritesNothing(t *testing.T) {
+	h, fake, dir := materializerFixture(t, 2)
+	writeKubeconfigFile(t, dir, "dep5359", "me-east-215-b", completeKubeconfigSameCluster)
+	deps := &cutoverDeps{core: fake, ns: cutoverTestNS}
+
+	const passes = 5
+	for i := 0; i < passes; i++ {
+		if _, err := h.materializeSecondaryKubeconfigsSecret(context.Background(), deps); err != nil {
+			t.Fatalf("pass %d: %v", i, err)
+		}
+	}
+	writes := 0
+	for _, a := range fake.Actions() {
+		if a.GetResource().Resource == "secrets" && (a.GetVerb() == "create" || a.GetVerb() == "update") {
+			writes++
+		}
+	}
+	if writes != 1 {
+		t.Fatalf("%d identical passes produced %d writes, want 1 — a churning Secret invalidates the "+
+			"organization-controller's per-region client cache on every tick", passes, writes)
+	}
+
+	// Vacuity arm: a CHANGED kubeconfig must still be written, or the check
+	// above would be satisfied by a producer that never updates anything.
+	writeKubeconfigFile(t, dir, "dep5359", "me-east-215-b",
+		strings.Replace(completeKubeconfigSameCluster, "token: fake-token", "token: rotated-token", 1))
+	if _, err := h.materializeSecondaryKubeconfigsSecret(context.Background(), deps); err != nil {
+		t.Fatalf("post-rotation pass: %v", err)
+	}
+	sec, err := getBridgeSecret(t, fake)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if !strings.Contains(string(sec.Data["me-east-215-b.yaml"]), "rotated-token") {
+		t.Fatalf("a ROTATED kubeconfig was not propagated — the convergence check is swallowing real changes")
+	}
+}
+
+// TestSecondaryKubeconfigSecret_DeliveryKicksTheMaterializer pins the fast
+// path: the endpoint that lands a peer-region kubeconfig asks for a pass, so
+// the credential is in-cluster about a second after delivery instead of on the
+// next tick. Uses a long interval so a pass within the deadline can only have
+// come from the kick.
+func TestSecondaryKubeconfigSecret_DeliveryKicksTheMaterializer(t *testing.T) {
+	h, fake, _ := materializerFixture(t, 2)
+	h.secondaryKubeconfigSecretInterval = time.Hour
+	h.k8sCache = newK8sCacheWithClusters(t, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go h.RunSecondaryKubeconfigSecretMaterializer(ctx)
+	time.Sleep(30 * time.Millisecond) // first pass runs, finds nothing, then blocks
+
+	if _, err := getBridgeSecret(t, fake); err == nil {
+		t.Fatalf("Secret existed before any kubeconfig was delivered")
+	}
+
+	rec := postSecondaryKubeconfig(t, h, map[string]string{
+		"deploymentId":   "dep5359",
+		"regionKey":      "me-east-215-b",
+		"kubeconfigYaml": completeKubeconfigSameCluster,
+	})
+	if rec.Code != 201 {
+		t.Fatalf("delivery POST status = %d, want 201: %s", rec.Code, rec.Body.String())
+	}
+
+	if sec := waitForBridgeSecret(t, fake, 3*time.Second); sec == nil {
+		t.Fatalf("the materializer did not run within 3s of a delivery while its tick is 1h — " +
+			"the delivery endpoint is not kicking it, so the credential would wait a full interval (#6027)")
+	}
+}
+
+// TestSecondaryKubeconfigSecret_MothershipDoesNotRun keeps the loop off the
+// side that has no cutover namespace and no deployment record of its own.
+func TestSecondaryKubeconfigSecret_MothershipDoesNotRun(t *testing.T) {
+	h, fake, dir := materializerFixture(t, 2)
+	writeKubeconfigFile(t, dir, "dep5359", "me-east-215-b", completeKubeconfigSameCluster)
+	t.Setenv("SOVEREIGN_FQDN", "") // mothership
+
+	done := make(chan struct{})
+	go func() { h.RunSecondaryKubeconfigSecretMaterializer(context.Background()); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("the materializer kept running on the mothership")
+	}
+	if _, err := getBridgeSecret(t, fake); err == nil {
+		t.Fatalf("the mothership wrote a cutover-namespace Secret")
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/sovereign_secondary_kubeconfig.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sovereign_secondary_kubeconfig.go
@@ -334,6 +334,15 @@ func (h *Handler) HandleSovereignSecondaryKubeconfig(w http.ResponseWriter, r *h
 		"region", body.RegionKey,
 		"clusterID", clusterID,
 	)
+
+	// #6027 — a delivered file is not yet a usable credential. The controllers
+	// that write per-region surfaces (organization-controller's per-Org console
+	// listener pair, and the cutover step Jobs) read the peer region's
+	// kubeconfig from an in-cluster Secret, never from this PVC. Ask the
+	// level-triggered materializer for an immediate pass so the two converge in
+	// about a second rather than on its next tick. Non-blocking, and a no-op
+	// when no loop is running (mothership), so the response path is unchanged.
+	h.kickSecondaryKubeconfigSecret()
 	writeJSON(w, http.StatusCreated, map[string]string{
 		"status":    "registered",
 		"clusterID": clusterID,


### PR DESCRIPTION
Refs #6015 #6027

## The measurement

`console.<slug>.<parent>` resolves to one shared EIP whose ELB round-robins every region's envoy. On hw293 dep `a0077ba47e3720e5`, read-only, both regions:

| object | region A | region B |
|---|---|---|
| `catalyst/cutover-secondary-kubeconfigs` | **NotFound** | **NotFound** |
| per-Org console listeners on `kube-system/cilium-gateway-console` | **5 pairs** | **0** |
| control: Secrets in `catalyst` | 11 | 11 |

The control matters: the namespace is populated, so the NotFound is that one object, not a dead query.

The organization-controller says so itself, live, once per Organization, on the image that already carries #6097:

```
1 of 1 secondary region(s) have no kubeconfig in catalyst/cutover-secondary-kubeconfigs
(sovereign-fqdn configuredRegions declares 1 remote region(s); wired region keys: none)
```

## Why the Secret was absent

`materializeSecondaryKubeconfigsSecret` had exactly **one** production call site. Counted, not assumed: one, in `cutover.go`, inside `runCutover`. So the credential existed only on a Sovereign that had already fired the self-sovereignty cutover — and `bp-self-sovereign-cutover` installs dormant at slot 06a and is operator-gated by design. Nothing was broken. Nothing had ever been asked to write it.

That is #6015 one layer down: there, both producers of the chroot's on-disk kubeconfigs sat behind `finalStatus == "ready"`, and the remedy was to give delivery its own level-triggered owner. This does the same for the step that turns a delivered file into the in-cluster credential the controllers read.

## What this ships

**One producer, two triggers.** The write did not move — two producers of one object generate drift by construction. `runCutover` keeps its pre-flight call and its fail-loud abort; a new level-triggered loop calls the **same** function every 60s and on a kick from the delivery endpoint, so a freshly-delivered kubeconfig becomes a usable credential in about a second.

Wiring it surfaced three defects in the shared function, each fixed there:

1. **Presence, not usability.** The only content check was `len(raw) != 0`, so the 95-byte hw293 stub materialized with `n=1, err=nil` into a value `clientcmd.RESTConfigFromKubeConfig` rejects. The org-controller would read region B as credentialled, fail to build a client, and record it Unreachable while the Secret looked complete. A file — or a Secret value on the #5488 recovery arm, which counted any non-empty key — that cannot build a client now counts as absent. Read-side twin of #6054, and what disqualifies the stub already on hw293's PVC.

2. **The disk decided single-region.** Path resolution unions the in-memory map with every on-disk `<depID>-<regionKey>.yaml`, unbounded by the declared count, so a one-region deployment carrying a file from a prior topology walked past the completeness check (`0 > 1` is false) and materialized a region that does not exist. The spec is now read before any file. **Caught by the single-region control, which failed on this change's first run.**

3. **The count came from a source that is blank on the target.** hw293's chroot logs `restored deployments from PVC count=0` — handover never fired, `resolveCutoverDeployment` returns nil. A record-only denominator hands the completeness check a zero and makes it unable to fail on exactly the Sovereign that needs it. The count is now `max(record, CATALYST_CONFIGURED_REGIONS)` and the record may be nil. That is the same witness `placementDeploymentIdentity` (#6015) and the org-controller (#6097) already take the max against; verified live on hw293 as `configuredRegions=hw-me-east-215-a-rtz-prod,hw-me-east-215-b-rtz-prod`. It supplies a **count** only — its cloud-region names never match the kubeconfig region keys, which still come from disk. When neither source declares anything, nothing is written **and nothing is reaped**: "I cannot see the topology" is not "the topology is one region".

A converged pass now writes nothing. The org-controller keys its per-region client cache on this Secret's `resourceVersion` and the `materialized` annotation is a timestamp, so an unconditional Update would discard every secondary-region client and re-run discovery against the peer apiserver once per Org per tick.

## Red -> green

| assertion | before | after |
|---|---|---|
| producer call sites outside `cutover.go` | 0 | 1 |
| 95-byte stub -> `(n, err)` | `(1, nil)` | `(0, refused)` |
| ...and the Secret it left behind | written | absent |
| writes for 5 identical passes | 5 | 1 |
| record-less 2-region chroot -> Secret | never | materialized, parses |
| **single-region Sovereign -> Secret** | (regression found) | **none** |

Every guard was watched failing first. Six probes, each reverting one production line, each turning the matching test red and nothing else:

| reverted | goes red |
|---|---|
| usability check | `StubIsRefused`, `RecordlessChrootWithNoUsableFile` |
| env witness | `RecordlessChrootStillMaterializes` |
| `main.go` spawn | `IsStartedByMain` |
| delivery kick | `DeliveryKicksTheMaterializer` |
| convergence check | `ConvergedPassWritesNothing` |
| spec-authority arm | all three single-region tests |

Assertions check the **value** — delivered bytes parsed back into a `rest.Config` carrying a Host and a credential — never that a key exists. The #5359 fixtures wrote `clusters: []` (41 bytes), so those tests asserted a Secret gets a **key** and never that the key is usable; they now write a complete document.

## Notes

- **Side effect worth naming:** a record-less 2-region chroot firing a cutover with no usable peer kubeconfig now aborts before step 1 instead of proceeding. That was an accidental bypass of the #5359 contract — the record-less arm returned 0 and skipped the completeness check — and a chain whose region-B legs silently no-op is the exact false-positive `cc=true` #5359 exists to kill.
- **Which side this runs on:** Sovereign-side only, in the catalyst-api image, which hw293 already tracks (running `e4c14ad`, an ancestor of `main`). The loop is gated on `SOVEREIGN_FQDN`, so nothing runs on the mothership.
- **No chart change, no RBAC change.** The Pod already runs as `catalyst-api-cutover-driver`, which #5359 granted `create` on secrets plus name-scoped `get/update/patch/delete` on `cutover-secondary-kubeconfigs`.
- **This alone does not close R16/87/90/95.** hw293's chroot registers `sovereigns: 1` and the only region-B document ever POSTed was the 95-byte stub, which #6054 refuses (`status=422`, twice on the record). The producer will correctly report the shortfall and write nothing until a complete kubeconfig reaches the chroot's `CATALYST_K8SCACHE_KUBECONFIGS_DIR`. The mothership PVC holds a complete 2959-byte copy. **ClusterMesh is not needed** for these rows: #6097 made the witness fall back to `configuredRegions`, and the org-controller reaches region B through a direct client built from the kubeconfig, not through the mesh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
