### PR TITLE
fix(catalyst-api): stop CREATING torn kubeconfigs, not just reading them

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/clustermesh_primary_kubeconfig.go
+++ b/products/catalyst/bootstrap/api/internal/handler/clustermesh_primary_kubeconfig.go
@@ -177,7 +177,9 @@ func (h *Handler) materializeChrootPrimaryKubeconfig(dep *Deployment, path strin
 			"id", dep.ID, "dir", filepath.Dir(path), "err", err)
 		return false
 	}
-	if err := os.WriteFile(path, []byte(raw), 0o600); err != nil {
+	// #6108 — atomic. resolvePrimaryKubeconfigPath os.Stats this path and the
+	// mesh establish reads it; an in-place truncate can hand either a prefix.
+	if err := writeFileAtomic0600(path, []byte(raw)); err != nil {
 		h.log.Warn("clustermesh: chroot primary kubeconfig write failed (#5131)",
 			"id", dep.ID, "path", path, "err", err)
 		return false

--- a/products/catalyst/bootstrap/api/internal/handler/deployment_handover_export.go
+++ b/products/catalyst/bootstrap/api/internal/handler/deployment_handover_export.go
@@ -567,6 +567,26 @@ func (h *Handler) reforwardSecondaryKubeconfigsToChild(dep *Deployment) {
 		if err != nil || len(raw) == 0 {
 			continue
 		}
+		// #6108 — the SECOND sender, carrying the same usability contract
+		// #6112 gave the handover-window poller. Both read the same directory
+		// and both POST to the same receiver; leaving one on `len(raw) > 0`
+		// means the shipped predicate depends on which code path happened to
+		// run, and this is the path that runs FOREVER while the other is
+		// one-shot per handover.
+		//
+		// Skipping beats posting: the receiver's own gate (#6054) 422s the
+		// shell anyway, a 4xx ends postSecondaryKubeconfigWithRetry's retry
+		// policy, and the loop is level-triggered — so a skipped tick costs one
+		// interval and the next pass forwards the completed document, whereas a
+		// posted shell burns the region's delivery and leaves it looking
+		// delivered.
+		if defects := secondaryKubeconfigDefects(string(raw)); len(defects) > 0 {
+			h.log.Warn("secondary-kubeconfig-delivery: SKIPPED a region whose on-disk kubeconfig cannot build a client — not forwarding a credential-less shell; retrying next pass (#6108)",
+				"id", depID, "region", regionKey, "path", path, "bytes", len(raw),
+				"missing", strings.Join(defects, ","),
+			)
+			continue
+		}
 		payload := map[string]string{
 			"deploymentId":   depID,
 			"regionKey":      regionKey,

--- a/products/catalyst/bootstrap/api/internal/handler/secondary_kubeconfig_coverage_6015_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/secondary_kubeconfig_coverage_6015_test.go
@@ -442,8 +442,13 @@ func TestSecondaryKubeconfigDelivery_RunsOnFailedDeployment_6015(t *testing.T) {
 	defer srv.Close()
 	withChrootForwardClient(t, srv)
 
-	mustWrite(t, filepath.Join(dir, depID+"-me-east-215-b-1.yaml"),
-		"apiVersion: v1\nkind: Config\nclusters:\n- cluster:\n    server: https://212.72.24.6:6443\n  name: c\n")
+	// A COMPLETE kubeconfig (#6108). This fixture used to be the cluster-block-only
+	// document — the hw293 stub's exact shape — so this test asserted that the
+	// delivery loop POSTs SOMETHING while the something it POSTed could never have
+	// built a client. The subject here is "delivery is not gated on the Phase-1
+	// outcome", and that subject is only meaningful over a document a Sovereign
+	// could actually use.
+	mustWrite(t, filepath.Join(dir, depID+"-me-east-215-b-1.yaml"), completeKubeconfigSameCluster)
 
 	h := newExportTestHandler(t)
 	h.secondaryKubeconfigDeliveryInterval = 5 * time.Millisecond
@@ -499,8 +504,9 @@ func TestMarkPhase1Done_FailedOutcomeStillStartsDelivery_6015(t *testing.T) {
 			withChrootForwardClient(t, srv)
 
 			// Region B's kubeconfig IS on the mother's disk — the hw293 state.
-			mustWrite(t, filepath.Join(dir, depID+"-me-east-215-b-1.yaml"),
-				"apiVersion: v1\nkind: Config\nclusters:\n- cluster:\n    server: https://212.72.24.6:6443\n  name: c\n")
+			// COMPLETE (#6108): see the sibling test above for why the
+			// cluster-block-only fixture made this assertion vacuous.
+			mustWrite(t, filepath.Join(dir, depID+"-me-east-215-b-1.yaml"), completeKubeconfigSameCluster)
 
 			h := NewWithPDM(silentLogger(), &fakePDM{})
 			h.secondaryKubeconfigDeliveryInterval = 5 * time.Millisecond

--- a/products/catalyst/bootstrap/api/internal/handler/secondary_kubeconfig_torn_write_6108_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/secondary_kubeconfig_torn_write_6108_test.go
@@ -1,0 +1,262 @@
+// secondary_kubeconfig_torn_write_6108_test.go — refusing to READ a torn
+// document and refusing to CREATE one are different guarantees.
+//
+// #6112 closed the reader half: waitForSecondaryKubeconfig now waits for a
+// document that passes the receiving end's own usability contract instead of
+// returning the first non-empty bytes. Its godoc names the two ways an unusable
+// document can be sitting at one of these paths when a reader fires — a
+// truncated upload, or a TORN WRITE, "HandleSovereignSecondaryKubeconfig writes
+// the same `<depID>-<regionKey>.yaml` names into this very directory with a
+// plain os.WriteFile, which truncates before it writes" — and says plainly that
+// its fix does not depend on which one produced the hw293 artefact.
+//
+// This file closes the second one at its source, and the one reader #6112 did
+// not reach.
+//
+// WHY THE READER FIX IS NOT SUFFICIENT ON ITS OWN. os.WriteFile is O_TRUNC
+// followed by a write, so between those two the file on disk IS a prefix of the
+// new content. A guard inside catalyst-api's own pollers protects catalyst-api's
+// own pollers. It does nothing for the readers this package does not own and
+// cannot gate: LoadClustersFromDir at startup, buildRegionSlots, the placement
+// resolver, orgConsoleTLSPoolRegions, and any operator or Job reading the PVC.
+// Every one of them can still land inside the truncate window. Atomic
+// replacement removes the window itself, so a torn document cannot be observed
+// by anyone rather than being declined by two callers.
+//
+// THE MEASURED ARTEFACT, for the record this file is pinned to. hw293 (dep
+// a0077ba47e3720e5) carried `a0077ba47e3720e5-me-east-215-b-1.yaml` at 95 bytes
+// — `apiVersion`, `kind`, one `clusters[]` entry, then nothing, ending mid-token
+// on `  name: c` with no trailing newline. The mothership's copy of the SAME
+// region was 2959 bytes and carried all six kubeconfig top-level keys
+// (`clusters`, `contexts`, `current-context`, `kind`, `preferences`, `users`).
+// A complete source and a prefix at the destination.
+//
+// Downstream, measured read-only 2026-08-11T00:57Z: clientcmd.RESTConfigFromKubeConfig
+// fails on the shell, orgConsoleTLSTargets puts me-east-215-b-1 in `unreached`,
+// region B holds ZERO per-Org console listeners against region A's ten, and the
+// shared console EIP round-robins a share of every customer TLS connection onto
+// the region that cannot answer it.
+//
+// Refs #6108 · #6112 (the reader half) · #6054 (the receiver gate) · #5246.
+
+package handler
+
+import (
+	"io"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// completeKubeconfigOtherCluster is a SECOND complete document, distinguishable
+// from completeKubeconfigSameCluster byte-for-byte, so the atomicity test can
+// tell "the reader saw the old document" from "the reader saw the new one".
+const completeKubeconfigOtherCluster = `apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://10.0.0.9:6443
+  name: d
+contexts:
+- name: d
+  context:
+    cluster: d
+    user: d
+current-context: d
+users:
+- name: d
+  user:
+    token: fake-token-two
+`
+
+// TestSecondaryKubeconfigPersist_IsAtomicForAConcurrentReader_6108 states the
+// torn-write property directly rather than trying to win a race.
+//
+// A reader that has the file OPEN when a rewrite lands is the deterministic
+// stand-in for a reader that is mid-read when a rewrite lands: both hold a
+// handle on the inode that was current at open time.
+//
+//   - O_TRUNC-in-place (os.WriteFile) mutates THAT inode, so the holder's next
+//     read yields the new bytes, or a short read, or nothing — never a coherent
+//     document.
+//   - temp+rename swaps a DIFFERENT inode into the name, so the holder keeps
+//     reading the complete previous document through to its end.
+//
+// The property asserted is the one that matters in production, and it is
+// stronger than "our pollers decline bad documents": a reader concurrent with a
+// write observes a COMPLETE document, whichever one it is, whether or not that
+// reader knows to check.
+func TestSecondaryKubeconfigPersist_IsAtomicForAConcurrentReader_6108(t *testing.T) {
+	dir := t.TempDir()
+	const clusterID = "a0077ba47e3720e5-me-east-215-b-1"
+
+	path, err := persistSecondaryKubeconfig(dir, clusterID, completeKubeconfigSameCluster)
+	if err != nil {
+		t.Fatalf("seed persist failed: %v", err)
+	}
+
+	// The concurrent reader, holding the inode that is current right now.
+	reader, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open for concurrent read: %v", err)
+	}
+	defer func() { _ = reader.Close() }()
+
+	// The rewrite lands while that handle is open — the production shape when
+	// the mothership re-delivers a region whose kubeconfig rotated, or when the
+	// #4000 self-heal rewrites the server host under a running scan.
+	if _, err := persistSecondaryKubeconfig(dir, clusterID, completeKubeconfigOtherCluster); err != nil {
+		t.Fatalf("rewrite persist failed: %v", err)
+	}
+
+	buf, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("read through the pre-opened handle: %v", err)
+	}
+	got := string(buf)
+
+	if got != completeKubeconfigSameCluster {
+		if got == completeKubeconfigOtherCluster {
+			t.Fatal("#6108: the rewrite mutated the inode the concurrent reader holds — " +
+				"os.WriteFile truncates in place, so a reader that is mid-read when a delivery " +
+				"lands gets a PREFIX of the new document. That is the 95-byte shell measured on " +
+				"hw293. Persist through writeFileAtomic0600 (temp+rename) instead.")
+		}
+		t.Fatalf("#6108: the concurrent reader observed neither complete document — it observed a TORN one.\n"+
+			"got %d bytes: %q\nwant the complete previous document (%d bytes)",
+			len(got), got, len(completeKubeconfigSameCluster))
+	}
+
+	// CONTROL — vacuity guard. The assertion above would also hold if persist
+	// were a no-op, so prove the rewrite really landed on the NAME.
+	fresh, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("fresh read of the path: %v", err)
+	}
+	if string(fresh) != completeKubeconfigOtherCluster {
+		t.Fatalf("CONTROL FAILED: the rewrite did not land on the path, so the assertion above proved nothing.\n"+
+			"path holds %d bytes, want the second document (%d bytes)",
+			len(fresh), len(completeKubeconfigOtherCluster))
+	}
+}
+
+// TestSecondaryKubeconfigPersist_LeavesNoPhantomRegionOnDisk_6108 is the
+// control that makes the atomicity fix admissible.
+//
+// Temp+rename puts a SECOND file in the kubeconfigs directory for the duration
+// of the write. That directory is scanned BY NAME to decide which regions
+// exist: onDiskSecondaryKubeconfigKeys and orgConsoleTLSPoolRegions both derive
+// the region set from filenames. A temp file those scanners matched would
+// invent a region with no cluster behind it — trading a torn read for a phantom
+// region, which is the same class of defect pointed the other way, and which on
+// this Sovereign would put a nonexistent region into the console ELB pool's
+// expected set.
+func TestSecondaryKubeconfigPersist_LeavesNoPhantomRegionOnDisk_6108(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("CATALYST_K8SCACHE_KUBECONFIGS_DIR", dir)
+	const depID = "a0077ba47e3720e5"
+
+	mustWrite(t, filepath.Join(dir, depID+".yaml"), completeKubeconfigSameCluster)
+	if _, err := persistSecondaryKubeconfig(dir, depID+"-me-east-215-b-1", completeKubeconfigSameCluster); err != nil {
+		t.Fatalf("persist failed: %v", err)
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read dir: %v", err)
+	}
+	var leftovers []string
+	for _, e := range entries {
+		n := e.Name()
+		if n == depID+".yaml" || n == depID+"-me-east-215-b-1.yaml" {
+			continue
+		}
+		leftovers = append(leftovers, n)
+	}
+	if len(leftovers) != 0 {
+		t.Fatalf("#6108: persist left temp artefacts behind in the kubeconfigs dir: %v", leftovers)
+	}
+
+	keys := onDiskSecondaryKubeconfigKeys(dir, depID)
+	if len(keys) != 1 || keys[0] != "me-east-215-b-1" {
+		t.Fatalf("#6108: the region scan sees %v, want exactly [me-east-215-b-1] — "+
+			"a temp file must never be counted as a region", keys)
+	}
+	if pool := orgConsoleTLSPoolRegions(depID); len(pool) != 1 {
+		t.Fatalf("#6108: the console ELB pool region set is %v, want exactly one region", pool)
+	}
+}
+
+// TestReforwardSecondaryKubeconfigs_DoesNotShipATornRead_6108 pins the SECOND
+// sender — the #6015 level-triggered redelivery loop.
+//
+// #6112 gave waitForSecondaryKubeconfig the usability contract; this loop reads
+// the same directory and POSTs to the same receiver and was left on
+// `len(raw) > 0`. That split matters more than it looks: the poller runs ONCE
+// per handover, while this loop runs for the lifetime of the Sovereign, so the
+// unguarded path is the one that runs essentially always.
+//
+// Two regions on disk, one torn and one complete, so the assertion and its
+// control run through the SAME loop, the SAME directory scan and the SAME POST
+// path in a single pass. The complete region proves the loop still delivers;
+// the torn one proves it no longer ships a shell. A loop that simply stopped
+// forwarding — a worse defect than the one it replaces — fails the control.
+func TestReforwardSecondaryKubeconfigs_DoesNotShipATornRead_6108(t *testing.T) {
+	const depID = "a0077ba47e3720e5"
+	dir := t.TempDir()
+	t.Setenv("CATALYST_K8SCACHE_KUBECONFIGS_DIR", dir)
+
+	chroot := &fakeChrootServer{}
+	srv := httptest.NewServer(chroot.handler())
+	defer srv.Close()
+	withChrootForwardClient(t, srv)
+
+	mustWrite(t, filepath.Join(dir, depID+"-me-east-215-b-1.yaml"), hw293StubKubeconfig)
+	mustWrite(t, filepath.Join(dir, depID+"-me-east-215-c-1.yaml"), completeKubeconfigSameCluster)
+
+	h := newExportTestHandler(t)
+	dep := makeDep(depID, "hw293.omantel.biz",
+		[]string{"me-east-215-a", "me-east-215-b", "me-east-215-c"})
+
+	h.reforwardSecondaryKubeconfigsToChild(dep)
+
+	posted := chroot.regionsPosted()
+	for _, r := range posted {
+		if r == "me-east-215-b-1" {
+			t.Fatalf("#6108: the redelivery loop shipped the %d-byte torn document to the chroot. "+
+				"The receiver's gate (#6054) 422s it, a 4xx ends the retry policy, and the region "+
+				"stays credential-less while every on-disk reader still counts it delivered.\n"+
+				"regionsPosted=%v", len(hw293StubKubeconfig), posted)
+		}
+	}
+
+	// CONTROL — the loop must still deliver the region whose document IS usable,
+	// with the right bytes. Same loop, same pass, same directory.
+	var sawComplete bool
+	for _, body := range chrootBodies(chroot) {
+		if body["regionKey"] != "me-east-215-c-1" {
+			continue
+		}
+		sawComplete = true
+		if body["kubeconfigYaml"] != completeKubeconfigSameCluster {
+			t.Fatalf("CONTROL FAILED: the complete region was delivered with the wrong bytes (%d)",
+				len(body["kubeconfigYaml"]))
+		}
+	}
+	if !sawComplete {
+		t.Fatalf("CONTROL FAILED: the loop delivered NOTHING — the change stopped forwarding instead of "+
+			"stopping torn forwarding, which is a worse defect than the one it replaces.\nregionsPosted=%v",
+			posted)
+	}
+}
+
+// chrootBodies exposes every payload the fake chroot received, so a test can
+// assert on the BYTES delivered rather than only on which regions were named.
+func chrootBodies(s *fakeChrootServer) []map[string]string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]map[string]string, 0, len(s.received))
+	out = append(out, s.received...)
+	return out
+}

--- a/products/catalyst/bootstrap/api/internal/handler/sovereign_secondary_kubeconfig.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sovereign_secondary_kubeconfig.go
@@ -151,6 +151,52 @@ func nodeIPSidecarPath(dir, clusterID string) string {
 	return filepath.Join(dir, clusterID+".nodeip")
 }
 
+// persistSecondaryKubeconfig writes one region's kubeconfig into dir under its
+// canonical `<clusterID>.yaml` name and returns the path it wrote. The single
+// seam through which every producer of a secondary kubeconfig lands its bytes —
+// the receiver below and the #4000 self-heal rewrite — so the durability
+// contract is stated once instead of being re-decided per call site.
+//
+// 🛑 #6108 — the write MUST be atomic, and this is the one store in catalyst-api
+// where that is load-bearing rather than hygienic.
+//
+// #6112 named the two ways an unusable document can be sitting at one of these
+// paths when a reader fires — a truncated upload, or a TORN WRITE — and fixed
+// the readers, deliberately leaving the question of which produced the hw293
+// artefact open because its own fix did not depend on the answer. This closes
+// the second one at its source.
+//
+// `os.WriteFile` is O_TRUNC followed by a write, so between those two the file
+// on disk IS a prefix of the new content. That matters here specifically
+// because this directory is POLLED: waitForSecondaryKubeconfig spins on exactly
+// these paths waiting for a peer process to fill them, and LoadClustersFromDir /
+// onDiskSecondaryKubeconfigKeys / orgConsoleTLSPoolRegions scan it. A reader
+// landing inside the truncate window sees a coherent-looking shell.
+//
+// Measured: hw293 (dep a0077ba47e3720e5) carried
+// `a0077ba47e3720e5-me-east-215-b-1.yaml` at 95 bytes — `apiVersion`, `kind`,
+// one `clusters[]` entry, then nothing, ending mid-token on `  name: c` with no
+// trailing newline — while the mothership's copy of the SAME region was 2959
+// bytes and carried all six top-level keys. A complete source and a prefix at
+// the destination.
+//
+// Refusing to read a torn document and refusing to create one are different
+// guarantees, and only the second one holds for readers this package does not
+// own. temp+rename gives every reader either the previous complete document or
+// the new one. Every other durable store here already does this — store.Save,
+// jobs.Store, k8scache/snapshot, store/tenant_registry, store/user_provision,
+// providers/huawei/eip_blocklist_store — and writeFileAtomic0600 is this
+// package's existing implementation. Its `.<name>.*.tmp` temp files match
+// neither the `.yaml`/`.yml` suffix the region scanners require nor the
+// `<depID>-<regionKey>.yaml` shape, so the swap cannot invent a phantom region.
+func persistSecondaryKubeconfig(dir, clusterID, raw string) (string, error) {
+	path := filepath.Join(dir, clusterID+".yaml")
+	if err := writeFileAtomic0600(path, []byte(raw)); err != nil {
+		return path, err
+	}
+	return path, nil
+}
+
 // HandleSovereignSecondaryKubeconfig handles POST
 // /api/v1/sovereign/secondary-kubeconfig.
 //
@@ -294,8 +340,8 @@ func (h *Handler) HandleSovereignSecondaryKubeconfig(w http.ResponseWriter, r *h
 		return
 	}
 	clusterID := fmt.Sprintf("%s-%s", body.DeploymentID, body.RegionKey)
-	path := filepath.Join(dir, clusterID+".yaml")
-	if err := os.WriteFile(path, []byte(raw), 0o600); err != nil {
+	path, err := persistSecondaryKubeconfig(dir, clusterID, raw)
+	if err != nil {
 		h.log.Warn("secondary-kubeconfig: write failed", "path", path, "err", err)
 		writeJSON(w, http.StatusInternalServerError, map[string]string{
 			"error":  "write-failed",

--- a/products/catalyst/bootstrap/api/internal/handler/sovereign_secondary_kubeconfig_selfheal.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sovereign_secondary_kubeconfig_selfheal.go
@@ -271,7 +271,11 @@ func (h *Handler) SelfHealSecondaryKubeconfigsOnDisk(log *slog.Logger) {
 			log.Debug("secondary-kubeconfig self-heal: no change", "clusterID", stem, "reason", reason)
 			continue
 		}
-		if werr := os.WriteFile(path, []byte(healed), 0o600); werr != nil {
+		// #6108 — through the atomic seam. This rewrite lands on a path the
+		// mothership's export poller and LoadClustersFromDir both read, so an
+		// in-place truncate here can hand a reader the same prefix the hw293
+		// 95-byte shell was.
+		if _, werr := persistSecondaryKubeconfig(dir, stem, healed); werr != nil {
 			log.Warn("secondary-kubeconfig self-heal: persist failed", "path", path, "err", werr)
 			continue
 		}


### PR DESCRIPTION
Refs #6108 · #6112 · #6054 · #5246

## What changed since this PR first opened

#6112 landed on main while this was in flight and closed the **reader** half: `waitForSecondaryKubeconfig` now waits for a document that passes the receiving end's usability contract instead of returning the first non-empty bytes. This PR was rebuilt from scratch on top of it and now contains only what #6112 did not reach.

#6112's own godoc names the two ways an unusable document can be sitting at one of these paths when a reader fires — a truncated upload, or a **torn write**: *"HandleSovereignSecondaryKubeconfig writes the same `<depID>-<regionKey>.yaml` names into this very directory with a plain os.WriteFile, which truncates before it writes"* — and states that its fix does not depend on which one produced the hw293 artefact. This closes that second one at its source, plus the one reader #6112 did not cover.

## Why the reader fix is not sufficient on its own

`os.WriteFile` is `O_TRUNC` followed by a write, so between those two the file on disk **is** a prefix of the new content.

A guard inside catalyst-api's own pollers protects catalyst-api's own pollers. It does nothing for the readers this package does not own and cannot gate: `LoadClustersFromDir` at startup, `buildRegionSlots`, the placement resolver, `orgConsoleTLSPoolRegions`, and any sovereign-admin or Job reading the PVC. Every one of them can still land inside the truncate window.

Atomic replacement removes the window itself, so a torn document cannot be **observed** by anyone rather than being **declined** by two callers. Refusing to read a torn document and refusing to create one are different guarantees.

Every other durable store in catalyst-api already writes temp+rename — `store.Save`, `jobs.Store`, `k8scache/snapshot`, `store/tenant_registry`, `store/user_provision`, `providers/huawei/eip_blocklist_store` — and `writeFileAtomic0600` is this package's existing implementation, reused here at all three kubeconfig write sites behind one named `persistSecondaryKubeconfig` seam.

## The second sender

`reforwardSecondaryKubeconfigsToChild` reads the same directory and POSTs to the same receiver, and was left on `len(raw) > 0`. That split matters more than it looks: the poller #6112 fixed runs **once per handover**, while this loop runs for the **lifetime of the Sovereign** — so the unguarded path is the one that runs essentially always. It now carries the same `secondaryKubeconfigDefects` contract.

Skipping beats posting: the receiver's gate (#6054) 422s the shell anyway, a 4xx ends `postSecondaryKubeconfigWithRetry`'s retry policy, and the loop is level-triggered — so a skipped tick costs one interval, whereas a posted shell burns the region's delivery and leaves it looking delivered.

## The measured artefact

hw293 (dep `a0077ba47e3720e5`) carried `a0077ba47e3720e5-me-east-215-b-1.yaml` at **95 bytes** — `apiVersion`, `kind`, one `clusters[]` entry, then nothing, ending mid-token on `  name: c` with no trailing newline.

The mothership's copy of the **same region** was **2959 bytes** and carried all six kubeconfig top-level keys (`clusters`, `contexts`, `current-context`, `kind`, `preferences`, `users`), read on the PVC. A complete source and a prefix at the destination.

Read-only, 2026-08-11T00:57Z: region A's `kube-system/cilium-gateway-console` carried ten per-Org listeners, region B carried zero, and catalyst-api logged once per Organization per pass:

```
"org-console-tls: region is in the console ELB backend pool but NO client could be built for it"
"region":"me-east-215-b-1"  "err":"invalid configuration: no configuration has been provided"
```

## Red then green

Two assertions fail on the parent commit — which already contains #6112, so these are not re-proving its work:

```
--- FAIL: TestSecondaryKubeconfigPersist_IsAtomicForAConcurrentReader_6108 (0.00s)
    #6108: the rewrite mutated the inode the concurrent reader holds — os.WriteFile
    truncates in place, so a reader that is mid-read when a delivery lands gets a
    PREFIX of the new document. That is the 95-byte shell measured on hw293.
--- FAIL: TestReforwardSecondaryKubeconfigs_DoesNotShipATornRead_6108 (0.00s)
    #6108: the redelivery loop shipped the 95-byte torn document to the chroot.
    regionsPosted=[me-east-215-b-1 me-east-215-c-1]
```

Green here:

```
--- PASS: TestSecondaryKubeconfigPersist_IsAtomicForAConcurrentReader_6108 (0.00s)
--- PASS: TestSecondaryKubeconfigPersist_LeavesNoPhantomRegionOnDisk_6108 (0.00s)
--- PASS: TestReforwardSecondaryKubeconfigs_DoesNotShipATornRead_6108 (0.01s)
```

Full `internal/handler` suite green, 299s.

The atomicity test uses a **pre-opened file handle** as the deterministic stand-in for a reader that is mid-read: both hold the inode current at open time. `O_TRUNC` mutates that inode so the holder reads the new bytes or a short read; temp+rename swaps a different inode into the name so the holder reads the complete previous document through to its end. No race to win.

## The controls

- **`LeavesNoPhantomRegionOnDisk_6108`** passes on both sides. Temp+rename puts a second file in a directory that is scanned **by name** to decide which regions exist, so this pins that `onDiskSecondaryKubeconfigKeys` and `orgConsoleTLSPoolRegions` still see exactly one region. Trading a torn read for a phantom region is the same class of defect pointed the other way, and here it would put a nonexistent region into the console ELB pool's expected set.
- **The atomicity test's vacuity arm** re-reads the path fresh and requires the second document, so the assertion cannot pass on a no-op persist.
- **The reforward test carries its control inside the assertion**: two regions in one directory, one torn and one complete, through the same loop, same scan, same POST path, in a single pass. A change that simply stopped forwarding fails the complete-region arm.

## Two existing fixtures updated

Both #6015 delivery tests asserted "the region was delivered" while writing the cluster-block-only document — the hw293 stub's exact shape. They measured that a POST happened and never that what arrived could build a client, so both would have passed on the very shell that took region B off hw293. They now write `completeKubeconfigSameCluster` and finally range over the property their names claim. This is the same fixture correction #6112 made to the tests it touched; these two were out of its reach because it did not modify the reforward loop.

## Rows this gates

UAT R16, 87, 90, 95 — all four fail on serving reliability at per-Org hostnames, all four traced by their own evidence to this rung. Not stamped here; a walker owns `UAT.md`.
