### PR TITLE
fix(bootstrap-kit): the Flux controllers must not be the only node workloads with no pull credential of their own (#6079)

### DIFF
--- a/.github/workflows/check-flux-controller-pull-credential.yaml
+++ b/.github/workflows/check-flux-controller-pull-credential.yaml
@@ -1,0 +1,66 @@
+name: check — Flux controller pull credential (#6079)
+
+# Permanent guard that the Flux controllers are never the only workloads on a
+# node whose image pull carries no credential of their own.
+#
+# #6079 (mothership, 2026-08-10/11): `ghcr.io/fluxcd/source-controller:v1.8.0`
+# returned `403 Forbidden` from the ghcr token endpoint for six hours while an
+# anonymous token request for that exact PUBLIC scope, egressing from that exact
+# node, returned 200. GHCR answers 401 for "no credentials" and 403 for
+# "credentials I reject", so the 403 proves a credential was presented — a stale
+# one in the node's kubelet docker keyring, invisible to every Kubernetes
+# object. kubelet tries every keyring credential and NEVER retries anonymously
+# once they fail, so a PUBLIC image that would pull fine with no auth failed
+# BECAUSE auth was configured and stale. Every other namespace survived because
+# a working imagePullSecret sat ahead of it; the four Flux controllers use their
+# own ServiceAccounts and carried none, so the loop that repairs everything else
+# was the one thing that could not start. Ten days of `deploy:` commits inert.
+#
+# The guard is source-side, network-free and needs no cluster. Its `--self-test`
+# negative control runs FIRST and is fully deterministic: it exercises every
+# assertion against a fixture that violates it, so a green run is evidence the
+# checks can fail rather than evidence they were skipped.
+#
+# Per CLAUDE.md "every workflow MUST be event-driven, NEVER scheduled": no
+# `schedule:` trigger.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'clusters/_template/bootstrap-kit/03-flux.yaml'
+      - 'platform/flux/**'
+      - 'infra/providers/_shared/cloudinit-control-plane.tftpl'
+      - 'scripts/check-flux-controller-pull-credential.sh'
+      - '.github/workflows/check-flux-controller-pull-credential.yaml'
+  pull_request:
+    paths:
+      - 'clusters/_template/bootstrap-kit/03-flux.yaml'
+      - 'platform/flux/**'
+      - 'infra/providers/_shared/cloudinit-control-plane.tftpl'
+      - 'scripts/check-flux-controller-pull-credential.sh'
+      - '.github/workflows/check-flux-controller-pull-credential.yaml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Flux controller ServiceAccounts carry a pull credential
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install PyYAML
+        run: python3 -m pip install --quiet pyyaml
+
+      # Negative control FIRST. If this step passes, the assertions in the next
+      # step are known to be capable of failing.
+      - name: Self-test (negative control)
+        run: bash scripts/check-flux-controller-pull-credential.sh --self-test
+
+      - name: Check
+        run: bash scripts/check-flux-controller-pull-credential.sh

--- a/clusters/_template/bootstrap-kit/03-flux.yaml
+++ b/clusters/_template/bootstrap-kit/03-flux.yaml
@@ -181,3 +181,81 @@ spec:
                       - name: data
                         emptyDir:
                           sizeLimit: 3Gi
+          # ── #6079 (2026-08-11): the four Flux controllers are the ONLY
+          # workloads on a node whose image pull carries no credential of its
+          # own — so ONE stale node-level registry credential strands the whole
+          # GitOps loop, and the controller that would repair it is the one that
+          # cannot start.
+          #
+          # MEASURED, read-only, on the mothership 2026-08-10/11:
+          #
+          #   Failed to pull ghcr.io/fluxcd/source-controller:v1.8.0: failed to
+          #   authorize: failed to fetch oauth token: GET https://ghcr.io/token
+          #   ?scope=repository:fluxcd/source-controller:pull -> 403 Forbidden
+          #
+          # `fluxcd/source-controller` is a PUBLIC repository, and an anonymous
+          # token request for that exact scope, egressing from that exact node,
+          # returned 200 at the same moment. GHCR answers 401 for "no
+          # credentials" and 403 for "credentials I reject", so the 403 is
+          # positive evidence that the node presented one. It did not come from
+          # k3s: wharfie logs `Using private registry config file at <path>`
+          # whenever /etc/rancher/k3s/registries.yaml exists, and that line is
+          # absent from the node's k3s start — so the credential came from the
+          # kubelet docker keyring (a node-local config.json), which no
+          # Kubernetes object shows.
+          #
+          # kubelet builds that keyring from the pod's imagePullSecrets PLUS the
+          # node's own docker-config files, tries every credential that matches
+          # the registry, and — the whole defect — NEVER retries anonymously
+          # once they have all failed (k8s pkg/kubelet/images/image_manager.go,
+          # EnsureImageExists). A public image that would pull fine with NO auth
+          # fails BECAUSE auth is configured and stale. There is no anonymous
+          # fallback to switch on; the only in-cluster lever is to put a WORKING
+          # credential in the pod's keyring, because kubelet returns on the
+          # first credential that succeeds.
+          #
+          # Every other namespace on that node survived the same stale
+          # credential for exactly that reason. flux-system did not: `flux
+          # install` gives each controller its OWN ServiceAccount
+          # (source-/kustomize-/helm-/notification-controller, never `default`),
+          # so every default-SA or namespace-level imagePullSecret misses them
+          # precisely. Ten days of `deploy:` commits went nowhere.
+          #
+          # This does NOT make public images require auth, and it does not
+          # replace removing the stale node credential — that is the node-side
+          # half and is an operator action (runbook on #6079). This half ships
+          # in git, is reconciled by helm-controller on every interval, and
+          # survives node replacement.
+          #
+          # WHY a postRenderer, same reason as the patch above: helm-controller
+          # owns these ServiceAccounts via the flux2 subchart and re-applies its
+          # rendered manifest on every reconcile, so a raw `kubectl patch` would
+          # be reverted. The flux2 2.14.1 SA templates expose only
+          # `serviceAccount.annotations` — there is no imagePullSecrets value to
+          # set — so the render pipeline is the only override point.
+          #
+          # The `ghcr-pull` Secret already exists in flux-system: cloud-init
+          # applies /var/lib/catalyst/ghcr-pull-secret.yaml before Flux
+          # bootstraps, and bp-reflector (slot 05a) keeps it mirrored.
+          # ServiceAccount imagePullSecrets are injected at POD CREATION, so
+          # this takes effect on the next controller pod — which is exactly the
+          # re-pull path that failed (image GC, node reboot, controller
+          # upgrade), not the first boot.
+          #
+          # The selector is an ANCHORED regex over every Flux controller
+          # ServiceAccount — the four that `flux install` v2.4.0 creates plus
+          # image-automation-/image-reflector-controller when an operator
+          # enables them, since the exposure is identical for any of them. It
+          # deliberately does NOT match the chart's other ServiceAccounts
+          # (bp-flux-stuck-hr-recovery, flux-flux-check), which are Job/CronJob
+          # identities pulling a Harbor-proxied image on a different path.
+          - target:
+              kind: ServiceAccount
+              name: ^[a-z-]+-controller$
+            patch: |
+              apiVersion: v1
+              kind: ServiceAccount
+              metadata:
+                name: flux-controller-pull-credential
+              imagePullSecrets:
+                - name: ghcr-pull

--- a/scripts/check-flux-controller-pull-credential.sh
+++ b/scripts/check-flux-controller-pull-credential.sh
@@ -1,0 +1,284 @@
+#!/usr/bin/env bash
+# check-flux-controller-pull-credential — the Flux controllers must never be the
+# only workloads on a node whose image pull carries no credential of their own.
+#
+# WHY (#6079). The mothership's GitOps loop was dead for ten days. Measured
+# read-only on the node 2026-08-10/11:
+#
+#   Failed to pull ghcr.io/fluxcd/source-controller:v1.8.0: failed to authorize:
+#   failed to fetch oauth token: GET https://ghcr.io/token
+#   ?scope=repository:fluxcd/source-controller:pull&service=ghcr.io -> 403 Forbidden
+#
+# `fluxcd/source-controller` is a PUBLIC repository. An anonymous token request
+# for that exact scope, egressing from that exact node, returned 200 at the same
+# moment. GHCR answers 401 for "no credentials" and 403 for "credentials I
+# reject", so the 403 is POSITIVE evidence that the node presented a credential
+# and GHCR refused it. It did not come from k3s: wharfie logs `Using private
+# registry config file at <path>` whenever /etc/rancher/k3s/registries.yaml
+# exists, and that line is absent from the node's k3s start — so the credential
+# came from the kubelet docker keyring (a node-local docker config.json), which
+# no Kubernetes object exposes.
+#
+# THE MECHANISM THAT MAKES THIS A CLASS, not an incident. kubelet builds its
+# keyring from the pod's imagePullSecrets PLUS the node's own docker-config
+# files, tries every credential that matches the registry, and NEVER retries
+# anonymously once they have all failed (k8s pkg/kubelet/images/image_manager.go,
+# EnsureImageExists). So a PUBLIC image that would pull fine with no auth at all
+# fails BECAUSE auth is configured and stale. There is no anonymous-fallback
+# switch. The only in-cluster lever is a WORKING credential in the pod's own
+# keyring, because kubelet returns on the first credential that succeeds.
+#
+# Every other namespace on the mothership survived the same stale node
+# credential for exactly that reason — a working imagePullSecret sat in front of
+# it. flux-system did not: `flux install` gives each controller its OWN
+# ServiceAccount (source-/kustomize-/helm-/notification-controller, never
+# `default`), so every default-SA or namespace-wide imagePullSecret misses them
+# precisely. The controllers that would have redeployed everything else were the
+# only ones that could not start.
+#
+# WHAT THIS GUARD ASSERTS (source-side, network-free, no cluster):
+#   1. the bp-flux HelmRelease carries a postRenderer patch that attaches an
+#      imagePullSecret to the Flux controller ServiceAccounts;
+#   2. the patch's target selector matches EVERY controller ServiceAccount the
+#      flux2 subchart renders — a partial selector leaves the un-selected
+#      controllers stranded and still reads green;
+#   3. the selector is ANCHORED, so it cannot silently widen onto unrelated
+#      ServiceAccounts;
+#   4. the named Secret is one the bootstrap actually creates in flux-system.
+#
+# It does NOT assert that public images need authentication — they do not. It
+# asserts that when a node-level credential exists and is bad, the controllers
+# that repair everything else are not the single workload with no way around it.
+# Removing a stale node credential is the node-side half and is an operator
+# action (see the remediation runbook on #6079).
+#
+# USAGE
+#   scripts/check-flux-controller-pull-credential.sh
+#   scripts/check-flux-controller-pull-credential.sh --self-test
+#
+# READ-ONLY. Reads repo files; never contacts a cluster, a registry or a node.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HR_FILE="${REPO_ROOT}/clusters/_template/bootstrap-kit/03-flux.yaml"
+
+# The controller ServiceAccounts the flux2 subchart renders. The first four are
+# what `flux install` creates unconditionally; the image-* pair appears when an
+# operator enables those controllers and carries the identical exposure.
+CONTROLLER_SAS=(
+  source-controller
+  kustomize-controller
+  helm-controller
+  notification-controller
+  image-automation-controller
+  image-reflector-controller
+)
+
+# ServiceAccounts in the same render that MUST NOT be swept up by the selector.
+# They are Job/CronJob identities on a different pull path; a selector that
+# matches them has widened past its warrant.
+NON_CONTROLLER_SAS=(
+  bp-flux-stuck-hr-recovery
+  flux-flux-check
+  default
+)
+
+fail=0
+note() { printf '%s\n' "$*"; }
+bad()  { printf 'FAIL: %s\n' "$*"; fail=1; }
+
+# ─── The extractor ────────────────────────────────────────────────────────
+#
+# Pulls, from a bp-flux HelmRelease document, the postRenderer patch that
+# attaches an imagePullSecret to ServiceAccounts, and prints two fields:
+#   <selector-regex>\t<secret-name>
+# Prints nothing when no such patch exists. python3 + PyYAML because the
+# structure is nested list-of-maps with an embedded YAML string; a grep over
+# this file would pass on a patch that targets the wrong kind.
+extract() {
+  python3 - "$1" <<'PY'
+import sys, yaml
+
+src = open(sys.argv[1]).read()
+for doc in yaml.safe_load_all(src):
+    if not doc or doc.get("kind") != "HelmRelease":
+        continue
+    for pr in (doc.get("spec", {}).get("postRenderers") or []):
+        for p in (pr.get("kustomize", {}).get("patches") or []):
+            tgt = p.get("target") or {}
+            if tgt.get("kind") != "ServiceAccount":
+                continue
+            body = yaml.safe_load(p.get("patch") or "") or {}
+            if body.get("kind") != "ServiceAccount":
+                continue
+            for ips in (body.get("imagePullSecrets") or []):
+                name = ips.get("name")
+                if name:
+                    print("%s\t%s" % (tgt.get("name", ""), name))
+PY
+}
+
+# ─── Self-test: the negative control ──────────────────────────────────────
+#
+# Every assertion below is exercised against a fixture that VIOLATES it, so a
+# green run of this script is evidence the checks can fail. Without this the
+# guard would be indistinguishable from a script that prints OK.
+if [ "${1:-}" = "--self-test" ]; then
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' EXIT
+  st_fail=0
+
+  mkfixture() { # $1=file  $2=target-name-regex (empty => omit the patch entirely)
+    {
+      printf 'apiVersion: helm.toolkit.fluxcd.io/v2\n'
+      printf 'kind: HelmRelease\n'
+      printf 'metadata:\n  name: bp-flux\n  namespace: flux-system\n'
+      printf 'spec:\n  postRenderers:\n    - kustomize:\n        patches:\n'
+      printf '          - target:\n              kind: Deployment\n              name: source-controller\n'
+      printf '            patch: |\n              apiVersion: apps/v1\n              kind: Deployment\n              metadata:\n                name: source-controller\n'
+      if [ -n "$2" ]; then
+        printf '          - target:\n              kind: ServiceAccount\n              name: %s\n' "$2"
+        printf '            patch: |\n              apiVersion: v1\n              kind: ServiceAccount\n              metadata:\n                name: x\n              imagePullSecrets:\n                - name: %s\n' "${3:-ghcr-pull}"
+      fi
+    } > "$1"
+  }
+
+  note "== self-test 1: NO ServiceAccount patch at all MUST be rejected =="
+  mkfixture "$tmp/none.yaml" ""
+  if [ -z "$(extract "$tmp/none.yaml")" ]; then
+    note "  ok — absent patch produces no extraction"
+  else
+    note "  BROKEN — extractor invented a patch that is not in the document"; st_fail=1
+  fi
+
+  note "== self-test 2: a selector covering only SOME controllers MUST be rejected =="
+  mkfixture "$tmp/partial.yaml" '^(source|kustomize)-controller$'
+  sel="$(extract "$tmp/partial.yaml" | cut -f1)"
+  missed=0
+  for sa in "${CONTROLLER_SAS[@]}"; do
+    printf '%s' "$sa" | grep -Eq "$sel" || missed=1
+  done
+  if [ "$missed" -eq 1 ]; then
+    note "  ok — partial selector '$sel' leaves controllers unmatched, as it must"
+  else
+    note "  BROKEN — a 2-of-6 selector was accepted as complete"; st_fail=1
+  fi
+
+  note "== self-test 3: an UNANCHORED selector MUST be rejected =="
+  mkfixture "$tmp/wide.yaml" 'controller'
+  wsel="$(extract "$tmp/wide.yaml" | cut -f1)"
+  leaked=0
+  for sa in "${NON_CONTROLLER_SAS[@]}"; do
+    printf '%s' "$sa" | grep -Eq "$wsel" && leaked=1
+  done
+  case "$wsel" in
+    ^*\$) note "  BROKEN — fixture selector was supposed to be unanchored"; st_fail=1 ;;
+    *)    note "  ok — '$wsel' is unanchored and is caught by the anchor check" ;;
+  esac
+
+  note "== self-test 4: a selector matching a NON-controller SA MUST be rejected =="
+  mkfixture "$tmp/greedy.yaml" '^[a-z-]+$'
+  gsel="$(extract "$tmp/greedy.yaml" | cut -f1)"
+  gleak=0
+  for sa in "${NON_CONTROLLER_SAS[@]}"; do
+    printf '%s' "$sa" | grep -Eq "$gsel" && gleak=1
+  done
+  if [ "$gleak" -eq 1 ]; then
+    note "  ok — greedy selector '$gsel' sweeps up a non-controller SA, as it must"
+  else
+    note "  BROKEN — a selector matching 'default' was accepted"; st_fail=1
+  fi
+
+  note "== self-test 5: the POSITIVE control — the shipped shape must pass =="
+  mkfixture "$tmp/good.yaml" '^[a-z-]+-controller$'
+  gsel2="$(extract "$tmp/good.yaml" | cut -f1)"
+  ok=1
+  for sa in "${CONTROLLER_SAS[@]}"; do
+    printf '%s' "$sa" | grep -Eq "$gsel2" || ok=0
+  done
+  for sa in "${NON_CONTROLLER_SAS[@]}"; do
+    printf '%s' "$sa" | grep -Eq "$gsel2" && ok=0
+  done
+  if [ "$ok" -eq 1 ]; then
+    note "  ok — the shipped selector covers every controller and nothing else"
+  else
+    note "  BROKEN — the shipped selector shape does not satisfy its own checks"; st_fail=1
+  fi
+
+  if [ "$st_fail" -eq 0 ]; then
+    note ""; note "SELF-TEST PASS — every assertion below can fail."
+    exit 0
+  fi
+  note ""; note "SELF-TEST FAIL — the checks below prove nothing."
+  exit 1
+fi
+
+# ─── The real check ───────────────────────────────────────────────────────
+
+[ -f "$HR_FILE" ] || { bad "$HR_FILE not found — bp-flux slot 03 moved or was deleted."; exit 1; }
+
+line="$(extract "$HR_FILE" || true)"
+
+if [ -z "$line" ]; then
+  bad "the bp-flux HelmRelease has NO postRenderer patch attaching an imagePullSecret"
+  bad "to the Flux controller ServiceAccounts."
+  note ""
+  note "Without it the four Flux controllers are the only workloads on the node"
+  note "whose ghcr pull has no credential of its own. kubelet never retries"
+  note "anonymously after a keyring credential is rejected, so ONE stale"
+  note "node-level credential strands the entire GitOps loop — and the controller"
+  note "that would repair it is the one that cannot start. Refs #6079."
+  exit 1
+fi
+
+selector="$(printf '%s' "$line" | cut -f1)"
+secret="$(printf '%s' "$line" | cut -f2)"
+
+note "bp-flux ServiceAccount pull-credential patch:"
+note "  selector: $selector"
+note "  secret:   $secret"
+note ""
+
+# 1. Every controller ServiceAccount is covered.
+for sa in "${CONTROLLER_SAS[@]}"; do
+  if printf '%s' "$sa" | grep -Eq "$selector"; then
+    note "  covered: $sa"
+  else
+    bad "controller ServiceAccount '$sa' is NOT matched by '$selector' — it keeps"
+    bad "        the exact exposure #6079 documents while the check reads green."
+  fi
+done
+
+# 2. Nothing else is.
+for sa in "${NON_CONTROLLER_SAS[@]}"; do
+  if printf '%s' "$sa" | grep -Eq "$selector"; then
+    bad "'$selector' also matches '$sa', which is not a Flux controller."
+  fi
+done
+
+# 3. The selector is anchored at both ends, so it cannot widen by accident.
+case "$selector" in
+  ^*\$) : ;;
+  *) bad "selector '$selector' is not anchored (^…\$). An unanchored kustomize name"
+     bad "        selector is a substring match and will drift onto unrelated objects." ;;
+esac
+
+# 4. The Secret is one the bootstrap actually creates in flux-system. A patch
+#    naming a Secret nothing produces is inert AND makes kubelet log
+#    FailedToRetrieveImagePullSecret on every controller pod.
+if grep -rq "name: ${secret}\$" "${REPO_ROOT}/infra/providers/_shared/cloudinit-control-plane.tftpl"; then
+  note ""
+  note "  secret '${secret}' is created by the shared cloud-init bootstrap"
+else
+  bad "the patch names imagePullSecret '${secret}', which the shared cloud-init"
+  bad "        bootstrap does not create in flux-system — the patch would be inert."
+fi
+
+note ""
+if [ "$fail" -eq 0 ]; then
+  note "PASS — every Flux controller ServiceAccount carries a pull credential of its own."
+  exit 0
+fi
+note "FAIL — see above. Refs #6079."
+exit 1


