### PR TITLE
fix(org): an unusable secondary kubeconfig is a MISSING artifact, not a transient blip

### DIFF
--- a/core/controllers/organization/internal/controller/tenant_console_tls_5246_test.go
+++ b/core/controllers/organization/internal/controller/tenant_console_tls_5246_test.go
@@ -173,6 +173,41 @@ type multiRegionFixture struct {
 	region client.Client
 }
 
+// regionKubeconfigMarker is the token embedded in a fixture kubeconfig so a
+// test can prove WHICH region's bytes reached a seam without comparing whole
+// documents.
+func regionKubeconfigMarker(region string) string { return "kubeconfig-for-" + region }
+
+// fixtureRegionKubeconfig returns a COMPLETE kubeconfig — one that satisfies
+// the shared usability contract in core/controllers/pkg/kubeconfig — whose
+// cluster name carries the region marker.
+//
+// The `users:` entry is required and deliberate: a kubeconfig with a context
+// but no user parses fine and builds an ANONYMOUS client, which the peer
+// apiserver refuses 403 on every write. Carrying no credential material
+// (`user: {}`) keeps the fixture safe for a public repository while still
+// making the section non-empty.
+func fixtureRegionKubeconfig(region string) string {
+	marker := regionKubeconfigMarker(region)
+	return `apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://10.0.0.1:6443
+    insecure-skip-tls-verify: true
+  name: ` + marker + `
+users:
+- name: u
+  user: {}
+contexts:
+- context:
+    cluster: ` + marker + `
+    user: u
+  name: c
+current-context: c
+`
+}
+
 func newMultiRegionFixture(t *testing.T, withMesh, withBridge bool, regionListeners []any) multiRegionFixture {
 	t.Helper()
 	org := multiRegionOrg()
@@ -234,7 +269,7 @@ func newMultiRegionFixture(t *testing.T, withMesh, withBridge bool, regionListen
 				Name:      consoleSecondaryKubeconfigSecretDefaultName,
 				Namespace: consoleSecondaryKubeconfigSecretDefaultNamespace,
 			},
-			Data: map[string][]byte{secondaryRegionKey + ".yaml": []byte("kubeconfig-for-" + secondaryRegionKey)},
+			Data: map[string][]byte{secondaryRegionKey + ".yaml": []byte(fixtureRegionKubeconfig(secondaryRegionKey))},
 		}
 		if err := r.Create(context.Background(), bridge); err != nil {
 			t.Fatalf("seed secondary-region kubeconfig bridge: %v", err)
@@ -242,8 +277,13 @@ func newMultiRegionFixture(t *testing.T, withMesh, withBridge bool, regionListen
 	}
 
 	r.RegionClientBuilder = func(kubeconfig []byte) (client.Client, error) {
-		if string(kubeconfig) != "kubeconfig-for-"+secondaryRegionKey {
-			t.Fatalf("region client built from unexpected kubeconfig %q", string(kubeconfig))
+		// Assert on the MARKER rather than on the whole document. The bytes
+		// used to be the literal string "kubeconfig-for-<region>", which is
+		// unparseable and only ever satisfied the pre-#6107 presence check;
+		// the fixture now carries a real kubeconfig so these tests exercise
+		// the shared usability contract instead of walking past it.
+		if !strings.Contains(string(kubeconfig), regionKubeconfigMarker(secondaryRegionKey)) {
+			t.Fatalf("region client built from an unexpected kubeconfig (%d bytes)", len(kubeconfig))
 		}
 		return peer, nil
 	}

--- a/core/controllers/organization/internal/controller/tenant_console_tls_regions.go
+++ b/core/controllers/organization/internal/controller/tenant_console_tls_regions.go
@@ -97,6 +97,8 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/openova-io/openova/core/controllers/pkg/kubeconfig"
 )
 
 // Console region fan-out defaults. All four are overridable through the
@@ -141,10 +143,12 @@ type consoleRegionTarget struct {
 type consoleRegionResolution struct {
 	// Targets — every region a write can actually be made to, host first.
 	Targets []consoleRegionTarget
-	// Unwired — regions the ClusterMesh witness proves exist but for which
-	// no kubeconfig is wired at all. STRUCTURAL: the listener can never be
-	// written there until an operator supplies the credential, so it is
-	// reported as a missing artifact, not as a transient.
+	// Unwired — regions a witness proves exist but for which no USABLE
+	// kubeconfig is wired. Two shapes qualify and they are equivalent in
+	// consequence: no key at all, and a key whose bytes cannot produce a
+	// client (#6107). STRUCTURAL: the listener can never be written there
+	// until the credential is replaced, so it is reported as a missing
+	// artifact, not as a transient.
 	Unwired []string
 	// Unreachable — regions whose kubeconfig IS wired but whose client could
 	// not be built or used this pass. TRANSIENT: an apiserver blip must not
@@ -353,10 +357,33 @@ func (r *Reconciler) consoleRegionTargets(ctx context.Context) consoleRegionReso
 
 	regions := make([]string, 0, len(bridge.Data))
 	kubeconfigFor := make(map[string][]byte, len(bridge.Data))
+	unusable := make([]string, 0, len(bridge.Data))
 	if err == nil {
 		for k, v := range bridge.Data {
 			region := consoleRegionKeyFromSecretKey(k)
 			if region == "" || len(v) == 0 {
+				continue
+			}
+			// PRESENCE IS NOT USABILITY (#6107). Emptiness was the whole
+			// test here, so the 95-byte credential-less document measured on
+			// hw293 counted as a WIRED region: the shortfall check below then
+			// saw 1 declared remote against 1 wired key, reported nothing, and
+			// the region degraded a few lines later into Unreachable — which
+			// feeds Unverifiable, and `complete()` is `len(Missing) == 0`. The
+			// Organization therefore read FULLY PROVISIONED while its per-Org
+			// listener pair had never been written to that region.
+			//
+			// The contract is the SHARED one (core/controllers/pkg/kubeconfig),
+			// the same bytes-level question catalyst-api's producer and its
+			// delivery leg ask, so a document accepted by one hop cannot be
+			// silently rejected by the next.
+			//
+			// This is STRUCTURAL, not transient: the verdict is a property of
+			// the bytes, so no amount of requeueing can change it, which is
+			// precisely the struct's own definition of Unwired.
+			if defects := kubeconfig.Defects(string(v)); len(defects) > 0 {
+				unusable = append(unusable, fmt.Sprintf("%s (missing: %s)",
+					region, kubeconfig.DescribeDefects(defects)))
 				continue
 			}
 			regions = append(regions, region)
@@ -364,6 +391,17 @@ func (r *Reconciler) consoleRegionTargets(ctx context.Context) consoleRegionReso
 		}
 	}
 	sort.Strings(regions)
+	sort.Strings(unusable)
+
+	// #6107 — a key that EXISTS but cannot produce a client is reported on its
+	// own terms. Folding it into the count message alone would repeat the very
+	// claim that is false here: that the region has "no kubeconfig", when the
+	// key is plainly present and an operator looking for it will find it.
+	for _, u := range unusable {
+		res.Unwired = append(res.Unwired, fmt.Sprintf(
+			"secondary region %s has a kubeconfig in %s/%s that cannot produce a client — the bytes are the fault, so no requeue repairs it and the per-Org console listener can never be written there until the credential is replaced",
+			u, bridgeNS, bridgeName))
+	}
 
 	// The shortfall check is the whole anti-vacuity point: a Sovereign that
 	// declares 1 remote region while 0 kubeconfigs are wired means every
@@ -373,8 +411,9 @@ func (r *Reconciler) consoleRegionTargets(ctx context.Context) consoleRegionReso
 	// than taken on faith.
 	if expectedRemotes > len(regions) {
 		res.Unwired = append(res.Unwired, fmt.Sprintf(
-			"%d of %d secondary region(s) have no kubeconfig in %s/%s (%s declares %d remote region(s); wired region keys: %s)",
-			expectedRemotes-len(regions), expectedRemotes, bridgeNS, bridgeName, witness, expectedRemotes, describeRegionKeys(regions)))
+			"%d of %d secondary region(s) have no usable kubeconfig in %s/%s (%s declares %d remote region(s); wired region keys: %s; present but unusable: %s)",
+			expectedRemotes-len(regions), expectedRemotes, bridgeNS, bridgeName, witness, expectedRemotes,
+			describeRegionKeys(regions), describeRegionKeys(unusable)))
 	}
 
 	cache := r.regionClientCache()

--- a/core/controllers/organization/internal/controller/tenant_console_tls_regions_6107_test.go
+++ b/core/controllers/organization/internal/controller/tenant_console_tls_regions_6107_test.go
@@ -1,0 +1,268 @@
+// tenant_console_tls_regions_6107_test.go — #6107. A secondary region's
+// kubeconfig that EXISTS but cannot yield a client is a missing artifact, not
+// a transient blip.
+//
+// THE DEFECT
+// ----------
+// #6027 closed the door where the #5359 bridge Secret is ABSENT: two witnesses
+// declare how many remote regions the Sovereign has, and a shortfall against
+// the wired-key count is reported as UNWIRED, which verifyProvisioned turns
+// into a NOT-provisioned Organization.
+//
+// The door where the Secret is PRESENT but its value is unusable was still
+// open, and the partition that decides which door a region goes through tested
+// only emptiness:
+//
+//	if region == "" || len(v) == 0 { continue }
+//	regions = append(regions, region)
+//
+// A 95-byte contextless kubeconfig stub — the shape #6054 and #6104 exist to
+// stop being WRITTEN, and the shape already on hw293's PVC — is non-empty, so
+// it entered `regions`. Two things then followed, in order:
+//
+//  1. the shortfall check `expectedRemotes > len(regions)` became `1 > 1`,
+//     which is FALSE, so no shortfall was reported at all; and
+//  2. the client build failed a few lines later and the region landed in
+//     Unreachable.
+//
+// Those two buckets are deliberately not equivalent. Unwired feeds
+// out.Missing; Unreachable feeds out.Unverifiable; and
+// `complete()` is `len(p.Missing) == 0` — Unverifiable does not hold an
+// Organization back. So the Organization read FULLY PROVISIONED while its
+// `console-https-<slug>` / `console-http-<slug>` pair had never been written
+// to region B, and one shared console EIP round-robins both regions' envoy.
+// That is the silent degradation tenant_console_tls_regions.go's own header
+// declares impossible under "WHY IT CANNOT DEGRADE SILENTLY".
+//
+// WHY THIS IS STRUCTURAL AND NOT TRANSIENT
+// ----------------------------------------
+// Measured in-package, no network and no apiserver: a contextless stub and an
+// apiVersion/kind-only document both fail `RESTConfigFromKubeConfig` with
+// "invalid configuration: no configuration has been provided", while a
+// complete credential-free kubeconfig parses and yields its Host. The verdict
+// is a property of the BYTES, so requeueing can never change it — which is the
+// struct's own definition of Unwired. `client.New` on the same config was
+// measured lazy (no discovery call), so a genuine live-build failure remains a
+// separate, genuinely transient signal and stays in Unreachable.
+//
+// WHAT IS ASSERTED HERE
+// ---------------------
+// Every case asserts on the VALUE the resolution produced, and the suite
+// carries two controls that share the suspect property — a NON-EMPTY value in
+// the bridge Secret — but must answer the other way, so the new constraint
+// cannot pass by having widened the arithmetic:
+//
+//   - case 1 (the defect): a stub value holds the Organization back and names
+//     the region plus the parse reason.
+//   - case 2 (CONTROL): a COMPLETE credential-free kubeconfig, equally
+//     non-empty, in the same fixture, still resolves to a writable target and
+//     reports no shortfall.
+//   - case 3 (CONTROL): a genuinely ABSENT key still produces the #6027
+//     message with `wired region keys: none`, so the new wording did not
+//     swallow the case it was built on.
+//
+// Refs #6015 #6027 #6104 #6107.
+package controller
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// stubSecondaryKubeconfig is the hw293 shape: valid YAML, a cluster server,
+// and NO contexts, users or CA data. It carries no credential material of any
+// kind — the point of the fixture is precisely that there is none to carry.
+const stubSecondaryKubeconfig = `apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://10.0.0.1:6443
+  name: r
+`
+
+// completeSecondaryKubeconfig is the CONTROL value: same non-emptiness, same
+// bridge-Secret key shape, but it satisfies the shared usability contract.
+//
+// The `users:` entry is load-bearing and is why the contract is deliberately
+// STRICTER than "RESTConfigFromKubeConfig returned no error". A kubeconfig
+// with a context but no user parses happily and builds an ANONYMOUS client —
+// one that reaches the peer apiserver as `system:anonymous` and is refused 403
+// on every write. That is the same silent-success class this whole chain
+// exists to kill: a client that builds and can never write the listener. The
+// first draft of this fixture omitted `users:` and the control caught it,
+// which is the reason the control is here.
+//
+// The user entry carries NO credential material — an empty `user: {}` is
+// enough to make the section non-empty, so nothing secret-shaped enters a
+// public repository.
+const completeSecondaryKubeconfig = `apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://10.0.0.1:6443
+    insecure-skip-tls-verify: true
+  name: r
+users:
+- name: u
+  user: {}
+contexts:
+- context:
+    cluster: r
+    user: u
+  name: c
+current-context: c
+`
+
+// seedBridgeSecret writes the #5359 bridge Secret with one secondary-region
+// key carrying exactly the supplied bytes, and drops the RegionClientBuilder
+// seam so the PRODUCTION resolution path runs — the parse under test is the
+// real one, not a fake injected by the fixture.
+func seedBridgeSecret(t *testing.T, f multiRegionFixture, kubeconfig string) {
+	t.Helper()
+	bridge := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      consoleSecondaryKubeconfigSecretDefaultName,
+			Namespace: consoleSecondaryKubeconfigSecretDefaultNamespace,
+		},
+		Data: map[string][]byte{secondaryRegionKey + ".yaml": []byte(kubeconfig)},
+	}
+	if err := f.r.Create(context.Background(), bridge); err != nil {
+		t.Fatalf("seed secondary-region kubeconfig bridge: %v", err)
+	}
+	f.r.RegionClientBuilder = nil
+}
+
+// TestConsoleRegionTargets_UnusableSecondaryKubeconfigIsUnwired_6107 is the
+// defect: a bridge Secret whose only value is a contextless stub must hold the
+// Organization back, not read as a wired region whose client happens to be
+// having a bad day.
+func TestConsoleRegionTargets_UnusableSecondaryKubeconfigIsUnwired_6107(t *testing.T) {
+	ctx := context.Background()
+
+	f := newMultiRegionFixture(t, false, false, regionGatewayListeners(9443, 9080))
+	f.r.ConfiguredRegions = hw293ConfiguredRegions
+	seedBridgeSecret(t, f, stubSecondaryKubeconfig)
+
+	res := f.r.consoleRegionTargets(ctx)
+
+	// Precondition: the stub cannot become a writable target either way. If
+	// this ever fails the rest of the case is meaningless.
+	if len(res.Targets) != 1 || !res.Targets[0].Host {
+		t.Fatalf("precondition: a stub kubeconfig must not yield a writable target, got %d targets", len(res.Targets))
+	}
+
+	joined := strings.Join(res.Unwired, " | ")
+	if len(res.Unwired) == 0 {
+		t.Fatalf("a %d-byte contextless kubeconfig stub was counted as a WIRED region — "+
+			"the shortfall check saw 1 declared remote against 1 wired key, reported nothing, and the "+
+			"region degraded into Unreachable, which only requeues. unwired=%v unreachable=%v",
+			len(stubSecondaryKubeconfig), res.Unwired, res.Unreachable)
+	}
+	// Assert on the VALUE: the message has to name the region whose credential
+	// is unusable and why, or it repeats the very claim that is false here —
+	// that there is "no kubeconfig" for a key that plainly exists.
+	if !strings.Contains(joined, secondaryRegionKey) {
+		t.Fatalf("the shortfall message does not name the region whose kubeconfig is unusable: %q", joined)
+	}
+	// The message must name WHAT is missing, in the shared contract's own
+	// vocabulary, or an operator cannot tell an unusable credential from an
+	// absent one — and cannot diff the rejected document against a healthy one.
+	for _, section := range []string{"contexts", "current-context", "users"} {
+		if !strings.Contains(joined, section) {
+			t.Fatalf("the shortfall message does not name the missing %q section: %q", section, joined)
+		}
+	}
+	if !strings.Contains(joined, "cannot produce a client") {
+		t.Fatalf("the shortfall message does not say the credential is unusable, only that it is absent: %q", joined)
+	}
+
+	// The consumer half, and the whole point: the Organization must NOT read
+	// fully provisioned. Its per-Org listener pair was never written to the
+	// declared secondary region.
+	if _, err := f.r.ensureConsoleOrgListener(ctx, f.r.Client, f.names); err != nil {
+		t.Fatalf("write the host-region listener: %v", err)
+	}
+	syncGatewayStatus(t, f.r.Client)
+
+	got := f.r.verifyProvisioned(ctx, f.org)
+	if got.complete() {
+		t.Fatalf("Organization reads FULLY PROVISIONED while region %q holds an unusable kubeconfig and "+
+			"carries zero per-Org listeners — the console EIP round-robins both regions, so a share of "+
+			"customer TLS to %q resets. missing=%v unverifiable=%v",
+			secondaryRegionKey, f.names.WildcardHost, got.Missing, got.Unverifiable)
+	}
+}
+
+// TestConsoleRegionTargets_CompleteSecondaryKubeconfigStaysWired_6107 is the
+// CONTROL for the case above. It shares the suspect property — a non-empty
+// value under the same bridge-Secret key — and must answer the other way.
+//
+// Without it, the case above would also pass if the change had simply started
+// treating EVERY secondary region as unwired, which would red-flag every
+// correctly-wired Sovereign on the estate.
+func TestConsoleRegionTargets_CompleteSecondaryKubeconfigStaysWired_6107(t *testing.T) {
+	ctx := context.Background()
+
+	f := newMultiRegionFixture(t, false, false, regionGatewayListeners(9443, 9080))
+	f.r.ConfiguredRegions = hw293ConfiguredRegions
+	seedBridgeSecret(t, f, completeSecondaryKubeconfig)
+
+	res := f.r.consoleRegionTargets(ctx)
+
+	if len(res.Unwired) != 0 {
+		t.Fatalf("a COMPLETE secondary kubeconfig was reported unwired — the check is discriminating on "+
+			"non-emptiness or on nothing at all, rather than on whether the bytes yield a client: %v", res.Unwired)
+	}
+	if len(res.Unreachable) != 0 {
+		t.Fatalf("a COMPLETE secondary kubeconfig was reported unreachable: %v", res.Unreachable)
+	}
+	if len(res.Targets) != 2 {
+		t.Fatalf("want host + secondary targets, got %d", len(res.Targets))
+	}
+	if res.Targets[1].Region != secondaryRegionKey || res.Targets[1].Host {
+		t.Fatalf("second target is not the secondary region: %+v", res.Targets[1].Region)
+	}
+}
+
+// TestConsoleRegionTargets_AbsentKeyKeepsTheNoneWording_6107 is the second
+// CONTROL: the #6027 case this change sits next to must be untouched. An
+// ABSENT key still reports the shortfall with `wired region keys: none`, and
+// must NOT acquire a parse reason it has no business carrying.
+func TestConsoleRegionTargets_AbsentKeyKeepsTheNoneWording_6107(t *testing.T) {
+	ctx := context.Background()
+
+	f := newMultiRegionFixture(t, false, false, regionGatewayListeners(9443, 9080))
+	f.r.ConfiguredRegions = hw293ConfiguredRegions
+	f.r.RegionClientBuilder = nil
+
+	res := f.r.consoleRegionTargets(ctx)
+
+	joined := strings.Join(res.Unwired, " | ")
+	if len(res.Unwired) == 0 {
+		t.Fatalf("#6027 regression: a 2-region Sovereign with no bridge Secret reported no shortfall")
+	}
+	if !strings.Contains(joined, "wired region keys: none") {
+		t.Fatalf("the absent-key message lost its `none` wording: %q", joined)
+	}
+	if strings.Contains(joined, "cannot produce a client") {
+		t.Fatalf("the absent-key message claims a credential is UNUSABLE, but there were no bytes at all — "+
+			"the two states must stay distinguishable: %q", joined)
+	}
+	if !strings.Contains(joined, "present but unusable: none") {
+		t.Fatalf("the absent-key message does not state that nothing was present-but-unusable: %q", joined)
+	}
+
+	// And it must still hold the Organization back — an absent credential was
+	// already a missing artifact before #6107 and must remain one.
+	if _, err := f.r.ensureConsoleOrgListener(ctx, f.r.Client, f.names); err != nil {
+		t.Fatalf("write the host-region listener: %v", err)
+	}
+	syncGatewayStatus(t, f.r.Client)
+	if got := f.r.verifyProvisioned(ctx, f.org); got.complete() {
+		t.Fatalf("#6027 regression: an ABSENT secondary kubeconfig no longer holds the Organization back. missing=%v", got.Missing)
+	}
+}

