### PR TITLE
fix(openova-mcp): surface the authoritative /whoami verdict, not the signature error it supersedes

### DIFF
--- a/products/openova-mcp/cmd/openova-mcp/main.go
+++ b/products/openova-mcp/cmd/openova-mcp/main.go
@@ -301,11 +301,40 @@ func (s *server) resolveBearer(bearer string) (*identity.Identity, error) {
 	// on any whoami error (401 / unreachable / not-verified) fall through to
 	// the ORIGINAL local-verify error so a catalyst-api hiccup can never widen
 	// the surface.
-	if wid, werr := s.whoamiFallback(bearer); werr == nil {
+	wid, werr := s.whoamiFallback(bearer)
+	if werr == nil {
 		return wid, nil
+	}
+	// …with ONE exception, and it is not a relaxation: when catalyst-api
+	// VERIFIED the session and this instance's own scope pin refused it
+	// anyway (#5206 wrong-door, the per-Org org-pin, an absent org scope),
+	// that refusal is the better-informed verdict and the local signature
+	// miss is a claim the server already holds evidence against. Returning
+	// the stale "token signature is invalid: crypto/rsa: verification error"
+	// there reports a FALSEHOOD about a token the issuer just vouched for,
+	// and points every reader at the key-pinning subsystem instead of the
+	// door. That is the whole diagnosis cost of UAT rows 212/213: the rows
+	// name NewRS256Resolver as the surface to look at, because that is what
+	// the masked error accused. Still an error, still fail-closed — only the
+	// REASON changes, and only when a positive whoami verdict exists.
+	var verdict *whoamiVerdictError
+	if errors.As(werr, &verdict) {
+		return nil, werr
 	}
 	return nil, err
 }
+
+// whoamiVerdictError marks a refusal issued AFTER catalyst-api verified the
+// session — i.e. the bearer is genuine and this instance's own context/org pin
+// is what turned the caller away. It is distinguished from every other whoami
+// failure (no client wired, transport error, upstream 401, not-verified)
+// precisely because those carry no evidence about the token and must leave the
+// original local-verify error standing.
+type whoamiVerdictError struct{ err error }
+
+func (e *whoamiVerdictError) Error() string { return e.err.Error() }
+
+func (e *whoamiVerdictError) Unwrap() error { return e.err }
 
 // whoamiFallback resolves identity via catalyst-api's /whoami for tokens the
 // local resolver cannot verify (session tokens signed by the deployment-local
@@ -326,7 +355,7 @@ func (s *server) whoamiFallback(bearer string) (*identity.Identity, error) {
 	if !w.Verified {
 		return nil, errors.New("whoami fallback: session not verified")
 	}
-	return s.resolver.FromWhoami(identity.WhoamiIdentity{
+	id, ferr := s.resolver.FromWhoami(identity.WhoamiIdentity{
 		Email:         w.Email,
 		Mode:          w.Mode,
 		Tier:          w.Tier,
@@ -335,6 +364,14 @@ func (s *server) whoamiFallback(bearer string) (*identity.Identity, error) {
 		DeploymentID:  w.DeploymentID,
 		SovereignFQDN: w.SovereignFQDN,
 	}, bearer)
+	if ferr != nil {
+		// Past this line catalyst-api has VOUCHED for the bearer; anything
+		// FromWhoami refuses is this instance's own pin decision, not a
+		// signature problem. Mark it so resolveBearer surfaces it instead of
+		// the local-verify error it supersedes.
+		return nil, &whoamiVerdictError{err: ferr}
+	}
+	return id, nil
 }
 
 // ── bearer plumbing (mirrors the sandbox MCP _auth envelope) ─────────────

--- a/products/openova-mcp/cmd/openova-mcp/wrong_door_verdict_test.go
+++ b/products/openova-mcp/cmd/openova-mcp/wrong_door_verdict_test.go
@@ -1,0 +1,218 @@
+package main
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/golang-jwt/jwt/v5"
+
+	sharedauth "github.com/openova-io/openova/core/services/shared/auth"
+	"github.com/openova-io/openova/products/openova-mcp/internal/catalystapi"
+	"github.com/openova-io/openova/products/openova-mcp/internal/identity"
+	"github.com/openova-io/openova/products/openova-mcp/internal/tools"
+)
+
+// ── the hw293 shape, reproduced ──────────────────────────────────────────
+//
+// UAT rows 212/213 recorded, verbatim off the wire against the Sovereign-mode
+// instance at https://mcp.<sovereign-fqdn>/mcp with a real Org-scoped session:
+//
+//	-32001 unauthenticated — identity: bearer rejected:
+//	token signature is invalid: crypto/rsa: verification error   (3/3)
+//
+// and the row's two controls proved that message FALSE on its face: the
+// byte-identical bearer was accepted by catalyst-api's own /whoami (200,
+// orgScoped:true), and a Sovereign session from the SAME catalyst-api was
+// accepted by the SAME MCP endpoint. A token the issuer verifies does not have
+// an invalid signature.
+//
+// The message is a MASK. resolveBearer runs the #5175 whoami fallback after a
+// local verify miss; catalyst-api answers "verified, organization-scoped"; the
+// resolver's #5206 instance pin then refuses the caller — correctly, by design,
+// a Sovereign-mode instance is the wrong door for an Org-scoped session — and
+// resolveBearer discards THAT verdict and returns the stale signature error
+// that preceded it. The server reports a signature failure while holding
+// positive evidence the signature is fine.
+//
+// The cost is not cosmetic: row 212's own "SURFACE TO LOOK AT" names
+// NewRS256Resolver / identity.go:213, i.e. the key-pinning subsystem, because
+// the key-pinning subsystem is what the error accused. The real verdict names
+// the door and the remedy ("use that Organization's own MCP instance").
+
+// mintRS256 signs claims with key and returns the compact JWT.
+func mintRS256(t *testing.T, key *rsa.PrivateKey, claims *sharedauth.Claims) string {
+	t.Helper()
+	tok, err := jwt.NewWithClaims(jwt.SigningMethodRS256, claims).SignedString(key)
+	if err != nil {
+		t.Fatalf("mint: %v", err)
+	}
+	return tok
+}
+
+func genKey(t *testing.T) *rsa.PrivateKey {
+	t.Helper()
+	k, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("genkey: %v", err)
+	}
+	return k
+}
+
+// whoamiStub serves GET /api/v1/whoami with the supplied status + body, and
+// 404s everything else, so a test that accidentally exercises another endpoint
+// fails loudly instead of silently passing.
+func whoamiStub(status int, body string) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/whoami" {
+			http.NotFound(w, r)
+			return
+		}
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+}
+
+const (
+	orgWhoamiVerdict = `{"email":"u@omani.homes","verified":true,"mode":"organization","tier":"org-admin","org":"hw293walkone","orgScoped":true,"deploymentId":"dep1"}`
+	sovWhoamiVerdict = `{"email":"a@omani.works","verified":true,"mode":"sovereign","tier":"owner","deploymentId":"dep1"}`
+)
+
+// SUBJECT (#5843 / UAT rows 212-213). A Sovereign-mode instance, an Org-scoped
+// bearer it cannot verify locally, and a catalyst-api that VERIFIES that bearer
+// as organization-scoped. The refusal is correct; the REASON must be the
+// instance-pin verdict, never the signature error the server already has
+// evidence against.
+func TestResolveBearer_SovereignInstance_OrgSession_SurfacesTheWrongDoorVerdict(t *testing.T) {
+	pinned, other := genKey(t), genKey(t)
+	bearer := mintRS256(t, other, &sharedauth.Claims{OrgID: "hw293walkone", Tier: "org-admin"})
+
+	ts := whoamiStub(http.StatusOK, orgWhoamiVerdict)
+	defer ts.Close()
+
+	srv := &server{
+		reg:      tools.NewRegistry(catalystapi.New(ts.URL)),
+		resolver: identity.NewRS256Resolver(&pinned.PublicKey, identity.ContextSovereign),
+	}
+
+	id, err := srv.resolveBearer(bearer)
+	if err == nil {
+		t.Fatalf("a Sovereign-mode instance ACCEPTED an Org-scoped session (surface widened): %+v", id)
+	}
+	got := err.Error()
+
+	if strings.Contains(got, "crypto/rsa") || strings.Contains(got, "signature is invalid") {
+		t.Fatalf("the signature error MASKED the authoritative verdict — catalyst-api verified this bearer, so the signature claim is false.\n  got: %s", got)
+	}
+	if !strings.Contains(got, "hw293walkone") {
+		t.Fatalf("the verdict does not name the caller's Organization, so a reader cannot tell which door to use.\n  got: %s", got)
+	}
+	if !strings.Contains(got, "own MCP instance") {
+		t.Fatalf("the verdict does not name the remedy (the Organization's own MCP instance).\n  got: %s", got)
+	}
+}
+
+// SUBJECT, second instance of the same class: a per-Org instance pinned to one
+// Organization, handed a session catalyst-api verifies for a DIFFERENT one. The
+// org-pin refusal is the authoritative verdict and must survive the same way.
+func TestResolveBearer_PerOrgInstance_ForeignOrgSession_SurfacesTheOrgPinVerdict(t *testing.T) {
+	pinned, other := genKey(t), genKey(t)
+	bearer := mintRS256(t, other, &sharedauth.Claims{OrgID: "hw293walkone", Tier: "org-admin"})
+
+	ts := whoamiStub(http.StatusOK, orgWhoamiVerdict)
+	defer ts.Close()
+
+	srv := &server{
+		reg: tools.NewRegistry(catalystapi.New(ts.URL)),
+		resolver: identity.NewRS256Resolver(&pinned.PublicKey, identity.ContextOrganization).
+			WithOrgPin("hw293walktwo"),
+	}
+
+	id, err := srv.resolveBearer(bearer)
+	if err == nil {
+		t.Fatalf("a per-Org instance ACCEPTED a foreign Org's session (surface widened): %+v", id)
+	}
+	got := err.Error()
+	if strings.Contains(got, "crypto/rsa") || strings.Contains(got, "signature is invalid") {
+		t.Fatalf("the signature error MASKED the org-pin verdict.\n  got: %s", got)
+	}
+	if !strings.Contains(got, "hw293walktwo") {
+		t.Fatalf("the verdict does not name this instance's pinned Organization.\n  got: %s", got)
+	}
+}
+
+// CONTROL — shares the suspect property (a bearer the local resolver CANNOT
+// verify, taking the identical whoami-fallback path) and must stay green both
+// before and after: when catalyst-api REFUSES the bearer, there is no
+// better-informed verdict, so the local signature error is the honest answer
+// and must be preserved verbatim.
+func TestResolveBearer_ControlCatalystApiRejects_KeepsTheSignatureError(t *testing.T) {
+	pinned, other := genKey(t), genKey(t)
+	bearer := mintRS256(t, other, &sharedauth.Claims{OrgID: "hw293walkone", Tier: "org-admin"})
+
+	ts := whoamiStub(http.StatusUnauthorized, `{"error":"unauthorized"}`)
+	defer ts.Close()
+
+	srv := &server{
+		reg:      tools.NewRegistry(catalystapi.New(ts.URL)),
+		resolver: identity.NewRS256Resolver(&pinned.PublicKey, identity.ContextSovereign),
+	}
+
+	id, err := srv.resolveBearer(bearer)
+	if err == nil {
+		t.Fatalf("accepted a bearer catalyst-api rejected (surface widened): %+v", id)
+	}
+	if !strings.Contains(err.Error(), "crypto/rsa: verification error") {
+		t.Fatalf("lost the local-verify error on a token catalyst-api also refuses.\n  got: %s", err.Error())
+	}
+}
+
+// CONTROL — the #5175 happy path is untouched: same unverifiable-by-local-key
+// bearer, Sovereign whoami verdict, Sovereign-pinned instance → ACCEPTED.
+func TestResolveBearer_ControlSovereignSession_StillAccepted(t *testing.T) {
+	pinned, other := genKey(t), genKey(t)
+	bearer := mintRS256(t, other, &sharedauth.Claims{Tier: "owner"})
+
+	ts := whoamiStub(http.StatusOK, sovWhoamiVerdict)
+	defer ts.Close()
+
+	srv := &server{
+		reg:      tools.NewRegistry(catalystapi.New(ts.URL)),
+		resolver: identity.NewRS256Resolver(&pinned.PublicKey, identity.ContextSovereign),
+	}
+
+	id, err := srv.resolveBearer(bearer)
+	if err != nil {
+		t.Fatalf("the #5175 sovereign fallback regressed: %v", err)
+	}
+	if id.Context != identity.ContextSovereign || id.Tier != identity.TierOwner {
+		t.Fatalf("resolved ctx=%s tier=%v", id.Context, id.Tier)
+	}
+}
+
+// CONTROL — a bearer the local resolver verifies fine still resolves locally
+// and never consults catalyst-api. The stub 404s any other path, and /whoami
+// here would refuse, so a regression that always delegates fails this test.
+func TestResolveBearer_ControlLocallyVerifiedBearer_NeverDelegates(t *testing.T) {
+	pinned := genKey(t)
+	bearer := mintRS256(t, pinned, &sharedauth.Claims{Role: "sovereign-admin", Tier: "owner"})
+
+	ts := whoamiStub(http.StatusUnauthorized, `{"error":"unauthorized"}`)
+	defer ts.Close()
+
+	srv := &server{
+		reg:      tools.NewRegistry(catalystapi.New(ts.URL)),
+		resolver: identity.NewRS256Resolver(&pinned.PublicKey, identity.ContextSovereign),
+	}
+
+	id, err := srv.resolveBearer(bearer)
+	if err != nil {
+		t.Fatalf("a locally-verifiable sovereign-admin bearer was refused: %v", err)
+	}
+	if id.Context != identity.ContextSovereign || id.Tier != identity.TierSovereignAdmin {
+		t.Fatalf("resolved ctx=%s tier=%v", id.Context, id.Tier)
+	}
+}


