### PR TITLE
test(uat): the new self-test mutants must land in the CLAUSE cell, not across the raw markdown

### DIFF
--- a/scripts/test_uat_clause_identity.py
+++ b/scripts/test_uat_clause_identity.py
@@ -201,6 +201,26 @@ def parse_uat(text: str):
                cells[2].strip(), cells[3].strip())
 
 
+def map_clause_cells(text: str, fn, only: str = None) -> str:
+    """Rewrite the CLAUSE cell of every row-ID row (or just `only`) through fn.
+
+    Self-test mutants have to land in the same cell the guard reads. A
+    substitution over the raw markdown can rewrite a number inside an Evidence
+    cell or match across a `|`, which desynchronises the two copies for a
+    reason unrelated to the leg being proven — and the mutant then reports a
+    guard defect that does not exist.
+    """
+    out = []
+    for line in text.split("\n"):
+        cells = UNESCAPED_PIPE.split(line)
+        if line.startswith("|") and len(cells) >= 8 and ROW_ID.match(cells[1].strip()) \
+                and (only is None or cells[1].strip() == only):
+            cells[4] = fn(cells[4])
+            line = "|".join(cells)
+        out.append(line)
+    return "\n".join(out)
+
+
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--self-test", action="store_true")
@@ -504,13 +524,21 @@ def self_test() -> int:
         else:
             shipped_n = len(shipped_cutover_steps())
             wrong = str(shipped_n - 3)
+
+            def bend_steps(text):
+                return STEP_CLAIM.sub(
+                    lambda m: m.group(0).replace(m.group(1) or m.group(2), wrong, 1), text)
+
             mutated = [dict(r) for r in canon_rows]
             for r in mutated:
-                r["test_case"] = STEP_CLAIM.sub(
-                    lambda m: m.group(0).replace(m.group(1) or m.group(2), wrong, 1),
-                    r["test_case"])
-            mutant_uat = STEP_CLAIM.sub(
-                lambda m: m.group(0).replace(m.group(1) or m.group(2), wrong, 1), uat_text)
+                r["test_case"] = bend_steps(r["test_case"])
+            # Applied CELL-WISE, not over the whole file. A sub across the raw
+            # markdown could rewrite a number inside an Evidence cell, or match
+            # across a cell boundary, and the two copies would then stop being
+            # identical for a reason that has nothing to do with E1 — the leg-C
+            # assertion below would go red and report a mutant defect as a guard
+            # defect.
+            mutant_uat = map_clause_cells(uat_text, bend_steps)
             rc, out = run(mutant_uat, mutated, ret_text)
             if rc == 0 or "LEG E1" not in out:
                 print("[self-test] FAIL — a step count wrong in BOTH files did not trip leg E1 "
@@ -542,7 +570,10 @@ def self_test() -> int:
                      if mm.group(2) in crd_groups)
             broken = "nosuchplural." + m.group(2)
             hit["test_case"] = hit["test_case"].replace(m.group(0), broken, 1)
-            mutant_uat = uat_text.replace(m.group(0), broken)
+            mutant_uat = map_clause_cells(
+                uat_text,
+                lambda t, _r=hit["row_id"]: t.replace(m.group(0), broken, 1),
+                only=hit["row_id"])
             rc, out = run(mutant_uat, mutated, ret_text)
             if rc == 0 or "LEG E2" not in out:
                 print("[self-test] FAIL — a resource the CRDs do not declare did not trip leg E2")


### PR DESCRIPTION
## What this changes

A follow-up to PR #6132, which added legs E and F to the ledger-identity guard.
It was pushed a minute after that PR auto-merged, so it did not make the squash.
Self-test only — no ledger cell, no clause, no verdict, no denominator.

## The defect

The E1 mutant asserts **leg C stays GREEN**, and that assertion is the entire
point: a mutant that also tripped leg C would prove nothing about the blindness
E1 exists to cover. But the substitution ran over the raw markdown of `UAT.md`,
not over the clause cell the guard reads. Two ways that goes wrong:

- it can rewrite a digit inside an **Evidence** cell, which the canon does not
  carry, so the two copies stop being identical;
- `STEP_CLAIM` is bounded by `[^.]{0,80}`, which does not stop at a `|`, so a
  match can begin in the clause and end in the next cell.

Either desynchronises `UAT.md` from `uat-testcases.csv` for a reason that has
nothing to do with E1. The self-test would then print *"the E1 mutant also
tripped leg C"* — reporting a **mutant** defect as a **guard** defect, and only
whenever the ledger's prose happened to line up that way. It passes on today's
tree, which is exactly what makes it worth fixing now rather than the morning it
starts failing for a reason nobody can reproduce.

The E2 mutant had the milder version of the same shape: it replaced its token
file-wide while the canon side replaced it in one row. E2 does not assert leg C,
so it could not misreport — but a mutant that lands in more places than it
claims to is a bad control regardless.

## The fix

One shared helper, `map_clause_cells(text, fn, only=None)`, rewrites column 4 of
each row-ID row through `fn` — the same cell `parse_uat` reads, split with the
same unescaped-pipe regex. E1 maps every row; E2 scopes to its single target
row. No other mutant is touched.

Self-test green on all eight mutants, and `--self-test` still reports the real
ledger as the control before any mutant runs:

```
[self-test] control (real ledger) exit=0 clean
[self-test] PASS — leg E1 catches a 8-step claim agreed by BOTH files against a chart that runs 11, with leg C green
[self-test] PASS — leg E2 catches `nosuchplural.dr.openova.io` (row G3)
```

Guards gated on exit codes: `test_uat_clause_identity.py --self-test` (0),
`test_uat_clause_identity.py` (0, six legs), `test_uat_table_shape.py` (0).

Refs #6111
