### PR TITLE
fix(catalyst-api): refuse a declared isolation the plan cannot deliver instead of accepting and substituting it (UAT row G7)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/org_create_isolation_contract_6135_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_create_isolation_contract_6135_test.go
@@ -1,0 +1,225 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// org_create_isolation_contract_6135_test.go — #6135 (UAT row G7).
+//
+// MEASURED on hw293.omantel.biz (dep a0077ba47e3720e5): the free-subdomain
+// signup door returned HTTP 202 acknowledging `isolation: vcluster`, and no
+// vCluster was ever created. The Organization was backed by the host `<slug>`
+// namespace.
+//
+// MECHANISM, at the line. `resolveOrgShape` let a valid explicit `isolation`
+// win over the tier gate:
+//
+//	isolation := strings.ToLower(strings.TrimSpace(req.Isolation))
+//	switch isolation {
+//	case "namespace", "vcluster":   // request value WINS
+//	default:
+//	        isolation = isolationForTier(planSlug)
+//	}
+//
+// while the plan normalised to "s" a few lines above (the signup form carries
+// no plan picker) and the gate that AUTHORS the backing —
+// core/controllers/organization/internal/gitops/manifests.go
+// `boundaryIsVcluster(planSlug)` — takes the plan and nothing else. No non-test
+// reader of the accepted `isolation` exists in the provisioning gitops
+// renderer, the provisioning consumer, or any core/controllers reconciler. So
+// the field could only ever agree with the plan or lie about it.
+//
+// The control on the same Sovereign was `hw293walkone`: same declared
+// isolation, plan `m`, a real vCluster 1/1. The variable was the plan.
+//
+// WHAT THESE TESTS PIN. The undeliverable combination is refused with 422 at
+// the door instead of accepted and silently substituted; every other declaring
+// body — the ones that AGREE with their plan — still returns 202 with the
+// declared value; and the marketplace funnel's own body, which declares
+// nothing, is byte-unchanged.
+
+// postCreateOrgRaw drives the create door and returns the recorder plus the
+// decoded generic body. Unlike postCreateOrg it does NOT assume the success
+// envelope, so an error response is readable field-by-field.
+func postCreateOrgRaw(t *testing.T, h *Handler, body string) (int, map[string]any) {
+	t.Helper()
+	w, _ := postCreateOrg(t, h, body)
+	var generic map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &generic); err != nil {
+		t.Fatalf("decode create response: %v body=%s", err, w.Body.String())
+	}
+	return w.Code, generic
+}
+
+// TestCreateOrganization_DeclaredIsolationThePlanCannotDeliverIsRefused_6135 is
+// the load-bearing case: the exact hw293 body. Pre-fix it returned 202 with
+// `"isolation":"vcluster"`; post-fix it returns 422 naming the conflict.
+func TestCreateOrganization_DeclaredIsolationThePlanCannotDeliverIsRefused_6135(t *testing.T) {
+	h, _ := newOrgPipelineHandlerWithCRs(t)
+
+	// No plan_slug — exactly what the signup door sends, since the form has no
+	// plan picker. The handler normalises it to "s", the one tier the gate
+	// backs with a host namespace.
+	code, body := postCreateOrgRaw(t, h, `{
+		"subdomain":   "g7conflict",
+		"admin_email": "admin@g7conflict.test",
+		"domain_mode": "free-subdomain",
+		"isolation":   "vcluster"
+	}`)
+
+	if code == http.StatusAccepted {
+		t.Fatalf("the door ACCEPTED a declared isolation it does not honour: 202 with isolation=%v. "+
+			"The org-controller keys the boundary off planSlug alone (BoundaryIsVcluster(\"s\") == false), "+
+			"so this 202 promises a vCluster that is never authored (#6135, hw293 dep a0077ba47e3720e5)",
+			body["isolation"])
+	}
+	if code != http.StatusUnprocessableEntity {
+		t.Fatalf("status: want 422 got %d body=%v", code, body)
+	}
+	if got, _ := body["error"].(string); got != "isolation-plan-conflict" {
+		t.Errorf("error code = %q, want %q", got, "isolation-plan-conflict")
+	}
+
+	// Assert on the VALUE of the refusal, not that a `detail` key exists: an
+	// empty or generic message leaves the caller in exactly the position the
+	// silent downgrade left them.
+	detail, _ := body["detail"].(string)
+	for _, want := range []string{"vcluster", "\"s\"", "namespace", "Omit `isolation`"} {
+		if !strings.Contains(detail, want) {
+			t.Errorf("422 detail %q does not name %q — the caller cannot tell what they asked for, "+
+				"what the plan gives, or how to get what they wanted", detail, want)
+		}
+	}
+	// It must also point at a plan that WOULD deliver the request, computed
+	// from the gate rather than transcribed.
+	for _, p := range plansDeliveringIsolation("vcluster") {
+		if !strings.Contains(detail, p) {
+			t.Errorf("422 detail %q omits plan %q, which the tier gate does back with a vCluster", detail, p)
+		}
+	}
+
+	// Nothing may have been persisted: a refusal that still mints the record is
+	// the same divergence with a different status code.
+	if _, ok := body["org_tenant_id"]; ok {
+		t.Errorf("refused create still returned an Organization id (%v) — the record was minted anyway", body["org_tenant_id"])
+	}
+}
+
+// TestCreateOrganization_DeclaredIsolationThatAgreesIsAccepted_6135 is the
+// CONTROL. It shares the suspect property — a non-empty declared `isolation`
+// on the same door, through the same adjudicator — and stays green, so the
+// diff above is a new constraint on the UNDELIVERABLE combination rather than
+// a blanket refusal of the field.
+func TestCreateOrganization_DeclaredIsolationThatAgreesIsAccepted_6135(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		plan string
+		want string
+	}{
+		{"vcluster declared on plan m", "m", "vcluster"},
+		{"vcluster declared on plan flexi", "flexi", "vcluster"},
+		{"namespace declared on plan s", "s", "namespace"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h, _ := newOrgPipelineHandlerWithCRs(t)
+			code, body := postCreateOrgRaw(t, h, `{
+				"subdomain":   "g7control",
+				"admin_email": "admin@g7control.test",
+				"domain_mode": "free-subdomain",
+				"plan_slug":   "`+tc.plan+`",
+				"isolation":   "`+tc.want+`"
+			}`)
+			if code != http.StatusAccepted {
+				t.Fatalf("declared isolation %q AGREES with plan %q and must still be accepted; got %d body=%v",
+					tc.want, tc.plan, code, body)
+			}
+			if got, _ := body["isolation"].(string); got != tc.want {
+				t.Errorf("accepted body isolation = %q, want %q", got, tc.want)
+			}
+			// The echoed value must equal what the authoring gate will do —
+			// that equality is the whole contract this row is about.
+			if got, _ := body["isolation"].(string); got != isolationForTier(tc.plan) {
+				t.Errorf("echoed isolation %q diverges from the tier gate's answer %q for plan %q",
+					got, isolationForTier(tc.plan), tc.plan)
+			}
+		})
+	}
+}
+
+// TestCreateOrganization_FunnelBodyWithNoDeclarationIsUnchanged_6135 is the
+// second CONTROL: the marketplace funnel declares no isolation at all, so the
+// door must behave exactly as before — 202, with the value DERIVED from the
+// resolved plan.
+func TestCreateOrganization_FunnelBodyWithNoDeclarationIsUnchanged_6135(t *testing.T) {
+	h, _ := newOrgPipelineHandlerWithCRs(t)
+
+	code, body := postCreateOrgRaw(t, h, `{
+		"subdomain":    "g7funnel",
+		"admin_email":  "admin@g7funnel.test",
+		"company_name": "G7 Funnel",
+		"domain_mode":  "free-subdomain"
+	}`)
+
+	if code != http.StatusAccepted {
+		t.Fatalf("the funnel body declares no isolation and must stay accepted; got %d body=%v", code, body)
+	}
+	if got, _ := body["isolation"].(string); got != "namespace" {
+		t.Errorf("derived isolation = %q, want %q — the funnel's plan resolves to \"s\" and the gate "+
+			"backs that with the host namespace", got, "namespace")
+	}
+	// A host-namespace Organization authors no vCluster, so the payload must
+	// carry no vcluster_name at all (#5501 omitempty contract). An empty string
+	// still reads as "this Org has a vCluster field".
+	if _, present := body["vcluster_name"]; present {
+		t.Errorf("namespace-backed Organization carries vcluster_name=%v — the response still "+
+			"advertises a boundary that was never authored", body["vcluster_name"])
+	}
+}
+
+// TestResolveOrgShape_IsolationHasExactlyOneProducer_6135 is the VACUITY CHECK
+// for the fix's central claim: the boundary label is produced by the tier gate
+// and by nothing else. It sweeps every catalog plan against every declarable
+// isolation value, INCLUDING the ones that contradict the plan, and requires
+// the resolver to answer isolationForTier(plan) every single time.
+//
+// It cannot pass on a stub: restore the old override branch and the
+// contradicting half of the sweep goes red immediately, and a resolver that
+// returned a constant fails the other half.
+func TestResolveOrgShape_IsolationHasExactlyOneProducer_6135(t *testing.T) {
+	t.Parallel()
+	declarations := []string{"", "namespace", "vcluster", "VCLUSTER", "  namespace  ", "bogus"}
+	sawAgreeing, sawContradicting := false, false
+
+	for _, plan := range catalogPlanSlugs {
+		want := isolationForTier(plan)
+		for _, decl := range declarations {
+			got := resolveOrgShape(orgTenantCreateRequest{
+				Kind: "customer", PlanSlug: plan, Isolation: decl,
+			})
+			if got.Isolation != want {
+				t.Errorf("resolveOrgShape(plan=%q, isolation=%q).Isolation = %q, want %q — "+
+					"a second input steered the boundary label away from the tier gate",
+					plan, decl, got.Isolation, want)
+			}
+			switch strings.ToLower(strings.TrimSpace(decl)) {
+			case "":
+			case want:
+				sawAgreeing = true
+			default:
+				sawContradicting = true
+			}
+		}
+	}
+
+	// Vacuity: the sweep is only meaningful if it actually exercised both a
+	// declaration that matches the plan and one that contradicts it.
+	if !sawAgreeing {
+		t.Fatal("sweep never exercised a declaration that AGREES with its plan — the guard proves nothing")
+	}
+	if !sawContradicting {
+		t.Fatal("sweep never exercised a declaration that CONTRADICTS its plan — that is the whole defect")
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/organization_orgshape_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/organization_orgshape_test.go
@@ -58,17 +58,34 @@ func TestResolveOrgShape(t *testing.T) {
 			want: orgShape{Kind: "customer", Tier: "org", BillingMode: "real", Isolation: "namespace", PlanSlug: "s"},
 		},
 		{
-			// #4539: an explicit isolation in the request still overrides the
-			// derived value (the advanced operator view) — an S-plan Org can be
-			// force-put onto a vcluster.
-			name: "advanced override: S-plan customer forced onto vcluster",
+			// #6135 (UAT row G7) — these two cases used to assert the OPPOSITE:
+			// that an explicit `isolation` overrides the tier gate, so an S-plan
+			// Org could be "force-put onto a vcluster". No force ever occurred.
+			// Nothing downstream reads this value — `boundaryIsVcluster(planSlug)`
+			// authors the backing from the plan alone — so the only thing the
+			// override produced was a 202 echoing `vcluster` over a host
+			// namespace (measured on hw293, dep a0077ba47e3720e5: 202 +
+			// isolation=vcluster, zero vClusters). The expectation encoded the
+			// defect. The shape now DERIVES unconditionally; a declaration that
+			// contradicts the plan is refused at the door with 422 by
+			// declaredIsolationConflict, so it never reaches this resolver.
+			name: "declared vcluster on an S plan does NOT override the tier gate",
 			in:   orgTenantCreateRequest{Kind: "customer", PlanSlug: "s", Isolation: "vcluster"},
-			want: orgShape{Kind: "customer", Tier: "org", BillingMode: "real", Isolation: "vcluster", PlanSlug: "s"},
+			want: orgShape{Kind: "customer", Tier: "org", BillingMode: "real", Isolation: "namespace", PlanSlug: "s"},
 		},
 		{
-			name: "advanced override: internal org forced onto chargeback + vcluster",
+			name: "declared vcluster on an internal org does NOT override the tier gate",
 			in:   orgTenantCreateRequest{Kind: "internal", BillingMode: "chargeback", Isolation: "vcluster"},
-			want: orgShape{Kind: "internal", Tier: "org", BillingMode: "chargeback", Isolation: "vcluster", PlanSlug: "s"},
+			want: orgShape{Kind: "internal", Tier: "org", BillingMode: "chargeback", Isolation: "namespace", PlanSlug: "s"},
+		},
+		{
+			// CONTROL for the two cases above: the declaration is not being
+			// ignored wholesale — kind still drives billingMode on the very same
+			// bodies, and an M-plan declaration of `vcluster` still resolves to
+			// vcluster. What changed is only which input decides the BOUNDARY.
+			name: "declared vcluster AGREEING with an M plan resolves to vcluster",
+			in:   orgTenantCreateRequest{Kind: "customer", PlanSlug: "m", Isolation: "vcluster"},
+			want: orgShape{Kind: "customer", Tier: "org", BillingMode: "real", Isolation: "vcluster", PlanSlug: "m"},
 		},
 		{
 			name: "corporate tier honored",

--- a/products/catalyst/bootstrap/api/internal/handler/organization_provisioning.go
+++ b/products/catalyst/bootstrap/api/internal/handler/organization_provisioning.go
@@ -271,7 +271,16 @@ type orgTenantCreateRequest struct {
 	Kind        string `json:"kind,omitempty"`
 	Tier        string `json:"tier,omitempty"`
 	BillingMode string `json:"billing_mode,omitempty"`
-	Isolation   string `json:"isolation,omitempty"`
+	// Isolation — a CONSTRAINT ASSERTION, not an override (#6135). The
+	// Organization's boundary primitive is authored downstream by
+	// `boundaryIsVcluster(planSlug)`, which takes exactly one argument: the
+	// plan. Nothing in the renderer or the org-controller reads this field.
+	// So a value here can only ever AGREE with the plan's boundary or LIE
+	// about it — and it used to be allowed to lie, silently, in a 202.
+	// Declaring it now asserts the boundary you expect: it must match the
+	// resolved plan's, or the create is refused with 422. Omit it to accept
+	// whatever the plan delivers (the marketplace funnel's path).
+	Isolation string `json:"isolation,omitempty"`
 
 	// PlanSlug — purchased catalog plan slug (s|m|l|xl|flexi). Carried onto
 	// the Organization CR so the org-controller materializes the matching
@@ -346,6 +355,81 @@ func isolationForTier(planSlug string) string {
 	}
 }
 
+// catalogPlanSlugs — the purchasable catalog plans, in tier order. ONE list:
+// resolveOrgShape's normalisation and the #6135 conflict message both read it,
+// so a new plan cannot be accepted by one and invisible to the other.
+var catalogPlanSlugs = []string{"s", "m", "l", "xl", "flexi"}
+
+// isCatalogPlanSlug reports whether `slug` names a purchasable plan.
+func isCatalogPlanSlug(slug string) bool {
+	for _, p := range catalogPlanSlugs {
+		if slug == p {
+			return true
+		}
+	}
+	return false
+}
+
+// plansDeliveringIsolation lists the catalog plans whose boundary primitive is
+// `want`, computed by asking the SAME tier gate the create path resolves with.
+// Never a hand-written table: a table would keep naming `m` after a policy flip
+// that moved M-tier Orgs onto a host namespace, which is the class of drift the
+// caller-facing message exists to prevent.
+func plansDeliveringIsolation(want string) []string {
+	var out []string
+	for _, p := range catalogPlanSlugs {
+		if isolationForTier(p) == want {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// declaredIsolationConflict adjudicates a DECLARED `isolation` against the
+// boundary the RESOLVED plan actually delivers (#6135, UAT row G7).
+//
+// The defect it closes: `resolveOrgShape` used to let any valid explicit
+// isolation WIN over the tier gate. The create door then returned 202 echoing
+// `isolation: vcluster` for a plan-`s` Organization that the org-controller
+// backs with the host `<slug>` namespace — and no vCluster was ever authored.
+// The signup form carries no plan picker, so the plan normalised to `s` and
+// EVERY declaring caller on that door got the substitution.
+//
+// The accepted value was never load-bearing: no non-test reader of it exists in
+// core/services/provisioning/gitops, the provisioning consumer, or any
+// core/controllers reconciler. `boundaryIsVcluster(planSlug)` authors the
+// backing from the plan alone. An override branch over a field nothing honours
+// can only produce a divergence, so it is removed rather than plumbed through:
+// making the declaration a second input to the boundary decision would give one
+// outcome two sources of truth, which is the row's own defect wearing a fix's
+// clothes.
+//
+// Returns ("", false) when there is nothing to refuse — an omitted declaration
+// (the marketplace funnel: byte-unchanged) or one that agrees with the plan.
+// Otherwise returns the caller-facing detail and true. An unrecognised enum
+// value lands here too: it cannot equal the plan's boundary, and silently
+// ignoring it is the same lie in a smaller font.
+func declaredIsolationConflict(declared, planSlug string) (string, bool) {
+	want := strings.ToLower(strings.TrimSpace(declared))
+	if want == "" {
+		return "", false
+	}
+	delivered := isolationForTier(planSlug)
+	if want == delivered {
+		return "", false
+	}
+	detail := fmt.Sprintf(
+		"isolation %q is not deliverable on plan %q: that plan's Organizations are backed by %s isolation. ",
+		want, planSlug, delivered)
+	if alt := plansDeliveringIsolation(want); len(alt) > 0 {
+		detail += fmt.Sprintf("Plans that deliver %q: %s. ", want, strings.Join(alt, ", "))
+	} else {
+		detail += fmt.Sprintf("No catalog plan currently delivers %q. ", want)
+	}
+	detail += "Omit `isolation` to accept the plan's boundary, or send a plan_slug that delivers it."
+	return detail, true
+}
+
 // resolveOrgShape applies the §2.1/§2.3 model: kind defaults to
 // "customer" (the marketplace door); billingMode defaults from kind
 // (internal → showback; customer → real); isolation is DERIVED from the
@@ -375,9 +459,7 @@ func resolveOrgShape(req orgTenantCreateRequest) orgShape {
 	}
 
 	planSlug := strings.ToLower(strings.TrimSpace(req.PlanSlug))
-	switch planSlug {
-	case "s", "m", "l", "xl", "flexi":
-	default:
+	if !isCatalogPlanSlug(planSlug) {
 		planSlug = "s"
 	}
 
@@ -385,14 +467,17 @@ func resolveOrgShape(req orgTenantCreateRequest) orgShape {
 	// vcluster for M+) so the label reflects the real backing. It keys off
 	// planSlug ALONE, exactly like the org-controller gate that authors that
 	// backing — `kind` selects the billing dimension above, never the boundary
-	// primitive (#4292 / UAT row 100). An explicit valid request override still
-	// wins.
-	isolation := strings.ToLower(strings.TrimSpace(req.Isolation))
-	switch isolation {
-	case "namespace", "vcluster":
-	default:
-		isolation = isolationForTier(planSlug)
-	}
+	// primitive (#4292 / UAT row 100).
+	//
+	// #6135 (UAT row G7) — the derivation is now UNCONDITIONAL. A declared
+	// `isolation` used to win here, which is how a plan-`s` create returned 202
+	// echoing `vcluster` while the org-controller authored a host namespace and
+	// no vCluster ever appeared. A declaration is adjudicated by
+	// declaredIsolationConflict at the door and refused with 422 when the plan
+	// cannot deliver it; by the time this runs, any surviving declaration
+	// already AGREES with the value below, so honouring it and deriving it are
+	// the same answer — and deriving it keeps ONE producer for the boundary.
+	isolation := isolationForTier(planSlug)
 
 	tier := strings.ToLower(strings.TrimSpace(req.Tier))
 	switch tier {
@@ -751,6 +836,20 @@ func (h *Handler) HandleCreateOrganization(w http.ResponseWriter, r *http.Reques
 	// internal door sends kind="internal" → showback + namespace, no
 	// voucher step. The resolved shape is stamped on the record below.
 	shape := resolveOrgShape(body)
+
+	// #6135 (UAT row G7) — a DECLARED isolation the resolved plan cannot
+	// deliver is refused here rather than accepted and silently substituted.
+	// Adjudicated against shape.PlanSlug (the RESOLVED plan, after the
+	// empty/unknown → "s" normalisation) so the check and the outcome read the
+	// same plan; against body.PlanSlug it would clear a declaration that the
+	// create then contradicts.
+	if detail, conflict := declaredIsolationConflict(body.Isolation, shape.PlanSlug); conflict {
+		writeJSON(w, http.StatusUnprocessableEntity, map[string]string{
+			"error":  "isolation-plan-conflict",
+			"detail": detail,
+		})
+		return
+	}
 
 	if mode == "" {
 		mode = string(store.OrganizationDomainFreeSubdomain)

--- a/products/catalyst/bootstrap/api/internal/handler/tier_gate_lockstep_4292_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/tier_gate_lockstep_4292_test.go
@@ -19,7 +19,10 @@
 // vocabulary, for the same cross-module reason.
 package handler
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 // tierGateHostNS is the exact set of plan slugs that back a HOST NAMESPACE. It
 // is the literal copy of the `case "", "s", "free":` arm in boundaryIsVcluster.
@@ -126,18 +129,120 @@ func TestIsolationForTier_IgnoresKind(t *testing.T) {
 	}
 }
 
-// TestIsolationForTier_ExplicitOverrideStillWins pins the advanced-operator
-// escape hatch, so the fix above cannot be mistaken for "isolation is now
-// unconditional". An explicit valid isolation in the request is still honoured
-// for either kind.
-func TestIsolationForTier_ExplicitOverrideStillWins(t *testing.T) {
+// TestIsolationForTier_DeclarationNeverOverridesTheTierGate replaces the former
+// TestIsolationForTier_ExplicitOverrideStillWins, which pinned an
+// "advanced-operator escape hatch" that never escaped anything (#6135, UAT row
+// G7). The hatch let a declared `isolation` win over the tier gate in
+// resolveOrgShape while `boundaryIsVcluster(planSlug)` — which takes the plan
+// and nothing else — went on authoring the host `<slug>` namespace. Measured on
+// hw293 (dep a0077ba47e3720e5): 202, `isolation: vcluster`, no vCluster.
+//
+// The declaration is now an ASSERTION, adjudicated at the door. Both halves
+// are pinned here so the change cannot be read as either "declarations are
+// ignored" or "declarations still steer the boundary".
+func TestIsolationForTier_DeclarationNeverOverridesTheTierGate(t *testing.T) {
 	t.Parallel()
 	for _, kind := range []string{"customer", "internal"} {
 		got := resolveOrgShape(orgTenantCreateRequest{
 			Kind: kind, PlanSlug: "s", Isolation: "vcluster",
 		})
-		if got.Isolation != "vcluster" {
-			t.Errorf("kind %s: explicit isolation override dropped, got %q", kind, got.Isolation)
+		if got.Isolation != "namespace" {
+			t.Errorf("kind %s: resolved isolation %q for plan s — a declaration steered the "+
+				"boundary again, and the org-controller will still author a host namespace "+
+				"(gitops.BoundaryIsVcluster(\"s\") == false)", kind, got.Isolation)
+		}
+	}
+}
+
+// TestDeclaredIsolationConflict_RefusesOnlyTheUndeliverable pins the door's
+// adjudicator. The CONTROL cases share the suspect property — they all carry a
+// non-empty declared `isolation` — and stay accepted, so the guard is a new
+// constraint on the undeliverable combination rather than a blanket rejection
+// of the field.
+func TestDeclaredIsolationConflict_RefusesOnlyTheUndeliverable(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name         string
+		declared     string
+		planSlug     string
+		wantConflict bool
+	}{
+		// The measured row: the signup door has no plan picker, so the plan
+		// resolves to "s" and a declared vcluster cannot be delivered.
+		{"row G7: vcluster declared on plan s", "vcluster", "s", true},
+		{"vcluster declared on plan s, mixed case + padding", "  VCluster ", "s", true},
+		{"namespace declared on plan m", "namespace", "m", true},
+		{"unrecognised enum on plan s", "dedicated-cluster", "s", true},
+
+		// CONTROLS — a declaration is present in every one of these.
+		{"vcluster declared on plan m (agrees)", "vcluster", "m", false},
+		{"vcluster declared on plan flexi (agrees)", "vcluster", "flexi", false},
+		{"namespace declared on plan s (agrees)", "namespace", "s", false},
+		// The marketplace funnel's own body: no declaration, nothing to refuse.
+		{"omitted declaration on plan s", "", "s", false},
+		{"omitted declaration on plan xl", "", "xl", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			detail, conflict := declaredIsolationConflict(tc.declared, tc.planSlug)
+			if conflict != tc.wantConflict {
+				t.Fatalf("declaredIsolationConflict(%q, %q) conflict = %v, want %v",
+					tc.declared, tc.planSlug, conflict, tc.wantConflict)
+			}
+			if !conflict {
+				if detail != "" {
+					t.Fatalf("no conflict but detail = %q, want empty", detail)
+				}
+				return
+			}
+			// Assert on the VALUE of the message, not on its presence: a
+			// refusal the caller cannot act on is the silent downgrade with
+			// extra steps. It must name what was asked, what the plan gives,
+			// and the way out.
+			for _, want := range []string{
+				strings.ToLower(strings.TrimSpace(tc.declared)),
+				tc.planSlug,
+				isolationForTier(tc.planSlug),
+				"Omit `isolation`",
+			} {
+				if !strings.Contains(detail, want) {
+					t.Errorf("422 detail %q does not name %q — the caller cannot tell what they "+
+						"were refused or how to proceed", detail, want)
+				}
+			}
+		})
+	}
+}
+
+// TestPlansDeliveringIsolation_ComesFromTheGate is the VACUITY CHECK for the
+// caller-facing plan list: it must be COMPUTED from isolationForTier, not
+// transcribed. A hand-written list would keep naming the same plans after a
+// policy flip and hand every refused caller a wrong instruction.
+//
+// It fails if the list is empty, if it names a plan the gate contradicts, or if
+// it omits a plan the gate qualifies — so it cannot pass on a stub.
+func TestPlansDeliveringIsolation_ComesFromTheGate(t *testing.T) {
+	t.Parallel()
+	for _, want := range []string{"namespace", "vcluster"} {
+		got := plansDeliveringIsolation(want)
+		if len(got) == 0 {
+			t.Fatalf("plansDeliveringIsolation(%q) = [] — the 422 message would tell the "+
+				"caller no plan delivers a boundary the gate does deliver", want)
+		}
+		named := map[string]bool{}
+		for _, p := range got {
+			named[p] = true
+			if isolationForTier(p) != want {
+				t.Errorf("plansDeliveringIsolation(%q) named plan %q, whose gate answer is %q",
+					want, p, isolationForTier(p))
+			}
+		}
+		for _, p := range catalogPlanSlugs {
+			if isolationForTier(p) == want && !named[p] {
+				t.Errorf("plansDeliveringIsolation(%q) omitted plan %q, which the gate DOES "+
+					"deliver — a refused caller is steered away from a plan that would work",
+					want, p)
+			}
 		}
 	}
 }

--- a/products/catalyst/bootstrap/ui/src/pages/org/CreateOrganizationPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/org/CreateOrganizationPage.tsx
@@ -183,18 +183,24 @@ export function CreateOrganizationPage({
         // (BoundaryIsVcluster("s") === false → the host `<slug>` namespace). It
         // never reads the record's Isolation.
         //
-        // resolveOrgShape lets a valid explicit `isolation` bypass the tier gate
-        // (organization_provisioning.go:373-377). Sending the kind default —
-        // 'vcluster' for every customer — therefore stamped every Door A Org
-        // `vcluster` while it was namespace-backed, re-introducing through the
-        // override branch the exact mislabel isolationForTier was written to
-        // remove: "an S-plan Org that correctly backs a host namespace was
-        // mislabeled vcluster ... The BACKING was always right — only the label
-        // ignored the tier."
+        // `resolveOrgShape` USED to let a valid explicit `isolation` bypass the
+        // tier gate. Sending the kind default — 'vcluster' for every customer —
+        // therefore stamped every Door A Org `vcluster` while it was
+        // namespace-backed, re-introducing the exact mislabel isolationForTier
+        // was written to remove: "an S-plan Org that correctly backs a host
+        // namespace was mislabeled vcluster ... The BACKING was always right —
+        // only the label ignored the tier."
         //
-        // Omitting it lets the server derive from the tier gate, so the label
-        // matches the backing. An operator who opens Advanced and chooses is
-        // still honoured — that is a deliberate override, not a default.
+        // #6135 closed the override branch server-side: `isolation` is now a
+        // CONSTRAINT ASSERTION. Omitted, the server derives from the tier gate
+        // (what this form relies on). Declared, it must MATCH the resolved
+        // plan's boundary or the create is refused with HTTP 422
+        // `isolation-plan-conflict` — no longer accepted-and-substituted. So an
+        // operator who opens Advanced and picks `vcluster` on this
+        // plan-less form gets a 422 that names the plans which deliver it,
+        // surfaced verbatim at `org-create-submit-error` (org.api.ts throws with
+        // the response body). That refusal is the point: the previous 202 said
+        // vcluster and delivered a namespace.
         ...(advancedOpen ? { isolation } : {}),
       })
       setCreated(result)


### PR DESCRIPTION
## What was measured

hw293.omantel.biz, dep `a0077ba47e3720e5`: the free-subdomain signup door returned **HTTP 202 acknowledging `isolation: vcluster`** and provisioned a host-namespace Organization. No vCluster was ever created.

Control on the same Sovereign: `hw293walkone` — same declared isolation, plan `m`, a real vCluster `1/1`. The variable is the plan, not the declaration.

## Mechanism, verified at the line before changing anything

`organization_provisioning.go` `resolveOrgShape` let a valid explicit `isolation` win over the tier gate:

```go
isolation := strings.ToLower(strings.TrimSpace(req.Isolation))
switch isolation {
case "namespace", "vcluster":   // request value WINS
default:
        isolation = isolationForTier(planSlug)
}
```

The signup form carries no plan picker, so the plan normalises to `s` a few lines above, and `s` is exactly the tier the authoring gate backs with a namespace.

**Nothing downstream reads the accepted value** — checked, not assumed:

- `grep -n 'Isolation\b' core/services/provisioning/gitops/*.go core/services/provisioning/handlers/consumer.go` (non-test) — zero matches
- `grep -rn '\.Isolation\b' core/controllers/ --include=*.go` (non-test) — zero matches

`boundaryIsVcluster(planSlug)` / `gitops.BoundaryIsVcluster(planSlug)` take exactly one argument. `BoundaryIsVcluster("s") == false`.

Four front-end trees checked for `isolation` senders: `core/console/` (none), `core/marketplace/` (none — the funnel declares no isolation), `products/catalyst/console/` (none), `products/catalyst/bootstrap/ui/src/pages/org/` (the one declaring caller, already narrowed to the Advanced override by #5857).

## The decision, and why

Three shapes were available. This PR takes **refuse at the door**.

**Honour the declaration** was rejected: the boundary is authored by one function that takes one argument, the plan. Feeding it a second input gives one outcome two sources of truth — that is the divergence this row is made of, re-implemented as a feature. It also means a caller could put an `s`-plan Organization on a dedicated vCluster, decoupling the boundary from what was purchased.

**Surface the plan choice** (a plan picker on the funnel) is complementary but not sufficient: a direct API call, the MCP tool, or a Git-authored request can still declare `vcluster` against plan `s`, so the hole stays open behind a nicer form.

**Refuse** keeps `planSlug` the single producer and makes the divergence impossible rather than unlikely. `isolation` becomes a **constraint assertion**: omitted, it derives from the tier gate exactly as before (the marketplace funnel is byte-unchanged); declared, it must equal the resolved plan's boundary or the create returns **422 `isolation-plan-conflict`** naming what was asked, what the plan delivers, and which plans would deliver the request — that list **computed from `isolationForTier`**, never transcribed, so a policy flip cannot leave the message steering callers at a plan that no longer qualifies.

An unrecognised enum value lands in the same refusal. It used to be silently swapped for the derived value, which is the same lie in a smaller font.

The 422 detail reaches the sovereign-admin verbatim: `org.api.ts` throws with the response body and `CreateOrganizationPage` renders it at `org-create-submit-error`.

## Red before, green after — verbatim

The fix is mutation-proven rather than stash-proven, so the guards compile in both states: the override branch is restored in `resolveOrgShape` and the 422 call is disabled with `&& false`.

**RED (pre-fix behaviour restored):**

```
--- FAIL: TestCreateOrganization_DeclaredIsolationThePlanCannotDeliverIsRefused_6135 (5.06s)
    org_create_isolation_contract_6135_test.go:74: the door ACCEPTED a declared isolation it does not honour: 202 with isolation=vcluster. The org-controller keys the boundary off planSlug alone (BoundaryIsVcluster("s") == false), so this 202 promises a vCluster that is never authored (#6135, hw293 dep a0077ba47e3720e5)
--- FAIL: TestResolveOrgShape (0.00s)
    --- FAIL: TestResolveOrgShape/declared_vcluster_on_an_S_plan_does_NOT_override_the_tier_gate (0.00s)
        organization_orgshape_test.go:133: resolveOrgShape({... Isolation:vcluster PlanSlug:s}) = {... Isolation:vcluster PlanSlug:s}, want {... Isolation:namespace PlanSlug:s}
    --- FAIL: TestResolveOrgShape/declared_vcluster_on_an_internal_org_does_NOT_override_the_tier_gate (0.00s)
        organization_orgshape_test.go:133: resolveOrgShape({... Isolation:vcluster PlanSlug:}) = {... Isolation:vcluster PlanSlug:s}, want {... Isolation:namespace PlanSlug:s}
--- FAIL: TestIsolationForTier_DeclarationNeverOverridesTheTierGate (0.00s)
    tier_gate_lockstep_4292_test.go:150: kind customer: resolved isolation "vcluster" for plan s — a declaration steered the boundary again, and the org-controller will still author a host namespace (gitops.BoundaryIsVcluster("s") == false)
    tier_gate_lockstep_4292_test.go:150: kind internal: resolved isolation "vcluster" for plan s — a declaration steered the boundary again, and the org-controller will still author a host namespace (gitops.BoundaryIsVcluster("s") == false)
--- FAIL: TestResolveOrgShape_IsolationHasExactlyOneProducer_6135 (0.00s)
    org_create_isolation_contract_6135_test.go:203: resolveOrgShape(plan="s", isolation="vcluster").Isolation = "vcluster", want "namespace" — a second input steered the boundary label away from the tier gate
    org_create_isolation_contract_6135_test.go:203: resolveOrgShape(plan="s", isolation="VCLUSTER").Isolation = "vcluster", want "namespace" — a second input steered the boundary label away from the tier gate
    org_create_isolation_contract_6135_test.go:203: resolveOrgShape(plan="m", isolation="namespace").Isolation = "namespace", want "vcluster" — a second input steered the boundary label away from the tier gate
    org_create_isolation_contract_6135_test.go:203: resolveOrgShape(plan="m", isolation="  namespace  ").Isolation = "namespace", want "vcluster" — a second input steered the boundary label away from the tier gate
    org_create_isolation_contract_6135_test.go:203: resolveOrgShape(plan="l", isolation="namespace").Isolation = "namespace", want "vcluster" — a second input steered the boundary label away from the tier gate
    org_create_isolation_contract_6135_test.go:203: resolveOrgShape(plan="l", isolation="  namespace  ").Isolation = "namespace", want "vcluster" — a second input steered the boundary label away from the tier gate
    org_create_isolation_contract_6135_test.go:203: resolveOrgShape(plan="xl", isolation="namespace").Isolation = "namespace", want "vcluster" — a second input steered the boundary label away from the tier gate
    org_create_isolation_contract_6135_test.go:203: resolveOrgShape(plan="xl", isolation="  namespace  ").Isolation = "namespace", want "vcluster" — a second input steered the boundary label away from the tier gate
    org_create_isolation_contract_6135_test.go:203: resolveOrgShape(plan="flexi", isolation="namespace").Isolation = "namespace", want "vcluster" — a second input steered the boundary label away from the tier gate
    org_create_isolation_contract_6135_test.go:203: resolveOrgShape(plan="flexi", isolation="  namespace  ").Isolation = "namespace", want "vcluster" — a second input steered the boundary label away from the tier gate
FAIL
FAIL	github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/handler	25.371s
FAIL
```

**GREEN (this branch, whole package, `-count=1`):**

```
ok  	github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/handler	321.335s
```

## The controls

Every control **shares the suspect property** — a non-empty declared `isolation` reaching the same adjudicator on the same door — and stayed **green under the mutation above** (none of them appear in the RED output). That is what makes this diff a new constraint rather than loosened behaviour:

| Control | Body | Expected |
|---|---|---|
| `TestCreateOrganization_DeclaredIsolationThatAgreesIsAccepted_6135` | declares `vcluster` on plan `m` / `flexi`, `namespace` on plan `s` | 202, echoed value equals `isolationForTier(plan)` |
| `TestCreateOrganization_FunnelBodyWithNoDeclarationIsUnchanged_6135` | the marketplace funnel body — no declaration | 202, derived `namespace`, and **no `vcluster_name` key at all** |
| `TestDeclaredIsolationConflict_RefusesOnlyTheUndeliverable` | 5 agreeing/omitted cases alongside 4 conflicting ones | only the undeliverable four refuse |

## Vacuity checks

`TestResolveOrgShape_IsolationHasExactlyOneProducer_6135` sweeps every catalog plan against every declarable value and then **asserts the sweep was non-trivial**: it fails outright if it never exercised a declaration that agrees with its plan, or never exercised one that contradicts it. A stub resolver returning a constant fails one half; the restored override branch fails the other.

`TestPlansDeliveringIsolation_ComesFromTheGate` proves the caller-facing plan list is computed, not transcribed: it fails on an empty list, on a plan the gate contradicts, and on a plan the gate qualifies but the list omits.

Assertions are on **values and shapes**, never key presence — the 422 body is checked for the declared value, the plan, the delivered boundary and the remedy sentence; the 202 body is checked for equality with the gate's own answer and for the **absence** of `vcluster_name`.

## Not changed

`allTiersVcluster` stays `false` in all three copies. The refusal is derived from `isolationForTier`, so flipping that switch moves the accepted set automatically and the 422 message with it.

Refs #6135 #5857 #4292 #4293
