### PR TITLE
fix(console): stop publishing a DR/suspend verdict from absent evidence (rows 197, 63)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.declared-standby-63.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.declared-standby-63.test.tsx
@@ -1,0 +1,194 @@
+/**
+ * TopologyTab.declared-standby-63.test.tsx — UAT row 63, the residual half.
+ *
+ * Row 63's clause: an Application **declaring** active-hot-standby with NO
+ * Continuum backing renders an honest no-backing DR section — "Switchover
+ * unavailable" copy, the control DISABLED, and NO synthesized lag / standby /
+ * target-region values.
+ *
+ * #6061 (`c4dd18f21`) fixed the half where `status.perCluster` SHADOWED a
+ * `status.targets` that already named the pair. That half is delivered and is
+ * locked by TopologyTab.statusTargets-shadowed.test.tsx. This file locks the
+ * half underneath it, which #6061 did not touch:
+ *
+ *   showDR = hasStandby || hasLiveDR
+ *
+ * Both terms are derived from OBSERVED state — a projected Standby target, or
+ * a live Continuum reading. Neither consults what the Application CR DECLARES.
+ * So an app whose `spec.placement.mode` says `active-hot-standby` while nothing
+ * has been observed yet (empty runtime placement, empty `status.targets`, and a
+ * `status.perCluster` that saw only region A) gets `showDR === false` and the
+ * whole `topology-tab-dr-*` subtree VANISHES.
+ *
+ * That is a verdict published from ABSENT evidence: the page states "this app
+ * has no DR" by omission, when the truth on the object is "a standby is
+ * declared and nothing has reported on it yet". An absent control and a
+ * disabled control are not the same statement, which is the precise confusion
+ * row 63 exists to forbid.
+ *
+ * THE CONTROL SHARES THE SUSPECT PROPERTY. `SINGLETON_SAME_OBSERVATION` is
+ * byte-identical to the failing fixture — same empty runtime placement, same
+ * empty `status.targets`, same one-entry `status.perCluster`, same pending
+ * Continuum answer — and differs ONLY in the declared mode. It must keep
+ * rendering NO DR panel (row 58: never arm a DR block against a phantom
+ * region). Without that half this file would pass just as well against a
+ * change that rendered a DR section for every application in the catalog.
+ */
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest'
+import { render, screen, cleanup, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+const getApplicationStatus = vi.fn()
+const getCatalogItem = vi.fn()
+const getApplicationPlacement = vi.fn()
+const getHierarchicalInfrastructure = vi.fn()
+const getContinuumReplicationStatus = vi.fn()
+
+vi.mock('@/lib/catalog.api', () => ({
+  getApplicationStatus: (...a: unknown[]) => getApplicationStatus(...a),
+  getCatalogItem: (...a: unknown[]) => getCatalogItem(...a),
+  getApplicationPlacement: (...a: unknown[]) => getApplicationPlacement(...a),
+}))
+
+vi.mock('@/lib/continuum.api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/continuum.api')>()
+  return {
+    ...actual,
+    getContinuumReplicationStatus: (...a: unknown[]) => getContinuumReplicationStatus(...a),
+  }
+})
+
+vi.mock('@/lib/infrastructure.types', () => ({
+  getHierarchicalInfrastructure: (...a: unknown[]) => getHierarchicalInfrastructure(...a),
+}))
+
+vi.mock('@/widgets/topology/PlacementEditor', () => ({
+  PlacementEditor: () => <div data-testid="stub-placement-editor" />,
+}))
+
+import { TopologyTab } from './TopologyTab'
+
+function withProviders(node: React.ReactNode) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return <QueryClientProvider client={qc}>{node}</QueryClientProvider>
+}
+
+const REGION_A = 'hw-me-east-215-a-rtz-prod'
+const REGION_B = 'hw-me-east-215-b-rtz-prod'
+
+/**
+ * The hw293 `hw293walkone/uat50-ahs-pg` shape, verbatim in structure: the CR
+ * DECLARES active-hot-standby with a standby region, and NOTHING has observed
+ * that standby — no runtime targets, no `status.targets`, and a
+ * `status.perCluster` carrying the single `singleton` entry the
+ * application-controller wrote after fanning the HelmRelease out to region A
+ * only.
+ */
+const DECLARED_AHS_NOTHING_OBSERVED = {
+  name: 'uat50-ahs-pg',
+  namespace: 'hw293walkone',
+  spec: { placement: { mode: 'active-hot-standby', standbyRegions: [REGION_B] } },
+  status: { perCluster: [{ cluster: REGION_A, role: 'singleton' }] },
+}
+
+/**
+ * THE CONTROL — identical in every observable respect, declaring `singleton`.
+ * Same empty runtime placement, same absent status.targets, same one-entry
+ * perCluster, same pending Continuum answer.
+ */
+const SINGLETON_SAME_OBSERVATION = {
+  name: 'uat50-single-pg',
+  namespace: 'hw293walkone',
+  spec: { placement: { mode: 'singleton' } },
+  status: { perCluster: [{ cluster: REGION_A, role: 'singleton' }] },
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  // Rung 1 answers EMPTY — the live hw293 reading was
+  // {"targets":[],"derivedFromRuntime":true}.
+  getApplicationPlacement.mockResolvedValue({ targets: [], derivedFromRuntime: true })
+  getCatalogItem.mockResolvedValue({ name: 'bp-postgres', placementCapability: 'active-hot-standby' })
+  getHierarchicalInfrastructure.mockResolvedValue({ regions: [] })
+  // NO live Continuum backing — the `source:"pending"` fallback envelope the
+  // endpoint really answers with (#5514). Never an error, never `live`.
+  getContinuumReplicationStatus.mockResolvedValue({ source: 'pending' })
+})
+
+afterEach(() => cleanup())
+
+describe('row 63 — a DECLARED standby with nothing observed must render the disabled control, not vanish', () => {
+  it('renders the DR section with a DISABLED switchover and a named reason', async () => {
+    getApplicationStatus.mockResolvedValue(DECLARED_AHS_NOTHING_OBSERVED)
+    render(
+      withProviders(
+        <TopologyTab
+          sovereignId="dep-1"
+          applicationName="uat50-ahs-pg"
+          namespace="hw293walkone"
+        />,
+      ),
+    )
+
+    // Anchor on the SUBJECT first — the replication answer this case is about —
+    // so the assertions below cannot pass on a page that has not painted.
+    await waitFor(() => expect(getContinuumReplicationStatus).toHaveBeenCalled())
+
+    // Clause part 1 + 2: the control EXISTS and is DISABLED.
+    const btn = await screen.findByTestId('topology-tab-dr-switchover-open')
+    expect(btn).toBeTruthy()
+    expect((btn as HTMLButtonElement).disabled).toBe(true)
+
+    // Clause part 1: the "Switchover unavailable" copy, with a reason.
+    const reason = screen.getByTestId('topology-tab-dr-switchover-reason')
+    expect(reason.textContent).toContain('Switchover unavailable')
+
+    // Clause part 3: NO synthesized lag / standby / target-region values.
+    // These must stay absent — the disabled control is the whole statement.
+    expect(screen.queryByTestId('topology-tab-dr-lag-value')).toBeNull()
+    expect(screen.queryByTestId('topology-tab-dr-regions')).toBeNull()
+    expect(screen.queryByTestId('topology-tab-dr-standby')).toBeNull()
+  })
+
+  it('names the declaration as the reason the section is there at all', async () => {
+    getApplicationStatus.mockResolvedValue(DECLARED_AHS_NOTHING_OBSERVED)
+    render(
+      withProviders(
+        <TopologyTab
+          sovereignId="dep-1"
+          applicationName="uat50-ahs-pg"
+          namespace="hw293walkone"
+        />,
+      ),
+    )
+
+    // The operator must be told WHY a DR section is showing for an app whose
+    // placement panel reads `singleton`: the CR declares a standby and nothing
+    // has reported on it. Silence here is the same absent-evidence defect one
+    // level down.
+    const note = await screen.findByTestId('topology-tab-dr-unbacked')
+    expect(note.textContent).toContain('DECLARES a standby')
+  })
+
+  it('CONTROL — the same observation declaring `singleton` still shows NO DR panel', async () => {
+    getApplicationStatus.mockResolvedValue(SINGLETON_SAME_OBSERVATION)
+    render(
+      withProviders(
+        <TopologyTab
+          sovereignId="dep-1"
+          applicationName="uat50-single-pg"
+          namespace="hw293walkone"
+        />,
+      ),
+    )
+
+    // Same anchor as the positive case, so this negative cannot pass merely
+    // because nothing has rendered yet.
+    await waitFor(() => expect(getContinuumReplicationStatus).toHaveBeenCalled())
+    await waitFor(() => expect(screen.getByTestId('topology-tab-placement-panel')).toBeTruthy())
+
+    expect(screen.queryByTestId('topology-tab-dr-panel')).toBeNull()
+    expect(screen.queryByTestId('topology-tab-dr-switchover')).toBeNull()
+    expect(screen.queryByTestId('topology-tab-dr-switchover-open')).toBeNull()
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.tsx
@@ -37,6 +37,10 @@ import {
 } from '@/lib/continuum.api'
 import { getHierarchicalInfrastructure } from '@/lib/infrastructure.types'
 import { PlacementEditor, type OwnedDependencyInfo } from '@/widgets/topology/PlacementEditor'
+// #3648/#3375 — the ONE canonicaliser for the topology-mode vocabulary, mirrored
+// from Go's placement.Canonicalize. Used here (row 63) so a CR declaring
+// `active-hotstandby` is read the same as one declaring `active-hot-standby`.
+import { canonicalizeMode } from '@/widgets/topology/modes'
 import { SwitchoverDialog } from '@/widgets/continuum/SwitchoverDialog'
 import {
   type Capability,
@@ -393,6 +397,54 @@ export function TopologyTab({
     () => targets.some((t) => t.role === 'Standby'),
     [targets],
   )
+
+  // UAT row 63 — WHAT THE CR DECLARES, independently of what was observed.
+  //
+  // `hasStandby` above and `hasLiveDR` below are both derived from OBSERVED
+  // state: a projected Standby target, or a live Continuum reading. Neither
+  // consults what the Application CR DECLARES. On hw293,
+  // `hw293walkone/uat50-ahs-pg` declared `spec.placement.mode:
+  // active-hot-standby` with `standbyRegions [<region-b>]` while nothing had
+  // observed that standby yet — /placement answered `{"targets":[]}`,
+  // `status.targets` was absent, and `status.perCluster` held the single
+  // `singleton` entry the controller wrote after fanning the HelmRelease out to
+  // region A only. So both observed terms were false, `showDR` was false, and
+  // the ENTIRE `topology-tab-dr-*` subtree was absent from the page.
+  //
+  // That is a verdict published from ABSENT evidence, which is the exact thing
+  // row 63 exists to forbid: the page stated "this app has no DR" by omission,
+  // when the object said "a standby is declared and nothing has reported on it
+  // yet". An absent control and a disabled control are not the same statement —
+  // only the second one tells the operator that switchover is a thing this app
+  // HAS and cannot currently do.
+  //
+  // #6061 fixed the rung ABOVE this one (an incomplete `status.perCluster`
+  // shadowing a `status.targets` that already named the pair). It does not help
+  // an app on which NEITHER field was ever written.
+  //
+  // Read only the DECLARED posture here — `spec.placement.mode` on the #3969
+  // object form, the legacy `spec.placement` string, or the pre-#3969
+  // `status.placement` string — and canonicalise it so both spellings of every
+  // mode compare correctly. `singleton` and `active-active` declare no standby
+  // and must NOT open the section: that keeps row 58 (never arm a DR block
+  // against a phantom region) intact, and it is what makes this a
+  // discrimination rather than a blanket promotion.
+  const declaresStandby = useMemo(() => {
+    const specPlacement = app?.spec?.placement
+    const status = (app?.status ?? {}) as Record<string, unknown>
+    const declaredMode =
+      specPlacement && typeof specPlacement === 'object'
+        ? (specPlacement as Record<string, unknown>).mode
+        : typeof specPlacement === 'string'
+          ? specPlacement
+          : typeof status.placement === 'string'
+            ? status.placement
+            : ''
+    if (typeof declaredMode !== 'string' || declaredMode === '') return false
+    const mode = canonicalizeMode(declaredMode)
+    return mode === 'active-hot-standby' || mode === 'active-passive'
+  }, [app])
+
   const continuumName = useMemo(() => `dr-${applicationName}`, [applicationName])
 
   // Poll the DR endpoint for every networked app and gate rendering on a
@@ -556,7 +608,13 @@ export function TopologyTab({
   // here; it was the client that ignored the flag.
   const drBacked = drStatus?.source === 'live'
 
-  const showDR = hasStandby || hasLiveDR
+  // UAT row 63 — the third term is the DECLARATION. `hasStandby` and
+  // `hasLiveDR` are both observations; when both are false the honest answer is
+  // "nothing has reported", not "this app has no DR". `declaresStandby` opens
+  // the section for an app whose CR asks for a standby, and the section's own
+  // `!drBacked` branch below then renders the DISABLED control with its reason
+  // and NOTHING numeric — so this can never arm a phantom switchover (#5514).
+  const showDR = hasStandby || hasLiveDR || declaresStandby
 
   // #4923/#4901 — the EXPLICIT standby-absent condition. The backend verifies
   // the standby leg off the live cnpg cluster-pair and reports the tri-state
@@ -937,7 +995,16 @@ export function TopologyTab({
                   ? 'Checking for a cross-region replica…'
                   : 'No cross-region replica reporting yet for this component.'}
               </p>
-              {hasStandby && drStatus && !drQ.isLoading ? (
+              {/* UAT row 63 — `declaresStandby` joins `hasStandby` here for the
+                  same reason it joins `showDR`: on an app whose standby was
+                  DECLARED but never observed, `hasStandby` is false, so without
+                  it the operator would be shown a DR section with no statement
+                  of why it is there while the Placement panel beside it reads
+                  `singleton`. Silence at that point is the same absent-evidence
+                  defect one level down. `drStatus` is still required — the note
+                  names the reading, so it may not be printed before one
+                  arrives. */}
+              {(hasStandby || declaresStandby) && drStatus && !drQ.isLoading ? (
                 <p
                   className="mt-2 text-xs text-yellow-400"
                   data-testid="topology-tab-dr-unbacked"

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/ReconcileTab.absent-evidence-197.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/ReconcileTab.absent-evidence-197.test.tsx
@@ -1,0 +1,209 @@
+/**
+ * ReconcileTab.absent-evidence-197.test.tsx — UAT row 197 (#6085).
+ *
+ * Row 197's clause: **Suspend/Resume** → `spec.suspend` flips on the live
+ * object. The 2026-08-10 hw293 walk measured the object-level flip working in
+ * BOTH directions (absent → true, then true → false), and the row still failed,
+ * because the operator cannot perform the Resume half from this surface: the
+ * `Resume` control NEVER RENDERS.
+ *
+ * Two distinct mechanisms, both in ReconcileTab.tsx, and BOTH are the same
+ * defect class — a verdict published from ABSENT evidence:
+ *
+ *  (1) STALE AFTER ACTION. `suspended` is `useMemo`'d off the `obj` prop, and
+ *      the mutation's `onSuccess` invalidates only `reconciler-logs` and
+ *      `reconciliation-dag`. It cannot invalidate the query that produced
+ *      `obj` — because there ISN'T one: ResourceDetailPage fetches the object
+ *      in a `useEffect` into `useState` (ResourceDetailPage.tsx:150-168), so no
+ *      react-query key exists for it at any spelling. The button therefore
+ *      cannot flip after its own action, and Resume stays unreachable forever.
+ *      The fix is a refetch seam the parent owns, not another query key.
+ *
+ *  (2) FAIL-OPEN ON AN ERRORED READ. `Boolean(obj?.spec?.suspend)` collapses
+ *      "the object fetch failed" into the confident reading `false`, and
+ *      ResourceDetailPage DELIBERATELY renders this tab on the `objErr` branch
+ *      (the #5210 graceful degrade, which passes `obj={null}`). So a failed
+ *      object GET produces a full status block asserting `SUSPENDED: no` over
+ *      an object nobody read — and offers `Suspend` as though the current state
+ *      were known. `readyStateOf` has the identical shape: no conditions →
+ *      `'Reconciling'`, a confident positive verdict synthesized from nothing.
+ *
+ * `blocked` / `missing` / `no` must rest on POSITIVE evidence. Absence is
+ * `unknown`, and `unknown` must be SAID.
+ *
+ * THE CONTROLS share the suspect property: they render the very same Suspended
+ * KV and the very same action row off an object that IS present, one suspended
+ * and one not. They must stay green — the fix has to DISCRIMINATE "read it and
+ * it said false" from "never read it", not relabel every reading `unknown`.
+ */
+
+import { describe, it, expect, afterEach, vi, beforeEach } from 'vitest'
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { K8sObject } from '@/widgets/architecture-graph/useK8sCacheStream'
+
+const fetchReconcilerLogs = vi.fn()
+const triggerReconcilerAction = vi.fn()
+
+vi.mock('@/lib/reconciler-manage.api', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/reconciler-manage.api')>(
+    '@/lib/reconciler-manage.api',
+  )
+  return {
+    ...actual,
+    fetchReconcilerLogs: (...a: unknown[]) => fetchReconcilerLogs(...a),
+    triggerReconcilerAction: (...a: unknown[]) => triggerReconcilerAction(...a),
+  }
+})
+
+import { ReconcileTab } from './ReconcileTab'
+
+afterEach(cleanup)
+
+function renderTab(obj: K8sObject | null, onActionApplied?: () => void) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={qc}>
+      <ReconcileTab
+        deploymentId="dep-1"
+        apiKind="gitrepository"
+        ns="flux-system"
+        name="catalyst-tenant-uat107vc"
+        obj={obj}
+        onActionApplied={onActionApplied}
+      />
+    </QueryClientProvider>,
+  )
+}
+
+/**
+ * The KV widget renders `<div testid><div>LABEL</div><div>VALUE</div></div>`,
+ * so the value cell is the last child. Reading it directly keeps every
+ * assertion below an EXACT match on the rendered verdict rather than a
+ * substring search over label+value concatenated.
+ */
+function suspendValue(): string {
+  const kv = screen.getByTestId('reconcile-kv-suspended')
+  return (kv.lastElementChild?.textContent ?? '').trim()
+}
+
+/** The live hw293 subject of the row, running and not suspended. */
+const RUNNING_GITREPO: K8sObject = {
+  apiVersion: 'source.toolkit.fluxcd.io/v1',
+  kind: 'GitRepository',
+  metadata: { name: 'catalyst-tenant-uat107vc', namespace: 'flux-system' },
+  spec: { suspend: false },
+  status: {
+    artifact: { revision: 'main@sha1:04ff0b8e20' },
+    conditions: [{ type: 'Ready', status: 'True', reason: 'Succeeded', message: 'stored artifact' }],
+  },
+} as unknown as K8sObject
+
+const SUSPENDED_GITREPO: K8sObject = {
+  ...RUNNING_GITREPO,
+  spec: { suspend: true },
+} as unknown as K8sObject
+
+beforeEach(() => {
+  fetchReconcilerLogs.mockReset()
+  triggerReconcilerAction.mockReset()
+  fetchReconcilerLogs.mockResolvedValue({
+    controller: 'source-controller',
+    object: 'flux-system/catalyst-tenant-uat107vc',
+    lines: [],
+    total: 0,
+  })
+  triggerReconcilerAction.mockResolvedValue({
+    kind: 'GitRepository',
+    namespace: 'flux-system',
+    name: 'catalyst-tenant-uat107vc',
+    action: 'suspend',
+    requestedAt: '2026-08-11T10:00:00Z',
+    requestedBy: 'sovereign-admin',
+  })
+})
+
+describe('row 197 (2) — an unread object must never be published as a negative fact', () => {
+  it('reads `unknown`, NOT `no`, when the object was never read', () => {
+    renderTab(null)
+    // Assert on the KV's VALUE cell, exactly — not on the block's textContent.
+    // Two traps live here and both produce a test that cannot fail:
+    //   • `toContain('unknown')` alone passes on the string "unknown" AND on
+    //     any longer string that happens to embed it;
+    //   • `not.toContain('no')` is worse than useless — "unknown" itself
+    //     contains "no" (u-n-k-**no**-w-n), so it fails on the CORRECT output,
+    //     while against the buggy block text "Suspendedno" the "no" is preceded
+    //     by a letter, so a word-boundary variant would pass on the DEFECT.
+    // An exact match on the value cell has neither hole.
+    expect(suspendValue()).toBe('unknown')
+  })
+
+  it('does not synthesize a `Reconciling` state from absent conditions', () => {
+    renderTab(null)
+    const state = screen.getByTestId('reconcile-kv-state').textContent ?? ''
+    expect(state).not.toContain('Reconciling')
+    expect(state).toContain('Unknown')
+  })
+
+  it('offers BOTH Suspend and Resume when the current state is unknown', () => {
+    // This is the operator-visible half of row 197: with `suspended` fail-open
+    // to false, only `Suspend` was ever offered, so the Resume half of the
+    // clause was unreachable from this surface and had to be performed by
+    // POSTing the endpoint by hand. When the state is unknown, withholding
+    // either control is itself a claim about which one applies.
+    renderTab(null)
+    expect(screen.getByTestId('reconcile-action-resume')).toBeTruthy()
+    expect(screen.getByTestId('reconcile-action-suspend')).toBeTruthy()
+    // …and the operator is told WHY both are on offer.
+    expect(screen.getByTestId('reconcile-state-unknown-reason').textContent).toContain(
+      'could not be read',
+    )
+  })
+})
+
+describe('row 197 (1) — the surface must re-read the object after its own action', () => {
+  it('notifies the parent to refetch after a successful action', async () => {
+    const onActionApplied = vi.fn()
+    renderTab(RUNNING_GITREPO, onActionApplied)
+
+    fireEvent.click(screen.getByTestId('reconcile-action-suspend'))
+
+    await waitFor(() => expect(triggerReconcilerAction).toHaveBeenCalled())
+    // Without this the button cannot flip after its own action: the object is
+    // parent `useState`, so there is no query key any invalidation can reach.
+    await waitFor(() => expect(onActionApplied).toHaveBeenCalledTimes(1))
+  })
+
+  it('does NOT ask for a refetch when the action failed', async () => {
+    const onActionApplied = vi.fn()
+    triggerReconcilerAction.mockRejectedValue(new Error('403 forbidden'))
+    renderTab(RUNNING_GITREPO, onActionApplied)
+
+    fireEvent.click(screen.getByTestId('reconcile-action-suspend'))
+
+    await waitFor(() =>
+      expect(screen.getByTestId('reconcile-action-msg').textContent).toContain('403'),
+    )
+    expect(onActionApplied).not.toHaveBeenCalled()
+  })
+})
+
+describe('CONTROLS — a READ object must still publish its real reading', () => {
+  it('CONTROL — a present object reading false still says `no` and offers only Suspend', () => {
+    renderTab(RUNNING_GITREPO)
+    expect(suspendValue()).toBe('no')
+    expect(screen.getByTestId('reconcile-kv-state').textContent).toContain('Reconciled')
+    expect(screen.getByTestId('reconcile-action-suspend')).toBeTruthy()
+    expect(screen.queryByTestId('reconcile-action-resume')).toBeNull()
+    expect(screen.queryByTestId('reconcile-state-unknown-reason')).toBeNull()
+  })
+
+  it('CONTROL — a present object reading true still says `yes` and offers only Resume', () => {
+    renderTab(SUSPENDED_GITREPO)
+    expect(suspendValue()).toBe('yes')
+    expect(screen.getByTestId('reconcile-kv-state').textContent).toContain('Suspended')
+    expect(screen.getByTestId('reconcile-action-resume')).toBeTruthy()
+    expect(screen.queryByTestId('reconcile-action-suspend')).toBeNull()
+    expect(screen.queryByTestId('reconcile-state-unknown-reason')).toBeNull()
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/ReconcileTab.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/ReconcileTab.tsx
@@ -49,9 +49,46 @@ export function isReconcilerManageable(apiKind: string): boolean {
   return wireKindFor(apiKind) !== ''
 }
 
+/**
+ * SuspendReading — the TRI-STATE answer to "is this reconciler suspended?".
+ *
+ * UAT row 197 / #6085. This used to be a `boolean` produced by
+ * `Boolean(obj?.spec?.suspend)`, which collapses two completely different
+ * facts onto the same value:
+ *
+ *   • the object was read and its `spec.suspend` is false/absent  → `no`
+ *   • the object was never read (the parent's GET failed, and this tab is
+ *     DELIBERATELY rendered on that branch by the #5210 graceful degrade,
+ *     which passes `obj={null}`)                                  → `unknown`
+ *
+ * The second case was published as a confident `SUSPENDED: no` — a verdict
+ * from absent evidence, over an object nobody read. `no` must require positive
+ * evidence; absence is `unknown` and has to say so.
+ */
+type SuspendReading = 'yes' | 'no' | 'unknown'
+
+/**
+ * readSuspend — the tri-state, derived ONLY from what was actually read.
+ *
+ * Deliberately NOT exported: `react-refresh/only-export-components` already
+ * fires twice on this file for `wireKindFor` / `isReconcilerManageable`, and a
+ * third value export would grow that. The behaviour is covered through the
+ * rendered surface in ReconcileTab.absent-evidence-197.test.tsx, which is the
+ * level row 197 is actually written at.
+ */
+function readSuspend(obj: K8sObject | null | undefined): SuspendReading {
+  // No object → nothing was read. That is the whole point of the type.
+  if (!obj) return 'unknown'
+  return (obj.spec as { suspend?: boolean } | undefined)?.suspend === true ? 'yes' : 'no'
+}
+
 /** Read the Ready condition off a Flux object → a display state string. */
-function readyStateOf(obj: K8sObject | null, suspended: boolean): string {
-  if (suspended) return 'Suspended'
+function readyStateOf(obj: K8sObject | null, suspend: SuspendReading): string {
+  // Row 197 — an unread object has no state to report. It previously fell
+  // through to `'Reconciling'`, the identical defect one field over: a
+  // confident positive verdict synthesized from an empty condition list.
+  if (!obj) return 'Unknown'
+  if (suspend === 'yes') return 'Suspended'
   const conds = ((obj?.status as { conditions?: unknown } | undefined)?.conditions ?? []) as {
     type?: string
     status?: string
@@ -93,18 +130,38 @@ export interface ReconcileTabProps {
   obj: K8sObject | null
   /** Mirrors the page's RBAC hint; the server is the authoritative gate. */
   isTierAdmin?: boolean
+  /**
+   * UAT row 197 / #6085 — THE REFETCH SEAM. Called after an action the server
+   * accepted, so the owner of `obj` can re-read it and this tab can reflect
+   * the flip it just caused.
+   *
+   * This is a callback and not another `invalidateQueries` key because `obj`
+   * is NOT a react-query query at all: ResourceDetailPage fetches it in a
+   * `useEffect` into `useState`. No key exists to invalidate at any spelling,
+   * which is why the old `onSuccess` — invalidating `reconciler-logs` and
+   * `reconciliation-dag` — could never flip this button after its own action.
+   * That is what made the Resume half of row 197 unreachable from this surface.
+   */
+  onActionApplied?: () => void
 }
 
-export function ReconcileTab({ deploymentId, apiKind, ns, name, obj, isTierAdmin = true }: ReconcileTabProps) {
+export function ReconcileTab({
+  deploymentId,
+  apiKind,
+  ns,
+  name,
+  obj,
+  isTierAdmin = true,
+  onActionApplied,
+}: ReconcileTabProps) {
   const qc = useQueryClient()
   const [actionMsg, setActionMsg] = useState<string>('')
   const wireKind = useMemo(() => wireKindFor(apiKind), [apiKind])
 
-  const suspended = useMemo(
-    () => Boolean((obj?.spec as { suspend?: boolean } | undefined)?.suspend),
-    [obj],
-  )
-  const state = readyStateOf(obj, suspended)
+  // Row 197 — tri-state, never `Boolean(...)`. See readSuspend above.
+  const suspend = useMemo(() => readSuspend(obj), [obj])
+  const suspendKnown = suspend !== 'unknown'
+  const state = readyStateOf(obj, suspend)
   const revision = revisionOf(obj)
   const message = readyMessageOf(obj)
 
@@ -115,6 +172,13 @@ export function ReconcileTab({ deploymentId, apiKind, ns, name, obj, isTierAdmin
       setActionMsg(`${res.action} requested by ${res.requestedBy}`)
       void qc.invalidateQueries({ queryKey: ['reconciler-logs', deploymentId, wireKind, ns, name] })
       void qc.invalidateQueries({ queryKey: ['reconciliation-dag', deploymentId] })
+      // Row 197 — re-read the OBJECT this tab renders its verdict from. The two
+      // invalidations above touch the logs pane and the DAG; neither reaches
+      // `obj`, so without this the Suspended reading and the Suspend/Resume
+      // control stay frozen at whatever they were BEFORE the action the
+      // operator just performed. Fires only on success: a rejected action
+      // changed nothing, and asking for a refetch would imply otherwise.
+      onActionApplied?.()
     },
     onError: (e: unknown) => setActionMsg(e instanceof Error ? e.message : 'action failed'),
   })
@@ -136,7 +200,12 @@ export function ReconcileTab({ deploymentId, apiKind, ns, name, obj, isTierAdmin
       <div className="grid grid-cols-1 gap-3 md:grid-cols-3" data-testid="reconcile-tab-status">
         <KV label="State" value={state} testId="reconcile-kv-state" />
         <KV label="Revision" value={revision || '—'} testId="reconcile-kv-revision" />
-        <KV label="Suspended" value={suspended ? 'yes' : 'no'} testId="reconcile-kv-suspended" />
+        {/* Row 197 — prints the tri-state VERBATIM. `unknown` is a real value
+            here, not a styling of `no`: the walk's fresh page load, taken while
+            the live object genuinely read `spec.suspend: true`, printed
+            `SUSPENDED | no` because an undefined `obj` was rendered as a
+            negative fact. */}
+        <KV label="Suspended" value={suspend} testId="reconcile-kv-suspended" />
       </div>
       {message ? (
         <p className="text-sm text-[var(--color-text-dim)]" data-testid="reconcile-tab-message">
@@ -157,7 +226,19 @@ export function ReconcileTab({ deploymentId, apiKind, ns, name, obj, isTierAdmin
           >
             Reconcile now
           </button>
-          {suspended ? (
+          {/* Row 197 — WHICH control to offer is itself a claim about the
+              current state. With the old fail-open boolean, an unread object
+              silently asserted "not suspended" and offered Suspend ALONE, which
+              is exactly why the walk could not reach Resume from this surface
+              and had to POST the endpoint by hand.
+
+              When the reading is `unknown` we make no such claim: BOTH halves
+              are offered, and the reason line below says why. Each action is
+              idempotent server-side (Flux `spec.suspend` is a desired-state
+              field, not a toggle), so offering both is safe — and after either
+              one lands, `onActionApplied` re-reads the object and this collapses
+              back to the single correct control. */}
+          {suspendKnown && suspend === 'no' ? null : (
             <button
               type="button"
               disabled={!isTierAdmin || action.isPending}
@@ -167,7 +248,8 @@ export function ReconcileTab({ deploymentId, apiKind, ns, name, obj, isTierAdmin
             >
               Resume
             </button>
-          ) : (
+          )}
+          {suspendKnown && suspend === 'yes' ? null : (
             <button
               type="button"
               disabled={!isTierAdmin || action.isPending}
@@ -177,6 +259,15 @@ export function ReconcileTab({ deploymentId, apiKind, ns, name, obj, isTierAdmin
             >
               Suspend
             </button>
+          )}
+          {suspendKnown ? null : (
+            <span
+              className="text-xs text-yellow-400"
+              data-testid="reconcile-state-unknown-reason"
+            >
+              This object could not be read, so its current suspend state is
+              unknown — both actions are offered rather than guessing one.
+            </span>
           )}
           {actionMsg ? (
             <span className="text-xs text-[var(--color-text-dim)]" data-testid="reconcile-action-msg">

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/ResourceDetailPage.suspend-flip-197.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/ResourceDetailPage.suspend-flip-197.test.tsx
@@ -1,0 +1,155 @@
+/**
+ * ResourceDetailPage.suspend-flip-197.test.tsx — UAT row 197 (#6085), the
+ * PAGE-LEVEL half.
+ *
+ * ReconcileTab.absent-evidence-197.test.tsx locks the tab's own contract: it
+ * calls `onActionApplied` after an action the server accepted. That is a SEAM,
+ * and a seam nobody wires is not a fix — the row fails identically whether the
+ * callback is absent or merely unconnected. This file walks the operator's
+ * actual clause end-to-end against the page that owns the object:
+ *
+ *   click Suspend → the object is RE-READ → the control becomes Resume
+ *
+ * The re-read is the whole mechanism. `obj` lives in ResourceDetailPage's
+ * `useState`, filled by a one-shot `useEffect` fetch, so the previous
+ * `invalidateQueries` calls in ReconcileTab could not reach it at ANY key
+ * spelling. That is why the hw293 walk found `spec.suspend` flipping correctly
+ * on the live object while the page kept offering `Suspend`, and Resume was
+ * reachable only by POSTing the endpoint by hand.
+ *
+ * THE CONTROL is the second case: an action the server REJECTS must NOT
+ * re-read and must NOT flip the control. Without it this file would pass
+ * against a page that simply refetched on every render or flipped the button
+ * optimistically — neither of which is the clause, and the second of which
+ * would publish a state change that never happened.
+ */
+
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest'
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+const getResource = vi.fn()
+const getResourceTree = vi.fn()
+const fetchReconcilerLogs = vi.fn()
+const triggerReconcilerAction = vi.fn()
+
+vi.mock('./resource.api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./resource.api')>()
+  return {
+    ...actual,
+    getResource: (...a: unknown[]) => getResource(...a),
+    getResourceTree: (...a: unknown[]) => getResourceTree(...a),
+  }
+})
+
+vi.mock('@/lib/reconciler-manage.api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/reconciler-manage.api')>()
+  return {
+    ...actual,
+    fetchReconcilerLogs: (...a: unknown[]) => fetchReconcilerLogs(...a),
+    triggerReconcilerAction: (...a: unknown[]) => triggerReconcilerAction(...a),
+  }
+})
+
+import { ResourceDetailPage } from './ResourceDetailPage'
+
+/** The live hw293 subject: `GitRepository/flux-system/catalyst-tenant-uat107vc`. */
+const RUNNING = {
+  apiVersion: 'source.toolkit.fluxcd.io/v1',
+  kind: 'GitRepository',
+  metadata: { name: 'catalyst-tenant-uat107vc', namespace: 'flux-system' },
+  spec: { suspend: false },
+  status: {
+    artifact: { revision: 'main@sha1:04ff0b8e20' },
+    conditions: [{ type: 'Ready', status: 'True', reason: 'Succeeded', message: 'stored artifact' }],
+  },
+}
+
+const SUSPENDED = { ...RUNNING, spec: { suspend: true } }
+
+function renderPage() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={qc}>
+      <ResourceDetailPage
+        deploymentId="dep-1"
+        basePath="/cloud"
+        kind="gitrepository"
+        ns="flux-system"
+        name="catalyst-tenant-uat107vc"
+        tab={'reconcile' as never}
+      />
+    </QueryClientProvider>,
+  )
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  getResourceTree.mockResolvedValue({ kind: 'GitRepository', name: 'catalyst-tenant-uat107vc' })
+  fetchReconcilerLogs.mockResolvedValue({
+    controller: 'source-controller',
+    object: 'flux-system/catalyst-tenant-uat107vc',
+    lines: [],
+    total: 0,
+  })
+})
+
+afterEach(cleanup)
+
+describe('row 197 — the Suspend/Resume control must flip after its own action', () => {
+  it('re-reads the object after a successful Suspend, and Resume appears', async () => {
+    // The live object as the apiserver would answer it: running first, then
+    // suspended once the action has landed.
+    getResource.mockResolvedValueOnce(RUNNING).mockResolvedValue(SUSPENDED)
+    triggerReconcilerAction.mockResolvedValue({
+      kind: 'GitRepository',
+      namespace: 'flux-system',
+      name: 'catalyst-tenant-uat107vc',
+      action: 'suspend',
+      requestedAt: '2026-08-11T10:00:00Z',
+      requestedBy: 'sovereign-admin',
+    })
+
+    renderPage()
+
+    // Before: the object read false, so Suspend is the only control — and that
+    // reading is CORRECT, which is what makes the flip below meaningful.
+    const suspendBtn = await screen.findByTestId('reconcile-action-suspend')
+    expect(screen.queryByTestId('reconcile-action-resume')).toBeNull()
+
+    fireEvent.click(suspendBtn)
+
+    await waitFor(() => expect(triggerReconcilerAction).toHaveBeenCalled())
+    // THE ROW. The page re-read the object and the surface now offers the other
+    // half of the clause. On the pre-fix page this stayed `Suspend` forever.
+    await waitFor(() => expect(screen.getByTestId('reconcile-action-resume')).toBeTruthy())
+    expect(screen.queryByTestId('reconcile-action-suspend')).toBeNull()
+
+    // …and the status block agrees, rather than still printing the pre-action
+    // reading beside a control that has moved on.
+    const kv = screen.getByTestId('reconcile-kv-suspended')
+    expect((kv.lastElementChild?.textContent ?? '').trim()).toBe('yes')
+
+    // Exactly two reads: the initial one and the post-action one. A page that
+    // polls would satisfy the flip assertion above without implementing it.
+    expect(getResource).toHaveBeenCalledTimes(2)
+  })
+
+  it('CONTROL — a REJECTED action neither re-reads nor flips the control', async () => {
+    getResource.mockResolvedValue(RUNNING)
+    triggerReconcilerAction.mockRejectedValue(new Error('403 forbidden'))
+
+    renderPage()
+
+    const suspendBtn = await screen.findByTestId('reconcile-action-suspend')
+    fireEvent.click(suspendBtn)
+
+    await waitFor(() =>
+      expect(screen.getByTestId('reconcile-action-msg').textContent).toContain('403'),
+    )
+    // Nothing changed server-side, so nothing may change here.
+    expect(screen.queryByTestId('reconcile-action-resume')).toBeNull()
+    expect(screen.getByTestId('reconcile-action-suspend')).toBeTruthy()
+    expect(getResource).toHaveBeenCalledTimes(1)
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/ResourceDetailPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/ResourceDetailPage.tsx
@@ -130,6 +130,15 @@ export function ResourceDetailPage(props: ResourceDetailPageProps) {
   const [tree, setTree] = useState<ResourceTreeNode | null>(initialTree ?? null)
   const [treeErr, setTreeErr] = useState<string | null>(null)
   const [isLoading, setIsLoading] = useState<boolean>(!initialObj && !!deploymentId)
+  // UAT row 197 / #6085 — the object re-read counter. The resource GET below is
+  // a `useEffect` + `useState`, NOT a react-query query, so nothing downstream
+  // can refresh it by invalidating a key: no key exists. ReconcileTab's
+  // suspend / resume mutation used to invalidate `reconciler-logs` and
+  // `reconciliation-dag` and then render a Suspended verdict off an `obj` that
+  // was fetched once, before the action — so the control could never flip after
+  // its own action, and Resume stayed unreachable from that surface. Bumping
+  // this re-runs the fetch effect, which is the only mechanism that can.
+  const [objRefreshTick, setObjRefreshTick] = useState(0)
 
   // Tab navigation lives entirely on the callsite: ResourceDetailRoute /
   // ResourceDetailNoTabPage pass an `onTabChange` that calls TanStack's
@@ -139,6 +148,9 @@ export function ResourceDetailPage(props: ResourceDetailPageProps) {
   // jsdom unit tests don't need a Router wrapper.
 
   useEffect(() => {
+    // Row 197 — `initialObj` is a TEST SEAM (and a deep-link preload), so a
+    // caller supplying it owns the object and the refetch is theirs to make.
+    // Only the live-fetch path re-runs on a tick.
     if (initialObj) return
     // Guard against chroot's brief window where `useResolvedDeploymentId`
     // is still resolving (returns null → page receives ''). Without the
@@ -169,7 +181,7 @@ export function ResourceDetailPage(props: ResourceDetailPageProps) {
       cancelled = true
       ac.abort()
     }
-  }, [deploymentId, apiKind, ns, name, initialObj])
+  }, [deploymentId, apiKind, ns, name, initialObj, objRefreshTick])
 
   useEffect(() => {
     if (initialTree || tab !== 'tree') return
@@ -312,6 +324,12 @@ export function ResourceDetailPage(props: ResourceDetailPageProps) {
             name={name}
             obj={null}
             isTierAdmin={isTierAdmin}
+            // Row 197 — retry the object GET after an action even on the
+            // degraded branch: the lens GET may have been a transient blip, and
+            // an action that the reconciler endpoints accepted is good evidence
+            // the apiserver is answering again. On success the tab leaves the
+            // `unknown` reading behind and shows the real one.
+            onActionApplied={() => setObjRefreshTick((t) => t + 1)}
           />
         </div>
       )}
@@ -394,6 +412,10 @@ export function ResourceDetailPage(props: ResourceDetailPageProps) {
                 name={name}
                 obj={obj}
                 isTierAdmin={isTierAdmin}
+                // Row 197 — THE flip. Re-read `spec.suspend` off the live
+                // object after the action that changed it, so Suspend becomes
+                // Resume (and back) on the surface the operator is looking at.
+                onActionApplied={() => setObjRefreshTick((t) => t + 1)}
               />
             ) : (
               <PlaceholderTab


### PR DESCRIPTION
fix(console): stop publishing a DR/suspend verdict from absent evidence (#6085)

UAT rows 197 and 63 are one defect class, not two epics: a surface that
states a NEGATIVE fact where the honest answer is "nothing was read".

Row 197 — ReconcileTab.tsx. `suspended` was `Boolean(obj?.spec?.suspend)`,
which collapses "the object was read and says false" into the same value as
"the object was never read". ResourceDetailPage DELIBERATELY renders this tab
with `obj={null}` on the failed-GET branch (the #5210 graceful degrade), so a
failed read produced a full status block asserting `SUSPENDED: no` — and
offered Suspend alone, as though the current state were known. That is why the
hw293 walk measured `spec.suspend` flipping correctly on the live object while
the page kept offering Suspend, and Resume was reachable only by POSTing the
endpoint by hand. `readyStateOf` had the identical shape: no conditions →
`Reconciling`, a confident positive verdict synthesized from nothing.

Now a tri-state. `unknown` is a real rendered value; when it is unknown BOTH
controls are offered with a reason line, because withholding either one is
itself a claim about which applies. Each action is idempotent server-side
(Flux `spec.suspend` is desired-state, not a toggle).

The stale-after-action half had a deeper cause than the wrong query key: `obj`
is NOT a react-query query at all. ResourceDetailPage fetches it in a
`useEffect` into `useState`, so no key exists to invalidate at ANY spelling,
and the two `invalidateQueries` calls could never have flipped the button.
Fixed with a refetch seam the parent owns (`onActionApplied` → a tick in the
fetch effect's deps), wired at BOTH call sites — including the degraded one,
where an accepted action is good evidence the apiserver is answering again.
Fires only on success: a rejected action changed nothing.

Row 63 — TopologyTab.tsx. `showDR = hasStandby || hasLiveDR`; both terms are
OBSERVATIONS, and neither consults what the CR DECLARES. On hw293,
`hw293walkone/uat50-ahs-pg` declared `spec.placement.mode: active-hot-standby`
with a standby region while /placement answered `{"targets":[]}`,
`status.targets` was absent and `status.perCluster` held one `singleton` entry
— so both observed terms were false and the ENTIRE `topology-tab-dr-*` subtree
was absent. The clause requires a DISABLED control with a named reason; an
absent control and a disabled one are not the same statement, which is
precisely what row 63 exists to forbid.

#6061 fixed the rung ABOVE this (an incomplete `status.perCluster` shadowing a
`status.targets` that already named the pair) and is already in the deployed
`85e2eaf`; it cannot help an app on which NEITHER field was ever written.
`declaresStandby` reads only the declared posture, canonicalised, so
`singleton` and `active-active` still open nothing — row 58 (never arm a DR
block against a phantom region) is intact, and the existing `!drBacked` branch
still renders nothing numeric and no armed control (#5514).

Tests — each RED before, GREEN after, each with a control that shares the
suspect property, and each control proven non-vacuous:

  * TopologyTab.declared-standby-63.test.tsx — 2 failed → 3 passed. The
    control is byte-identical to the failing fixture except for the declared
    mode; forcing `declaresStandby` true unconditionally makes it FAIL
    ("CONTROL — the same observation declaring `singleton` still shows NO DR
    panel"), so it is a discrimination and not a blanket promotion.
  * ReconcileTab.absent-evidence-197.test.tsx — 4 failed → 7 passed. Asserts
    on the KV's VALUE cell exactly: `not.toContain('no')` is worse than
    useless here because "unknown" itself contains "no", and a word-boundary
    variant passes on the DEFECT text "Suspendedno". Verified RED against the
    pre-fix source with the corrected assertions: `expected 'no' to be
    'unknown'`.
  * ResourceDetailPage.suspend-flip-197.test.tsx — the operator's clause
    end-to-end (click Suspend → object re-read → Resume appears). Proven
    non-vacuous by unwiring the page: it fails with row 197's exact symptom,
    `Unable to find an element by: [data-testid="reconcile-action-resume"]`.
    Its own control asserts a REJECTED action neither re-reads nor flips.

31 test files / 228 tests green across cloud-list + AppDetail; `tsc -b
--noEmit` clean; eslint unchanged from HEAD on every touched file (the 2
pre-existing `react-refresh` errors in ReconcileTab.tsx stay 2 — `readSuspend`
is deliberately module-local rather than a third value export).

Refs #6114
Refs #6085

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

