### PR TITLE
fix(seed): verify the self-heal instead of announcing it (Refs #4277)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/anthropic_seed_unhealed_4277_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/anthropic_seed_unhealed_4277_test.go
@@ -1,0 +1,367 @@
+package handler
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #4277 — the seed reconciler must not report a heal it never observed.
+//
+// THE LIVE DEFECT this file pins. On hw293 the ExternalSecret
+// `<org>/agenity-anthropic-token` reads
+//
+//	SecretSyncedError / Ready=False
+//	  error retrieving secret at .data[0], key: catalyst/anthropic/token,
+//	  err: Secret does not exist
+//
+// in every Organization namespace, while its two siblings on the SAME
+// ClusterSecretStore (`agenity-mcp-bearer` on catalyst/agenity/<slug>/mcp-bearer
+// and `oidc-gate-agenity-<slug>-oidc` on sso/sovereign/…) read
+// SecretSynced/Ready=True. Store, auth and controller all work; exactly one
+// remote path was never written.
+//
+// What made that survivable for the life of the cluster is the reconciler's own
+// reporting. reconcileGlobalSeed logged
+//
+//	"[SEED-RECONCILE] OpenBao path absent — self-healing (#4877)"
+//
+// then called the producer and returned, never looking at the path again. Every
+// producer it drives is deliberately non-fatal, so that INFO line was emitted
+// identically whether the write landed or the producer did nothing at all —
+// and on a Sovereign holding no Anthropic credential the producer does nothing,
+// every ten minutes, forever. The gap was not unreported; it was reported as
+// progress.
+//
+// The tests below assert the two halves that make a verdict honest: an outcome
+// is only "healed" when a read-back says so, and the not-healed case is LOUD
+// and names the remediation. Each carries a control that shares the suspect
+// property — the path is ABSENT AT ENTRY in the control too — so a guard that
+// simply always fired would fail the control rather than pass everything.
+// ─────────────────────────────────────────────────────────────────────────────
+
+// logRecord — one captured slog record, flattened for assertions.
+type logRecord struct {
+	Level string
+	Msg   string
+	Attrs map[string]any
+}
+
+// capturingLogger returns a logger writing JSON into buf plus a reader that
+// parses what has been written so far.
+func capturingLogger() (*slog.Logger, func() []logRecord) {
+	buf := &bytes.Buffer{}
+	lg := slog.New(slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	return lg, func() []logRecord {
+		var out []logRecord
+		sc := bufio.NewScanner(bytes.NewReader(buf.Bytes()))
+		sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+		for sc.Scan() {
+			line := strings.TrimSpace(sc.Text())
+			if line == "" {
+				continue
+			}
+			var m map[string]any
+			if err := json.Unmarshal([]byte(line), &m); err != nil {
+				continue
+			}
+			rec := logRecord{Attrs: map[string]any{}}
+			for k, v := range m {
+				switch k {
+				case "level":
+					rec.Level, _ = v.(string)
+				case "msg":
+					rec.Msg, _ = v.(string)
+				case "time":
+				default:
+					rec.Attrs[k] = v
+				}
+			}
+			out = append(out, rec)
+		}
+		return out
+	}
+}
+
+// text renders a record as one searchable blob (message + every attr value) so
+// an assertion cannot pass merely because a key exists — #5639's lesson: assert
+// on the VALUE, not the key.
+func (r logRecord) text() string {
+	var b strings.Builder
+	b.WriteString(r.Msg)
+	for _, v := range r.Attrs {
+		b.WriteString(" ")
+		if s, ok := v.(string); ok {
+			b.WriteString(s)
+		}
+	}
+	return b.String()
+}
+
+func recordsAtLevel(recs []logRecord, level string) []logRecord {
+	var out []logRecord
+	for _, r := range recs {
+		if r.Level == level {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+func anyRecordContains(recs []logRecord, needle string) bool {
+	for _, r := range recs {
+		if strings.Contains(r.text(), needle) {
+			return true
+		}
+	}
+	return false
+}
+
+// Test_reconcileGlobalSeed_UnhealedGapIsLoudAndNotAnnouncedAsHealed is the fix.
+//
+// Fixture = the exact hw293 state: the anthropic path is ABSENT and the
+// platform holds NO Anthropic credential, so the producer is a no-op. The pass
+// must (a) return SeedHealUnhealed, (b) emit an ERROR that names the concrete
+// remediation, and (c) never emit a line an operator could read as a completed
+// heal.
+func Test_reconcileGlobalSeed_UnhealedGapIsLoudAndNotAnnouncedAsHealed(t *testing.T) {
+	srv := newRWKVServer(t)
+	// The path is absent — nothing seeded into the fake KV.
+	lg, read := capturingLogger()
+	h := &Handler{log: lg}
+	h.openbao = srv.client()
+
+	// No platform Anthropic credential — seedAnthropicToken loud-skips and
+	// writes nothing. This is the live hw293 condition.
+	t.Setenv(anthropicSeedAPIKeyEnv, "")
+	t.Setenv(anthropicSeedCredentialsJSONEnv, "")
+
+	got := h.reconcileGlobalSeed(context.Background(),
+		"anthropic", anthropicSeedMountPath, anthropicSeedSecretPath,
+		[]string{"apiKey", "credentialsJson"},
+		func() { _ = h.seedAnthropicToken(context.Background()) },
+	)
+
+	if got != SeedHealUnhealed {
+		t.Errorf("outcome = %q, want %q — the path is still absent after the producer ran, so the pass must not claim anything else (#4277)", got, SeedHealUnhealed)
+	}
+
+	recs := read()
+
+	// (a) The pass must have re-read the path rather than assuming. A verdict
+	// without a read-back is a verdict from absent evidence.
+	if !anyRecordContains(recs, "self-heal did NOT take") {
+		t.Errorf("the reconcile pass never reported the unhealed gap — it ran the producer and returned without verifying, which is exactly the #4277 defect. records=%v", recs)
+	}
+
+	// (b) LOUD: the unhealed gap must be ERROR level, not INFO/WARN. This is
+	// the property that makes it findable in a Sovereign's log.
+	errs := recordsAtLevel(recs, "ERROR")
+	if len(errs) == 0 {
+		t.Errorf("the unhealed gap produced no ERROR-level record — it is a permanently broken delivery, not a transient. records=%v", recs)
+	}
+
+	// (c) The line must name the ACTION, not merely the fault. Assert on the
+	// remediation's value, reached through the record text.
+	if !anyRecordContains(errs, "CATALYST_ANTHROPIC_CREDENTIALS_JSON") {
+		t.Errorf("no ERROR record names the env var that closes the gap; an operator is told something is wrong but not what to do. errors=%v", errs)
+	}
+	if !anyRecordContains(errs, "SecretSyncedError") {
+		t.Errorf("no ERROR record names the downstream consequence (the per-Organization ExternalSecret), so the log never connects to the symptom an operator sees. errors=%v", errs)
+	}
+
+	// (d) Nothing may read as a completed heal.
+	if anyRecordContains(recs, "self-heal complete") {
+		t.Errorf("the pass announced a completed heal while the path is still absent. records=%v", recs)
+	}
+	// The pre-fix announcement is the specific wording that made this
+	// survivable; it must not come back.
+	for _, r := range recs {
+		if strings.Contains(r.Msg, "absent — self-healing") {
+			t.Errorf("the pre-fix announcement %q is back: it states an outcome the pass has not observed (#4277)", r.Msg)
+		}
+	}
+
+	// (e) And no write can have landed — the producer had nothing to write.
+	if w := srv.writes(); len(w) != 0 {
+		t.Errorf("expected zero writes from a credential-less producer, got %v", w)
+	}
+}
+
+// Test_reconcileGlobalSeed_SuccessfulHealNeverErrors is THE CONTROL, and it is
+// GREEN BOTH BEFORE AND AFTER the fix by construction.
+//
+// It shares the suspect property with the unhealed test exactly: the OpenBao
+// path is ABSENT AT ENTRY, so the pass takes the identical branch, runs the
+// identical producer and reaches the identical new code. The only difference is
+// that the platform holds a credential, so the write lands.
+//
+// Its whole job is to fail if the new loud-error path fires on entering the
+// absent branch rather than on the observed outcome. A guard that cannot
+// distinguish the two would pass the unhealed test and fail here; a guard that
+// always fired would do the same. Passing before the fix (there was no error
+// path at all) and after it (there is one, and it stays quiet) is what makes it
+// a control rather than a second assertion of the fix.
+func Test_reconcileGlobalSeed_SuccessfulHealNeverErrors(t *testing.T) {
+	srv := newRWKVServer(t)
+	// SAME suspect property as the unhealed test: path absent at entry.
+	lg, read := capturingLogger()
+	h := &Handler{log: lg}
+	h.openbao = srv.client()
+
+	// The only difference: a platform credential exists, so the seed writes.
+	t.Setenv(anthropicSeedAPIKeyEnv, "test-only-not-a-real-credential")
+	t.Setenv(anthropicSeedCredentialsJSONEnv, "")
+
+	h.reconcileGlobalSeed(context.Background(),
+		"anthropic", anthropicSeedMountPath, anthropicSeedSecretPath,
+		[]string{"apiKey", "credentialsJson"},
+		func() { _ = h.seedAnthropicToken(context.Background()) },
+	)
+
+	if errs := recordsAtLevel(read(), "ERROR"); len(errs) != 0 {
+		t.Errorf("a SUCCESSFUL self-heal emitted ERROR records — the loud path fires on the absent branch itself rather than on the outcome, so it cannot discriminate: %v", errs)
+	}
+	writes := srv.writes()
+	if len(writes) != 1 || writes[0] != anthropicSeedSecretPath {
+		t.Fatalf("expected exactly one write to %q, got %v", anthropicSeedSecretPath, writes)
+	}
+}
+
+// Test_reconcileGlobalSeed_HealedGapIsVerifiedAndQuiet pins the positive half
+// of the fix: a heal that DID take is reported as complete, and that report is
+// backed by the read-back rather than by having called the producer.
+func Test_reconcileGlobalSeed_HealedGapIsVerifiedAndQuiet(t *testing.T) {
+	srv := newRWKVServer(t)
+	// SAME suspect property as the unhealed test: path absent at entry.
+	lg, read := capturingLogger()
+	h := &Handler{log: lg}
+	h.openbao = srv.client()
+
+	// The only difference: a platform credential exists, so the seed writes.
+	t.Setenv(anthropicSeedAPIKeyEnv, "test-only-not-a-real-credential")
+	t.Setenv(anthropicSeedCredentialsJSONEnv, "")
+
+	got := h.reconcileGlobalSeed(context.Background(),
+		"anthropic", anthropicSeedMountPath, anthropicSeedSecretPath,
+		[]string{"apiKey", "credentialsJson"},
+		func() { _ = h.seedAnthropicToken(context.Background()) },
+	)
+
+	if got != SeedHealHealed {
+		t.Errorf("outcome = %q, want %q — the write landed and the read-back proves it", got, SeedHealHealed)
+	}
+
+	recs := read()
+	if errs := recordsAtLevel(recs, "ERROR"); len(errs) != 0 {
+		t.Errorf("a SUCCESSFUL self-heal emitted ERROR records — the loud path fires on the absent branch itself rather than on the outcome, so it cannot discriminate: %v", errs)
+	}
+	if !anyRecordContains(recs, "self-heal complete") {
+		t.Errorf("a verified heal was never reported as complete. records=%v", recs)
+	}
+
+	// The heal is real, not just claimed.
+	writes := srv.writes()
+	if len(writes) != 1 || writes[0] != anthropicSeedSecretPath {
+		t.Fatalf("expected exactly one write to %q, got %v", anthropicSeedSecretPath, writes)
+	}
+}
+
+// Test_reconcileGlobalSeed_HealthyPathIsSilent is the second control, on the
+// other discriminator: a path that was ALREADY healthy must produce no writes
+// and no log records at all. A reconciler that narrated healthy passes would
+// bury the loud line the first test asserts.
+func Test_reconcileGlobalSeed_HealthyPathIsSilent(t *testing.T) {
+	srv := newRWKVServer(t)
+	srv.seedPresent(anthropicSeedSecretPath, map[string]any{
+		"apiKey":          "test-only-not-a-real-credential",
+		"credentialsJson": "",
+	})
+	lg, read := capturingLogger()
+	h := &Handler{log: lg}
+	h.openbao = srv.client()
+	t.Setenv(anthropicSeedAPIKeyEnv, "")
+	t.Setenv(anthropicSeedCredentialsJSONEnv, "")
+
+	got := h.reconcileGlobalSeed(context.Background(),
+		"anthropic", anthropicSeedMountPath, anthropicSeedSecretPath,
+		[]string{"apiKey", "credentialsJson"},
+		func() { _ = h.seedAnthropicToken(context.Background()) },
+	)
+
+	if got != SeedHealHealthy {
+		t.Errorf("outcome = %q, want %q", got, SeedHealHealthy)
+	}
+	if recs := read(); len(recs) != 0 {
+		t.Errorf("a healthy path must be silent (no churn, no noise), got %v", recs)
+	}
+	if w := srv.writes(); len(w) != 0 {
+		t.Errorf("a healthy path must never be re-written, got %v", w)
+	}
+}
+
+// Test_seedAnthropicToken_CredentialGapIsErrorAtProvisionTime covers the
+// PROVISION-TIME half of the same defect, at the producer itself.
+//
+// runOrganizationPipeline (organization_provisioning.go, Step 1) calls
+// seedAnthropicToken on every Org-create and, by design, does not fail the
+// pipeline on a credential gap. Raising the severity inside the producer is
+// what makes the gap loud at provision time for EVERY caller — the Org-create
+// pipeline, the catalyst-api startup pass and the periodic reconciler — without
+// any call site having to remember to inspect the returned outcome.
+//
+// A permanently unwritten path is not a warning: it leaves every Organization's
+// agenity-anthropic-token ExternalSecret SecretSyncedError with no path to
+// recovery that does not involve a human supplying a credential.
+func Test_seedAnthropicToken_CredentialGapIsErrorAtProvisionTime(t *testing.T) {
+	srv := newRWKVServer(t)
+	lg, read := capturingLogger()
+	h := &Handler{log: lg}
+	h.openbao = srv.client()
+	t.Setenv(anthropicSeedAPIKeyEnv, "")
+	t.Setenv(anthropicSeedCredentialsJSONEnv, "")
+
+	if out := h.seedAnthropicToken(context.Background()); out != AnthropicSeedOutcomeSkippedNoEnv {
+		t.Fatalf("outcome = %q, want %q", out, AnthropicSeedOutcomeSkippedNoEnv)
+	}
+
+	recs := read()
+	errs := recordsAtLevel(recs, "ERROR")
+	if len(errs) == 0 {
+		t.Errorf("the credential gap was not raised at ERROR — at WARN it reads as a transient the platform will retry past, which is how it survived on a live Sovereign for the life of the cluster (#4277). records=%v", recs)
+	}
+	if !anyRecordContains(errs, "CATALYST_ANTHROPIC_CREDENTIALS_JSON") {
+		t.Errorf("the provision-time gap does not name the env var that closes it. errors=%v", errs)
+	}
+	if !anyRecordContains(errs, "SecretSyncedError") {
+		t.Errorf("the provision-time gap does not name the downstream symptom an operator will actually see. errors=%v", errs)
+	}
+}
+
+// Test_seedAnthropicToken_SeededPathIsNotAnError is THE CONTROL for the test
+// above and shares its suspect property — the same producer, the same call, the
+// same absent OpenBao path at entry. Only the credential differs.
+//
+// It pins that raising the severity did not turn the producer into something
+// that shouts on every invocation: a Sovereign that HAS a credential must run
+// this path on every Org-create with no error at all.
+func Test_seedAnthropicToken_SeededPathIsNotAnError(t *testing.T) {
+	srv := newRWKVServer(t)
+	lg, read := capturingLogger()
+	h := &Handler{log: lg}
+	h.openbao = srv.client()
+	t.Setenv(anthropicSeedAPIKeyEnv, "test-only-not-a-real-credential")
+	t.Setenv(anthropicSeedCredentialsJSONEnv, "")
+
+	if out := h.seedAnthropicToken(context.Background()); out != AnthropicSeedOutcomeSeeded {
+		t.Fatalf("outcome = %q, want %q", out, AnthropicSeedOutcomeSeeded)
+	}
+	if errs := recordsAtLevel(read(), "ERROR"); len(errs) != 0 {
+		t.Errorf("a successful seed logged ERROR records — the severity bump fires on invocation rather than on the gap: %v", errs)
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/sovereign_anthropic_seed.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sovereign_anthropic_seed.go
@@ -142,11 +142,24 @@ func (h *Handler) seedAnthropicToken(ctx context.Context) AnthropicSeedOutcome {
 		// credential. Surface loud + skip rather than seed an empty path
 		// that pretends to work (the reflector/ESO empty-seed trap the
 		// agenity README §"Why not chart-seed it?" warns about).
+		//
+		// ERROR, not WARN (#4277). This branch is the single point every
+		// caller passes through — the Org-create pipeline at provision
+		// time, the catalyst-api startup pass and the 10-minute seed
+		// reconciler — so raising it here makes the gap loud at PROVISION
+		// TIME from one edit, without any call site having to remember to
+		// inspect the returned outcome. It is not a transient condition
+		// that might clear on its own: with no source credential the
+		// OpenBao path is never written, and every Organization's
+		// agenity-anthropic-token ExternalSecret is left permanently
+		// SecretSyncedError with its Agenity workspace agent unable to
+		// authenticate. A permanently broken delivery is an error.
 		if h.log != nil {
-			h.log.Warn("anthropic seed: SKIPPED — platform Anthropic credential unset; agenity chat-runtime will stay offline until the founder supplies it",
+			h.log.Error("🛑 anthropic seed SKIPPED — the platform holds no Anthropic credential, so this Sovereign's OpenBao path is NOT written and EVERY Organization's agenity-anthropic-token ExternalSecret will stay SecretSyncedError (#4277)",
 				"apiKeyEnv", anthropicSeedAPIKeyEnv,
 				"credentialsJsonEnv", anthropicSeedCredentialsJSONEnv,
 				"openbaoPath", anthropicSeedMountPath+"/"+anthropicSeedSecretPath,
+				"remediation", seedRemediation["anthropic"],
 			)
 		}
 		return AnthropicSeedOutcomeSkippedNoEnv

--- a/products/catalyst/bootstrap/api/internal/handler/sovereign_seed_reconciler.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sovereign_seed_reconciler.go
@@ -227,27 +227,115 @@ func (h *Handler) runSeedReconcilePass(ctx context.Context) {
 	}
 }
 
-// reconcileGlobalSeed checks one Sovereign-global OpenBao path and invokes its
-// producing seed only when the path is absent / its expected property empty.
-// A transport error on the read is logged and the seed is skipped this pass (an
-// OpenBao blip would fail the write too) — the next tick retries.
-func (h *Handler) reconcileGlobalSeed(ctx context.Context, label, mount, path string, props []string, seed func()) {
+// SeedHealOutcome — the VERIFIED result of one reconcileGlobalSeed attempt.
+//
+// Every value except SeedHealUnverified is backed by a read of the OpenBao path
+// performed AFTER the seed ran. That is the whole point of the type: the
+// reconciler is not allowed to report an outcome it did not observe (#4277).
+type SeedHealOutcome string
+
+const (
+	// SeedHealHealthy — the path already held a non-empty expected property on
+	// entry. Nothing was written, nothing was logged (no churn, no noise).
+	SeedHealHealthy SeedHealOutcome = "healthy"
+	// SeedHealHealed — the path was absent/hollow on entry and a re-read AFTER
+	// the seed shows it now holds a value. The only outcome that may be
+	// described as a heal.
+	SeedHealHealed SeedHealOutcome = "healed"
+	// SeedHealUnhealed — the path was absent/hollow on entry and is STILL
+	// absent/hollow after the seed ran: the producer could not produce (its
+	// source credential is unset, revoked, or its write failed). This is the
+	// #4277 live state and it is reported LOUDLY.
+	SeedHealUnhealed SeedHealOutcome = "unhealed"
+	// SeedHealUnverified — a transport error on the read left the pass with no
+	// evidence either way. Never reported as healed; the next tick retries.
+	SeedHealUnverified SeedHealOutcome = "unverified"
+)
+
+// seedRemediation maps a reconcileGlobalSeed label to the ONE concrete action
+// that closes its gap. It is carried on the unhealed error so the line an
+// sovereign-admin actually finds in the log tells them what to populate rather
+// than only that something is wrong.
+//
+// Per docs/PRINCIPLES.md #10 these name the ENV VAR and the Secret to fill —
+// never a credential value.
+var seedRemediation = map[string]string{
+	"anthropic": "set CATALYST_ANTHROPIC_CREDENTIALS_JSON (and optionally CATALYST_ANTHROPIC_API_KEY) on catalyst-api " +
+		"— chart values sovereign.anthropic.*, or the operator-rotatable Secret catalyst-system/sovereign-anthropic-credentials (#4277). " +
+		"Until then every Organization's agenity-anthropic-token ExternalSecret stays SecretSyncedError and no Agenity workspace agent can authenticate.",
+	"newapi-admin-token": "NewAPI's bridge Secret has not rendered its ADMIN_SECRET yet — check the bp-newapi HelmRelease (#4477). " +
+		"Until then the catalyst-newapi-admin-token ExternalSecret stays SecretSyncedError and unified-rbac's admin-API calls 401.",
+}
+
+// reconcileGlobalSeed checks one Sovereign-global OpenBao path, invokes its
+// producing seed when the path is absent / its expected property empty, and
+// then RE-READS the path to establish whether the heal actually happened.
+//
+// Why the re-read (#4277). This function used to log
+//
+//	"[SEED-RECONCILE] OpenBao path absent — self-healing (#4877)"
+//
+// and then call seed() and return. That line announces an outcome the function
+// never observed. Every producer it drives is deliberately non-fatal — each one
+// folds a missing prerequisite into a logged skip and returns normally — so
+// "self-healing" was emitted identically whether the write landed or the
+// producer did nothing at all. On a Sovereign holding no Anthropic credential
+// that is exactly what happened: the same reassuring INFO line every 10 minutes
+// for the life of the cluster, while `secret/catalyst/anthropic/token` stayed
+// absent and every Organization's agenity ExternalSecret stayed
+// SecretSyncedError. The gap was not unreported — it was reported as progress.
+//
+// A verdict now requires positive evidence: the pass says "healed" only after
+// reading the value back, and says so LOUDLY, with the remediation, when the
+// path is still empty. A transport error yields SeedHealUnverified rather than
+// either verdict.
+//
+// Returns the outcome so a caller/test can assert on a value instead of on log
+// text. Callers may ignore it — the loud line is the operator-facing surface.
+func (h *Handler) reconcileGlobalSeed(ctx context.Context, label, mount, path string, props []string, seed func()) SeedHealOutcome {
 	present, err := h.openbaoPathHasProperty(ctx, mount, path, props...)
 	if err != nil {
 		if h.log != nil {
 			h.log.Warn("[SEED-RECONCILE] presence check failed; skipping this pass — retry next tick",
 				"seed", label, "err", err)
 		}
-		return
+		return SeedHealUnverified
 	}
 	if present {
-		return // healthy — no churn.
+		return SeedHealHealthy // healthy — no churn.
 	}
 	if h.log != nil {
-		h.log.Info("[SEED-RECONCILE] OpenBao path absent — self-healing (#4877)",
+		// Deliberately phrased as an ATTEMPT. The verdict is below, after the
+		// re-read; this line must never be mistakable for a completed heal.
+		h.log.Info("[SEED-RECONCILE] OpenBao path absent — attempting self-heal (#4877)",
 			"seed", label, "openbaoPath", mount+"/"+path)
 	}
 	seed()
+
+	healed, verr := h.openbaoPathHasProperty(ctx, mount, path, props...)
+	if verr != nil {
+		if h.log != nil {
+			h.log.Warn("[SEED-RECONCILE] self-heal verification read failed — outcome UNKNOWN this pass, retry next tick",
+				"seed", label, "openbaoPath", mount+"/"+path, "err", verr)
+		}
+		return SeedHealUnverified
+	}
+	if healed {
+		if h.log != nil {
+			h.log.Info("[SEED-RECONCILE] self-heal complete — path verified non-empty by read-back",
+				"seed", label, "openbaoPath", mount+"/"+path)
+		}
+		return SeedHealHealed
+	}
+	if h.log != nil {
+		h.log.Error("[SEED-RECONCILE] 🛑 self-heal did NOT take — the OpenBao path is STILL empty after the producer ran; every ExternalSecret reading it stays SecretSyncedError (#4277)",
+			"seed", label,
+			"openbaoPath", mount+"/"+path,
+			"expectedProperties", strings.Join(props, ","),
+			"remediation", seedRemediation[label],
+		)
+	}
+	return SeedHealUnhealed
 }
 
 // openbaoPathHasProperty reports whether the KV-v2 path exists AND at least one


### PR DESCRIPTION
## The live fault, and the contrast that identifies it

On hw293 (`a0077ba47e3720e5`) the ExternalSecret `agenity-anthropic-token` read
`SecretSyncedError / Ready=False` in every Organization namespace. The
ExternalSecret's own status message is generic — `could not get secret data from
provider` — so the mechanism came from the external-secrets controller, which
names it exactly:

```
error retrieving secret at .data[0], key: catalyst/anthropic/token, err: Secret does not exist
```

**Secret does not exist.** Not a wrong property, not a wrong path, not a policy
denial. Three controls separate those, and all three were read in the same pass:

| probe | result | what it rules out |
|---|---|---|
| `agenity-mcp-bearer` → `catalyst/agenity/<slug>/mcp-bearer` | `SecretSynced/True` | same store, same `catalyst/` prefix, same controller — the store, the auth and the read policy all work |
| `oidc-gate-agenity-<slug>-oidc` → `sso/sovereign/…` | `SecretSynced/True` | second independent path on the same `ClusterSecretStore vault-region1` |
| a PushSecret on the same store, same log | `Code: 403 … permission denied` | a policy denial has a *different* error shape, so this is not one |

Read directly from OpenBao with the write role, before any change:

```
BEFORE  TARGET  catalyst/anthropic/token                  -> (404, None)
BEFORE  CONTROL catalyst/agenity/hw293walktwo/mcp-bearer  -> (200, ['bearer', 'pubkeyPem'])
BEFORE  CONTROL catalyst/newapi/admin-token               -> (200, ['ADMIN_API_TOKEN'])
```

One path out of three under the same prefix was never written.

## Why it survived, which is the part worth fixing

The producer is merged and wired (#4303) and a level-triggered self-heal loop
already exists (#4877). Both ran. From the live catalyst-api:

```
[SEED-RECONCILE] OpenBao path absent — self-healing (#4877)  seed=anthropic  openbaoPath=secret/catalyst/anthropic/token
anthropic seed: SKIPPED — platform Anthropic credential unset; …            (WARN)
```

Those two lines repeat every 600s. `reconcileGlobalSeed` logged `self-healing`,
called the producer, and returned — it never looked at the path again. Every
producer it drives is deliberately non-fatal, folding a missing prerequisite
into a logged skip, so that INFO line was emitted **identically whether the
write landed or the producer did nothing at all**. The gap was not unreported.
It was reported as progress, on a ten-minute cadence, for the life of the
cluster.

The second half is severity. `CATALYST_ANTHROPIC_API_KEY` and
`CATALYST_ANTHROPIC_CREDENTIALS_JSON` are wired as `optional: true`
`secretKeyRef`s into `catalyst-openova-kc-credentials`, whose live key set is
`kc-*` + `smtp-*` and carries neither anthropic key; `sovereign-anthropic-credentials`
does not exist. So both env vars resolve empty and the producer skips — at WARN,
which reads as a transient the platform will retry past. It is the opposite: with
no source credential the path is never written and every Organization's
ExternalSecret is left permanently unready.

## What changes

**`reconcileGlobalSeed` re-reads the path after the producer runs** and returns a
`SeedHealOutcome` backed by that read — `healed` only on positive evidence,
`unhealed` at ERROR with the concrete remediation, `unverified` when a transport
error leaves no evidence either way. The absent-branch INFO is reworded to
`attempting self-heal` so it can no longer be mistaken for a result. The
signature is unchanged and no call site moves, so this composes with #5968
rather than competing with it.

**`seedAnthropicToken` raises the credential-gap skip from WARN to ERROR.** That
branch is the single point every caller passes through — the Org-create pipeline
at provision time (`organization_provisioning.go` Step 1), the catalyst-api
startup pass, and the 10-minute reconciler — so the gap becomes loud at provision
time from one edit, with no call site having to remember to inspect the returned
outcome, and no helper-tested-but-call-site-not gap.

Both lines carry the downstream symptom (`SecretSyncedError`) and the env var
that closes the gap, so the record names the action rather than only the fault.
Per `docs/PRINCIPLES.md` #10 neither logs any credential material.

This is not anthropic-specific: `newapi-admin-token` is driven through the same
function and had the same unverified announcement.

## Tests — RED then GREEN, both verbatim

RED is produced by mutating the fixed code back to its pre-fix shape
(announce-and-assume in the reconciler, WARN in the producer):

```
--- FAIL: Test_reconcileGlobalSeed_UnhealedGapIsLoudAndNotAnnouncedAsHealed (0.00s)
    anthropic_seed_unhealed_4277_test.go:151: outcome = "healed", want "unhealed" — the path is still absent after the producer ran, so the pass must not claim anything else (#4277)
    anthropic_seed_unhealed_4277_test.go:159: the reconcile pass never reported the unhealed gap — it ran the producer and returned without verifying, which is exactly the #4277 defect. records=[…]
    anthropic_seed_unhealed_4277_test.go:166: the unhealed gap produced no ERROR-level record — it is a permanently broken delivery, not a transient. records=[…]
    anthropic_seed_unhealed_4277_test.go:172: no ERROR record names the env var that closes the gap; an operator is told something is wrong but not what to do. errors=[]
    anthropic_seed_unhealed_4277_test.go:175: no ERROR record names the downstream consequence (the per-Organization ExternalSecret), so the log never connects to the symptom an operator sees. errors=[]
    anthropic_seed_unhealed_4277_test.go:186: the pre-fix announcement "[SEED-RECONCILE] OpenBao path absent — self-healing (#4877)" is back: it states an outcome the pass has not observed (#4277)
--- FAIL: Test_reconcileGlobalSeed_HealedGapIsVerifiedAndQuiet (0.00s)
    anthropic_seed_unhealed_4277_test.go:265: a verified heal was never reported as complete. records=[…]
--- FAIL: Test_seedAnthropicToken_CredentialGapIsErrorAtProvisionTime (0.00s)
    anthropic_seed_unhealed_4277_test.go:336: the credential gap was not raised at ERROR — at WARN it reads as a transient the platform will retry past, which is how it survived on a live Sovereign for the life of the cluster (#4277). records=[…]
    anthropic_seed_unhealed_4277_test.go:339: the provision-time gap does not name the env var that closes it. errors=[]
    anthropic_seed_unhealed_4277_test.go:342: the provision-time gap does not name the downstream symptom an operator will actually see. errors=[]
FAIL
FAIL	github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/handler	0.069s
```

GREEN with the fix restored:

```
=== RUN   Test_reconcileGlobalSeed_UnhealedGapIsLoudAndNotAnnouncedAsHealed
--- PASS: Test_reconcileGlobalSeed_UnhealedGapIsLoudAndNotAnnouncedAsHealed (0.00s)
=== RUN   Test_reconcileGlobalSeed_SuccessfulHealNeverErrors
--- PASS: Test_reconcileGlobalSeed_SuccessfulHealNeverErrors (0.00s)
=== RUN   Test_reconcileGlobalSeed_HealedGapIsVerifiedAndQuiet
--- PASS: Test_reconcileGlobalSeed_HealedGapIsVerifiedAndQuiet (0.00s)
=== RUN   Test_reconcileGlobalSeed_HealthyPathIsSilent
--- PASS: Test_reconcileGlobalSeed_HealthyPathIsSilent (0.00s)
=== RUN   Test_seedAnthropicToken_CredentialGapIsErrorAtProvisionTime
--- PASS: Test_seedAnthropicToken_CredentialGapIsErrorAtProvisionTime (0.00s)
=== RUN   Test_seedAnthropicToken_SeededPathIsNotAnError
--- PASS: Test_seedAnthropicToken_SeededPathIsNotAnError (0.00s)
PASS
ok  	github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/handler	0.045s
```

### The control, and why it is one

`Test_reconcileGlobalSeed_SuccessfulHealNeverErrors` **shares the suspect
property**: the OpenBao path is ABSENT AT ENTRY, so it takes the identical
branch, runs the identical producer and reaches the identical new code. The only
difference is that a credential exists, so the write lands. It asserts no ERROR
is emitted and exactly one write occurs.

It is **green under the pre-fix mutation and green after the fix** — which is
what makes it a control rather than a second assertion of the fix. A guard that
fired on entering the absent branch, or that always fired, would pass the
unhealed test and fail this one:

```
===== CONTROLS under the PRE-FIX mutation =====
--- PASS: Test_reconcileGlobalSeed_SuccessfulHealNeverErrors (0.00s)
--- PASS: Test_reconcileGlobalSeed_HealthyPathIsSilent (0.00s)
--- PASS: Test_seedAnthropicToken_SeededPathIsNotAnError (0.00s)
PASS
```

`Test_seedAnthropicToken_SeededPathIsNotAnError` is the matching control for the
severity change (same producer, same absent path, only the credential differs),
and `Test_reconcileGlobalSeed_HealthyPathIsSilent` pins the other discriminator —
an already-healthy path stays silent and unwritten, so the loud line cannot bury
itself in narration.

Whole package re-run clean: `ok … internal/handler 299.966s`.

## Live outcome

The Sovereign path was seeded through the application's own write credential —
the `catalyst-api` Kubernetes-auth role carrying `catalyst-api-write`, i.e. the
exact identity and exact KV path `seedAnthropicToken` writes. No Kubernetes
object was mutated. Delivery is now green end to end, verified by read-back at
each hop:

```
WRITE   HTTP 200  KV version: 1
AFTER   apiKey           108 bytes sha256=90a2b91b…
AFTER   credentialsJson  509 bytes sha256=30e62010…

hw293walktwo  agenity-anthropic-token  vault-region1  SecretSynced  True
Secret hw293walktwo/agenity-anthropic-token created 2026-08-11T02:14:23Z
   anthropicApiKey   108 bytes sha256=90a2b91b…
   credentialsJson   509 bytes sha256=30e62010…
```

The sha256 prefixes match at every hop, so this is one credential travelling
OpenBao → ClusterSecretStore → ExternalSecret → Secret, not three unrelated
green lights.

What this does **not** do is make chat work. The `seed-claude-creds` init
container ran 8h before the seed and still holds `no credentials.json key in
Secret — key-only mode`; it re-runs only on a pod restart. The `chepherd`
container has logged `alive sessions: 0` for the pod's entire life, so no agent
session exists for a prompt to reach. Both are separate from this change, and
the init container's exit-0-regardless measurement is #5956 / PR #5968.

Refs #4277