--- a/core/controllers/pkg/kubeconfig/kubeconfig.go
+++ b/core/controllers/pkg/kubeconfig/kubeconfig.go
@@ -1,0 +1,128 @@
+// Package kubeconfig holds the ONE usability contract for a secondary
+// region's kubeconfig — the single question "can these bytes produce a working
+// client?" — shared by every component that either writes such a document or
+// reads one back.
+//
+// WHY THIS IS A SHARED PACKAGE AND NOT TWO COPIES
+// -----------------------------------------------
+// A secondary region's kubeconfig crosses three hops, and each hop had its own
+// idea of what "delivered" meant:
+//
+//	catalyst-api  export  →  waitForSecondaryKubeconfig   len(raw) > 0
+//	catalyst-api  receive →  HandleSovereignSecondaryKubeconfig   non-empty
+//	org-controller read   →  consoleRegionTargets   len(v) != 0
+//
+// All three measured PRESENCE. On hw293 (dep a0077ba47e3720e5) that produced a
+// 95-byte credential-less document — valid YAML, one `clusters[]` entry with a
+// server URL, no contexts, no users, no CA data — which every hop happily
+// passed along. #6054 fixed the receive hop, #6015/#6112 the export hop, #6107
+// the read hop. Three fixes to one question is exactly the shape that drifts:
+// the moment two of them disagree about what "usable" means, a document is
+// accepted by one component and rejected by the next, and the region is
+// credential-less again with nothing reporting it.
+//
+// So the question is answered in ONE place and imported by both sides. The
+// dependency direction already exists — products/catalyst/bootstrap/api
+// requires core/controllers (see its go.mod replace) — so this introduces no
+// new module edge, and the org-controller is in this module already.
+//
+// THE DECISIVE CHECK IS THE CONSUMER'S OWN PARSER
+// -----------------------------------------------
+// `clientcmd.RESTConfigFromKubeConfig` is the EXACT call
+// k8scache.AddCluster makes (internal/k8scache/factory.go) and the exact call
+// the org-controller's newRegionClient makes. Binding to it is deliberate: a
+// bespoke structural re-implementation could drift from what actually builds a
+// client, and then this gate would pass documents the consumers still reject.
+//
+// The structural walk exists ONLY to name the missing sections for an
+// operator — it never overrides the parser's verdict.
+//
+// Refs #6015 #6054 #6104 #6107 #6112.
+package kubeconfig
+
+import (
+	"sort"
+	"strings"
+
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// Defects reports why raw cannot produce a working client, as a stable, sorted
+// list of section names suitable for a log line or an operator-facing
+// condition message. An empty slice means the document is usable.
+//
+// The returned names are deliberately the kubeconfig's own top-level keys
+// ("clusters", "contexts", "users", "current-context") so an operator reading
+// the message can diff the rejected document against a healthy one without
+// needing this source file.
+func Defects(raw string) []string {
+	if strings.TrimSpace(raw) == "" {
+		return []string{"empty"}
+	}
+
+	cfg, err := clientcmd.Load([]byte(raw))
+	if err != nil || cfg == nil {
+		return []string{"unparseable"}
+	}
+
+	missing := map[string]struct{}{}
+
+	// A cluster entry with no server URL is the shape the hw293 stub had AFTER
+	// its truncation point removed everything else: the section is present, so
+	// a "has clusters?" check passes, yet nothing dialable is declared. Assert
+	// on the VALUE, not the presence of the KEY.
+	hasServer := false
+	for _, c := range cfg.Clusters {
+		if c != nil && strings.TrimSpace(c.Server) != "" {
+			hasServer = true
+			break
+		}
+	}
+	if !hasServer {
+		missing["clusters"] = struct{}{}
+	}
+	if len(cfg.Contexts) == 0 {
+		missing["contexts"] = struct{}{}
+	}
+	if len(cfg.AuthInfos) == 0 {
+		missing["users"] = struct{}{}
+	}
+	if strings.TrimSpace(cfg.CurrentContext) == "" {
+		missing["current-context"] = struct{}{}
+	}
+
+	// Decisive gate — the consumer's own parser. A document that satisfies
+	// every structural check above but still cannot build a rest.Config
+	// (unresolvable current-context, a context naming a cluster or user that
+	// does not exist, a user carrying no credential at all) is rejected here
+	// rather than later, at the point of use.
+	if _, rerr := clientcmd.RESTConfigFromKubeConfig([]byte(raw)); rerr != nil {
+		if len(missing) == 0 {
+			missing["client-unbuildable"] = struct{}{}
+		}
+	} else if len(missing) == 0 {
+		return nil
+	}
+
+	out := make([]string, 0, len(missing))
+	for k := range missing {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// Usable reports whether raw can produce a client — the boolean form of
+// Defects for call sites that do not need to name the gap.
+func Usable(raw string) bool {
+	return len(Defects(raw)) == 0
+}
+
+// DescribeDefects renders a defect list for an operator-facing message,
+// naming the empty case explicitly rather than rendering "[]".
+func DescribeDefects(defects []string) string {
+	if len(defects) == 0 {
+		return "none"
+	}
+	return strings.Join(defects, ",")
+}

--- a/core/controllers/pkg/kubeconfig/kubeconfig_test.go
+++ b/core/controllers/pkg/kubeconfig/kubeconfig_test.go
@@ -1,0 +1,124 @@
+// kubeconfig_test.go — the shared usability contract must answer BOTH ways.
+//
+// This package exists so the producer of a secondary-region kubeconfig and the
+// consumers that read it back cannot disagree about what "usable" means. A
+// contract that only ever says "unusable" would be as broken as the
+// presence-only checks it replaces — it would red-flag every correctly-wired
+// Sovereign on the estate — so every case below is paired against a control
+// that answers the other way.
+//
+// Refs #6015 #6054 #6107 #6112.
+package kubeconfig
+
+import (
+	"strings"
+	"testing"
+)
+
+// hw293Stub is the measured live artefact: valid YAML, one cluster with a
+// server URL, and nothing else. The absent trailing newline is part of the
+// evidence — the document was cut mid-token rather than generated short.
+const hw293Stub = "apiVersion: v1\n" +
+	"kind: Config\n" +
+	"clusters:\n" +
+	"- cluster:\n" +
+	"    server: https://212.72.24.6:6443\n" +
+	"  name: c"
+
+// completeSameCluster keeps the stub's exact cluster block and adds ONLY the
+// three sections it lacks. If brevity, the server URL, or the cluster count
+// were what made the stub unusable, this control would be refused too.
+// Carries no credential material: an empty `user: {}` is enough.
+const completeSameCluster = `apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://212.72.24.6:6443
+  name: c
+users:
+- name: c
+  user: {}
+contexts:
+- name: c
+  context:
+    cluster: c
+    user: c
+current-context: c
+`
+
+func TestDefects_NamesEachGapAndAcceptsTheControl(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+		want []string
+	}{
+		{"empty", "", []string{"empty"}},
+		{"whitespace only", "   \n\t\n", []string{"empty"}},
+		{"not a kubeconfig at all", "kubeconfig-for-me-east-215-b", []string{"unparseable"}},
+		{"the hw293 artefact", hw293Stub, []string{"contexts", "current-context", "users"}},
+		{
+			"cluster KEY present but server VALUE empty",
+			"apiVersion: v1\nkind: Config\nclusters:\n- cluster:\n    server: \"\"\n  name: c\n",
+			[]string{"clusters", "contexts", "current-context", "users"},
+		},
+		// The vacuity arm. Without it, an implementation that returned a
+		// defect for every input would pass every case above.
+		{"complete", completeSameCluster, nil},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Defects(tc.raw)
+			if strings.Join(got, ",") != strings.Join(tc.want, ",") {
+				t.Fatalf("Defects() = %v, want %v", got, tc.want)
+			}
+			if usable := Usable(tc.raw); usable != (len(tc.want) == 0) {
+				t.Fatalf("Usable() = %v, but Defects() reported %v", usable, got)
+			}
+		})
+	}
+}
+
+// TestDefects_AnonymousClientIsRefused pins the reason the contract is
+// deliberately stricter than "the parser returned no error": a kubeconfig with
+// a context but NO user parses fine and builds an ANONYMOUS client, which the
+// peer apiserver refuses 403 on every write. A client that builds and can
+// never write the listener is the exact silent-success shape this chain exists
+// to kill, so it must count as unusable.
+func TestDefects_AnonymousClientIsRefused(t *testing.T) {
+	noUser := `apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://212.72.24.6:6443
+  name: c
+contexts:
+- name: c
+  context:
+    cluster: c
+    user: ""
+current-context: c
+`
+	got := Defects(noUser)
+	if len(got) == 0 {
+		t.Fatal("a kubeconfig with no users section was accepted; it builds an anonymous client that is 403 on every write")
+	}
+	if strings.Join(got, ",") != "users" {
+		t.Fatalf("Defects() = %v, want exactly [users] — the other sections are present", got)
+	}
+
+	// CONTROL: the same document with a user entry is accepted, so the check
+	// discriminates on the users section and not on something incidental.
+	if !Usable(completeSameCluster) {
+		t.Fatalf("the control with a users entry was refused: %v", Defects(completeSameCluster))
+	}
+}
+
+func TestDescribeDefects_NamesTheEmptyCase(t *testing.T) {
+	if got := DescribeDefects(nil); got != "none" {
+		t.Fatalf("DescribeDefects(nil) = %q, want %q — an operator must not read a bare [] ", got, "none")
+	}
+	if got := DescribeDefects([]string{"users", "contexts"}); got != "users,contexts" {
+		t.Fatalf("DescribeDefects() = %q", got)
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/secondary_kubeconfig_completeness.go
+++ b/products/catalyst/bootstrap/api/internal/handler/secondary_kubeconfig_completeness.go
@@ -62,81 +62,32 @@
 package handler
 
 import (
-	"sort"
-	"strings"
-
-	"k8s.io/client-go/tools/clientcmd"
+	"github.com/openova-io/openova/core/controllers/pkg/kubeconfig"
 )
 
 // secondaryKubeconfigDefects reports why raw cannot produce a working
 // client, as a stable, sorted list of section names for the log + the HTTP
 // response. An empty slice means the document is usable.
 //
-// The returned names are deliberately the kubeconfig's own top-level keys
-// ("clusters", "contexts", "users", "current-context") so an operator
-// reading the 422 can diff the rejected document against a healthy one
-// without needing this source file.
+// The implementation lives in core/controllers/pkg/kubeconfig so that the
+// PRODUCER of a secondary kubeconfig and the CONSUMER that later reads it back
+// cannot disagree about what "usable" means (#6107). This document crosses
+// three hops — export, receive, and the org-controller's region resolver — and
+// each of them previously carried its own presence-only check. A shared
+// contract is what stops a document being accepted by one hop and rejected by
+// the next while nothing reports the region as credential-less.
+//
+// The dependency direction already existed: this module requires
+// core/controllers (see go.mod replace), so nothing new is coupled here.
+//
+// Refs #6015, #6040, #6107.
 func secondaryKubeconfigDefects(raw string) []string {
-	if strings.TrimSpace(raw) == "" {
-		return []string{"empty"}
-	}
-
-	cfg, err := clientcmd.Load([]byte(raw))
-	if err != nil || cfg == nil {
-		return []string{"unparseable"}
-	}
-
-	missing := map[string]struct{}{}
-
-	// A cluster entry with no server URL is the shape the hw293 stub had
-	// AFTER its truncation point removed everything else: the section is
-	// present, so a "has clusters?" check passes, yet nothing dialable is
-	// declared. Assert on the VALUE, not the presence of the KEY.
-	hasServer := false
-	for _, c := range cfg.Clusters {
-		if c != nil && strings.TrimSpace(c.Server) != "" {
-			hasServer = true
-			break
-		}
-	}
-	if !hasServer {
-		missing["clusters"] = struct{}{}
-	}
-	if len(cfg.Contexts) == 0 {
-		missing["contexts"] = struct{}{}
-	}
-	if len(cfg.AuthInfos) == 0 {
-		missing["users"] = struct{}{}
-	}
-	if strings.TrimSpace(cfg.CurrentContext) == "" {
-		missing["current-context"] = struct{}{}
-	}
-
-	// Decisive gate — the consumer's own parser. A document that satisfies
-	// every structural check above but still cannot build a rest.Config
-	// (unresolvable current-context, a context naming a cluster or user
-	// that does not exist, a user carrying no credential at all) is
-	// rejected here rather than at AddCluster time, which is what the
-	// pre-fix ordering deferred until after the write.
-	if _, rerr := clientcmd.RESTConfigFromKubeConfig([]byte(raw)); rerr != nil {
-		if len(missing) == 0 {
-			missing["client-unbuildable"] = struct{}{}
-		}
-	} else if len(missing) == 0 {
-		return nil
-	}
-
-	out := make([]string, 0, len(missing))
-	for k := range missing {
-		out = append(out, k)
-	}
-	sort.Strings(out)
-	return out
+	return kubeconfig.Defects(raw)
 }
 
 // secondaryKubeconfigUsable reports whether raw can produce a client — the
 // boolean form of secondaryKubeconfigDefects for call sites that do not
 // need to name the gap.
 func secondaryKubeconfigUsable(raw string) bool {
-	return len(secondaryKubeconfigDefects(raw)) == 0
+	return kubeconfig.Usable(raw)
 }


### PR DESCRIPTION
Refs #6107 #6015 #6054 #6104 #6112

## The defect

`consoleRegionTargets` partitioned the #5359 bridge Secret's keys on emptiness alone:

```go
if region == "" || len(v) == 0 { continue }
regions = append(regions, region)
```

So the 95-byte credential-less document measured on hw293 counted as a **wired** region. Two things followed, in order:

1. the anti-vacuity shortfall check became `1 declared remote > 1 wired key` — **false**, so nothing was reported;
2. the client build failed a few lines later and the region landed in `Unreachable`.

Those buckets are deliberately not equivalent (`provisioning_postconditions.go`):

| bucket | consumer | effect on the Organization |
|---|---|---|
| `Unwired` | `out.Missing` | Org reads NOT provisioned |
| `Unreachable` | `out.Unverifiable` | requeue only |

and `complete()` is `len(p.Missing) == 0`.

Measured on unmodified `main`, with the host listener written and its Gateway status synced so the secondary region was the only variable:

```
complete()=true
Missing=[]
Unverifiable=[console Gateway listeners for "*.uatco.omani.homes" in every region —
  region "me-east-215-b" kubeconfig in catalyst/cutover-secondary-kubeconfigs did not
  yield a client: parse kubeconfig: invalid configuration: no configuration has been
  provided, try setting KUBERNETES_MASTER environment variable]
```

The Organization read **fully provisioned** while its `console-https-<slug>` / `console-http-<slug>` pair had never been written to region B, and one shared console EIP round-robins both regions' envoy. That is precisely the degradation the file's own header declares impossible under "WHY IT CANNOT DEGRADE SILENTLY". #6027 closed the door where the Secret is **absent**; this is the door where it is **present and unusable** — and with #6104 merged the Secret now exists on every Sovereign, so this door is the one the fleet walks through.

The verdict is a property of the **bytes**, so no requeue can change it — which is the struct's own definition of `Unwired`, and the opposite of `Unreachable` ("an apiserver blip must not red-flag every Organization").

## One contract, two consumers

The check is **not** reimplemented here. This document crosses three hops — export, receive, and this region resolver — and each previously carried its own presence-only test. The moment two of them disagree, a document is accepted by one hop and rejected by the next while nothing reports the region credential-less.

So the question moved to `core/controllers/pkg/kubeconfig`, and catalyst-api's `secondaryKubeconfigDefects` now delegates to it.

Note the direction, because it constrains the design: the reader **cannot** import the writer — `internal/handler` is unreachable across modules and the edge would be a cycle — but `products/catalyst/bootstrap/api` **already requires** `core/controllers` via a `go.mod` replace. The shared home therefore introduces no new module edge.

That the delegation is faithful is not asserted; the writer's entire #6054 suite passes unchanged against it (20 tests, including the ones that pin each defect name individually).

## Why the contract is stricter than "the parser returned no error"

A kubeconfig with a context but **no `users:` section** parses fine and builds an **anonymous** client — one that reaches the peer apiserver as `system:anonymous` and is refused 403 on every write. A client that builds and can never write the listener is the same silent-success class this chain exists to kill, so it counts as unusable. Pinned by `TestDefects_AnonymousClientIsRefused`, with a control proving the check discriminates on that section and not on something incidental.

## Red, then green

Against unmodified reader code:

```
--- FAIL: TestConsoleRegionTargets_UnusableSecondaryKubeconfigIsUnwired_6107 (0.00s)
    a 93-byte contextless kubeconfig stub was counted as a WIRED region — the shortfall
    check saw 1 declared remote against 1 wired key, reported nothing, and the region
    degraded into Unreachable, which only requeues. unwired=[] unreachable=[region
    "me-east-215-b" ... did not yield a client: parse kubeconfig: invalid configuration:
    no configuration has been provided ...]
--- PASS: TestConsoleRegionTargets_CompleteSecondaryKubeconfigStaysWired_6107 (0.01s)
--- FAIL: TestConsoleRegionTargets_AbsentKeyKeepsTheNoneWording_6107 (0.00s)
    the absent-key message does not state that nothing was present-but-unusable:
    "1 of 1 secondary region(s) have no kubeconfig in catalyst/cutover-secondary-kubeconfigs
    (sovereign-fqdn configuredRegions declares 1 remote region(s); wired region keys: none)"
FAIL
```

After:

```
--- PASS: TestConsoleRegionTargets_UnusableSecondaryKubeconfigIsUnwired_6107 (0.01s)
--- PASS: TestConsoleRegionTargets_CompleteSecondaryKubeconfigStaysWired_6107 (0.00s)
--- PASS: TestConsoleRegionTargets_AbsentKeyKeepsTheNoneWording_6107 (0.00s)
ok
```

### The controls

**`CompleteSecondaryKubeconfigStaysWired` passes before AND after.** It shares the suspect property — a non-empty value under the same bridge-Secret key — and must answer the other way. It is what stops this change becoming "everything is incomplete", which would red-flag every correctly-wired Sovereign on the estate.

That control earned its place rather than decorating the diff. Its first fixture omitted the `users:` section, and it failed on the *green* run — catching that the reader had become stricter than the test assumed. The fixture was wrong, not the contract; the anonymous-client reasoning above is the answer, and it is now written down in both places.

**`AbsentKeyKeepsTheNoneWording`** guards the #6027 case next door: an absent key still reports `wired region keys: none`, must NOT acquire an unusable-credential claim it has no basis for, and must still hold the Organization back.

`pkg/kubeconfig` carries its own table test including an explicit vacuity arm — without it, an implementation returning a defect for every input would pass every other case.

## Fixtures

`newMultiRegionFixture` seeded the literal bytes `kubeconfig-for-<region>` — unparseable, and green only under the presence-only check being removed here. It now seeds a real kubeconfig carrying the same marker in its cluster name, and the `RegionClientBuilder` seam asserts on the marker rather than whole-document equality, so those tests exercise the shared contract instead of walking past it.

No fixture carries credential material — an empty `user: {}` is enough to make the section non-empty.

## Verification

- `core/controllers` full suite `./...` — **EXIT=0**, including the new `pkg/kubeconfig`
- `products/catalyst/bootstrap/api/internal/handler` full suite green against the delegated contract
- `go vet ./...` clean in both modules
- read-only on live clusters throughout; no NodePort anywhere in this change