### PR DESCRIPTION
## A public image pull failed BECAUSE authentication was configured and stale

Measured read-only on the mothership node (`vmi3116389`, single-node k3s
`v1.34.4+k3s1`, `containerd://2.1.5-k3s1`) on 2026-08-10/11. Nothing was applied,
patched, scaled or deleted.

```
Failed to pull ghcr.io/fluxcd/source-controller:v1.8.0: failed to authorize:
failed to fetch oauth token: GET https://ghcr.io/token
  ?scope=repository:fluxcd/source-controller:pull&service=ghcr.io -> 403 Forbidden
```

`fluxcd/source-controller` is a **public** repository. The token endpoint's two
answers are inverted from the intuition, and both were reproduced independently
rather than taken on trust:

```
$ curl -s -o /dev/null -w '%{http_code}\n' \
    'https://ghcr.io/token?scope=repository:fluxcd/source-controller:pull&service=ghcr.io'
200                       # anonymous            -> token issued
$ curl -s -o /dev/null -w '%{http_code}\n' -u 'nosuchuser:<invalid>' '...same URL...'
403                       # credential presented -> DENIED
$ curl ... scope=repository:fluxcd/kustomize-controller:pull ...
200                       # the other failing image, same result
```

A **403 is positive evidence that a credential was presented and refused.** The
node's pull is therefore not anonymous.

