### PR TITLE
fix(netpol): the catalyst-pin backchannel moved in-cluster and no policy followed it — both halves, ClusterMesh-safe (#6106)

### DIFF
--- a/clusters/_template/bootstrap-kit/09-keycloak.yaml
+++ b/clusters/_template/bootstrap-kit/09-keycloak.yaml
@@ -226,7 +226,17 @@ spec:
       #   values.yaml wires keycloak.auth.existingSecret=keycloak-admin so the
       #   password is reused (never regenerated) across reinstall + re-home. Chart
       #   + blueprint bumped in lockstep.
-      version: 1.5.8
+      # 1.5.9 — #6106 (Refs #6089): the catalyst-pin backchannel NetworkPolicy the
+      #   1.5.8 URL split needed and did not ship. Moving tokenUrl/userInfoUrl/
+      #   jwksUrl from the public api.<fqdn> to catalyst-api.catalyst-system.svc:8080
+      #   moved the dial from an allowed hop (world:443) to a denied one, and every
+      #   catalyst-pin brokered login ConnectTimeout'd from the moment the realm
+      #   re-imported on hw293. New CiliumNetworkPolicy
+      #   `keycloak-allow-catalyst-api-backchannel-egress`, derived from
+      #   catalystAPIInternalURL, with a ClusterMesh-safe toEndpoints selector so the
+      #   region-B Keycloak (this slot is NOT SECONDARY_HR_SUSPEND'd) can reach the
+      #   region-A catalyst-api over the mesh. Ingress half in bp-catalyst-platform.
+      version: 1.5.9
       sourceRef:
         kind: HelmRepository
         name: bp-keycloak

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1374,7 +1374,22 @@ spec:
       #   provisioned. Env injection ships inside this umbrella, so the
       #   witness reaches the controller only once this pin advances. Lockstep
       #   w/ products/catalyst/chart/Chart.yaml.
-      version: 1.4.1383
+      # 1.4.1384 (#6106, Refs #6089, UAT rows 30/31/33/34/35/37/39/219): the
+      #   catalyst-system INGRESS half of the catalyst-pin backchannel fix. The
+      #   #6089 split moved Keycloak's tokenUrl/userInfoUrl/jwksUrl from the
+      #   public api.<fqdn> — where they arrived as the reserved `ingress`
+      #   (cilium-gateway) identity baseline-default-deny already admits — to
+      #   catalyst-api.catalyst-system.svc:8080, which that policy's ingress
+      #   allow-list does not cover. New CiliumNetworkPolicy
+      #   `baseline-allow-keycloak-oidc-backchannel` admits ns keycloak to the
+      #   catalyst-api Pods on TCP/8080 ONLY, with io.cilium.k8s.policy.cluster
+      #   named so a peer-region Keycloak is admitted too. baseline-default-deny
+      #   itself is untouched: adding `keycloak` to its blanket
+      #   allowedIngressNamespaces would have granted every port on org-pg,
+      #   guacamole-pg and the shared-pg family as well. Egress half in
+      #   bp-keycloak 1.5.9; neither half alone restores a brokered login.
+      #   Lockstep w/ products/catalyst/chart/Chart.yaml.
+      version: 1.4.1384
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/platform/keycloak/blueprint.yaml
+++ b/platform/keycloak/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.5.8
+  version: 1.5.9
   card:
     title: keycloak
     summary: Keycloak — user identity. Topology decided by Sovereign CRD spec.keycloakTopology (per-organization for Organizations, shared-sovereign for corporate).

--- a/platform/keycloak/chart/Chart.yaml
+++ b/platform/keycloak/chart/Chart.yaml
@@ -469,7 +469,37 @@ name: bp-keycloak
 #   entry paths ONLY: a PathPrefix would swallow /realms/<realm>/account/config
 #   and the rest of the account REST surface. New knob
 #   gateway.accountConsoleRedirect.
-version: 1.5.8
+#
+# 1.5.9 (#6106, UAT rows 30/31/33/34/35/37/39/219): the backchannel split
+# shipped in 1.5.8 without the NetworkPolicy that lets the new dial happen, so
+# it moved catalyst-pin from a permitted hop to a denied one. Keycloak's egress
+# to `world:443` was already allowed; `catalyst-api.catalyst-system.svc:8080`
+# was not, and from the moment the realm re-imported on hw293
+# (2026-08-10T23:43:49Z) EVERY catalyst-pin brokered login died in keycloak-0's
+# own log with `ConnectTimeoutException: Connect to
+# catalyst-api.catalyst-system.svc.cluster.local:8080 [10.96.1.11] failed:
+# Connection timed out` -- grafana, gitea, openbao, guacamole, newapi, hubble,
+# and the Keycloak admin console, which falls back to the realm login form
+# because no keycloak session is obtainable while the broker is down.
+#   New template `templates/catalyst-backchannel-egress-cnp.yaml` emits
+# CiliumNetworkPolicy `keycloak-allow-catalyst-api-backchannel-egress` --
+# destination namespace, Pod label and port all DERIVED from
+# catalystAPIInternalURL so the policy cannot drift from the URL that needs it,
+# and `catalystAPIInternalURL: ""` removes both together.
+#   The destination is a `toEndpoints` selector that NAMES
+# io.cilium.k8s.policy.cluster with Exists, not a toCIDR. bp-keycloak carries no
+# SECONDARY_HR_SUSPEND so it renders in BOTH regions, while
+# bp-catalyst-platform is suspended on every secondary CP (G2 #2574) and
+# catalyst-api is published as a ClusterMesh global Service (#5289) -- so a
+# region-B Keycloak Pod's backchannel is a cross-cluster hop whose destination
+# arrives with a REMOTE-CLUSTER identity. A CIDR match can never resolve that:
+# it would render clean and leave half a 2-region Sovereign's brokered logins
+# dark. Same idiom, same reason as plane-isolation's crossregion-db-egress CNP.
+#   The companion INGRESS half ships in bp-catalyst-platform
+# (baseline-allow-keycloak-oidc-backchannel); neither half alone restores a
+# brokered login. Gated on the cilium.io/v2 Capabilities check so CRD-less
+# clusters still install. Guarded by tests/catalyst-backchannel-netpol-6106.sh.
+version: 1.5.9
 description: |
   1.5.2 (#4246): the per-tenant `openclaw-oidc-client-secret` Secret now
   emits BOTH `client-secret` AND `OIDC_CLIENT_SECRET` keys (it previously

--- a/platform/keycloak/chart/templates/catalyst-backchannel-egress-cnp.yaml
+++ b/platform/keycloak/chart/templates/catalyst-backchannel-egress-cnp.yaml
@@ -1,0 +1,179 @@
+{{- /*
+CiliumNetworkPolicy — keycloak → catalyst-api OIDC BACKCHANNEL egress (#6106).
+
+WHY THIS EXISTS
+───────────────────────────────────────────────────────────────────────────
+#6087/#6089 split the sovereign realm's `catalyst-pin` identity provider so
+its SERVER-SIDE legs stop hairpinning through the Sovereign's own public EIP:
+
+  authorizationUrl  https://api.<sovereignFQDN>/oidc/auth      (browser — PUBLIC)
+  tokenUrl          {{ "{{ .Values.catalystAPIInternalURL }}" }}/oidc/token    (KC server — INTERNAL)
+  userInfoUrl       {{ "{{ .Values.catalystAPIInternalURL }}" }}/oidc/userinfo (KC server — INTERNAL)
+  jwksUrl           {{ "{{ .Values.catalystAPIInternalURL }}" }}/oidc/certs    (KC server — INTERNAL)
+
+That split moved the dial from `world:443` — which the keycloak namespace's
+egress policy set already permitted — to an IN-CLUSTER endpoint on :8080, and
+nothing granted the new hop. Measured on hw293 region A, from keycloak-0's own
+log:
+
+  ERROR [org.keycloak.broker.oidc.AbstractOAuth2IdentityProvider]
+  Failed to make identity provider oauth callback:
+  org.apache.http.conn.ConnectTimeoutException: Connect to
+  catalyst-api.catalyst-system.svc.cluster.local:8080 [10.96.1.11] failed:
+  Connection timed out
+
+Every brokered login through catalyst-pin — grafana, gitea, openbao,
+guacamole, newapi, hubble, and the Keycloak admin console itself — terminates
+on Keycloak's "Unexpected error when authenticating with identity provider"
+page while that hop is denied.
+
+WHY IT IS NEEDED EVEN THOUGH A LOCAL DIAL LOOKS ALLOWED — THE REGION-B LEG
+───────────────────────────────────────────────────────────────────────────
+bp-plane-isolation's `keycloak-default-deny` NetworkPolicy already carries an
+egress rule `to: [{namespaceSelector: {}}]`, and in the LOCAL region that rule
+does match a catalyst-api Pod, so region A's egress leg is not the denial —
+region A is denied on the catalyst-system INGRESS side (the companion half of
+this fix, `products/catalyst/chart/templates/network-policies/
+keycloak-backchannel-ingress.yaml`). This policy exists for the leg that has
+NO allow at all in either policy set: region B.
+
+  * bp-keycloak (bootstrap-kit slot 09) carries NO `SECONDARY_HR_SUSPEND`, so
+    keycloak — and this realm import, and the catalyst-pin IdP with the
+    internal backchannel — renders in BOTH regions of a 2-region Sovereign.
+  * bp-catalyst-platform (slot 13) IS suspended on every secondary CP
+    (`suspend: ${SECONDARY_HR_SUSPEND:=false}`, G2 #2574), so catalyst-api
+    exists ONLY in region A. Slot 13e (bp-catalyst-secondary-edge, #5289)
+    renders a ClusterMesh global-Service STUB with zero local backends into
+    region B's catalyst-system, and `products/catalyst/chart/templates/
+    api-service.yaml` publishes the real Service with
+    `service.cilium.io/global: "true"`.
+
+So a region-B Keycloak Pod's backchannel dial to
+`catalyst-api.catalyst-system.svc.cluster.local:8080` resolves ACROSS the
+ClusterMesh to the single region-A Pod. That destination arrives with a
+REMOTE-CLUSTER identity, and the documented trap (memory
+`reference_k8s_netpol_ipblock_never_matches_clustermesh_remote_identity`,
+restated at length in `platform/plane-isolation/chart/templates/
+crossregion-db-egress-cnp.yaml`) is that neither half of the default-deny's
+egress allow-list can match it: `namespaceSelector: {}` resolves to LOCAL pod
+identities only, and `ipBlock: 0.0.0.0/0` resolves to `world`. A cross-region
+backchannel is therefore dropped with the SAME ConnectTimeout, and a fix that
+lands only on the ingress side leaves half of a 2-region Sovereign's brokered
+logins dark.
+
+FORM — `toEndpoints`, never `toCIDR`/`ipBlock`
+───────────────────────────────────────────────────────────────────────────
+The destination is expressed as an ENDPOINT selector for exactly that reason.
+`io.cilium.k8s.policy.cluster` is referenced with `Exists` (the idiom proven
+live on hw228 for grafana → shared-pg, crossregion-db-egress-cnp.yaml): a bare
+`toEndpoints` is implicitly ANDed with `cluster=<local>`, which would silently
+re-exclude the peer-region catalyst-api; naming the key suppresses that
+AND-injection so ONE rule covers both the local and the meshed destination.
+`k8s:io.kubernetes.pod.namespace` is likewise named explicitly, which
+suppresses the namespace AND-injection a namespaced CNP would otherwise apply.
+
+SCOPE — deliberately narrow on the DESTINATION
+───────────────────────────────────────────────────────────────────────────
+This is not a namespace-wide grant. The allow is pinned to
+  * the destination namespace + Pod label derived from
+    `.Values.catalystAPIInternalURL` (default catalyst-system /
+    app.kubernetes.io/name=catalyst-api — the exact selector
+    `products/catalyst/chart/templates/api-service.yaml` uses), and
+  * the single TCP port that URL names (default 8080).
+`endpointSelector: {}` on the SOURCE side matches the sibling CNPs already in
+this namespace (`keycloak-allow-apiserver-egress`,
+`keycloak-allow-crossregion-db-egress`) and is correct here: both the Keycloak
+server Pod and the keycloak-config-cli import Job dial the backchannel, and the
+policy is already namespace-scoped by construction.
+
+Every field is DERIVED from `.Values.catalystAPIInternalURL` rather than
+restated, so the policy cannot drift from the realm import that created the
+need for it (Inviolable Principle #4). Set that value to "" — the documented
+escape hatch for a cluster whose EIP does hairpin — and the realm goes back to
+an all-public backchannel and this policy is not emitted at all.
+
+Gated on the `cilium.io/v2` Capabilities check (the #2988/#3102 idiom) so the
+chart still installs on CRD-less clusters (kind CI). Cilium evaluates the UNION
+of every policy selecting an endpoint, so this is purely additive to the
+plane-isolation default-deny — it grants one destination on one port and
+weakens nothing.
+*/ -}}
+{{- if and .Values.sovereignRealm.enabled (not (and .Values.realmConfig (and .Values.realmConfig.tenant .Values.realmConfig.tenant.enabled))) }}
+{{- $url := trimSuffix "/" (trim (.Values.catalystAPIInternalURL | default "")) }}
+{{- if $url }}
+{{- $scheme := "" }}
+{{- $rest := "" }}
+{{- if hasPrefix "http://" $url }}
+{{- $scheme = "http" }}
+{{- $rest = trimPrefix "http://" $url }}
+{{- else if hasPrefix "https://" $url }}
+{{- $scheme = "https" }}
+{{- $rest = trimPrefix "https://" $url }}
+{{- else }}
+{{- fail (printf "bp-keycloak: catalystAPIInternalURL must be an http:// or https:// URL, got %q. An unparseable value would silently emit NO backchannel egress policy and re-break every catalyst-pin brokered login (#6106)." $url) }}
+{{- end }}
+{{- $authority := first (splitList "/" $rest) }}
+{{- $hostport := splitList ":" $authority }}
+{{- $host := index $hostport 0 }}
+{{- $port := "" }}
+{{- if gt (len $hostport) 1 }}
+{{- $port = index $hostport 1 }}
+{{- else if eq $scheme "https" }}
+{{- $port = "443" }}
+{{- else }}
+{{- $port = "80" }}
+{{- end }}
+{{- $dnsLabels := splitList "." $host }}
+{{- /* In-cluster Service DNS shapes ONLY: <svc>.<ns>, <svc>.<ns>.svc,
+       <svc>.<ns>.svc.cluster.local. A PUBLIC host (the all-public backchannel
+       an operator restores on a hairpin-capable EIP) is reached over the
+       existing world egress and needs no endpoint policy — emit nothing. */}}
+{{- $inCluster := and (ge (len $dnsLabels) 2) (or (eq (len $dnsLabels) 2) (eq (index $dnsLabels 2) "svc")) }}
+{{- if and $inCluster (.Capabilities.APIVersions.Has "cilium.io/v2") }}
+{{- $svc := index $dnsLabels 0 }}
+{{- $ns := index $dnsLabels 1 }}
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: keycloak-allow-catalyst-api-backchannel-egress
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app.kubernetes.io/name: bp-keycloak
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    catalyst.openova.io/component: keycloak-catalyst-backchannel-netpol
+  annotations:
+    policies.openova.io/title: Keycloak → catalyst-api OIDC backchannel egress
+    policies.openova.io/description: |
+      Permits the sovereign realm's catalyst-pin identity provider to reach
+      catalyst-api's OIDC token/userinfo/certs endpoints in-cluster, including
+      across the ClusterMesh from a secondary region where catalyst-api runs
+      only in region A. Derived from catalystAPIInternalURL (#6106).
+spec:
+  description: "keycloak → {{ $svc }}.{{ $ns }}:{{ $port }} — catalyst-pin OIDC backchannel (#6106)."
+  # Every endpoint in the keycloak namespace — the Keycloak server Pod dials
+  # the backchannel on each brokered login and the config-cli import Job
+  # validates the IdP at import time. Matches the scope of the sibling
+  # keycloak-allow-* CNPs bp-plane-isolation already renders here.
+  endpointSelector: {}
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: {{ $ns | quote }}
+            k8s:app.kubernetes.io/name: {{ $svc | quote }}
+          matchExpressions:
+            # Naming the cluster key suppresses Cilium's implicit
+            # `cluster=<local>` AND-injection, so this ONE rule matches the
+            # local catalyst-api in region A and the ClusterMesh-resolved
+            # region-A backend dialled from region B. An ipBlock/toCIDR here
+            # would render clean and silently deny the peer-region hop.
+            - key: io.cilium.k8s.policy.cluster
+              operator: Exists
+      toPorts:
+        - ports:
+            - port: {{ $port | quote }}
+              protocol: TCP
+{{- end }}
+{{- end }}
+{{- end }}

--- a/platform/keycloak/chart/tests/catalyst-backchannel-netpol-6106.sh
+++ b/platform/keycloak/chart/tests/catalyst-backchannel-netpol-6106.sh
@@ -1,0 +1,251 @@
+#!/usr/bin/env bash
+# bp-keycloak — catalyst-pin OIDC BACKCHANNEL egress policy gate (#6106).
+#
+# WHAT THIS GUARDS
+# ────────────────────────────────────────────────────────────────────────
+# #6087/#6089 repointed the sovereign realm's `catalyst-pin` identity
+# provider so its server-side legs stop hairpinning through the Sovereign's
+# own public EIP:
+#
+#   authorizationUrl  https://api.<sovereignFQDN>/oidc/auth   (browser  — PUBLIC)
+#   tokenUrl / userInfoUrl / jwksUrl                          (KC server — INTERNAL)
+#
+# The realm ConfigMap carrying that split was re-imported on hw293 at
+# 2026-08-10T23:43:49Z and every catalyst-pin brokered login went dark —
+# grafana, gitea, openbao, guacamole, newapi, hubble and the Keycloak admin
+# console — with keycloak-0 logging, verbatim:
+#
+#   ERROR [org.keycloak.broker.oidc.AbstractOAuth2IdentityProvider]
+#   Failed to make identity provider oauth callback:
+#   org.apache.http.conn.ConnectTimeoutException: Connect to
+#   catalyst-api.catalyst-system.svc.cluster.local:8080 [10.96.1.11] failed:
+#   Connection timed out
+#
+# The dial moved from `world:443` (already permitted) to an in-cluster
+# endpoint on :8080, and no policy granted the new hop. UAT rows
+# 30/31/33/34/35/37/39/219 all terminate there.
+#
+# This gate asserts the chart that MOVED the URL also ships the policy that
+# permits it, and — crucially — that the policy is DERIVED from that same
+# value rather than restated, so the two can never drift apart again.
+#
+# Cases:
+#   1. the egress CNP renders, with the destination + port DERIVED from
+#      catalystAPIInternalURL (asserted on VALUES, not on key presence)
+#   2. PAIRING — the realm's tokenUrl/userInfoUrl/jwksUrl name exactly the
+#      host:port the policy permits
+#   3. CONTROL — authorizationUrl + issuer stay PUBLIC and unchanged; they
+#      share the suspect property (catalyst-pin IdP URLs) and must NOT move
+#   4. FORM — toEndpoints + io.cilium.k8s.policy.cluster Exists, never CIDR
+#   5. VACUITY — catalystAPIInternalURL="" removes the policy AND restores
+#      the public backchannel (proves case 1 can fail)
+#   6. VACUITY — no cilium.io/v2 capability removes the policy (proves the
+#      Capabilities gate is real, not decorative)
+#   7. DERIVATION — a different URL moves namespace + Pod label + port with
+#      it (proves case 1's assertions are not tautologies over hardcoded text)
+#
+# Usage: bash tests/catalyst-backchannel-netpol-6106.sh [CHART_DIR]
+
+set -euo pipefail
+
+chart_dir="${1:-$(cd "$(dirname "$0")/.." && pwd)}"
+helm="${HELM_BIN:-helm}"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+"$helm" dependency build "$chart_dir" >/dev/null 2>&1 || true
+
+fqdn="smoke.omani.works"
+tpl="templates/catalyst-backchannel-egress-cnp.yaml"
+cnp_name="keycloak-allow-catalyst-api-backchannel-egress"
+
+render() {
+  # $1.. = extra helm args. Cilium CRDs are declared so the Capabilities gate
+  # is satisfied — helm-controller discovers them server-side on a live
+  # Sovereign, `helm template` needs them stated.
+  "$helm" template keycloak "$chart_dir" \
+    --namespace keycloak \
+    --api-versions cilium.io/v2 \
+    --set sovereignFQDN="$fqdn" \
+    "$@" 2>/dev/null
+}
+
+# ── Case 1: the egress CNP renders with derived VALUES ────────────────────
+echo "[bp-keycloak/6106] Case 1: catalyst-pin backchannel egress CNP renders with derived values"
+cnp="$(render --show-only "$tpl" || true)"
+if [ -z "$cnp" ]; then
+  echo "FAIL: $tpl did not render. Without it a Keycloak Pod cannot reach catalyst-api's OIDC backchannel and every brokered SSO login ConnectTimeouts (#6106)." >&2
+  exit 1
+fi
+if ! grep -q "name: ${cnp_name}" <<<"$cnp"; then
+  echo "FAIL: CNP ${cnp_name} missing from the render (#6106)." >&2
+  echo "$cnp" >&2
+  exit 1
+fi
+if ! grep -q '^kind: CiliumNetworkPolicy$' <<<"$cnp"; then
+  echo "FAIL: the backchannel allow is not a CiliumNetworkPolicy — a vanilla NetworkPolicy cannot express the ClusterMesh cluster key (#6106)." >&2
+  exit 1
+fi
+# Slice the egress block so the assertions below cannot be satisfied by text
+# living somewhere else in the document (the comment block names the same
+# service and port).
+#
+# Comment-only lines are dropped first: this template documents the CIDR trap
+# it avoids, and a form check that greps the raw text would fail on its own
+# rationale. Every assertion below therefore runs against real YAML only.
+strip_comments() { grep -v '^[[:space:]]*#' || true; }
+egress_block="$(awk '/^  egress:/,0' <<<"$cnp" | strip_comments)"
+if [ -z "$egress_block" ]; then
+  echo "FAIL: could not slice the egress block out of ${cnp_name} — the awk range is broken, not the policy." >&2
+  exit 1
+fi
+# Assert on the VALUE of each selector key. `k8s:io.kubernetes.pod.namespace: ""`
+# would carry the key and match nothing.
+if ! grep -q 'k8s:io.kubernetes.pod.namespace: "catalyst-system"' <<<"$egress_block"; then
+  echo "FAIL: the egress destination namespace is not catalyst-system (#6106)." >&2
+  echo "$egress_block" >&2
+  exit 1
+fi
+if ! grep -q 'k8s:app.kubernetes.io/name: "catalyst-api"' <<<"$egress_block"; then
+  echo "FAIL: the egress destination is not scoped to the catalyst-api Pods — a namespace-only destination would grant keycloak the whole control-plane namespace (#6106)." >&2
+  echo "$egress_block" >&2
+  exit 1
+fi
+if ! grep -q 'port: "8080"' <<<"$egress_block"; then
+  echo "FAIL: the egress allow does not name TCP/8080 — the port keycloak-0 timed out on (#6106)." >&2
+  echo "$egress_block" >&2
+  exit 1
+fi
+if ! grep -q 'protocol: TCP' <<<"$egress_block"; then
+  echo "FAIL: the egress port rule carries no TCP protocol (#6106)." >&2
+  exit 1
+fi
+echo "[bp-keycloak/6106] Case 1: PASS (egress -> catalyst-system/catalyst-api on TCP/8080)"
+
+# ── Case 2: PAIRING — realm backchannel URLs match what the policy permits ─
+echo "[bp-keycloak/6106] Case 2: the realm's backchannel URLs name exactly the host:port the policy permits"
+realm="$(render --show-only templates/configmap-sovereign-realm.yaml || true)"
+if [ -z "$realm" ]; then
+  echo "FAIL: the sovereign realm ConfigMap did not render — this pairing check would be vacuous." >&2
+  exit 1
+fi
+backchannel="http://catalyst-api.catalyst-system.svc.cluster.local:8080"
+for leg in tokenUrl userInfoUrl jwksUrl; do
+  if ! grep -q "\"${leg}\": \\\\\"${backchannel}/oidc/" <<<"$realm"; then
+    # The realm JSON is embedded, so quoting is escaped; fall back to a plain
+    # substring check that still asserts the VALUE, not the key.
+    if ! grep -q "${leg}" <<<"$realm" || ! grep -q "${backchannel}" <<<"$realm"; then
+      echo "FAIL: catalyst-pin ${leg} does not point at ${backchannel} — the policy this chart ships permits a destination the realm no longer dials (#6106)." >&2
+      exit 1
+    fi
+  fi
+done
+echo "[bp-keycloak/6106] Case 2: PASS (tokenUrl/userInfoUrl/jwksUrl -> ${backchannel})"
+
+# ── Case 3: CONTROL — the frontchannel must NOT have moved ────────────────
+# authorizationUrl and issuer share the suspect property — they are
+# catalyst-pin IdP URLs in the same realm block — and they must stay PUBLIC.
+# authorizationUrl is a BROWSER redirect (an internal URL is unresolvable from
+# the User's machine) and issuer is compared against the `iss` claim
+# catalyst-api mints from its own SOVEREIGN_FQDN (an internal value would
+# trade a connectivity failure for a validation failure). If the #6106 diff
+# had loosened rather than added, this control is what catches it.
+echo "[bp-keycloak/6106] Case 3: CONTROL — authorizationUrl + issuer stay PUBLIC"
+if ! grep -q "\"authorizationUrl\"" <<<"$realm"; then
+  echo "FAIL: authorizationUrl absent from the realm — the control has no subject." >&2
+  exit 1
+fi
+auth_line="$(grep '"authorizationUrl"' <<<"$realm" | head -1)"
+if ! grep -q "https://api.${fqdn}/oidc/auth" <<<"$auth_line"; then
+  echo "FAIL: authorizationUrl is no longer the public https://api.${fqdn}/oidc/auth. It is a BROWSER redirect; an in-cluster URL is unresolvable from the User's machine. Got: ${auth_line}" >&2
+  exit 1
+fi
+if grep -q "catalyst-api.catalyst-system" <<<"$auth_line"; then
+  echo "FAIL: authorizationUrl was moved to the in-cluster backchannel host — the frontchannel must stay public (#6087)." >&2
+  exit 1
+fi
+issuer_line="$(grep '"issuer"' <<<"$realm" | head -1)"
+if ! grep -q "https://api.${fqdn}" <<<"$issuer_line"; then
+  echo "FAIL: catalyst-pin issuer is no longer public https://api.${fqdn}. It is compared against the iss claim catalyst-api mints from SOVEREIGN_FQDN; pointing it inward trades a connectivity failure for a validation failure. Got: ${issuer_line}" >&2
+  exit 1
+fi
+echo "[bp-keycloak/6106] Case 3: PASS (frontchannel + issuer unchanged and public)"
+
+# ── Case 4: FORM — ClusterMesh-safe endpoint selectors, never CIDR ────────
+echo "[bp-keycloak/6106] Case 4: toEndpoints + io.cilium.k8s.policy.cluster Exists, never CIDR"
+if ! grep -q 'toEndpoints:' <<<"$egress_block"; then
+  echo "FAIL: the backchannel allow does not use toEndpoints (#6106)." >&2
+  exit 1
+fi
+if ! grep -q 'key: io.cilium.k8s.policy.cluster' <<<"$egress_block"; then
+  echo "FAIL: io.cilium.k8s.policy.cluster is not named. Cilium AND-injects cluster=<local> into a bare toEndpoints, so a region-B Keycloak Pod's dial to the ClusterMesh-resolved region-A catalyst-api is silently denied — the policy renders clean and half the Sovereign's brokered logins stay dark (#6106)." >&2
+  exit 1
+fi
+if ! grep -A1 'key: io.cilium.k8s.policy.cluster' <<<"$egress_block" | grep -q 'operator: Exists'; then
+  echo "FAIL: io.cilium.k8s.policy.cluster is named but not with operator Exists — the suppression of the AND-injection is the whole point (#6106)." >&2
+  exit 1
+fi
+for bad in toCIDR toCIDRSet ipBlock; do
+  if grep -q "${bad}" <<<"$egress_block"; then
+    echo "FAIL: the backchannel allow uses ${bad} — a CIDR match NEVER resolves a ClusterMesh remote pod identity (#6106)." >&2
+    exit 1
+  fi
+done
+for wild in world cluster all; do
+  if grep -qE "^\s*-\s*${wild}\s*$" <<<"$egress_block"; then
+    echo "FAIL: the backchannel allow includes the '${wild}' entity — that is a wildcard, not a carve-out (#6106)." >&2
+    exit 1
+  fi
+done
+echo "[bp-keycloak/6106] Case 4: PASS (endpoint-identity selectors only)"
+
+# ── Case 5: VACUITY — the empty escape hatch removes BOTH halves ──────────
+echo "[bp-keycloak/6106] Case 5: VACUITY — catalystAPIInternalURL='' removes the policy and restores the public backchannel"
+off="$(render --set catalystAPIInternalURL= --show-only "$tpl" 2>/dev/null || true)"
+if grep -q "${cnp_name}" <<<"$off"; then
+  echo "FAIL: the CNP still renders with catalystAPIInternalURL='' — the conditional is dead and Case 1 proves nothing." >&2
+  exit 1
+fi
+realm_off="$(render --set catalystAPIInternalURL= --show-only templates/configmap-sovereign-realm.yaml || true)"
+if [ -z "$realm_off" ]; then
+  echo "FAIL: the realm ConfigMap did not render with catalystAPIInternalURL='' — cannot verify the escape hatch." >&2
+  exit 1
+fi
+if grep -q "catalyst-api.catalyst-system.svc" <<<"$realm_off"; then
+  echo "FAIL: with catalystAPIInternalURL='' the realm still carries the in-cluster backchannel — the chart would ship a dial with no policy behind it." >&2
+  exit 1
+fi
+echo "[bp-keycloak/6106] Case 5: PASS (both halves follow the same value)"
+
+# ── Case 6: VACUITY — the Capabilities gate is real ───────────────────────
+echo "[bp-keycloak/6106] Case 6: VACUITY — no cilium.io/v2 capability means no CNP"
+nocaps="$("$helm" template keycloak "$chart_dir" --namespace keycloak --set sovereignFQDN="$fqdn" --show-only "$tpl" 2>/dev/null || true)"
+if grep -q "${cnp_name}" <<<"$nocaps"; then
+  echo "FAIL: the CNP renders without the cilium.io/v2 API version — the Capabilities gate is decorative and the chart would fail to install on a CRD-less cluster." >&2
+  exit 1
+fi
+echo "[bp-keycloak/6106] Case 6: PASS (Capabilities gate genuinely gates)"
+
+# ── Case 7: DERIVATION — the policy follows the URL, it does not restate it ─
+echo "[bp-keycloak/6106] Case 7: DERIVATION — a different backchannel URL moves the policy with it"
+alt="$(render --set catalystAPIInternalURL=http://cat-api.other-ns.svc.cluster.local:9090 --show-only "$tpl" || true)"
+if [ -z "$alt" ]; then
+  echo "FAIL: the CNP did not render for an alternate in-cluster backchannel URL." >&2
+  exit 1
+fi
+alt_egress="$(awk '/^  egress:/,0' <<<"$alt" | strip_comments)"
+if ! grep -q 'k8s:io.kubernetes.pod.namespace: "other-ns"' <<<"$alt_egress"; then
+  echo "FAIL: the destination namespace did not follow catalystAPIInternalURL — it is hardcoded, so Case 1's catalyst-system assertion is a tautology." >&2
+  exit 1
+fi
+if ! grep -q 'k8s:app.kubernetes.io/name: "cat-api"' <<<"$alt_egress"; then
+  echo "FAIL: the destination Pod label did not follow catalystAPIInternalURL — it is hardcoded." >&2
+  exit 1
+fi
+if ! grep -q 'port: "9090"' <<<"$alt_egress"; then
+  echo "FAIL: the destination port did not follow catalystAPIInternalURL — it is hardcoded, so Case 1's 8080 assertion is a tautology." >&2
+  exit 1
+fi
+echo "[bp-keycloak/6106] Case 7: PASS (namespace + Pod label + port all derived)"
+
+echo "[bp-keycloak/6106] All gates green."

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-10T23:57:47.871Z",
+  "generatedAt": "2026-08-11T01:17:31.392Z",
   "blueprints": [
     {
       "id": "bp-agenity",
@@ -2235,7 +2235,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "1.5.8",
+      "version": "1.5.9",
       "section": "pts-2-3-per-sovereign-supporting-services",
       "depends": [
         "bp-postgres"

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -2370,7 +2370,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "1.5.8",
+    "version": "1.5.9",
     "section": "pts-2-3-per-sovereign-supporting-services",
     "depends": [
       "bp-postgres"

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3819,7 +3819,43 @@ name: bp-catalyst-platform
 #   arming it without a non-empty activeDeploymentIds protect-list is a
 #   RENDER-TIME failure, not a runtime surprise (#4466's belt-and-suspenders
 #   against the b9f9590b self-reap). Lockstep w/ slot-13 pin.
-version: 1.4.1383
+#
+# 1.4.1384 — #6106 (Refs #6089, UAT rows 30/31/33/34/35/37/39/219): the
+#   catalyst-system INGRESS half of the catalyst-pin OIDC backchannel. #6089
+#   repointed the sovereign realm's tokenUrl/userInfoUrl/jwksUrl at
+#   catalyst-api.catalyst-system.svc:8080 to stop the Keycloak Pod hairpinning
+#   through the Sovereign's own EIP. That was the right move and it landed
+#   without an allow: before the split Keycloak reached catalyst-api over the
+#   PUBLIC api.<fqdn> route and arrived as the reserved `ingress`
+#   (cilium-gateway) identity that baseline-default-deny rule 1 already
+#   admits; after it, the leg is east-west from a namespace that policy's
+#   ingress allow-list (catalyst, flux-system, kube-system, oidc-gate,
+#   guacamole, cnpg-system) does not name. Measured on hw293 in keycloak-0's
+#   own log from the 2026-08-10T23:43:49Z realm re-import onward:
+#   `ConnectTimeoutException: Connect to
+#   catalyst-api.catalyst-system.svc.cluster.local:8080 [10.96.1.11] failed:
+#   Connection timed out`, with IDENTITY_PROVIDER_LOGIN_ERROR for clientId
+#   grafana, gitea, openbao, guacamole-gate and newapi-admin, and the Keycloak
+#   admin console dropping to the realm login form because no keycloak session
+#   is obtainable while the broker is down.
+#   New templates/network-policies/keycloak-backchannel-ingress.yaml emits
+#   `baseline-allow-keycloak-oidc-backchannel`: endpointSelector
+#   app.kubernetes.io/name=catalyst-api, fromEndpoints ns keycloak, toPorts
+#   TCP/8080 — one namespace, one workload, one port.
+#   baseline-default-deny is deliberately UNTOUCHED. Appending `keycloak` to
+#   security.baselineCnp.allowedIngressNamespaces was the one-line version and
+#   is wrong: that rule carries no toPorts, so it would admit the namespace to
+#   every Pod in catalyst-system on every port, org-pg / guacamole-pg / the
+#   shared-pg family included. tests/baseline-cnp-allowlist.sh Case 17 is the
+#   control that keeps the blanket list free of `keycloak`; Case 16 pins the
+#   ClusterMesh-safe form (fromEndpoints + io.cilium.k8s.policy.cluster
+#   Exists, never ipBlock — a CIDR can never match a remote pod identity, and
+#   bp-keycloak renders in BOTH regions while this umbrella is
+#   SECONDARY_HR_SUSPEND'd, so the region-B backchannel is a cross-cluster
+#   hop); Case 18 proves the policy can actually be absent.
+#   Egress half in bp-keycloak 1.5.9. Neither half alone restores a brokered
+#   login. Lockstep w/ slot-13 pin.
+version: 1.4.1384
 # 1.4.1229 — #5389: catalog-seed bp-newapi declares its `ui` endpoint
 #   (newapi.<fqdn>, ssoEnabled, launchDefault, ssoInitPath "/") instead of
 #   `endpoints: []`. The empty list made userUIGatePasses fail closed, which
@@ -3974,7 +4010,7 @@ version: 1.4.1383
 # scripts/check-chart-version-forward.sh (#5743) fails unless the two match —
 # main was carrying a pre-existing 1.4.1330/1.4.1329 split, so this bump heals
 # it in the same commit, exactly as the documented self-heal contract does.
-appVersion: 1.4.1383
+appVersion: 1.4.1384
 # 1.4.239 — Wave 3 / Issue #2140 (2026-05-23): Huawei provider
 # implementation lands behind the Wave 2 CloudProvider interface.
 # Adds the OpenTofu module at infra/providers/huawei/ (VPC + Subnet +

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -592,7 +592,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "1.5.8"
+  version: "1.5.9"
   visibility: listed
   card:
     title: "Keycloak"
@@ -620,7 +620,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-keycloak
-    version: "1.5.8"
+    version: "1.5.9"
   # G117.1+G117.4+G117.6 #2744-followup (2026-06-03): bp-keycloak
   # catalog-seed needs topology + endpoints + sso so application-
   # controller can fan out HRs and operator console can mint silent-SSO

--- a/products/catalyst/chart/templates/network-policies/keycloak-backchannel-ingress.yaml
+++ b/products/catalyst/chart/templates/network-policies/keycloak-backchannel-ingress.yaml
@@ -1,0 +1,118 @@
+{{- /*
+CiliumNetworkPolicy — catalyst-api ingress for the catalyst-pin OIDC
+BACKCHANNEL from the keycloak namespace (#6106).
+
+THE INGRESS HALF of the #6089 backchannel split. The egress half ships in
+`platform/keycloak/chart/templates/catalyst-backchannel-egress-cnp.yaml`;
+neither half alone restores a brokered login.
+
+WHAT BROKE
+───────────────────────────────────────────────────────────────────────────
+#6087/#6089 repointed the sovereign realm's `catalyst-pin` identity provider
+so its SERVER-SIDE legs (tokenUrl / userInfoUrl / jwksUrl) stop hairpinning
+through the Sovereign's own public EIP and dial
+`catalyst-api.catalyst-system.svc.cluster.local:8080` directly. The realm
+ConfigMap was re-imported on hw293 at 2026-08-10T23:43:49Z, and from that
+moment every catalyst-pin brokered login failed — measured in keycloak-0's
+own log, region A:
+
+  ERROR [org.keycloak.broker.oidc.AbstractOAuth2IdentityProvider]
+  Failed to make identity provider oauth callback:
+  org.apache.http.conn.ConnectTimeoutException: Connect to
+  catalyst-api.catalyst-system.svc.cluster.local:8080 [10.96.1.11] failed:
+  Connection timed out
+  WARN [org.keycloak.events] type="IDENTITY_PROVIDER_LOGIN_ERROR"
+  realmName="sovereign" clientId="grafana"
+
+…with the same line for clientId `gitea`, `openbao`, `guacamole-gate` and
+`newapi-admin`. The Keycloak admin console falls back to the realm login form
+for the same reason: no keycloak session is obtainable while the broker leg
+is down. UAT rows 30/31/33/34/35/37/39/219 all terminate here.
+
+The denial is in `baseline-catalyst-system.yaml`, this file's sibling: its
+`baseline-default-deny` CNP is `endpointSelector: {}` over the whole
+catalyst-system namespace and its ingress allow-list admits `catalyst`,
+`flux-system`, `kube-system`, `oidc-gate`, `guacamole`, `cnpg-system` — and
+not `keycloak`. Before #6089 that was correct, because Keycloak reached
+catalyst-api over the PUBLIC api.<sovereignFQDN> route, arriving as the
+reserved `ingress` (cilium-gateway) identity that rule 1 already admits.
+Moving the leg in-cluster moved it out of every allow this policy grants.
+
+WHY THIS IS A SEPARATE POLICY, NOT ANOTHER ENTRY IN THE BLANKET LIST
+───────────────────────────────────────────────────────────────────────────
+Adding `keycloak` to `security.baselineCnp.allowedIngressNamespaces` would
+have been one line, and it would have admitted the keycloak namespace to
+EVERY Pod in catalyst-system on EVERY port — that allow-list rule carries no
+`toPorts` — including org-pg, guacamole-pg and the shared-pg family that are
+host-rendered into this namespace. What the backchannel needs is one
+namespace reaching one workload on one port, so it is expressed as its own
+policy with its own `endpointSelector`. Cilium evaluates the UNION of every
+policy selecting an endpoint, so this is purely additive to the
+default-deny; `baseline-default-deny` itself is unchanged by this fix, and
+`tests/baseline-cnp-allowlist.sh` Case 17 asserts `keycloak` never appears in
+that blanket list so a later "simplification" cannot quietly widen it.
+
+CLUSTERMESH — WHY `fromEndpoints` NAMES THE CLUSTER KEY
+───────────────────────────────────────────────────────────────────────────
+On a 2-region Sovereign the source of this traffic is not always local.
+bp-keycloak (slot 09) carries no `SECONDARY_HR_SUSPEND`, so Keycloak and the
+sovereign realm — internal backchannel included — render in BOTH regions,
+while bp-catalyst-platform (slot 13) is suspended on every secondary CP (G2
+#2574) so catalyst-api runs ONLY in region A and is published as a ClusterMesh
+global Service (`api-service.yaml`, `service.cilium.io/global: "true"`,
+#5289). A region-B Keycloak Pod's backchannel therefore arrives here over the
+mesh carrying a REMOTE-CLUSTER identity.
+
+A bare `fromEndpoints` is implicitly ANDed with `cluster=<local>`, which would
+admit region A and silently deny region B — a policy that renders clean and
+drops half the Sovereign's brokered logins. Naming
+`io.cilium.k8s.policy.cluster` with `Exists` suppresses that AND-injection
+(the idiom proven live on hw228, `platform/plane-isolation/chart/templates/
+crossregion-db-egress-cnp.yaml`). An `ipBlock`/`fromCIDR` here would be worse
+still: it can NEVER match a ClusterMesh remote pod identity.
+*/}}
+{{- if and .Values.security.baselineCnp.enabled .Values.security.baselineCnp.keycloakBackchannel.enabled }}
+{{- $bc := .Values.security.baselineCnp.keycloakBackchannel }}
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: baseline-allow-keycloak-oidc-backchannel
+  namespace: catalyst-system
+  labels:
+    openova.io/managed-by: catalyst-baseline
+    openova.io/policy-tier: baseline
+    catalyst.openova.io/component: keycloak-backchannel-cnp
+  annotations:
+    policies.openova.io/title: Catalyst-API OIDC Backchannel Ingress From Keycloak
+    policies.openova.io/description: |
+      Admits the keycloak namespace — in this cluster and, over the
+      ClusterMesh, in the peer region — to catalyst-api's OIDC backchannel
+      port only. Companion to the catalyst-pin frontchannel-public /
+      backchannel-internal split (#6089); without it every brokered SSO login
+      fails with ConnectTimeoutException (#6106).
+spec:
+  description: "keycloak -> catalyst-api:{{ $bc.port }} — catalyst-pin OIDC backchannel ingress (#6106)."
+  # Scoped to the catalyst-api Pods ONLY — the same selector
+  # templates/api-service.yaml uses to pick its backends. The rest of
+  # catalyst-system (catalyst-ui, the controllers, org-pg, guacamole-pg, the
+  # shared-pg family) stays exactly as closed to the keycloak namespace as it
+  # was before this policy.
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: catalyst-api
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: {{ $bc.namespace | quote }}
+          matchExpressions:
+            # See the ClusterMesh note above: naming this key is what lets the
+            # rule match a peer-region Keycloak Pod. Dropping it re-breaks
+            # region B while region A keeps passing.
+            - key: io.cilium.k8s.policy.cluster
+              operator: Exists
+      toPorts:
+        - ports:
+            # catalyst-api's only Service port (templates/api-service.yaml).
+            - port: {{ $bc.port | quote }}
+              protocol: TCP
+{{- end }}

--- a/products/catalyst/chart/tests/baseline-cnp-allowlist.sh
+++ b/products/catalyst/chart/tests/baseline-cnp-allowlist.sh
@@ -294,8 +294,6 @@ if ! grep -q '"tenant-acme"' "$TMP/cnp-extra.yaml"; then
 fi
 echo "  PASS (allowedIngressNamespaces is operator-tunable)"
 
-echo "[baseline-cnp] All gates green."
-
 # ── Case 14 (#4444 / UAT row R22): cnpg-system must be in BOTH directions ──
 #
 # The CNPG operator reverse-probes the Pods it manages. Several CNPG Clusters
@@ -352,3 +350,166 @@ if ! printf '%s' "$_egr14" | grep -q '"cnpg-system"'; then
   exit 1
 fi
 echo "  PASS (cnpg-system present in both ingress and egress)"
+
+# ─────────────────────────────────────────────────────────────────────────
+# Cases 15-18 (#6106) — the catalyst-pin OIDC backchannel ingress carve-out.
+#
+# #6087/#6089 repointed the sovereign realm's catalyst-pin IdP so tokenUrl /
+# userInfoUrl / jwksUrl dial catalyst-api.catalyst-system.svc:8080 in-cluster
+# instead of hairpinning through the Sovereign's public EIP. Before that split
+# Keycloak arrived as the reserved `ingress` (cilium-gateway) identity rule 1
+# admits; after it, the leg had NO allow anywhere and every brokered login
+# died in keycloak-0's log with
+#   ConnectTimeoutException: Connect to
+#   catalyst-api.catalyst-system.svc.cluster.local:8080 [10.96.1.11] timed out
+# (hw293, UAT rows 30/31/33/34/35/37/39/219).
+#
+# The allow ships as its OWN policy — baseline-allow-keycloak-oidc-backchannel,
+# templates/network-policies/keycloak-backchannel-ingress.yaml — rather than as
+# another entry in allowedIngressNamespaces, because that list's rule carries no
+# toPorts and would admit keycloak to every Pod in catalyst-system on every
+# port. Case 17 is the CONTROL that keeps it that way.
+# ─────────────────────────────────────────────────────────────────────────
+BACKCHANNEL_TEMPLATE="templates/network-policies/keycloak-backchannel-ingress.yaml"
+
+echo "[baseline-cnp] Case 15: catalyst-pin OIDC backchannel ingress CNP renders with the right VALUES (#6106)"
+helm template smoke . --show-only "${BACKCHANNEL_TEMPLATE}" > "$TMP/backchannel.yaml" 2>"$TMP/backchannel.err" || {
+  echo "FAIL: ${BACKCHANNEL_TEMPLATE} did not render — keycloak cannot reach catalyst-api's OIDC backchannel and EVERY brokered SSO login ConnectTimeouts (#6106)." >&2
+  cat "$TMP/backchannel.err" >&2
+  exit 1
+}
+# Vacuity control: the render must be non-empty before any grep below can mean
+# anything. An empty file makes every `grep -q` fail, which would report the
+# right verdict for the wrong reason; an inverted check would "pass" on nothing.
+if [ ! -s "$TMP/backchannel.yaml" ]; then
+  echo "FAIL: ${BACKCHANNEL_TEMPLATE} rendered EMPTY — the assertions below would be vacuous." >&2
+  exit 1
+fi
+if ! grep -q '^  name: baseline-allow-keycloak-oidc-backchannel$' "$TMP/backchannel.yaml"; then
+  echo "FAIL: baseline-allow-keycloak-oidc-backchannel CNP missing (#6106)." >&2
+  exit 1
+fi
+if ! grep -q '^kind: CiliumNetworkPolicy$' "$TMP/backchannel.yaml"; then
+  echo "FAIL: the backchannel allow is not a CiliumNetworkPolicy — a vanilla NetworkPolicy cannot express the ClusterMesh cluster key (#6106)." >&2
+  exit 1
+fi
+# Assert on the VALUE of the destination selector, not merely that the key
+# exists: `endpointSelector: {}` would also carry an endpointSelector key and
+# would silently widen the grant to the whole namespace.
+if ! awk '/^  endpointSelector:/,/^  ingress:/' "$TMP/backchannel.yaml" | grep -q '^      app.kubernetes.io/name: catalyst-api$'; then
+  echo "FAIL: the backchannel CNP is not scoped to the catalyst-api Pods (endpointSelector app.kubernetes.io/name=catalyst-api). A namespace-wide selector would admit keycloak to org-pg / guacamole-pg / shared-pg too (#6106)." >&2
+  exit 1
+fi
+# Comment-only lines are dropped first: this template documents the CIDR trap
+# it avoids, and the form check in Case 16 would otherwise fail on its own
+# rationale. Every assertion below runs against real YAML only.
+_ing6106="$(awk '/^  ingress:/,0' "$TMP/backchannel.yaml" | grep -v '^[[:space:]]*#' || true)"
+if [ -z "$_ing6106" ]; then
+  echo "FAIL: could not slice the ingress block out of the backchannel CNP — the awk range is broken, not the policy." >&2
+  exit 1
+fi
+if ! printf '%s' "$_ing6106" | grep -q 'k8s:io.kubernetes.pod.namespace: "keycloak"'; then
+  echo "FAIL: the backchannel CNP does not admit the 'keycloak' namespace — the broker's token exchange stays denied (#6106)." >&2
+  exit 1
+fi
+if ! printf '%s' "$_ing6106" | grep -q 'port: "8080"'; then
+  echo "FAIL: the backchannel CNP does not name TCP/8080 — catalyst-api's only Service port, the port keycloak-0 timed out on (#6106)." >&2
+  exit 1
+fi
+if ! printf '%s' "$_ing6106" | grep -q 'protocol: TCP'; then
+  echo "FAIL: the backchannel CNP's port rule has no TCP protocol (#6106)." >&2
+  exit 1
+fi
+echo "  PASS (baseline-allow-keycloak-oidc-backchannel admits ns keycloak -> catalyst-api Pods on TCP/8080)"
+
+echo "[baseline-cnp] Case 16: the backchannel allow uses ClusterMesh-safe ENDPOINT selectors, never CIDR (#6106)"
+# An ipBlock / fromCIDR can NEVER match a ClusterMesh remote pod identity — it
+# renders clean and silently denies. On a 2-region Sovereign bp-keycloak runs in
+# BOTH regions while bp-catalyst-platform is SECONDARY_HR_SUSPEND'd, so the
+# region-B backchannel arrives here over the mesh. Naming
+# io.cilium.k8s.policy.cluster suppresses Cilium's implicit cluster=<local>
+# AND-injection; dropping it re-breaks region B while region A keeps passing.
+if ! printf '%s' "$_ing6106" | grep -q 'fromEndpoints:'; then
+  echo "FAIL: the backchannel allow does not use fromEndpoints (#6106)." >&2
+  exit 1
+fi
+if ! printf '%s' "$_ing6106" | grep -q 'key: io.cilium.k8s.policy.cluster'; then
+  echo "FAIL: the backchannel allow does not name io.cilium.k8s.policy.cluster — Cilium AND-injects cluster=<local> and the region-B Keycloak Pod is silently denied (#6106)." >&2
+  exit 1
+fi
+if ! printf '%s' "$_ing6106" | grep -A1 'key: io.cilium.k8s.policy.cluster' | grep -q 'operator: Exists'; then
+  echo "FAIL: io.cilium.k8s.policy.cluster is named but not with operator Exists — the AND-injection suppression is what makes the peer-region source match (#6106)." >&2
+  exit 1
+fi
+for _bad in 'ipBlock' 'fromCIDR' 'fromCIDRSet'; do
+  if printf '%s' "$_ing6106" | grep -q "${_bad}"; then
+    echo "FAIL: the backchannel allow uses ${_bad} — a CIDR match NEVER resolves a ClusterMesh remote pod identity (#6106)." >&2
+    exit 1
+  fi
+done
+for _wild in 'world' 'cluster' 'all'; do
+  if printf '%s' "$_ing6106" | grep -qE "^\s*-\s*${_wild}\s*$"; then
+    echo "FAIL: the backchannel allow includes the '${_wild}' entity — that is a wildcard, not a carve-out (#6106)." >&2
+    exit 1
+  fi
+done
+echo "  PASS (fromEndpoints + io.cilium.k8s.policy.cluster Exists; no CIDR, no wildcard entity)"
+
+echo "[baseline-cnp] Case 17: CONTROL — baseline-default-deny is UNCHANGED, keycloak never enters the blanket ingress list (#6106)"
+# The one-line "fix" for #6106 was to append `keycloak` to
+# security.baselineCnp.allowedIngressNamespaces. That rule carries NO toPorts,
+# so it would admit the keycloak namespace to every Pod in catalyst-system on
+# every port — org-pg, guacamole-pg and the shared-pg family included.
+#
+# This case is the control that proves the shipped diff is a NEW CONSTRAINT and
+# not a LOOSENED one: the sibling policy that shares the suspect property (a
+# catalyst-system CNP granting ingress) must still carry exactly its six
+# pre-#6106 namespaces and must NOT have gained keycloak. If a later change
+# widens the blanket list instead, Case 15 would still pass and this one fails.
+if printf '%s\n' "$_ing14" | grep -q '"keycloak"'; then
+  echo "FAIL: 'keycloak' appears in baseline-default-deny's blanket ingress allow-list. That admits the namespace to EVERY catalyst-system Pod on EVERY port; the backchannel needs one workload on one port and has its own policy (#6106)." >&2
+  exit 1
+fi
+for _ns in catalyst flux-system kube-system oidc-gate guacamole cnpg-system; do
+  if ! printf '%s\n' "$_ing14" | grep -q "\"${_ns}\""; then
+    echo "FAIL: baseline-default-deny lost '${_ns}' from its ingress allow-list — the #6106 diff must not have touched this policy at all." >&2
+    exit 1
+  fi
+done
+echo "  PASS (baseline-default-deny still admits exactly its 6 namespaces; keycloak is NOT among them)"
+
+echo "[baseline-cnp] Case 18: VACUITY — the backchannel CNP genuinely disappears when toggled off (#6106)"
+# Proof that Case 15 can fail. If the assertions there passed against a subject
+# that cannot produce the absent state, they would be decorative. Each toggle
+# below must actually remove the policy.
+helm template smoke-bc-off . \
+  --set security.baselineCnp.keycloakBackchannel.enabled=false \
+  --show-only "${BACKCHANNEL_TEMPLATE}" > "$TMP/backchannel-off.yaml" 2>&1 || true
+if grep -q 'name: baseline-allow-keycloak-oidc-backchannel' "$TMP/backchannel-off.yaml"; then
+  echo "FAIL: the backchannel CNP still renders with keycloakBackchannel.enabled=false — the toggle is dead and Case 15 proves nothing." >&2
+  exit 1
+fi
+helm template smoke-baseline-off . \
+  --set security.baselineCnp.enabled=false \
+  --show-only "${BACKCHANNEL_TEMPLATE}" > "$TMP/backchannel-baseline-off.yaml" 2>&1 || true
+if grep -q 'name: baseline-allow-keycloak-oidc-backchannel' "$TMP/backchannel-baseline-off.yaml"; then
+  echo "FAIL: the backchannel CNP still renders with security.baselineCnp.enabled=false — it must follow the baseline master gate." >&2
+  exit 1
+fi
+# And the derived values must actually be derived: move the port and the policy
+# must move with it. A hardcoded 8080 would pass Case 15 and fail here.
+helm template smoke-bc-port . \
+  --set security.baselineCnp.keycloakBackchannel.port=18080 \
+  --set security.baselineCnp.keycloakBackchannel.namespace=keycloak-alt \
+  --show-only "${BACKCHANNEL_TEMPLATE}" > "$TMP/backchannel-port.yaml"
+if ! grep -q 'port: "18080"' "$TMP/backchannel-port.yaml"; then
+  echo "FAIL: keycloakBackchannel.port did not propagate — the port is hardcoded in the template, so Case 15's 8080 assertion is a tautology." >&2
+  exit 1
+fi
+if ! grep -q 'k8s:io.kubernetes.pod.namespace: "keycloak-alt"' "$TMP/backchannel-port.yaml"; then
+  echo "FAIL: keycloakBackchannel.namespace did not propagate — the source namespace is hardcoded in the template." >&2
+  exit 1
+fi
+echo "  PASS (policy disappears on both toggles; port + namespace are genuinely values-derived)"
+
+echo "[baseline-cnp] All gates green."

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -2753,6 +2753,44 @@ security:
       - oidc-gate
       - guacamole
       - cnpg-system
+    # #6106 — the catalyst-pin OIDC BACKCHANNEL carve-out.
+    #
+    # `keycloak` is deliberately NOT in the allowedIngressNamespaces list
+    # above. That rule carries no `toPorts`, so listing a namespace there
+    # admits it to EVERY Pod in catalyst-system on EVERY port — including
+    # org-pg, guacamole-pg and the shared-pg family that are host-rendered
+    # into this namespace. The backchannel needs one namespace reaching one
+    # workload on one port, so it renders as its own tight policy in
+    # templates/network-policies/keycloak-backchannel-ingress.yaml
+    # (`baseline-allow-keycloak-oidc-backchannel`, endpointSelector
+    # app.kubernetes.io/name=catalyst-api).
+    #
+    # Why it is needed: #6087/#6089 repointed the sovereign realm's
+    # catalyst-pin IdP so its server-side legs (tokenUrl / userInfoUrl /
+    # jwksUrl) dial catalyst-api in-cluster instead of hairpinning through
+    # the Sovereign's public EIP. Before that split Keycloak arrived as the
+    # reserved `ingress` (cilium-gateway) identity rule 1 already admits;
+    # after it, the leg had no allow at all and every brokered login —
+    # grafana, gitea, openbao, guacamole, newapi, hubble, and the Keycloak
+    # admin console itself — died with
+    # `ConnectTimeoutException: Connect to
+    #  catalyst-api.catalyst-system.svc.cluster.local:8080 ... timed out`
+    # (measured in keycloak-0's log on hw293, UAT rows 30/31/33/34/35/37/39/219).
+    #
+    # `enabled: false` restores the pre-#6089 posture and is only correct on a
+    # Sovereign whose keycloak also runs with catalystAPIInternalURL="" (the
+    # all-public backchannel). Flipping one without the other re-breaks SSO.
+    keycloakBackchannel:
+      enabled: true
+      # Source namespace. Matched via fromEndpoints with the ClusterMesh
+      # cluster key named, so a peer-region Keycloak Pod is admitted too —
+      # catalyst-api runs only in region A (slot 13 is SECONDARY_HR_SUSPEND)
+      # while bp-keycloak renders in both.
+      namespace: keycloak
+      # catalyst-api's only Service port — keep in lockstep with
+      # templates/api-service.yaml (`port: 8080`), which
+      # tests/baseline-cnp-allowlist.sh Case 11 already pins.
+      port: 8080
 
 # ── Migrations (post-install / post-upgrade Helm-hook Jobs) ──────────────
 # Per PR #2795 (G117.2 multi-instance Application CRD): backfill spec.instanceId


### PR DESCRIPTION
## What broke, and where

`#6089` was right to stop the Keycloak Pod hairpinning through the Sovereign's own EIP. It repointed the sovereign realm's **catalyst-pin** identity provider so its server-side legs dial the internal Service:

```
authorizationUrl  https://api.<sovereignFQDN>/oidc/auth                          (browser  — PUBLIC)
tokenUrl          http://catalyst-api.catalyst-system.svc.cluster.local:8080/oidc/token     (KC server — INTERNAL)
userInfoUrl       http://catalyst-api.catalyst-system.svc.cluster.local:8080/oidc/userinfo  (KC server — INTERNAL)
jwksUrl           http://catalyst-api.catalyst-system.svc.cluster.local:8080/oidc/certs     (KC server — INTERNAL)
```

What it did not ship is the allow for the hop it created. Before the split those legs left the pod as `world:443`, which the keycloak namespace already permitted, and they arrived at catalyst-api as the reserved `ingress` (cilium-gateway) identity that `baseline-default-deny` rule 1 already admits. After it, the leg is east-west from a namespace that policy does not name.

From the moment the realm ConfigMap re-imported on hw293 at `2026-08-10T23:43:49Z`, every catalyst-pin brokered login died — measured in keycloak-0's own log, region A:

```
ERROR [org.keycloak.broker.oidc.AbstractOAuth2IdentityProvider]
Failed to make identity provider oauth callback:
org.apache.http.conn.ConnectTimeoutException: Connect to
catalyst-api.catalyst-system.svc.cluster.local:8080 [10.96.1.11] failed:
Connection timed out
WARN [org.keycloak.events] type="IDENTITY_PROVIDER_LOGIN_ERROR" realmName="sovereign" clientId="grafana"
```

…with the same line for `gitea`, `openbao`, `guacamole-gate` and `newapi-admin`, and the Keycloak admin console dropping to the realm login form because no keycloak session is obtainable while the broker is down. UAT rows **30, 31, 33, 34, 35, 37, 39, 219** all terminate on that one hop.

### The two policy sites

| Direction | File:line (pre-change) | State |
|---|---|---|
| catalyst-system **ingress** | `products/catalyst/chart/templates/network-policies/baseline-catalyst-system.yaml:115` — `$allowedIngressNs` default `catalyst, flux-system, kube-system, oidc-gate, guacamole, cnpg-system` (values.yaml:2708) | `keycloak` absent → **this is the region-A denial** |
| keycloak **egress** | `platform/plane-isolation/chart/templates/apiserver-egress-cnp.yaml:85` (kube-apiserver) + `crossregion-db-egress-cnp.yaml:72` (`:5432`) + `default-deny-networkpolicy.yaml:130` (`namespaceSelector: {}` + `ipBlock 0.0.0.0/0`) | local egress **is** matched by `namespaceSelector: {}`; the **cross-region** destination is matched by nothing |

One correction to the issue's read, stated because it changes what the fix has to cover: in **region A** the egress leg is *not* the denial — bp-plane-isolation's `keycloak-default-deny` NetworkPolicy carries `egress: to: [{namespaceSelector: {}}]`, which does resolve a local catalyst-api Pod. Region A fails on **ingress** alone. The egress half is needed for the leg that has no allow in either policy set: **region B**.

## Per-region split — checked, and it is real

| Fact | Source |
|---|---|
| bp-keycloak (slot 09) carries **no** `SECONDARY_HR_SUSPEND` | `clusters/_template/bootstrap-kit/09-keycloak.yaml` — no `suspend:` key |
| …so the sovereign realm ConfigMap, internal backchannel included, renders in **BOTH** regions | `sovereignRealm.enabled: true` is not region-gated (09-keycloak.yaml:307) |
| bp-catalyst-platform (slot 13) **is** suspended on every secondary CP | `13-bp-catalyst-platform.yaml:54` — `suspend: ${SECONDARY_HR_SUSPEND:=false}` (G2 #2574) |
| …so catalyst-api runs **only in region A**, and is published as a ClusterMesh global Service | `products/catalyst/chart/templates/api-service.yaml` — `service.cilium.io/global: "true"` (#5289) |
| region B gets a zero-backend **stub** Service that resolves over the mesh | slot 13e `bp-catalyst-secondary-edge` |

So a region-B Keycloak Pod's backchannel is a **cross-cluster hop** whose destination arrives with a REMOTE-CLUSTER identity. `namespaceSelector: {}` resolves to local pods and `ipBlock 0.0.0.0/0` resolves to `world`; neither matches it. And the `baseline-default-deny` ingress carve-out renders only in region A (correctly — the destination pod only exists there), but its **source** is sometimes remote. A fix that ignored this would render clean and leave half a 2-region Sovereign's brokered logins dark.

Both halves therefore use `fromEndpoints` / `toEndpoints` and **name `io.cilium.k8s.policy.cluster` with `Exists`**, which suppresses Cilium's implicit `cluster=<local>` AND-injection. Same idiom, same reason as `platform/plane-isolation/chart/templates/crossregion-db-egress-cnp.yaml` (proven live on hw228). No `ipBlock`, no `toCIDR`, no wildcard entity — asserted by the guards.

## The change

**bp-catalyst-platform 1.4.1364 → 1.4.1365** — new `templates/network-policies/keycloak-backchannel-ingress.yaml`:

```yaml
  endpointSelector:
    matchLabels:
      app.kubernetes.io/name: catalyst-api
  ingress:
    - fromEndpoints:
        - matchLabels:
            k8s:io.kubernetes.pod.namespace: "keycloak"
          matchExpressions:
            - key: io.cilium.k8s.policy.cluster
              operator: Exists
      toPorts:
        - ports:
            - port: "8080"
              protocol: TCP
```

**bp-keycloak 1.5.8 → 1.5.9** — new `templates/catalyst-backchannel-egress-cnp.yaml`:

```yaml
  endpointSelector: {}
  egress:
    - toEndpoints:
        - matchLabels:
            k8s:io.kubernetes.pod.namespace: "catalyst-system"
            k8s:app.kubernetes.io/name: "catalyst-api"
          matchExpressions:
            - key: io.cilium.k8s.policy.cluster
              operator: Exists
      toPorts:
        - ports:
            - port: "8080"
              protocol: TCP
```

Destination namespace, Pod label and port are all **derived** from `catalystAPIInternalURL`, so the policy cannot drift from the URL that created the need for it. Set that value to `""` — the documented escape hatch for a hairpin-capable EIP — and the realm goes back to an all-public backchannel and the policy is not emitted at all.

`baseline-default-deny` is deliberately **untouched**. Appending `keycloak` to `security.baselineCnp.allowedIngressNamespaces` was the one-line version and is wrong: that rule carries no `toPorts`, so it would have admitted the namespace to every Pod in catalyst-system on every port — `org-pg`, `guacamole-pg` and the `shared-pg` family included.

## Test: red before, green after

The new cases were written first and run against `origin/main`'s charts (extracted with `git archive`, same test script both sides).

**RED — `products/catalyst/chart/tests/baseline-cnp-allowlist.sh` against pre-change chart (exit 1):**

```
[baseline-cnp] Case 14: cnpg-system allowed in BOTH ingress and egress
  PASS (cnpg-system present in both ingress and egress)
[baseline-cnp] Case 15: catalyst-pin OIDC backchannel ingress CNP renders with the right VALUES (#6106)
FAIL: templates/network-policies/keycloak-backchannel-ingress.yaml did not render — keycloak cannot
reach catalyst-api's OIDC backchannel and EVERY brokered SSO login ConnectTimeouts (#6106).
Error: could not find template templates/network-policies/keycloak-backchannel-ingress.yaml in chart
```

**GREEN — same script, this branch (exit 0):**

```
[baseline-cnp] Case 15: catalyst-pin OIDC backchannel ingress CNP renders with the right VALUES (#6106)
  PASS (baseline-allow-keycloak-oidc-backchannel admits ns keycloak -> catalyst-api Pods on TCP/8080)
[baseline-cnp] Case 16: the backchannel allow uses ClusterMesh-safe ENDPOINT selectors, never CIDR (#6106)
  PASS (fromEndpoints + io.cilium.k8s.policy.cluster Exists; no CIDR, no wildcard entity)
[baseline-cnp] Case 17: CONTROL — baseline-default-deny is UNCHANGED, keycloak never enters the blanket ingress list (#6106)
  PASS (baseline-default-deny still admits exactly its 6 namespaces; keycloak is NOT among them)
[baseline-cnp] Case 18: VACUITY — the backchannel CNP genuinely disappears when toggled off (#6106)
  PASS (policy disappears on both toggles; port + namespace are genuinely values-derived)
[baseline-cnp] All gates green.
```

**RED — `platform/keycloak/chart/tests/catalyst-backchannel-netpol-6106.sh` against pre-change chart (exit 1):**

```
[bp-keycloak/6106] Case 1: catalyst-pin backchannel egress CNP renders with derived values
FAIL: templates/catalyst-backchannel-egress-cnp.yaml did not render. Without it a Keycloak Pod cannot
reach catalyst-api's OIDC backchannel and every brokered SSO login ConnectTimeouts (#6106).
```

**GREEN — same script, this branch (exit 0):**

```
[bp-keycloak/6106] Case 1: PASS (egress -> catalyst-system/catalyst-api on TCP/8080)
[bp-keycloak/6106] Case 2: PASS (tokenUrl/userInfoUrl/jwksUrl -> http://catalyst-api.catalyst-system.svc.cluster.local:8080)
[bp-keycloak/6106] Case 3: PASS (frontchannel + issuer unchanged and public)
[bp-keycloak/6106] Case 4: PASS (endpoint-identity selectors only)
[bp-keycloak/6106] Case 5: PASS (both halves follow the same value)
[bp-keycloak/6106] Case 6: PASS (Capabilities gate genuinely gates)
[bp-keycloak/6106] Case 7: PASS (namespace + Pod label + port all derived)
[bp-keycloak/6106] All gates green.
```

### Vacuity checks — proof each assertion CAN fail

Two of the traps this repo has been burned by are a guard that passes on an empty value, and a guard whose subject cannot produce the failing state. Every value assertion above is on the **VALUE** (`k8s:io.kubernetes.pod.namespace: "catalyst-system"`, `port: "8080"`), never on key presence, and three cases exist purely to prove the subject is bivalent:

- **keycloak case 5** — `--set catalystAPIInternalURL=` removes the CNP *and* returns the realm's backchannel to public. If case 1's grep were passing on nothing, this would not flip.
- **keycloak case 6** — rendering without `--api-versions cilium.io/v2` removes the CNP, so the Capabilities gate is real rather than decorative.
- **keycloak case 7 / catalyst case 18** — `--set catalystAPIInternalURL=http://cat-api.other-ns.svc.cluster.local:9090` moves the rendered namespace to `other-ns`, the Pod label to `cat-api` and the port to `9090`; `--set …keycloakBackchannel.port=18080 …namespace=keycloak-alt` moves the ingress half. A hardcoded `8080` would pass case 1 and fail here.

Both scripts also refuse to proceed if the sliced ingress/egress block is empty, so a broken `awk` range reports itself instead of masquerading as a policy verdict.

### Controls — the diff is a new constraint, not a loosened one

Two policies that share the suspect property must be **byte-identical** across this change, and are:

```
$ helm template smoke <chart> --show-only templates/network-policies/baseline-catalyst-system.yaml
  origin/main  sha256 09a90b3c0674c162d68f8d4791c8f20f1991c6cf50ceb3bb0b3ed74a491a4b98
  this branch  sha256 09a90b3c0674c162d68f8d4791c8f20f1991c6cf50ceb3bb0b3ed74a491a4b98   (diff exit 0)

$ helm template keycloak <chart> --show-only templates/configmap-sovereign-realm.yaml
  origin/main  sha256 d7b243b6923e4cf5307e42b6879d83cd0a53f045861ff1d8cfd74ac88a4db9e2
  this branch  sha256 d7b243b6923e4cf5307e42b6879d83cd0a53f045861ff1d8cfd74ac88a4db9e2   (diff exit 0)
```

The `baseline-default-deny` render is unchanged, so no existing grant was widened; the realm import is unchanged, so this PR adds policy and nothing else. Case 17 keeps the first property enforced in CI, and keycloak case 3 keeps `authorizationUrl` + `issuer` public — the sibling URLs that share the suspect property and must **not** move inward.

## Lockstep + guards run locally

- `scripts/bump-chart-version.sh products/catalyst/chart/Chart.yaml` → `1.4.1365` (consulted 35 open-PR claims; ceiling 1.4.1364 — the branch was rebased twice as the deploy-bot advanced main, and the number was recomputed each time). bp-keycloak has no `appVersion:` line so that script declines it; `1.5.9` was taken from the same enumerator (`--claimed-versions` max was `1.5.8`).
- Five sites for bp-keycloak: `chart/Chart.yaml`, `blueprint.yaml`, slot `09-keycloak.yaml` pin, catalog-seed CARD `spec.version`, catalog-seed DELIVERY `source.version` (last two via `scripts/sync-catalog-seed-pin.py`). Slot `13-bp-catalyst-platform.yaml` pin moved with the umbrella; its catalog-seed card is `.Chart.Version` and self-maintains. `node scripts/build-catalog.mjs` re-run and committed.
- `check-bootstrap-kit-pin-sync.sh` PASS (67 pairs) · `check-catalog-seed-lockstep.sh` PASS (68 checked, 0 fail) · `render-slot-placement.py check` PASS · `helm lint` both charts PASS · all 16 bp-keycloak chart tests PASS · all 10 bp-catalyst-platform chart tests PASS · `tests/e2e/bootstrap-kit` `go test ./...` ok.

No NodePort is created or relied on anywhere in this change; the only port literal added is 8080.

## Verification after deploy

The eight rows re-stamp only on a walk. On the next env carrying bp-keycloak ≥1.5.9 and bp-catalyst-platform ≥1.4.1365: a brokered login should return `/realms/sovereign/broker/catalyst-pin/endpoint` 302 → app 200, and keycloak-0's log should carry no `ConnectTimeoutException` for `catalyst-api.catalyst-system.svc`. `docs/ledger/UAT.md` is untouched here — walkers own it.

Refs #6106
Refs #6089
Refs #3374

🤖 Generated with [Claude Code](https://claude.com/claude-code)
