### PR TITLE
fix(jobs): the cutover tree had no root — an empty dependsOn could not say "I am the root"

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/cutover_resume_seed_root_edge_6131_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/cutover_resume_seed_root_edge_6131_test.go
@@ -1,0 +1,215 @@
+// cutover_resume_seed_root_edge_6131_test.go — the #3646 durability
+// replay must still replay, and must leave a ROOTED tree behind (#6131).
+//
+// This is the end-to-end control for #6131 at the seam that actually
+// runs on a Sovereign: chrootSeedCutoverActivity -> projectCutoverResumeSeed
+// -> ActivityBridge.SeedSteps. #6131 lets SeedSteps assert an empty
+// DependsOn as "this node is the ROOT" instead of having it silently
+// inherit the stored edge; if that were to weaken the replay, this test
+// is where it would show, because every step here replays its terminal
+// state out of the durable status ConfigMap exactly as it does after a
+// completed cutover whose step ConfigMaps have been reaped.
+package handler
+
+import (
+	"fmt"
+	"sort"
+	"testing"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/jobs"
+)
+
+// cutoverOrder6131 is the true execution sequence, from the
+// `bp.openova.io/cutover-order` label on each cutover-step ConfigMap in
+// platform/self-sovereign-cutover/chart/templates/.
+var cutoverOrder6131 = []string{
+	"gitea-mirror",              // 1
+	"harbor-projects",           // 2
+	"harbor-prewarm",            // 3
+	"registry-pivot",            // 4
+	"flux-gitrepository-patch",  // 5
+	"helmrepository-patches",    // 6
+	"catalyst-api-env-patch",    // 7
+	"egress-block-test",         // 8
+	"gitea-token-mint",          // 9
+	"vcluster-registry-pivot",   // 10
+	"crossplane-provider-pivot", // 11
+}
+
+// TestProjectCutoverResumeSeed_ReplaysAndLeavesARootedTree_6131 replays a
+// COMPLETED cutover from the durable status record onto a store that was
+// first seeded by the pre-#6099 alphabetical build, and requires both
+// halves: every step's durable result still lands, AND the execution
+// tree comes out acyclic and rooted at gitea-mirror.
+func TestProjectCutoverResumeSeed_ReplaysAndLeavesARootedTree_6131(t *testing.T) {
+	h, _ := fakeHandlerWithCutover(t)
+	js, err := jobs.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("jobs.NewStore: %v", err)
+	}
+	h.jobs = js
+	const depID = "dep-6131-resume"
+	h.cutoverActivityDepID = depID
+
+	// 1. Poison the store the way the pre-#6099 read path did: the
+	//    sequence came from listStepNamesFromStatus, which ends in
+	//    sort.Strings.
+	alpha := append([]string(nil), cutoverOrder6131...)
+	sort.Strings(alpha)
+	// Control on the INPUT — if a step is ever renamed this stops
+	// reproducing the hw293 store and must say so rather than pass.
+	if got := predecessorOf6131(alpha, "gitea-mirror"); got != "flux-gitrepository-patch" {
+		t.Fatalf("input control: alphabetical predecessor of gitea-mirror is %q, want flux-gitrepository-patch — this test no longer reproduces the hw293 store", got)
+	}
+	h.projectCutoverResumeSeed(alpha, map[string]string{})
+
+	rootJob := jobs.ActivityStepJobName(jobs.GroupCutover, "gitea-mirror")
+	poisoned := stepEdges6131(t, js, depID)
+	wantStale := jobs.ActivityStepJobName(jobs.GroupCutover, "flux-gitrepository-patch")
+	if got := poisoned[rootJob]; len(got) != 1 || got[0] != wantStale {
+		t.Fatalf("setup: poisoned store should carry the stale alphabetical edge on %s, got %v want [%s]", rootJob, got, wantStale)
+	}
+
+	// 2. Replay a COMPLETED cutover the way a post-#6099 /jobs read does:
+	//    the order comes from the cutover-order labels, the per-step
+	//    results come from the durable status ConfigMap.
+	status := map[string]string{"cutoverComplete": "true"}
+	for _, slug := range cutoverOrder6131 {
+		status["step."+slug+".result"] = "success"
+		status["step."+slug+".startedAt"] = "2026-08-11T01:00:00Z"
+		status["step."+slug+".finishedAt"] = "2026-08-11T01:05:00Z"
+	}
+	h.projectCutoverResumeSeed(cutoverOrder6131, status)
+
+	// 3. The replay itself must still work — this is the case the
+	//    DependsOn preservation exists to protect, so it is the control
+	//    on the fix.
+	all, err := js.ListJobs(depID)
+	if err != nil {
+		t.Fatalf("ListJobs: %v", err)
+	}
+	byName := map[string]jobs.Job{}
+	for _, j := range all {
+		byName[j.JobName] = j
+	}
+	for _, slug := range cutoverOrder6131 {
+		name := jobs.ActivityStepJobName(jobs.GroupCutover, slug)
+		j, ok := byName[name]
+		if !ok {
+			t.Fatalf("durability replay lost step %s", name)
+		}
+		if j.Status != jobs.StatusSucceeded {
+			t.Errorf("step %s replayed status = %q, want %q", name, j.Status, jobs.StatusSucceeded)
+		}
+		if j.LatestExecutionID == "" {
+			t.Errorf("step %s replayed without an Execution — the Exec Log surface would be empty", name)
+		}
+	}
+	if group, ok := byName[jobs.GroupCutover]; !ok {
+		t.Fatal("durability replay lost the Cutover group")
+	} else if group.Status != jobs.StatusSucceeded {
+		t.Errorf("Cutover group rolled up to %q, want %q after an all-success replay", group.Status, jobs.StatusSucceeded)
+	}
+
+	// 4. And the tree it leaves behind is rooted and acyclic.
+	edges := stepEdges6131(t, js, depID)
+	for i, slug := range cutoverOrder6131 {
+		name := jobs.ActivityStepJobName(jobs.GroupCutover, slug)
+		got := edges[name]
+		if i == 0 {
+			if len(got) != 0 {
+				t.Errorf("%s is cutover-order=1 and must be the ROOT, got dependsOn %v", name, got)
+			}
+			continue
+		}
+		want := jobs.ActivityStepJobName(jobs.GroupCutover, cutoverOrder6131[i-1])
+		if len(got) != 1 || got[0] != want {
+			t.Errorf("%s dependsOn = %v, want [%s]", name, got, want)
+		}
+	}
+	if err := acyclicUniqueRoot6131(edges, rootJob); err != nil {
+		t.Errorf("rendered execution tree after a durable replay: %v", err)
+	}
+}
+
+func predecessorOf6131(order []string, slug string) string {
+	for i, s := range order {
+		if s == slug && i > 0 {
+			return order[i-1]
+		}
+	}
+	return ""
+}
+
+func stepEdges6131(t *testing.T, js *jobs.Store, depID string) map[string][]string {
+	t.Helper()
+	all, err := js.ListJobs(depID)
+	if err != nil {
+		t.Fatalf("ListJobs: %v", err)
+	}
+	edges := map[string][]string{}
+	for _, j := range all {
+		if j.Type == jobs.JobTypeGroup {
+			continue
+		}
+		edges[j.JobName] = j.DependsOn
+	}
+	return edges
+}
+
+// acyclicUniqueRoot6131 mirrors the assertion in the jobs package: the
+// rendered graph must be acyclic with exactly one root, and that root
+// must be wantRoot. Cycle first, so a cyclic graph reports the cycle
+// rather than the "0 roots" it also causes.
+func acyclicUniqueRoot6131(edges map[string][]string, wantRoot string) error {
+	const (
+		white = 0
+		grey  = 1
+		black = 2
+	)
+	colour := map[string]int{}
+	names := make([]string, 0, len(edges))
+	for n := range edges {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	var walk func(n string, stack []string) error
+	walk = func(n string, stack []string) error {
+		switch colour[n] {
+		case black:
+			return nil
+		case grey:
+			return fmt.Errorf("cycle through %v -> %s", stack, n)
+		}
+		colour[n] = grey
+		for _, d := range edges[n] {
+			if _, known := edges[d]; !known {
+				continue
+			}
+			if err := walk(d, append(stack, n)); err != nil {
+				return err
+			}
+		}
+		colour[n] = black
+		return nil
+	}
+	for _, n := range names {
+		if err := walk(n, nil); err != nil {
+			return err
+		}
+	}
+	roots := []string{}
+	for n, deps := range edges {
+		if len(deps) == 0 {
+			roots = append(roots, n)
+		}
+	}
+	sort.Strings(roots)
+	if len(roots) != 1 {
+		return fmt.Errorf("graph has %d roots %v, want exactly 1 (%s)", len(roots), roots, wantRoot)
+	}
+	if roots[0] != wantRoot {
+		return fmt.Errorf("root is %s, want %s", roots[0], wantRoot)
+	}
+	return nil
+}

--- a/products/catalyst/bootstrap/api/internal/jobs/activity_bridge.go
+++ b/products/catalyst/bootstrap/api/internal/jobs/activity_bridge.go
@@ -59,6 +59,15 @@
 // non-empty prior DependsOn, so re-seeding a step never un-starts it or
 // drops its edges. StartStep reuses an already-open Execution rather
 // than allocating a second one.
+//
+// That DependsOn preservation has one deliberate exception: SeedSteps
+// marks its writes DependsOnAuthoritative because it has just been
+// handed the complete ordered step set, so its EMPTY list means "this
+// step is the root", not "no edge information" (issue #6131). Every
+// other write path here leaves the flag false and keeps inheriting —
+// including ensureStepLocked, which may be registering a step against a
+// partial in-memory set and therefore cannot be believed about an
+// absent edge.
 package jobs
 
 import (
@@ -240,6 +249,16 @@ func (a *ActivityBridge) dependsOnForStepLocked(slug string) []string {
 // StartedAt/Status), so a source may seed lazily once its step list is
 // known and again on resume without regressing live rows.
 //
+// Re-seeding also CORRECTS the edges, including the root's. The caller
+// hands over the complete ordered set, so these writes are marked
+// DependsOnAuthoritative and an empty DependsOn is written through as
+// "this step has no predecessor" rather than inheriting the stored
+// value (#6131). Without that, a store seeded once under a WRONG order
+// could never have its root repaired: every non-root step recomputes to
+// a non-empty edge that overwrites cleanly, while the root recomputes to
+// the one value the preservation rule refuses to write, so it keeps the
+// stale edge forever and the tree stays cyclic.
+//
 // Steps with an empty Slug are skipped (defence against a malformed
 // source). An empty step list materialises just the group Job (so the
 // group is visible as pending even before steps are discovered).
@@ -276,7 +295,18 @@ func (a *ActivityBridge) SeedSteps(steps []ActivityStep) error {
 			Kind:         KindStep,
 			ParentID:     parent,
 			DependsOn:    a.dependsOnForStepLocked(s.Slug),
-			Status:       StatusPending,
+			// SeedSteps was just handed the COMPLETE ordered step set, so
+			// it is the one writer entitled to assert an absence: an empty
+			// DependsOn here means "no predecessor", i.e. this is the
+			// root, not "I don't know the edges". mergeJob inherits the
+			// stored list from every other writer's empty value, which is
+			// what stranded cutover-step-gitea-mirror on its pre-#6099
+			// alphabetical edge (#6131). The lazy ensureStepLocked path
+			// below deliberately does NOT set this: it may be registering
+			// a step against a partial in-memory set, where empty really
+			// does mean "no information".
+			DependsOnAuthoritative: true,
+			Status:                 StatusPending,
 		}); err != nil {
 			return err
 		}

--- a/products/catalyst/bootstrap/api/internal/jobs/activity_bridge_root_edge_6131_test.go
+++ b/products/catalyst/bootstrap/api/internal/jobs/activity_bridge_root_edge_6131_test.go
@@ -260,6 +260,43 @@ func TestCheckAcyclicUniqueRoot_VacuityOnThePoisonedGraph_6131(t *testing.T) {
 	t.Logf("vacuity ok (root branch) — assertion rejects a two-root graph: %v", err)
 }
 
+// TestActivityBridge_ReseedWithoutAnOrderBearingSourceStaysAcyclic_6131
+// pins the one remaining case where the platform cannot know the true
+// order: a completed cutover whose step ConfigMaps have been reaped, so
+// listCutoverSteps returns nothing and the sequence can only come from
+// the durable record — which is alphabetical by construction, because a
+// ConfigMap's data is an unordered map. #6099 accepted that trade.
+//
+// The order is then wrong, and nothing here can fix it. But the tree must
+// still be a TREE. Before #6131 this case produced a CYCLE: the ten
+// non-root steps were rewritten alphabetically while the previously-
+// correct root kept its old edge, because that edge was the empty list
+// the preservation refused to overwrite. So this is a case #6131 quietly
+// improves, and it is asserted rather than assumed.
+func TestActivityBridge_ReseedWithoutAnOrderBearingSourceStaysAcyclic_6131(t *testing.T) {
+	st := newTestStore(t)
+	const depID = "dep-6131-no-order-source"
+
+	// A correctly-ordered store, from when the ConfigMaps still existed.
+	seedCutoverSteps6131(t, st, depID, cutoverStepOrder6131)
+	if err := checkAcyclicUniqueRoot(cutoverEdges6131(t, st, depID),
+		ActivityStepJobName(GroupCutover, "gitea-mirror")); err != nil {
+		t.Fatalf("setup: correctly-ordered store should already be a rooted tree: %v", err)
+	}
+
+	// The ConfigMaps are reaped; a later read can only offer the durable
+	// record's alphabetical list.
+	alpha := alphabeticalCutoverOrder6131()
+	seedCutoverSteps6131(t, st, depID, alpha)
+
+	edges := cutoverEdges6131(t, st, depID)
+	// The order is wrong — that is known and accepted — but the graph is
+	// a tree, rooted at whatever the only available source put first.
+	if err := checkAcyclicUniqueRoot(edges, ActivityStepJobName(GroupCutover, alpha[0])); err != nil {
+		t.Fatalf("re-seed with no order-bearing source must still leave a rooted, acyclic tree: %v", err)
+	}
+}
+
 func cloneEdges6131(in map[string][]string) map[string][]string {
 	out := make(map[string][]string, len(in))
 	for k, v := range in {

--- a/products/catalyst/bootstrap/api/internal/jobs/activity_bridge_root_edge_6131_test.go
+++ b/products/catalyst/bootstrap/api/internal/jobs/activity_bridge_root_edge_6131_test.go
@@ -1,0 +1,355 @@
+// activity_bridge_root_edge_6131_test.go — the cutover execution tree
+// must have a ROOT, and re-seeding must be able to say so (issue #6131).
+//
+// #6099 fixed the ORDER the eleven self-sovereign cutover steps are
+// seeded in, and ten of the eleven edges corrected themselves on the
+// next /jobs read. The eleventh — the root — did not, because the only
+// way to express "this node has no predecessor" is an empty DependsOn,
+// and mergeJob treats empty as "this write carries no edge information"
+// and inherits the stored value instead. On hw293 that left
+// cutover-step-gitea-mirror (bp.openova.io/cutover-order=1) pointing at
+// cutover-step-flux-gitrepository-patch — its predecessor under the OLD
+// alphabetical seed — closing a five-node cycle and denying the tree a
+// root.
+//
+// These tests assert on EDGE VALUES and the resulting root, never on a
+// count: a count passes on any permutation, which is exactly how the
+// alphabetical tree shipped green in the first place.
+package jobs
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+)
+
+// cutoverStepOrder6131 is the true execution sequence, taken from the
+// `bp.openova.io/cutover-order` label on each cutover-step ConfigMap in
+// platform/self-sovereign-cutover/chart/templates/. That label is the
+// authoritative source of order — the durable status ConfigMap's data
+// is an unordered map and cannot carry a sequence at all.
+var cutoverStepOrder6131 = []string{
+	"gitea-mirror",              // cutover-order=1  (01-gitea-mirror-job.yaml)
+	"harbor-projects",           // cutover-order=2  (02-harbor-projects-job.yaml)
+	"harbor-prewarm",            // cutover-order=3  (03-harbor-prewarm-job.yaml)
+	"registry-pivot",            // cutover-order=4  (04-registry-pivot-daemonset.yaml)
+	"flux-gitrepository-patch",  // cutover-order=5  (05-flux-gitrepository-patch-job.yaml)
+	"helmrepository-patches",    // cutover-order=6  (06-helmrepository-patches-job.yaml)
+	"catalyst-api-env-patch",    // cutover-order=7  (07-catalyst-api-env-patch-job.yaml)
+	"egress-block-test",         // cutover-order=8  (08-egress-block-test-job.yaml)
+	"gitea-token-mint",          // cutover-order=9  (09-gitea-token-mint-job.yaml)
+	"vcluster-registry-pivot",   // cutover-order=10 (10-vcluster-registry-pivot-job.yaml)
+	"crossplane-provider-pivot", // cutover-order=11 (11-crossplane-provider-pivot-job.yaml)
+}
+
+// alphabeticalCutoverOrder6131 reproduces the pre-#6099 seed: the read
+// path took its sequence from listStepNamesFromStatus, which ends in
+// sort.Strings. Computed rather than hardcoded so a step rename makes
+// the reproduction fail loudly instead of silently ceasing to reproduce.
+func alphabeticalCutoverOrder6131() []string {
+	out := append([]string(nil), cutoverStepOrder6131...)
+	sort.Strings(out)
+	return out
+}
+
+// seedCutoverSteps6131 seeds a store through ActivityBridge exactly the
+// way projectCutoverResumeSeed does: full ordered set, Order = i+1.
+func seedCutoverSteps6131(t *testing.T, st *Store, depID string, slugs []string) {
+	t.Helper()
+	steps := make([]ActivityStep, 0, len(slugs))
+	for i, s := range slugs {
+		steps = append(steps, ActivityStep{Slug: s, DisplayName: s, Order: i + 1})
+	}
+	ab := NewActivityBridge(st, depID, GroupCutover, "Cutover")
+	if err := ab.SeedSteps(steps); err != nil {
+		t.Fatalf("SeedSteps: %v", err)
+	}
+}
+
+// cutoverEdges6131 reads the persisted dependsOn edges of the cutover
+// step leaves back out of the store, keyed by JobName.
+func cutoverEdges6131(t *testing.T, st *Store, depID string) map[string][]string {
+	t.Helper()
+	all, err := st.ListJobs(depID)
+	if err != nil {
+		t.Fatalf("ListJobs: %v", err)
+	}
+	edges := map[string][]string{}
+	for _, j := range all {
+		if j.Type == JobTypeGroup {
+			continue
+		}
+		edges[j.JobName] = j.DependsOn
+	}
+	return edges
+}
+
+// checkAcyclicUniqueRoot verifies that the rendered graph is acyclic and
+// that wantRoot is its ONE root (the only node with no outgoing
+// dependsOn edge). Returns an error rather than failing the test so the
+// vacuity check below can prove the assertion is capable of failing.
+func checkAcyclicUniqueRoot(edges map[string][]string, wantRoot string) error {
+	// Cycle detection runs FIRST so a cyclic graph is reported as the
+	// cycle it is. A cycle also starves the graph of roots, and reporting
+	// "0 roots" would describe the symptom rather than the defect.
+	//
+	// Depth-first cycle hunt over the dependsOn edges.
+	const (
+		white = 0 // unvisited
+		grey  = 1 // on the current stack
+		black = 2 // fully explored
+	)
+	colour := make(map[string]int, len(edges))
+	names := make([]string, 0, len(edges))
+	for n := range edges {
+		names = append(names, n)
+	}
+	sort.Strings(names) // deterministic reporting
+	var walk func(n string, stack []string) error
+	walk = func(n string, stack []string) error {
+		switch colour[n] {
+		case black:
+			return nil
+		case grey:
+			return fmt.Errorf("cycle through %v -> %s", stack, n)
+		}
+		colour[n] = grey
+		for _, d := range edges[n] {
+			if _, known := edges[d]; !known {
+				continue // edge out of the projected set
+			}
+			if err := walk(d, append(stack, n)); err != nil {
+				return err
+			}
+		}
+		colour[n] = black
+		return nil
+	}
+	for _, n := range names {
+		if err := walk(n, nil); err != nil {
+			return err
+		}
+	}
+
+	roots := make([]string, 0, 1)
+	for name, deps := range edges {
+		if len(deps) == 0 {
+			roots = append(roots, name)
+		}
+	}
+	sort.Strings(roots)
+	if len(roots) != 1 {
+		return fmt.Errorf("graph has %d roots %v, want exactly 1 (%s)", len(roots), roots, wantRoot)
+	}
+	if roots[0] != wantRoot {
+		return fmt.Errorf("root is %s, want %s", roots[0], wantRoot)
+	}
+	return nil
+}
+
+// TestActivityBridge_ReseedRepairsRootEdgeOnAPoisonedStore_6131 is the
+// headline. A store first seeded under the pre-#6099 alphabetical build
+// is re-seeded with the label-derived order — what every /jobs read does
+// after #6099 — and every edge, including the root's, must end up
+// correct.
+func TestActivityBridge_ReseedRepairsRootEdgeOnAPoisonedStore_6131(t *testing.T) {
+	st := newTestStore(t)
+	const depID = "dep-6131"
+
+	// Control on the INPUT: the reproduction is only a reproduction if
+	// the alphabetical seed really does hand gitea-mirror the
+	// flux-gitrepository-patch predecessor that was measured live on
+	// hw293. If a step is ever renamed this fails loudly rather than
+	// quietly ceasing to reproduce the defect.
+	alpha := alphabeticalCutoverOrder6131()
+	gotAlphaPred := ""
+	for i, s := range alpha {
+		if s == "gitea-mirror" && i > 0 {
+			gotAlphaPred = alpha[i-1]
+		}
+	}
+	if gotAlphaPred != "flux-gitrepository-patch" {
+		t.Fatalf("input control: alphabetical predecessor of gitea-mirror is %q, want %q — this test no longer reproduces the hw293 store",
+			gotAlphaPred, "flux-gitrepository-patch")
+	}
+
+	// 1. Poison the store the way the pre-#6099 build did.
+	seedCutoverSteps6131(t, st, depID, alpha)
+	poisoned := cutoverEdges6131(t, st, depID)
+	rootJob := ActivityStepJobName(GroupCutover, "gitea-mirror")
+	if got, want := poisoned[rootJob], []string{ActivityStepJobName(GroupCutover, "flux-gitrepository-patch")}; len(got) != 1 || got[0] != want[0] {
+		t.Fatalf("setup: poisoned store should carry the stale alphabetical edge on %s, got %v want %v", rootJob, got, want)
+	}
+
+	// 2. Re-seed with the authoritative label order — the post-#6099
+	//    read path, on a fresh catalyst-api process.
+	seedCutoverSteps6131(t, st, depID, cutoverStepOrder6131)
+
+	// 3. Assert the WHOLE edge map by value.
+	edges := cutoverEdges6131(t, st, depID)
+	for i, slug := range cutoverStepOrder6131 {
+		name := ActivityStepJobName(GroupCutover, slug)
+		got := edges[name]
+		if i == 0 {
+			if len(got) != 0 {
+				t.Errorf("%s is cutover-order=1 and must be the ROOT, got dependsOn %v", name, got)
+			}
+			continue
+		}
+		want := ActivityStepJobName(GroupCutover, cutoverStepOrder6131[i-1])
+		if len(got) != 1 || got[0] != want {
+			t.Errorf("%s dependsOn = %v, want [%s]", name, got, want)
+		}
+	}
+
+	// 4. Cycle assertion: the rendered graph must be acyclic and
+	//    gitea-mirror must be its unique root.
+	if err := checkAcyclicUniqueRoot(edges, rootJob); err != nil {
+		t.Errorf("rendered execution tree: %v", err)
+	}
+}
+
+// TestCheckAcyclicUniqueRoot_VacuityOnThePoisonedGraph_6131 proves the
+// assertion in step 4 above is capable of failing. Fed the exact graph
+// measured on hw293 — every #6099-corrected edge plus the one surviving
+// stale root edge — it must report the five-node cycle rather than pass.
+func TestCheckAcyclicUniqueRoot_VacuityOnThePoisonedGraph_6131(t *testing.T) {
+	edges := map[string][]string{}
+	for i, slug := range cutoverStepOrder6131 {
+		name := ActivityStepJobName(GroupCutover, slug)
+		if i == 0 {
+			edges[name] = nil
+			continue
+		}
+		edges[name] = []string{ActivityStepJobName(GroupCutover, cutoverStepOrder6131[i-1])}
+	}
+	rootJob := ActivityStepJobName(GroupCutover, "gitea-mirror")
+
+	// Sanity: corrected, this graph passes.
+	if err := checkAcyclicUniqueRoot(edges, rootJob); err != nil {
+		t.Fatalf("corrected graph should pass, got %v", err)
+	}
+
+	// Branch 1 — the CYCLE detector. Re-introduce the single surviving
+	// stale edge and the graph is the hw293 one.
+	cyclic := cloneEdges6131(edges)
+	cyclic[rootJob] = []string{ActivityStepJobName(GroupCutover, "flux-gitrepository-patch")}
+	err := checkAcyclicUniqueRoot(cyclic, rootJob)
+	if err == nil {
+		t.Fatal("vacuity check FAILED: the assertion passed on the known-bad hw293 graph, so it cannot catch this defect")
+	}
+	if !strings.Contains(err.Error(), "cycle") {
+		t.Fatalf("vacuity check FAILED: the hw293 graph is a five-node cycle but the assertion reported %q — the cycle detector never fired", err)
+	}
+	t.Logf("vacuity ok (cycle branch) — assertion rejects the hw293 graph: %v", err)
+
+	// Branch 2 — the ROOT-uniqueness check, which the cycle branch would
+	// otherwise mask. An acyclic graph with a second root must also fail,
+	// or "unique root" is a claim nothing tests.
+	twoRoots := cloneEdges6131(edges)
+	twoRoots[ActivityStepJobName(GroupCutover, "egress-block-test")] = nil
+	err = checkAcyclicUniqueRoot(twoRoots, rootJob)
+	if err == nil {
+		t.Fatal("vacuity check FAILED: the assertion passed on an acyclic graph with TWO roots")
+	}
+	if !strings.Contains(err.Error(), "roots") {
+		t.Fatalf("vacuity check FAILED: expected a root-count complaint, got %q", err)
+	}
+	t.Logf("vacuity ok (root branch) — assertion rejects a two-root graph: %v", err)
+}
+
+func cloneEdges6131(in map[string][]string) map[string][]string {
+	out := make(map[string][]string, len(in))
+	for k, v := range in {
+		out[k] = append([]string(nil), v...)
+	}
+	return out
+}
+
+// TestMergeJob_UpdateWithNoEdgeInformationStillInherits_6131 is the
+// CONTROL that shares the suspect property: an update whose DependsOn is
+// empty because the writer simply does not carry edge information must
+// still inherit the stored edges. This is the #1467 / prov #73 durability
+// case — the helmwatch bridge's per-event transition path writes
+// DependsOn: []string{} on every state change, and without inheritance
+// all 135 install Jobs flattened to dependsOn=[] and the canvas lost its
+// edges. Whatever #6131 ships must NOT re-open that.
+func TestMergeJob_UpdateWithNoEdgeInformationStillInherits_6131(t *testing.T) {
+	st := newTestStore(t)
+	const depID = "dep-6131-durability"
+
+	seed := Job{
+		DeploymentID: depID,
+		JobName:      "install-cert-manager",
+		AppID:        "cert-manager",
+		Type:         JobTypeInstall,
+		ParentID:     JobID(depID, GroupBootstrapKit),
+		DependsOn:    []string{"install-cilium"},
+		Status:       StatusPending,
+	}
+	if err := st.UpsertJob(seed); err != nil {
+		t.Fatalf("seed UpsertJob: %v", err)
+	}
+
+	// The per-event transition shape: same Job, new status, no edge
+	// information at all.
+	transition := Job{
+		DeploymentID: depID,
+		JobName:      "install-cert-manager",
+		AppID:        "cert-manager",
+		Type:         JobTypeInstall,
+		ParentID:     JobID(depID, GroupBootstrapKit),
+		DependsOn:    []string{},
+		Status:       StatusRunning,
+	}
+	if err := st.UpsertJob(transition); err != nil {
+		t.Fatalf("transition UpsertJob: %v", err)
+	}
+
+	got, _, err := st.GetJob(depID, JobID(depID, "install-cert-manager"))
+	if err != nil {
+		t.Fatalf("GetJob: %v", err)
+	}
+	if len(got.DependsOn) != 1 || got.DependsOn[0] != "install-cilium" {
+		t.Fatalf("a transition carrying no edge information erased the seeded edge: dependsOn = %v, want [install-cilium] (#1467 prov #73 regression)",
+			got.DependsOn)
+	}
+	if got.Status != StatusRunning {
+		t.Fatalf("status = %q, want %q — the transition itself must still land", got.Status, StatusRunning)
+	}
+}
+
+// TestActivityBridge_LazyStepTransitionDoesNotEraseSeededEdges_6131 is
+// the same control one layer up, on the path #6131 must leave alone: a
+// transition arriving for a step the bridge never declared registers it
+// lazily against a PARTIAL in-memory step set, so its computed dependsOn
+// is meaningless. It must inherit, not overwrite.
+func TestActivityBridge_LazyStepTransitionDoesNotEraseSeededEdges_6131(t *testing.T) {
+	st := newTestStore(t)
+	const depID = "dep-6131-lazy"
+
+	seedCutoverSteps6131(t, st, depID, cutoverStepOrder6131)
+
+	// A brand-new bridge (fresh Pod) that has NOT been seeded receives a
+	// transition for a mid-chain step. Its in-memory set holds one entry,
+	// so dependsOnForStepLocked computes "no predecessor" — which is
+	// wrong, and must not be written.
+	fresh := NewActivityBridge(st, depID, GroupCutover, "Cutover")
+	if err := fresh.StartStep(ActivityStep{Slug: "egress-block-test", DisplayName: "Egress Block Test", Order: 8},
+		"resumed without a seed", time.Now().UTC()); err != nil {
+		t.Fatalf("StartStep: %v", err)
+	}
+
+	edges := cutoverEdges6131(t, st, depID)
+	name := ActivityStepJobName(GroupCutover, "egress-block-test")
+	want := ActivityStepJobName(GroupCutover, "catalyst-api-env-patch")
+	if got := edges[name]; len(got) != 1 || got[0] != want {
+		t.Fatalf("an unseeded transition erased the seeded edge on %s: dependsOn = %v, want [%s]", name, got, want)
+	}
+	// And the tree still has its root.
+	if err := checkAcyclicUniqueRoot(edges, ActivityStepJobName(GroupCutover, "gitea-mirror")); err != nil {
+		t.Fatalf("rendered execution tree after a lazy transition: %v", err)
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/jobs/store.go
+++ b/products/catalyst/bootstrap/api/internal/jobs/store.go
@@ -286,6 +286,11 @@ func (s *Store) UpsertJob(j Job) error {
 			return s.persistIndex(idx)
 		}
 	}
+	// First write for this id — there is no prior edge set to preserve or
+	// override, so the directive has nothing to say. Clear it for the
+	// same reason mergeJob does: it describes a write, not a record
+	// (#6131).
+	j.DependsOnAuthoritative = false
 	idx.Jobs = append(idx.Jobs, j)
 	return s.persistIndex(idx)
 }
@@ -309,8 +314,23 @@ func (s *Store) UpsertJob(j Job) error {
 // proper deps, because every HR Ready=True event after the seed wrote
 // empty deps. Founder caught the resulting flat-leaf canvas 4 sessions
 // in a row.
+//
+// The one exception is Job.DependsOnAuthoritative (issue #6131). That
+// preservation reads an empty DependsOn as "this write carries no edge
+// information", which is true of every per-event path — but it is false
+// for a writer that holds the complete ordered set, where empty means
+// "no predecessor", i.e. THIS IS THE ROOT. Such a writer says so
+// explicitly and its empty list is written through. Without that,
+// nothing could ever clear a stale edge off a root: the ten non-root
+// cutover steps self-corrected after #6099 because their recomputed
+// edge was non-empty, and gitea-mirror alone stayed wrong because its
+// correct value was the one value this rule refuses to write.
 func mergeJob(prev, next Job) Job {
 	out := next
+	// The directive describes the incoming WRITE, not the record. Drop
+	// it here so a stored row can never re-assert an old write's intent
+	// on some later merge.
+	out.DependsOnAuthoritative = false
 	if next.StartedAt == nil && prev.StartedAt != nil {
 		out.StartedAt = prev.StartedAt
 	}
@@ -320,7 +340,7 @@ func mergeJob(prev, next Job) Job {
 	if next.LatestExecutionID == "" && prev.LatestExecutionID != "" {
 		out.LatestExecutionID = prev.LatestExecutionID
 	}
-	if len(next.DependsOn) == 0 && len(prev.DependsOn) > 0 {
+	if len(next.DependsOn) == 0 && len(prev.DependsOn) > 0 && !next.DependsOnAuthoritative {
 		out.DependsOn = prev.DependsOn
 	}
 	// Carry forward Region — the seed fan-out stamps it once, but a

--- a/products/catalyst/bootstrap/api/internal/jobs/types.go
+++ b/products/catalyst/bootstrap/api/internal/jobs/types.go
@@ -381,6 +381,30 @@ type Job struct {
 	// arrows to render the canvas resolves these by exact ID match.
 	DependsOn []string `json:"dependsOn"`
 
+	// DependsOnAuthoritative — a WRITE-TIME DIRECTIVE, never record
+	// state, and therefore never persisted (`json:"-"`). It answers the
+	// one question an empty DependsOn cannot (issue #6131).
+	//
+	// mergeJob inherits the stored DependsOn whenever an incoming write
+	// carries an empty one, because for almost every writer empty means
+	// "this write carries no edge information" — the helmwatch bridge's
+	// per-event transition path does not re-derive sibling deps on every
+	// state change, and without that inheritance all 135 install Jobs
+	// flattened to `dependsOn=[]` on prov #73 (#1467).
+	//
+	// But empty has a second, opposite meaning: "I hold the complete
+	// ordered set and this node has no predecessor" — i.e. THIS IS THE
+	// ROOT. Inheriting there is wrong, and it is what left
+	// cutover-step-gitea-mirror (bp.openova.io/cutover-order=1) pointing
+	// at its pre-#6099 alphabetical predecessor on hw293, closing a
+	// five-node cycle and leaving the execution tree with no root.
+	//
+	// A writer sets this to true ONLY when it has just been handed the
+	// full, ordered edge set and can therefore be believed about an
+	// absence. Today that is exactly ActivityBridge.SeedSteps. Every
+	// lazy/per-event path leaves it false and keeps inheriting.
+	DependsOnAuthoritative bool `json:"-"`
+
 	// Status — pending|running|succeeded|failed. For group jobs the
 	// persisted value is ignored on read; the runtime status is
 	// derived from descendants (failed > running > pending >


### PR DESCRIPTION
#6099 corrected the cutover execution tree's `dependsOn` edges and ten of the eleven steps came out right. The eleventh is the **root**, and it is the one that decides whether the graph is a tree at all.

Measured on hw293.omantel.biz against catalyst-api `852de2b`, `cutover-step-gitea-mirror` — `bp.openova.io/cutover-order=1`, the true first step — still renders

```
cutover-step-gitea-mirror   dependsOn [cutover-step-flux-gitrepository-patch]
```

`flux-gitrepository-patch` is `gitea-mirror`'s predecessor under the OLD alphabetical seed. With the other ten edges now correct, that single stale edge completes a **five-node cycle**:

```
gitea-mirror -> flux-gitrepository-patch(5) -> registry-pivot(4)
             -> harbor-prewarm(3) -> harbor-projects(2) -> gitea-mirror(1)
```

so the tree is cyclic and has no root. UAT row 162 stays red.

## Verified at the line

The read-path re-seed computes the **right** answer. `mergeJob` refuses to write it.

`ActivityBridge.dependsOnForStepLocked` (`internal/jobs/activity_bridge.go:222`) returns an empty list for the step at index 0 — correct, the root has no predecessor. `internal/jobs/store.go:323` then does

```go
if len(next.DependsOn) == 0 && len(prev.DependsOn) > 0 { out.DependsOn = prev.DependsOn }
```

The ten non-root steps recompute to a **non-empty** list, so their corrected edge overwrites the stale one cleanly — which is exactly why #6099 looked like it worked. The root recomputes to the **empty** list, hits the preservation, and keeps its pre-#6099 edge forever. #6099 is correct for a store seeded fresh under the new build; it cannot repair a store first seeded under the old one, and hw293's was.

The diagnosis reproduces arithmetically, which is how it was confirmed without a live write: sort the eleven slugs and `gitea-mirror` lands at index 4 with `flux-gitrepository-patch` at index 3 — the measured value exactly. The eleven order labels were read from `platform/self-sovereign-cutover/chart/templates/` (`01-gitea-mirror-job.yaml:29` through `11-crossplane-provider-pivot-job.yaml:102`).

## The preservation rule is not the defect, and is not removed

Origin: #1467 (prov #73, `8cd1ff1a80430dc5`, 2026-05-14). The helmwatch bridge's per-event transition path writes `DependsOn: []string{}` because it does not re-derive sibling deps on every state change; without inheritance every state change after the seed flattened all 135 install Jobs to `dependsOn=[]` and the canvas lost its edges. Deleting the guard re-opens that, so it stays.

The real defect is that an empty `DependsOn` is **ambiguous** and `mergeJob` can only see one of its two meanings:

| the write says | who says it | correct action |
|---|---|---|
| "I carry no edge information" | every per-event transition path | inherit the stored edges |
| "I hold the complete ordered set and this node has no predecessor" | a seed writer | **write the empty list — this is the root** |

## The fix

`Job.DependsOnAuthoritative` — a **write-time directive**, never record state, never persisted (`json:"-"`), and explicitly cleared on the stored row by both the merge path and the append path so a stored record can never re-assert an old write's intent.

`ActivityBridge.SeedSteps` sets it, and nothing else does. That is the whole distinction: authority comes from **having just been handed the complete ordered set** (derived from the `bp.openova.io/cutover-order` label), not from the value happening to be empty. `ensureStepLocked` — the lazy path that registers a step a transition arrived for — deliberately leaves it false, because it may be working from a partial in-memory set where empty really does mean "no information".

**No separate repair path is needed.** `projectCutoverResumeSeed` re-seeds the full ordered set on every `/jobs` read, so an already-poisoned store corrects itself on the next read. That claim is not asserted — it is the thing the headline test measures, by poisoning a store the pre-#6099 way and then re-seeding it once.

## Red before green, uncached, verbatim

Before, both suites (`-count=1`):

```
--- FAIL: TestActivityBridge_ReseedRepairsRootEdgeOnAPoisonedStore_6131 (0.05s)
    cutover-step-gitea-mirror is cutover-order=1 and must be the ROOT, got dependsOn [cutover-step-flux-gitrepository-patch]
    rendered execution tree: cycle through [cutover-step-catalyst-api-env-patch cutover-step-helmrepository-patches cutover-step-flux-gitrepository-patch cutover-step-registry-pivot cutover-step-harbor-prewarm cutover-step-harbor-projects cutover-step-gitea-mirror] -> cutover-step-flux-gitrepository-patch
--- FAIL: TestProjectCutoverResumeSeed_ReplaysAndLeavesARootedTree_6131 (0.21s)
    cutover-step-gitea-mirror is cutover-order=1 and must be the ROOT, got dependsOn [cutover-step-flux-gitrepository-patch]
    rendered execution tree after a durable replay: cycle through [... cutover-step-harbor-projects cutover-step-gitea-mirror] -> cutover-step-flux-gitrepository-patch
```

After:

```
--- PASS: TestActivityBridge_ReseedRepairsRootEdgeOnAPoisonedStore_6131 (0.04s)
--- PASS: TestCheckAcyclicUniqueRoot_VacuityOnThePoisonedGraph_6131 (0.00s)
--- PASS: TestMergeJob_UpdateWithNoEdgeInformationStillInherits_6131 (0.00s)
--- PASS: TestActivityBridge_LazyStepTransitionDoesNotEraseSeededEdges_6131 (0.03s)
--- PASS: TestProjectCutoverResumeSeed_ReplaysAndLeavesARootedTree_6131 (0.19s)
```

Every assertion is on **edge values and the resulting root**, never a count — a count passes on any permutation, which is precisely how the alphabetical tree shipped green.

## The controls

**Cycle assertion.** The rendered graph must be acyclic with `gitea-mirror` as its unique root. Cycle detection runs FIRST, so a cyclic graph is reported as the cycle it is rather than the "0 roots" it also causes — the first draft reported `0 roots` and never exercised the cycle detector at all.

**Durability control — the primary one, at two layers.** A write that legitimately carries no edge information must still inherit:
- `TestMergeJob_UpdateWithNoEdgeInformationStillInherits_6131` — the #1467 shape directly: seed `install-cert-manager` with `[install-cilium]`, then send the per-event transition with `DependsOn: []string{}`. The edge survives and the status still lands.
- `TestActivityBridge_LazyStepTransitionDoesNotEraseSeededEdges_6131` — an unseeded bridge receiving a mid-chain transition must not overwrite the seeded edge from its partial in-memory set.
- `TestProjectCutoverResumeSeed_ReplaysAndLeavesARootedTree_6131` — end-to-end at the seam that actually runs on a Sovereign. It replays a **completed** cutover from the durable status ConfigMap onto a poisoned store and requires both halves: every step still replays its terminal state **and its Execution** (the #3646 case an operator hits opening `/jobs` long after handover), and the tree left behind is rooted and acyclic.

The six pre-existing `TestMergeCutoverStepOrder_*` tests from #6099 — including the durable-only-step-survives case — stay green.

**Control on the input.** Both new suites fail loudly if the alphabetical sort ever stops handing `gitea-mirror` the `flux-gitrepository-patch` predecessor that was measured live, so a step rename makes the reproduction announce that it no longer reproduces instead of passing vacuously.

**Vacuity check, both halves.** `TestCheckAcyclicUniqueRoot_VacuityOnThePoisonedGraph_6131` proves the new assertion can fail on each of its two branches independently — the cycle detector against the hw293 graph, and the root-uniqueness check against an acyclic graph with two roots (which the cycle branch would otherwise mask). Separately, temporarily flipping the one-line directive back to `false` turns **both** new test files red at the exact live value, so neither guard is decorative.

## Delivery

No chart rendered surface changed, so no bump is due — `scripts/check-chart-version-bumped.sh` reports `PASS: no chart rendered-surface changes`. `catalyst-build.yaml` already triggers on `products/catalyst/bootstrap/**` and bumps the umbrella atomically (#5743), which is the same path #6099's Go-side change took.

`go vet` clean. `go test -race -count=1` green in `internal/jobs` (28s) and `internal/handler` (309s).

No live-cluster writes were made and the cutover chain was not fired. `docs/ledger/UAT.md` is untouched — row 162 re-stamps on a walk once this deploys.

Refs #3379 #6131 #6093 #6099 #3646 #1467

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## One case #6131 quietly repairs, measured rather than assumed

There is a case the platform genuinely cannot get right: a completed cutover whose step ConfigMaps have been reaped, where `listCutoverSteps` returns nothing and the sequence can only come from the durable record — alphabetical by construction. #6099 accepted that trade deliberately.

The **order** is unrecoverable there. The **tree shape** is not, and it was wrong. Reverting the directive and re-seeding a correctly-ordered store from the alphabetical-only source produces a **nine-node cycle**:

```
cycle through [cutover-step-catalyst-api-env-patch ... cutover-step-crossplane-provider-pivot]
  -> cutover-step-catalyst-api-env-patch
```

because the ten non-root steps get rewritten alphabetically while the previously-correct root keeps its old edge — that edge being the empty list the preservation refuses to overwrite. With the directive, the same re-seed yields a rooted acyclic chain in the wrong-but-honest order the only available source could offer. `TestActivityBridge_ReseedWithoutAnOrderBearingSourceStaysAcyclic_6131` pins it.