### Where the credential comes from — established, not assumed

It is **not** k3s. wharfie's `GetPrivateRegistries` logs
`Using private registry config file at %s` at INFO **whenever the file exists**
(it returns early without logging only on `os.IsNotExist` — `registries.go:51`).
The node's k3s start is in the journal, reachable read-only through the kubelet
log proxy:

```
$ kubectl get --raw "/api/v1/nodes/vmi3116389/proxy/metrics" | grep process_start_time_seconds
process_start_time_seconds 1.78547062432e+09          # 2026-07-31T04:03:44Z

$ kubectl get --raw ".../proxy/logs/journal/<machine-id>/system@...-000657d35b13e8e4.journal" \
    | strings | grep 'time="2026-07-31T06:0[34]' | grep -iE 'registr|containerd'
... msg="Starting k3s v1.34.4+k3s1 (c6017918)"
... msg="Running containerd -c /var/lib/rancher/k3s/agent/etc/containerd/config.toml"
... msg="containerd is now running"
... msg="Running kubelet --cloud-provider=external ..."
```

**No `Using private registry config file` line.** So `/etc/rancher/k3s/registries.yaml`
does not exist on this node, and neither does any k3s-derived `certs.d`/`hosts.toml`
auth for `ghcr.io`. That negative is only meaningful because the log line was
first confirmed to be emitted unconditionally when the file is present — the
vacuity check. The remaining source for a pod with no `imagePullSecrets` is the
**kubelet docker keyring**: a node-local `config.json`/`.dockercfg`, which no
Kubernetes object exposes.

