### PR TITLE
fix(catalyst-api): the secondary-kubeconfig delivery leg must forward a USABLE document, not the first non-empty bytes

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/deployment_handover_export.go
+++ b/products/catalyst/bootstrap/api/internal/handler/deployment_handover_export.go
@@ -251,27 +251,85 @@ func (h *Handler) exportSecondaryKubeconfigsToChild(dep *Deployment, fqdn, depID
 	wg.Wait()
 }
 
-// waitForSecondaryKubeconfig polls for the kubeconfig file at path to
-// appear (and be non-empty) within budget. Returns (bytes, true) on
-// success, (nil, false) on timeout. Emits a single
+// waitForSecondaryKubeconfig polls for the kubeconfig file at path to appear
+// AND to describe a cluster a client can be built from, within budget. Returns
+// (bytes, true) on success, (nil, false) on timeout. Emits a single
 // `d16-export: waiting on secondary kubeconfig` log every 30s so the
 // catalyst-api journal shows progress instead of going silent.
+//
+// PRESENCE IS NOT USABILITY (#6015). The gate here used to be `len(raw) > 0`,
+// and that is how hw293 (dep a0077ba47e3720e5) ended up with the mothership
+// holding a COMPLETE 2959-byte region-B kubeconfig while the only document
+// ever forwarded to the Sovereign was a 95-byte credential-less shell — no
+// contexts, no users, no CA data.
+//
+// Both facts are true at once because this function read the file once, read
+// it too early, and judged it on length. There are two ways a non-usable
+// document can be sitting at that path when the poll fires, and the repo
+// contains both:
+//
+//   - a TRUNCATED UPLOAD. HandleKubeconfigPUT persists whatever body it
+//     receives with writeFileAtomic0600, gated only on len(body) != 0, so a
+//     secondary CP that uploads a partial k3s kubeconfig lands an atomic,
+//     complete file of 95 bytes. Atomicity guarantees no torn READ; it
+//     guarantees nothing about whether the bytes describe a cluster.
+//   - a TORN WRITE. HandleSovereignSecondaryKubeconfig writes the same
+//     `<depID>-<regionKey>.yaml` names into this very directory with a plain
+//     os.WriteFile, which truncates before it writes, and its route is
+//     registered unconditionally in cmd/api/main.go.
+//
+// Which one produced the hw293 artefact is not decidable from here, and the
+// fix does not depend on the answer: a document that cannot build a client is
+// refused whichever way it arrived.
+//
+// What made it PERMANENT is this function. The old check saw non-empty and
+// returned, the caller captured those bytes, and when the complete document
+// later occupied the path nothing re-read it: the export is one-shot per
+// handover, and postSecondaryKubeconfigWithRetry retries the TRANSPORT with
+// the same captured body. Both of the Sovereign's 422 rejections (#6054)
+// carried the identical stale stub, and a 4xx ends the retry policy, so region
+// B was left permanently credential-less.
+//
+// So the wait is now for a document that PASSES the same usability contract
+// the receiving end enforces — secondaryKubeconfigDefects, which binds to
+// clientcmd, the parser k8scache.AddCluster itself uses. A region whose file
+// is present but unusable keeps polling, which is exactly what lets the
+// complete retry PUT be picked up. Deliberately NOT a byte-length heuristic:
+// a padded credential-less document many times the stub's size is refused, and
+// a shorter complete one is accepted.
+//
+// Per-region by construction: exportSecondaryKubeconfigsToChild fans out one
+// goroutine per region key, each with its own path, so one region's unusable
+// document can neither delay nor displace another's.
 func (h *Handler) waitForSecondaryKubeconfig(path string, budget, poll time.Duration, depID, regionKey string) ([]byte, bool) {
 	deadline := time.Now().Add(budget)
 	logEvery := 30 * time.Second
 	nextLog := time.Now().Add(logEvery)
+	var lastDefects []string
+	lastBytes := 0
 	for {
 		raw, err := os.ReadFile(path)
 		if err == nil && len(raw) > 0 {
-			return raw, true
+			defects := secondaryKubeconfigDefects(string(raw))
+			if len(defects) == 0 {
+				return raw, true
+			}
+			lastDefects, lastBytes = defects, len(raw)
 		}
 		if time.Now().After(deadline) {
+			if len(lastDefects) > 0 {
+				h.log.Error("d16-export: secondary kubeconfig is on disk but cannot produce a client; REFUSING to forward it — the region keeps whatever it already had rather than being overwritten by a credential-less document",
+					"id", depID, "region", regionKey, "path", path,
+					"bytes", lastBytes, "missing", strings.Join(lastDefects, ","),
+				)
+			}
 			return nil, false
 		}
 		if time.Now().After(nextLog) {
 			h.log.Info("d16-export: waiting on secondary kubeconfig PUT-back",
 				"id", depID, "region", regionKey, "path", path,
 				"remaining", time.Until(deadline).Truncate(time.Second).String(),
+				"missing", strings.Join(lastDefects, ","),
 			)
 			nextLog = time.Now().Add(logEvery)
 		}

--- a/products/catalyst/bootstrap/api/internal/handler/deployment_handover_export_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/deployment_handover_export_test.go
@@ -221,8 +221,8 @@ func TestExportSecondaryKubeconfigs_FiresAtHandover(t *testing.T) {
 
 	// Pre-place both secondary kubeconfigs on disk — the realistic
 	// state when both secondary CPs PUT before primary Phase-1 ready.
-	mustWrite(t, filepath.Join(dir, depID+"-nbg1-1.yaml"), "apiVersion: v1\nkind: Config\n# nbg1\n")
-	mustWrite(t, filepath.Join(dir, depID+"-sin-2.yaml"), "apiVersion: v1\nkind: Config\n# sin\n")
+	mustWrite(t, filepath.Join(dir, depID+"-nbg1-1.yaml"), taggedKubeconfig("nbg1"))
+	mustWrite(t, filepath.Join(dir, depID+"-sin-2.yaml"), taggedKubeconfig("sin"))
 
 	runExportWithFakeChroot(t, h, dep, fqdn, depID, srv)
 
@@ -269,7 +269,7 @@ func TestExportSecondaryKubeconfigs_WaitsForLateKubeconfig(t *testing.T) {
 	// catch this and proceed to POST.
 	go func() {
 		time.Sleep(2 * time.Second)
-		mustWrite(t, filepath.Join(dir, depID+"-nbg1-1.yaml"), "apiVersion: v1\nkind: Config\n# nbg1 late\n")
+		mustWrite(t, filepath.Join(dir, depID+"-nbg1-1.yaml"), taggedKubeconfig("nbg1 late"))
 	}()
 
 	runExportWithFakeChroot(t, h, dep, fqdn, depID, srv)
@@ -305,7 +305,7 @@ func TestExportSecondaryKubeconfigs_SlowRegionDoesNotBlockReady(t *testing.T) {
 	dep := makeDep(depID, fqdn, []string{"fsn1", "nbg1", "sin"})
 
 	// nbg1-1 ready immediately, sin-2 never lands.
-	mustWrite(t, filepath.Join(dir, depID+"-nbg1-1.yaml"), "apiVersion: v1\nkind: Config\n# nbg1 ready\n")
+	mustWrite(t, filepath.Join(dir, depID+"-nbg1-1.yaml"), taggedKubeconfig("nbg1 ready"))
 
 	start := time.Now()
 	runExportWithFakeChroot(t, h, dep, fqdn, depID, srv)
@@ -331,4 +331,19 @@ func mustWrite(t *testing.T, path, content string) {
 	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
 		t.Fatalf("os.WriteFile(%s): %v", path, err)
 	}
+}
+
+// taggedKubeconfig returns a COMPLETE kubeconfig carrying tag as a leading
+// comment, so a fixture stays humanly distinguishable in a multi-region test
+// while still describing a cluster a client can be built from.
+//
+// The fixtures here used to be `apiVersion: v1\nkind: Config\n` plus a
+// comment. That is a well-formed YAML document and a credential-less one, and
+// it passed because delivery's only content check was non-emptiness — the
+// #6015 defect these tests sit next to. Once the export waits for a USABLE
+// document, a placeholder body would make every one of these tests wait out
+// its budget, so the placeholder is replaced by the real shape rather than the
+// gate being relaxed to keep them green.
+func taggedKubeconfig(tag string) string {
+	return "# " + tag + "\n" + completeKubeconfigSameCluster
 }

--- a/products/catalyst/bootstrap/api/internal/handler/secondary_kubeconfig_delivery_usability_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/secondary_kubeconfig_delivery_usability_test.go
@@ -1,0 +1,202 @@
+// secondary_kubeconfig_delivery_usability_test.go — the DELIVERY leg must
+// forward a kubeconfig that can produce a client, not the first non-empty
+// bytes it happens to observe.
+//
+// THE MEASUREMENT (hw293, dep a0077ba47e3720e5, region me-east-215-b-1)
+// ---------------------------------------------------------------------
+// The mothership PVC holds a COMPLETE 2959-byte region-B kubeconfig. The only
+// document ever POSTed to the Sovereign was a 95-byte credential-less shell —
+// `apiVersion`, `kind: Config`, one `clusters[]` entry with a `server:` URL,
+// and then nothing, ending mid-token on `  name: c` with no trailing newline.
+// No contexts, no users, no CA data.
+//
+// Both facts are true at once because delivery reads the file ONCE, and reads
+// it too early. waitForSecondaryKubeconfig's entire content contract was:
+//
+//	raw, err := os.ReadFile(path)
+//	if err == nil && len(raw) > 0 { return raw, true }
+//
+// The secondary control plane's cloud-init PUTs its kubeconfig to the
+// mothership, which persists it atomically (writeFileAtomic0600). A first PUT
+// carrying a partial document therefore lands as a COMPLETE, atomic file of 95
+// bytes — atomicity guarantees the reader never sees a torn write, it does not
+// guarantee the bytes describe a cluster. The export goroutine polls, sees
+// non-empty, and forwards. When the retry PUT later replaces the file with the
+// full 2959-byte document, nothing re-reads it: the export is one-shot per
+// handover, and postSecondaryKubeconfigWithRetry retries the TRANSPORT with
+// the same captured body — it never re-reads the FILE. So both of the
+// Sovereign's 422s (#6054) carried the identical stale stub.
+//
+// The downstream cost is region B having no credential at all: the
+// organization-controller reaches a secondary region through exactly that
+// kubeconfig, so the per-Org `console-https-<slug>` / `console-http-<slug>`
+// pair is never written there, while one shared console EIP round-robins both
+// regions' envoy — a share of every customer TLS connection to
+// `console.<slug>.<parent>` reaches a region with no listener for that SNI and
+// resets.
+//
+// WHAT IS ASSERTED HERE
+// ---------------------
+// Case 1 is the defect. The other three are controls, each answering the
+// opposite way, so the fix cannot pass by having simply made the wait stricter
+// for everyone:
+//
+//   - CONTROL A (vacuity): a usable kubeconfig present from the start returns
+//     promptly and unchanged. A gate that cannot pass is as useless as one
+//     that cannot fail.
+//   - CONTROL B (per-region): one region's unusable document must not hold up
+//     or corrupt another's. A fix that lands only for the first region
+//     reproduces the failure on the other side.
+//   - CONTROL C (not byte length): a document 9x LARGER than the stub but
+//     still credential-less is refused, while a SMALLER complete one is
+//     accepted. The constraint is usability; size is not evidence.
+//
+// Refs #6015 #6054 #6104.
+package handler
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// The stub and its control are the measured artefacts already pinned by the
+// #6054 completeness tests in this package — hw293StubKubeconfig (the 95-byte
+// document lifted off the chroot PVC, trailing newline deliberately absent)
+// and completeKubeconfigSameCluster (the same cluster block plus only the
+// three sections the stub lacks). Reusing them keeps ONE copy of the evidence
+// and means the delivery leg and the persistence gate are proven against
+// byte-identical inputs.
+const completeRegionKubeconfig = completeKubeconfigSameCluster
+
+// paddedCredentiallessKubeconfig is far LARGER than the stub and just as
+// unusable — the control that stops any future "looks big enough" heuristic.
+var paddedCredentiallessKubeconfig = "apiVersion: v1\nkind: Config\n" +
+	strings.Repeat("# padding so this document dwarfs the 95-byte stub\n", 12) +
+	"clusters:\n- cluster:\n    server: https://10.0.0.1:6443\n  name: r\n"
+
+// writeKubeconfigAtomic mirrors the mothership's own writeFileAtomic0600: the
+// reader never observes a torn write, so every fixture below is a COMPLETE
+// file whose CONTENT is the only variable.
+func writeKubeconfigAtomic(t *testing.T, path, content string) {
+	t.Helper()
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, []byte(content), 0o600); err != nil {
+		t.Fatalf("write temp kubeconfig: %v", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		t.Fatalf("rename kubeconfig into place: %v", err)
+	}
+}
+
+// TestWaitForSecondaryKubeconfig_ForwardsUsableNotMerelyPresent_6015 is the
+// hw293 reproduction: the stub lands first, the complete document replaces it
+// shortly after, and delivery must carry the one that can build a client.
+func TestWaitForSecondaryKubeconfig_ForwardsUsableNotMerelyPresent_6015(t *testing.T) {
+	h := newExportTestHandler(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "a0077ba47e3720e5-me-east-215-b-1.yaml")
+
+	// The first PUT: a credential-less shell, atomically complete on disk.
+	writeKubeconfigAtomic(t, path, hw293StubKubeconfig)
+
+	// The retry PUT the mothership actually received, landing while the
+	// export is polling — the 2959-byte document in the live measurement.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		time.Sleep(150 * time.Millisecond)
+		writeKubeconfigAtomic(t, path, completeRegionKubeconfig)
+	}()
+	defer func() { <-done }()
+
+	raw, ok := h.waitForSecondaryKubeconfig(path, 5*time.Second, 10*time.Millisecond, "a0077ba47e3720e5", "me-east-215-b-1")
+	if !ok {
+		t.Fatalf("delivery gave up while a usable kubeconfig was landing")
+	}
+	if defects := secondaryKubeconfigDefects(string(raw)); len(defects) > 0 {
+		t.Fatalf("delivery forwarded a %d-byte document that cannot produce a client (missing: %s) — "+
+			"the wait returned on the FIRST non-empty read, so the complete kubeconfig that replaced it "+
+			"milliseconds later was never read. The export is one-shot, so region B stays credential-less "+
+			"and its per-Org console listeners are never written.",
+			len(raw), strings.Join(defects, ","))
+	}
+}
+
+// TestWaitForSecondaryKubeconfig_UsableReturnsPromptly_6015 is CONTROL A, the
+// vacuity arm: the gate must still PASS, and fast, on a healthy delivery.
+func TestWaitForSecondaryKubeconfig_UsableReturnsPromptly_6015(t *testing.T) {
+	h := newExportTestHandler(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "dep1-region-b.yaml")
+	writeKubeconfigAtomic(t, path, completeRegionKubeconfig)
+
+	start := time.Now()
+	raw, ok := h.waitForSecondaryKubeconfig(path, 5*time.Second, 50*time.Millisecond, "dep1", "region-b")
+	elapsed := time.Since(start)
+
+	if !ok {
+		t.Fatalf("a complete kubeconfig was not accepted — the gate cannot pass, which is as broken as one that cannot fail")
+	}
+	if string(raw) != completeRegionKubeconfig {
+		t.Fatalf("delivery altered the kubeconfig bytes it forwarded")
+	}
+	if elapsed > time.Second {
+		t.Fatalf("a healthy delivery waited %s; the gate must not add latency to the common path", elapsed)
+	}
+}
+
+// TestWaitForSecondaryKubeconfig_IsPerRegion_6015 is CONTROL B. The export
+// fans out one goroutine per region; a region whose document never becomes
+// usable must fail on its OWN terms without touching its peer.
+func TestWaitForSecondaryKubeconfig_IsPerRegion_6015(t *testing.T) {
+	h := newExportTestHandler(t)
+	dir := t.TempDir()
+
+	goodPath := filepath.Join(dir, "dep1-region-a.yaml")
+	badPath := filepath.Join(dir, "dep1-region-b.yaml")
+	writeKubeconfigAtomic(t, goodPath, completeRegionKubeconfig)
+	writeKubeconfigAtomic(t, badPath, hw293StubKubeconfig)
+
+	goodRaw, goodOK := h.waitForSecondaryKubeconfig(goodPath, 300*time.Millisecond, 10*time.Millisecond, "dep1", "region-a")
+	if !goodOK || string(goodRaw) != completeRegionKubeconfig {
+		t.Fatalf("the healthy region was held back by its peer's unusable document (ok=%v)", goodOK)
+	}
+
+	badRaw, badOK := h.waitForSecondaryKubeconfig(badPath, 300*time.Millisecond, 10*time.Millisecond, "dep1", "region-b")
+	if badOK {
+		t.Fatalf("a permanently credential-less region reported delivery success with %d bytes — "+
+			"forwarding it writes an unusable document over the region's slot", len(badRaw))
+	}
+	if badRaw != nil {
+		t.Fatalf("a refused delivery must hand back no bytes at all, got %d", len(badRaw))
+	}
+}
+
+// TestWaitForSecondaryKubeconfig_RejectsOnUsabilityNotLength_6015 is CONTROL C.
+// The larger document loses and the smaller one wins, so no future reader can
+// mistake this gate for a size threshold.
+func TestWaitForSecondaryKubeconfig_RejectsOnUsabilityNotLength_6015(t *testing.T) {
+	if len(paddedCredentiallessKubeconfig) <= len(completeRegionKubeconfig) {
+		t.Fatalf("fixture precondition: the credential-less document (%d bytes) must be LARGER than the complete one (%d bytes)",
+			len(paddedCredentiallessKubeconfig), len(completeRegionKubeconfig))
+	}
+
+	h := newExportTestHandler(t)
+	dir := t.TempDir()
+
+	bigPath := filepath.Join(dir, "dep1-region-big.yaml")
+	writeKubeconfigAtomic(t, bigPath, paddedCredentiallessKubeconfig)
+	if _, ok := h.waitForSecondaryKubeconfig(bigPath, 200*time.Millisecond, 10*time.Millisecond, "dep1", "region-big"); ok {
+		t.Fatalf("a %d-byte credential-less document was accepted — the gate is keying on size, not on whether the bytes build a client",
+			len(paddedCredentiallessKubeconfig))
+	}
+
+	smallPath := filepath.Join(dir, "dep1-region-small.yaml")
+	writeKubeconfigAtomic(t, smallPath, completeRegionKubeconfig)
+	if _, ok := h.waitForSecondaryKubeconfig(smallPath, 200*time.Millisecond, 10*time.Millisecond, "dep1", "region-small"); !ok {
+		t.Fatalf("the smaller COMPLETE kubeconfig (%d bytes) was refused", len(completeRegionKubeconfig))
+	}
+}


### PR DESCRIPTION
Refs #6015 #6054 #6104

## The measurement

On hw293 (dep `a0077ba47e3720e5`, 2-region `me-east-215-a` / `-b-1`) two facts were true at the same time:

| artefact | state |
|---|---|
| mothership PVC, region-B kubeconfig | **complete**, 2959 bytes |
| document ever POSTed to the Sovereign | **95 bytes**, credential-less |
| Sovereign's response to it (#6054) | 422, twice, identical body |

The 95-byte document is the one already pinned as evidence by the #6054 tests: `apiVersion`, `kind: Config`, one `clusters[]` entry with a `server:` URL, ending mid-token on `  name: c` with no trailing newline. No contexts, no users, no CA data.

## Root cause — delivery read the file once, and read it too early

`waitForSecondaryKubeconfig`'s entire content contract was:

```go
raw, err := os.ReadFile(path)
if err == nil && len(raw) > 0 {
    return raw, true
}
```

Two paths in this repo can leave a non-usable document at that path when the poll fires, and both are live:

- **a truncated upload** — `HandleKubeconfigPUT` persists whatever body it receives with `writeFileAtomic0600`, gated only on `len(body) != 0`, so a secondary CP that uploads a partial k3s kubeconfig lands an *atomic, complete* file of 95 bytes. Atomicity guarantees the reader never sees a torn write; it guarantees nothing about whether the bytes describe a cluster.
- **a torn write** — `HandleSovereignSecondaryKubeconfig` writes the same `<depID>-<regionKey>.yaml` names into this very directory with a plain `os.WriteFile`, which truncates before it writes, and its route is registered unconditionally in `cmd/api/main.go`.

Which one produced the hw293 artefact is not decidable from the repo, and this change does not depend on the answer: a document that cannot build a client is refused whichever way it arrived. What made it **permanent** is the poll.

Nothing re-read it afterwards. The export is one-shot per handover, and `postSecondaryKubeconfigWithRetry` retries the **transport** with the body already captured — it never re-reads the **file**. That is why both of the Sovereign's 422s carried the identical stale stub, and a 4xx ends the retry policy. Region B was left permanently credential-less, which is the same "presence, not usability" shape #6054 fixed on the persistence side and #6104 fixed on the producer side. This is the third and last hop.

The consumer cost: the organization-controller reaches a secondary region through exactly that kubeconfig, so the per-Org `console-https-<slug>` / `console-http-<slug>` pair is never written there, while one shared console EIP round-robins both regions' envoy — a share of every customer TLS connection to `console.<slug>.<parent>` reaches a region with no listener for that SNI and resets.

## What ships

The wait is now for a document that passes the **same usability contract the receiving end enforces** — `secondaryKubeconfigDefects`, which binds to `clientcmd`, the parser `k8scache.AddCluster` itself uses. A region whose file is present but unusable keeps polling, which is precisely what lets the complete retry PUT be picked up. On timeout the log names the missing sections instead of going quiet.

Deliberately **not** a byte-length heuristic, and there is a test that fails if anyone makes it one.

Per-region by construction: `exportSecondaryKubeconfigsToChild` already fans out one goroutine per region key, each with its own path, so one region's unusable document can neither delay nor displace another's — asserted rather than assumed.

## Red, then green

Against unmodified code (`go test -run 'TestWaitForSecondaryKubeconfig_.*_6015'`):

```
--- FAIL: TestWaitForSecondaryKubeconfig_ForwardsUsableNotMerelyPresent_6015 (0.15s)
    delivery forwarded a 95-byte document that cannot produce a client
    (missing: contexts,current-context,users)
--- PASS: TestWaitForSecondaryKubeconfig_UsableReturnsPromptly_6015 (0.00s)
--- FAIL: TestWaitForSecondaryKubeconfig_IsPerRegion_6015 (0.00s)
    a permanently credential-less region reported delivery success with 95 bytes
--- FAIL: TestWaitForSecondaryKubeconfig_RejectsOnUsabilityNotLength_6015 (0.00s)
    a 705-byte credential-less document was accepted — the gate is keying on size
FAIL
```

After:

```
--- PASS: TestWaitForSecondaryKubeconfig_ForwardsUsableNotMerelyPresent_6015 (0.16s)
--- PASS: TestWaitForSecondaryKubeconfig_UsableReturnsPromptly_6015 (0.00s)
--- PASS: TestWaitForSecondaryKubeconfig_IsPerRegion_6015 (0.30s)
--- PASS: TestWaitForSecondaryKubeconfig_RejectsOnUsabilityNotLength_6015 (0.21s)
ok
```

### The controls

`UsableReturnsPromptly` passes **before and after** — it is the vacuity arm, and it also asserts the healthy path stays under a second, so the new wait cannot have been bought with latency on every good delivery.

`RejectsOnUsabilityNotLength` is the one that matters most for the next reader: the refused document is **705 bytes**, the accepted one is **220**, and the reproduced stub is **95** — byte-identical to the live artefact. The largest document loses and the smallest wins. Anyone who later "optimises" this into a size check fails that test.

`IsPerRegion` pins the fan-out property the coordinator's brief called out — a fix that landed only for the first region would reproduce the failure on the other side.

## Fixture change, and why it is not the gate being relaxed

Three existing export tests seeded `apiVersion: v1\nkind: Config\n` plus a comment. That is a well-formed YAML document and a credential-less one — it only ever passed because delivery's content check was non-emptiness, which is the defect. They now seed a complete kubeconfig via `taggedKubeconfig(tag)`, keeping their per-region distinguishability. The alternative — loosening the gate so the placeholders stay green — would have preserved the defect to keep the tests quiet.

Fixtures carry no credential material: the shared `completeKubeconfigSameCluster` is the #6054 control, and the new padded fixture is comment padding.

## Verification

The whole `internal/handler` package was run before and after, and the package-level verdict flipped:

```
before (fix applied, fixtures not yet updated):
FAIL  .../internal/handler   305.901s

after:
ok    .../internal/handler   293.015s
```

The intermediate FAIL is worth keeping in the record: it is the three placeholder-fixture tests timing out, which is the change correctly refusing documents that were never usable. They were repaired by fixing the fixtures, not by weakening the check.

- `go vet ./internal/handler/` clean; `gofmt -l` clean on all three changed files
- every call site of the changed function is covered — 3 `runExportWithFakeChroot` tests plus 6 direct calls, counted rather than assumed
- read-only on live clusters throughout; no NodePort anywhere in this change; no credential material in any fixture