### PR DESCRIPTION
## The MCP returned a claim it already had evidence against

UAT rows 212/213 recorded this off the wire against the Sovereign-mode instance
at `https://mcp.<sovereign-fqdn>/mcp`, presenting a real Org-scoped session, 3/3:

```
-32001 unauthenticated — identity: bearer rejected:
token signature is invalid: crypto/rsa: verification error
```

The rows' own two controls refute it: the **byte-identical** bearer is accepted
by catalyst-api's `GET /api/v1/whoami` (`200 {"tier":"org-admin","orgScoped":true,…}`),
and a Sovereign session from the SAME catalyst-api is accepted by the SAME MCP
endpoint, interleaved probe-for-probe. A token its issuer verifies does not have
an invalid signature.

## Mechanism

`resolveBearer` misses local verify (the #5175 shape — the session is signed by a
deployment-local catalyst-api signer whose public half the MCP does not hold),
`whoamiFallback` asks the session-token authority, catalyst-api answers
**verified, organization-scoped**, and `Resolver.FromWhoami`
(`internal/identity/whoami.go:87-89`) refuses — **correctly, by design**: #5206
says a Sovereign-mode instance must never relabel an Org-scoped caller as
Sovereign, and its message names the remedy (*"use that Organization's own MCP
instance instead"*). `resolveBearer` then discarded that verdict and returned the
stale signature error.

The surfaced reason was the one thing the server held positive evidence against,
and the true reason never reached the caller. Row 212's own *"SURFACE TO LOOK AT"*
names `NewRS256Resolver` / `identity.go:213` and the per-realm JWKS follow-up —
the key-pinning subsystem, because that is what the masked error accused. The
refusal was never about a key.

## The change

A refusal issued **after** catalyst-api verified the session is marked
(`whoamiVerdictError`) and surfaced. Every other whoami failure — no client
wired, transport error, upstream 401, `verified:false` — carries no evidence
about the token and leaves the original local-verify error standing.

Not a relaxation: still an error, still fail-closed, still a refusal. Only the
REASON changes, and only when a positive whoami verdict exists.

## RED → GREEN

Pre-fix, both subjects, verbatim:

```
--- FAIL: TestResolveBearer_SovereignInstance_OrgSession_SurfacesTheWrongDoorVerdict
    the signature error MASKED the authoritative verdict — catalyst-api verified
    this bearer, so the signature claim is false.
      got: identity: bearer rejected: token signature is invalid: crypto/rsa: verification error
--- FAIL: TestResolveBearer_PerOrgInstance_ForeignOrgSession_SurfacesTheOrgPinVerdict
    the signature error MASKED the org-pin verdict.
      got: identity: bearer rejected: token signature is invalid: crypto/rsa: verification error
```

Post-fix, verbatim:

```
--- PASS: TestResolveBearer_SovereignInstance_OrgSession_SurfacesTheWrongDoorVerdict (0.27s)
--- PASS: TestResolveBearer_PerOrgInstance_ForeignOrgSession_SurfacesTheOrgPinVerdict (0.46s)
```

## Controls

Each shares the suspect property — a bearer the local resolver **cannot** verify,
taking the identical whoami-fallback path — and is green BEFORE and AFTER, so the
subjects cannot be passing by breaking the path:

| Control | Asserts | Before | After |
|---|---|---|---|
| catalyst-api REJECTS (401) | local signature error preserved verbatim; bearer still refused | PASS | PASS |
| Sovereign whoami verdict, Sovereign-pinned instance | still ACCEPTED (#5175 untouched) | PASS | PASS |
| locally-verifiable sovereign-admin bearer | resolves locally, never delegates (stub 401s, so an always-delegate regression fails) | PASS | PASS |
| the three pre-existing #5175 tests | unchanged | PASS | PASS |

Full module: `go vet ./...` clean, `go test ./...` green across all four packages.

## Relationship to open PR #6068 — disjoint, not a rival

#6068 makes the local RS256 verify succeed by publishing and consuming a key
SET. This PR does not touch `buildResolver`, `parseRSAPublicKey`, `identity.go`
or any chart, and #6068 does not touch `resolveBearer`, `whoamiFallback` or
`whoami.go`. They compose: with #6068 the Org bearer verifies locally and reaches
the same #5206 refusal through `fromClaims`; without it the refusal arrives
through the whoami path this PR stops masking.

No chart or rendered-surface change (`check-chart-version-bumped.sh`: *"no chart
rendered-surface changes … nothing to bump"*, exit 0), so this carries no version
claim and cannot collide with #6068's `bp-openova-mcp` 0.1.7 / appVersion 0.2.6
bump. Delivery to a Sovereign rides the next appVersion bump.

## What this does NOT do

It does not turn rows 212/213 green, and nothing here should be read as doing so.
A Sovereign-mode instance refusing an Org-scoped session is the design (#5206);
those rows need a **per-Org** instance, and that install door is built and live —
see the audit posted on #5843.

Refs #6109 #5843 #5206 #5175 #3988

🤖 Generated with [Claude Code](https://claude.com/claude-code)