Ruled out along the way, each with a read rather than an argument:

| candidate | why not |
|---|---|
| ghcr rate-limiting / IP flagged | anonymous from the same node returned 200 during the outage |
| IPv6 dual-stack (the #3840 class) | `dig AAAA ghcr.io` is **empty**; the token request is IPv4-only |
| mirror / proxy interposing | the error names `ghcr.io`; no `registries.yaml`, no rewriting DaemonSet |
| token scoped to a private repo | the scope in the URL is the public `fluxcd/source-controller` |

### Why this is a class, not an incident

kubelet builds its keyring from the pod's `imagePullSecrets` **plus** the node's
docker-config files, tries every credential that matches the registry, and
**never retries anonymously** once they have all failed
(`pkg/kubelet/images/image_manager.go`, `EnsureImageExists`). There is no
anonymous-fallback switch to turn on. One stale node credential turns every
public pull on that node into a hard failure.

Every other namespace on the mothership survived it, and the live cluster shows
why in a single read:

```
$ kubectl -n flux-system get sa -o custom-columns=NAME:.metadata.name,PULLSECRETS:.imagePullSecrets
default                   [map[name:ghcr-bypass-secret]]
helm-controller           <none>
kustomize-controller      <none>
notification-controller   <none>
source-controller         <none>
```

`flux install` gives each controller its **own** ServiceAccount, never `default`,
so the `ghcr-bypass-secret` bolted onto seven `default` SAs on 2026-05-25 misses
exactly the four pods that matter. The controllers that would have redeployed
everything else were the only ones that could not start. The images were gone
(`kubectl get node -o json | jq '.status.images[].names[]' | grep fluxcd` returns
nothing — kubelet image-GC took them during the 10-day scale-to-zero), so the
next pull was a real one.

## The change

One postRenderer patch on the `bp-flux` HelmRelease attaching the **already
existing** `flux-system/ghcr-pull` Secret to every Flux controller ServiceAccount.

A postRenderer for the same reason as the #3735 patch directly above it in that
file: helm-controller owns these objects through the `flux2` subchart and
re-applies its render on every reconcile, so a raw `kubectl patch` is reverted.
The flux2 2.14.1 SA templates expose only `serviceAccount.annotations` — there is
no `imagePullSecrets` value to set — so the render pipeline is the only override
point.

**Chosen over a cloud-init `runcmd` deliberately.** The equivalent shell line
measures 158 bytes, and `infra/providers/hetzner/main.tf` has raised its guardrail
three times (31744 to 32256 to 32512 to 32576, now **192 B** below the 32768 hard
cap) with the comment *"the render is already at its documented floor"*.

That version was built first and proved red-then-green against the `tofu test`
harness, then reverted on the byte budget. Stating the budget evidence precisely,
because it is the one thing here that is an inference rather than a measurement:
the standalone harness renders at **21035 B**, but it substitutes
`registry_mirror_yaml = "mirrors: {}"` and four empty provider blocks, so it is
not the production number. The production number is not measurable without the
full provider module; what `main.tf` records is that the three-region render stood
at **32306 B** at #5057 and that each of the three guardrail raises happened
because the render had reached the previous ceiling. 158 B on top of that is close
enough to 32576 to be a plan-time `precondition` failure on every Hetzner prov,
and the failure mode is worse than the benefit. This alternative lands at **zero
cloud-init bytes**, is reconciled every interval instead of applied once at boot,
and survives node replacement.

This does **not** make public images require authentication, and it does not
replace removing the stale node credential — that is the node-side half, and it
is an operator action. The ordered runbook is below.

### Red, then green

```
# RED — the guard against the pre-fix file
$ scripts/check-flux-controller-pull-credential.sh
FAIL: the bp-flux HelmRelease has NO postRenderer patch attaching an imagePullSecret
FAIL: to the Flux controller ServiceAccounts.
exit 1

# GREEN — after the patch
$ scripts/check-flux-controller-pull-credential.sh
  covered: source-controller / kustomize-controller / helm-controller /
           notification-controller / image-automation-controller /
           image-reflector-controller
PASS
```

End-to-end, not a string match: `helm dependency build` + `helm template` of
`platform/flux/chart` with our own values, then `kubectl kustomize` applying the
HelmRelease's real `postRenderers` list — exactly what helm-controller does.

```
ServiceAccount                 BEFORE  AFTER
helm-controller                None    [{'name': 'ghcr-pull'}]
kustomize-controller           None    [{'name': 'ghcr-pull'}]
notification-controller        None    [{'name': 'ghcr-pull'}]
source-controller              None    [{'name': 'ghcr-pull'}]
image-automation-controller    None    [{'name': 'ghcr-pull'}]
image-reflector-controller     None    [{'name': 'ghcr-pull'}]
bp-flux-stuck-hr-recovery      None    None      <- control, untouched
flux-flux-check                None    None      <- control, untouched

source-controller Deployment RollingUpdate patch still intact: True
```

### Controls that share the suspect property and stay green

- The two **non-controller** ServiceAccounts in the same render are not swept up
  by the selector. They are the objects an unanchored selector would take, so
  they are the ones that prove the anchor works.
- The pre-existing **#3735 / #4849 source-controller Deployment patch** survives
  an edit to the same `postRenderers` list — a control on the edit itself.
- `kubectl kustomize clusters/_template/bootstrap-kit` still builds.
- The guard's `--self-test` runs **five negative controls first**, including a
  2-of-6 selector that must be rejected as incomplete and a greedy selector that
  must be rejected for matching `default`. A green run is evidence the checks
  *can* fail, not evidence they were skipped.

---

# Remediation runbook — the live mothership

**Order matters: credential first, controllers second, reconciliation third, image
roll last.** Rolling `catalyst-api` first is unsafe and stays unsafe until step 1
lands: its Deployment is `strategy=Recreate, replicas=1`, so the old Pod
terminates *before* the new image is pulled and a 403 takes the mothership down
with no recovery path.

Every step states what it asserts before the next one may run, and its recovery
path. **Steps marked WRITE require a cluster or node write and were not performed
here — this session was read-only on all clusters.**

### Step 0 — preflight (READ-ONLY)

```bash
K=~/.kube/config     # mothership

kubectl --kubeconfig $K -n flux-system get deploy \
  -o custom-columns=NAME:.metadata.name,SPEC:.spec.replicas,READY:.status.readyReplicas
kubectl --kubeconfig $K -n flux-system get pod
kubectl --kubeconfig $K -n flux-system get sa \
  -o custom-columns=NAME:.metadata.name,PULLSECRETS:.imagePullSecrets
kubectl --kubeconfig $K -n flux-system get secret \
  --field-selector type=kubernetes.io/dockerconfigjson

curl -s -o /dev/null -w '%{http_code}\n' \
  'https://ghcr.io/token?scope=repository:fluxcd/source-controller:pull&service=ghcr.io'
```

**Assert before proceeding:** the four controller SAs show `<none>`; `ghcr-pull`
and `ghcr-bypass-secret` both exist in `flux-system`; the anonymous token request
returns **200**. If it returns anything else the cause is upstream, not this one,
and the rest of this runbook does not apply.

### Step 1 — WRITE (cluster). The credential, before anything else

```bash
for c in source kustomize helm notification; do
  kubectl --kubeconfig $K -n flux-system patch sa ${c}-controller \
    -p '{"imagePullSecrets":[{"name":"ghcr-pull"}]}'
done
```

**Asserts:**
```bash
kubectl --kubeconfig $K -n flux-system get sa \
  -o custom-columns=NAME:.metadata.name,PULLSECRETS:.imagePullSecrets
# all four must now name a pull secret
```

**Recovery:** fully reversible, touches nothing else.
```bash
kubectl --kubeconfig $K -n flux-system patch sa <name> \
  --type=json -p '[{"op":"remove","path":"/imagePullSecrets"}]'
```

If `ghcr-pull` is itself stale, use `ghcr-bypass-secret` instead — the four stored
ghcr credentials on this cluster were tested against the token endpoint and all
returned 200. If a **freshly minted** PAT also 403s, stop: the failure is not
credential-shaped and step 2 must not run.

### Step 2 — WRITE (cluster). Force the two stuck controllers to re-pull

ServiceAccount `imagePullSecrets` are injected at **pod creation**, so step 1 does
nothing until the pods are recreated. Both are `0/1` and serving nothing, so
deleting them costs no availability.

```bash
kubectl --kubeconfig $K -n flux-system delete pod \
  source-controller-696b487d8b-pkxb2 kustomize-controller-dbc66fb7-zsbcp
```

**Asserts (must hold before step 3):**
```bash
kubectl --kubeconfig $K -n flux-system get pod -w      # both 1/1 Running within ~5m
kubectl --kubeconfig $K -n flux-system get pod \
  -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.spec.imagePullSecrets[*].name}{"\n"}{end}'
```

**Recovery:** if they return to `ImagePullBackOff`, read the *new* waiting message
before changing anything. `403` again means the credential used is also rejected;
mint a fresh one and repeat step 1. A different error (`no such host`, `i/o
timeout`, `manifest unknown`) is a different fault and this runbook stops here.
Reverting step 1 restores the exact prior state.

### Step 3 — WRITE (cluster). Only now, the other two controllers

```bash
kubectl --kubeconfig $K -n flux-system scale deploy \
  helm-controller notification-controller --replicas=1
```

**Asserts:**
```bash
kubectl --kubeconfig $K -n flux-system get deploy \
  -o custom-columns=NAME:.metadata.name,SPEC:.spec.replicas,READY:.status.readyReplicas
scripts/check-flux-gitops-loop-live.sh              # reads status.readyReplicas, not spec
```

`status.readyReplicas` is the only field the cluster writes from observation —
`spec.replicas` records what an operator asked for and cannot fail, which is
exactly how the previous attempt read `VERDICT LIVE` on two `ImagePullBackOff`
pods.

**Recovery:** `--replicas=0` restores the prior state exactly.

### Step 4 — verify reconciliation actually resumes (READ-ONLY)

```bash
kubectl --kubeconfig $K -n flux-system get gitrepository,kustomization
kubectl --kubeconfig $K -n flux-system get kustomization -o json | jq -r \
 '.items[] | "\(.metadata.name)\t\(.status.lastAppliedRevision)\t\((.status.conditions[]|select(.type=="Ready")).lastTransitionTime)"'
```

**Assert:** every `lastTransitionTime` is **now**, not the ~9.5-day-stale values
frozen at `2026-07-31T04:04:22Z`. `Ready=True` alone is not evidence — a
Kustomization owned by a dead controller keeps its last value forever, which is
the whole reason this went unnoticed for ten days.

**Expect a large replay.** Ten days of accumulated commits apply in one step; the
`apps` Kustomization already carries a health-check timeout on
`bp-openova-flow-*` / `powerdns`. Watch it, do not restart it.

### Step 5 — the image roll happens by itself. Do not do it by hand

Once `kustomize-controller` is live it applies the pending `deploy: update
catalyst images` commits and rolls `catalyst-api` itself. The `Recreate,
replicas=1` hazard is safe by then **because** the credential path was fixed
first — and independently, `catalyst-api` already pulls with a working credential
(`catalyst/ghcr-pull`), which is why it pulled fine on 2026-08-10T12:22:08Z while
flux-system could not.

**Assert:**
```bash
kubectl --kubeconfig $K -n catalyst get deploy catalyst-api -o jsonpath='{..image}'
# returns tag T; then, in the repo:
git merge-base --is-ancestor b89d0d621 <T> && echo delivered
```

### Step 6 — WRITE (node). Hygiene, last, and optional

The loop recovers without this. It removes the underlying cause so the next
credential-less pod is not stranded again.

```bash
# find the keyring entry (kubectl cannot see these; node shell required)
grep -l ghcr /var/lib/kubelet/config.json /root/.docker/config.json \
             /root/.dockercfg /.docker/config.json 2>/dev/null
cat /etc/rancher/k3s/registries.yaml 2>/dev/null   # expected: does not exist
```

Remove **only** the `ghcr.io` entry — public `fluxcd` images need none. Verify
with a credential-free pull:

```bash
ctr -n k8s.io images pull ghcr.io/fluxcd/source-controller:v1.8.0   # must succeed
```

**Do not `systemctl restart k3s`** to make this take effect unless that pull still
fails. A control-plane restart on the single-node mothership is the highest-risk
action in this runbook and is not required for the loop to recover.

Worth scrubbing while there: `flux-system/ghcr-bypass-secret` carries a stale
credential in plaintext inside its
`kubectl.kubernetes.io/last-applied-configuration` annotation, readable by anyone
with `get secret`, and it does not match the live `.data`. No value is reproduced
here or anywhere in this repo.

### What this unblocks

Steps 1-5 move **30 of the 61** remaining non-green UAT rows — Cluster A of
`docs/ledger/PATH-TO-100.md`, every one of them MERGED-BUT-UNDEPLOYED on the
mothership and none needing a line of code:

| sub-cluster | rows |
|---|---|
| A1 region-B kubeconfig never forwarded | 55, 62, 64, 65, 66, 187, 188, 189 |
| A2 crossplane adoption never parameterised | G1, G6, 206, 207, 208, 239 |
| A3 deployment wizard is mothership-served | W1, W2 |
| A4 handover never fired | G11, 166, 227 |
| A5 region-B consumer-hub Secrets never delivered | R13, 32, 36, 67, 69, 70, 111, 235, 236 |
| A6 cnpg-pair flip never happens | 60, 71 |

`docs/ledger/UAT.md` is not touched by this PR.

Refs #6079
Refs #5573

🤖 Generated with [Claude Code](https://claude.com/claude-code)
