### PR TITLE
fix(delivery): the per-Organization console pin had no writer for 3.5 months

### DIFF
--- a/.github/workflows/admin-build.yaml
+++ b/.github/workflows/admin-build.yaml
@@ -52,13 +52,25 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Update deployment manifest
+      - name: Bump images.admin.tag in values.yaml
+        # #5451: identical break to console-build.yaml. 83ec889f0 (PR #580)
+        # templated org-services/admin.yaml's `image:` line and moved the SHA
+        # into values.yaml `images.admin.tag`; the sed here matched nothing,
+        # exited 0, and froze the pin at 3c2f7e4 (2026-04-28) while GHCR went
+        # on receiving builds (latest admin:06ea9d4, 2026-08-02). hw293 ran
+        # admin:3c2f7e4.
+        #
+        # Note the chart renders this pin as
+        # `default .Values.images.orgTag .Values.images.admin.tag` — admin is
+        # decoupled from the orgTag bundle on purpose (t132 2026-05-16
+        # ImagePullBackOff on admin:b0ed216, an orgTag SHA admin never
+        # published). That fallback is what made the freeze survivable rather
+        # than loud, and is exactly why the pin needs its own working writer.
+        env:
+          SHA_SHORT: ${{ needs.build.outputs.sha_short }}
         run: |
-          SHA=$(echo $GITHUB_SHA | head -c 7)
-          FILE="products/catalyst/chart/templates/org-services/admin.yaml"
-          if [ -f "$FILE" ]; then
-            sed -i "s|image: ${IMAGE}:.*|image: ${IMAGE}:${SHA}|" "$FILE"
-          fi
+          bash scripts/bump-values-image-tag.sh \
+            products/catalyst/chart/values.yaml admin "${SHA_SHORT}"
 
       # TBD-V32 / openova-io/openova#2062 — race-safe push via the shared
       # composite action. The previous 3-attempt inline loop omitted
@@ -67,5 +79,5 @@ jobs:
       - name: Commit and push
         uses: ./.github/actions/deploy-bump
         with:
-          paths: products/catalyst/chart/templates/org-services/admin.yaml
+          paths: products/catalyst/chart/values.yaml
           commit-message: "deploy: update Catalyst admin image to ${{ needs.build.outputs.sha_short }}"

--- a/.github/workflows/check-image-pin-writer-targets.yaml
+++ b/.github/workflows/check-image-pin-writer-targets.yaml
@@ -1,0 +1,79 @@
+name: Image-pin writer-target guard
+
+# Refs #5451. A build workflow only moves a chart pin if the file it MUTATES
+# is the file the pin LIVES IN. On 2026-05-02, 83ec889f0 (PR #580) templated
+# products/catalyst/chart/templates/org-services/console.yaml's `image:` line
+# and moved the SHA into values.yaml `images.console.tag`, while
+# console-build.yaml kept sed-ing the template. `sed -i` matching zero lines
+# exits 0, deploy-bump pushed an empty diff, and the workflow stayed green for
+# 101 days: `images.console.tag` sat at 3c2f7e4 (2026-04-28) while GHCR
+# received console:ea10f7d on 2026-07-27. Live on hw293 (dep
+# a0077ba47e3720e5), org-services/console ran April's binary with nine merged
+# per-Organization console commits undeployed. admin and marketplace-api were
+# frozen by the identical break, same day, same commit.
+#
+# Nothing in CI could see it. The build leg was green, GHCR had the tag, main
+# had the code, and the only artifact that disagreed was a running Pod.
+#
+# This guard asks the cheap structural question — *can this writer reach this
+# pin at all?* — with no network and no token, so it goes red the moment a
+# chart reshape decouples a pin from its writer rather than months later on a
+# live walk. It is deliberately NOT the shape of
+# scripts/check-bootstrap-kit-pin-sync.sh, which compares a pin to its own
+# chart and stays green when both are equally stale.
+#
+# The complementary after-the-fact detector is
+# scripts/check-controller-image-tag-freshness.sh, which compares each pin to
+# the latest GHCR push — a source of truth that moves independently of the
+# repo. The same change that adds this file extends that guard to cover these
+# pins too.
+#
+# Event-driven only, no `schedule:` — per docs/PRINCIPLES.md this guard is a
+# property of a commit, not of elapsed time.
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - 'products/catalyst/chart/values.yaml'
+      - 'products/catalyst/chart/templates/**'
+      - 'scripts/check-image-pin-writer-targets.sh'
+      - 'scripts/bump-values-image-tag.sh'
+      - 'scripts/tests/test-image-pin-writer-targets.sh'
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/**'
+      - 'products/catalyst/chart/values.yaml'
+      - 'products/catalyst/chart/templates/**'
+      - 'scripts/check-image-pin-writer-targets.sh'
+      - 'scripts/bump-values-image-tag.sh'
+      - 'scripts/tests/test-image-pin-writer-targets.sh'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: image-pin-writer-targets-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: Image-pin writer targets
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # A guard never observed rejecting the real defect is decorative. This
+      # replays the pre-fix console-build.yaml against the real frozen pin and
+      # REQUIRES rejection, and pairs it with marketplace-build.yaml — same
+      # chart, same directory, same templated `image:` line, same deploy-bump
+      # action — which must stay green.
+      - name: Self-test — prove the guard can FAIL, and does not fail everything
+        run: bash scripts/tests/test-image-pin-writer-targets.sh
+
+      - name: check-image-pin-writer-targets.sh
+        run: bash scripts/check-image-pin-writer-targets.sh

--- a/.github/workflows/console-build.yaml
+++ b/.github/workflows/console-build.yaml
@@ -52,18 +52,36 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Update deployment manifest
+      - name: Bump images.console.tag in values.yaml
+        # #5451: this step used to sed the `image:` line of
+        # products/catalyst/chart/templates/org-services/console.yaml. On
+        # 2026-05-02, 83ec889f0 (PR #580, global.imageRegistry) rewrote that
+        # line into a Helm expression and moved the mutable SHA into
+        # values.yaml `images.console.tag`. From that day the sed matched ZERO
+        # lines; `sed -i` with no match exits 0, deploy-bump saw an empty diff,
+        # and this workflow reported success on every run while the pin sat at
+        # 3c2f7e4 (2026-04-28) for three and a half months. GHCR proves the
+        # build leg was fine the whole time — console:ea10f7d (the #5452 fix)
+        # was pushed 2026-07-27 and never pinned. Live on hw293
+        # (dep a0077ba47e3720e5): org-services/console ran April's binary with
+        # nine merged per-Organization console fixes undeployed.
+        #
+        # The shared script is fail-closed on a missing/reshaped field AND
+        # asserts the post-condition (the field re-reads as the new SHA), so a
+        # no-op write can never again be reported as a successful deploy.
+        env:
+          SHA_SHORT: ${{ needs.build.outputs.sha_short }}
         run: |
-          SHA=$(echo $GITHUB_SHA | head -c 7)
-          FILE="products/catalyst/chart/templates/org-services/console.yaml"
-          if [ -f "$FILE" ]; then
-            sed -i "s|image: ${IMAGE}:.*|image: ${IMAGE}:${SHA}|" "$FILE"
-          fi
+          bash scripts/bump-values-image-tag.sh \
+            products/catalyst/chart/values.yaml console "${SHA_SHORT}"
 
       # TBD-V32 / openova-io/openova#2062 — race-safe push via the shared
-      # composite action.
+      # composite action. Its per-line cherry-pick (#4464) merges this
+      # images.console.tag bump cleanly against a concurrent services-build
+      # orgTag or catalyst-build catalystApi.tag bump on the same values.yaml —
+      # each job owns a different line.
       - name: Commit and push
         uses: ./.github/actions/deploy-bump
         with:
-          paths: products/catalyst/chart/templates/org-services/console.yaml
+          paths: products/catalyst/chart/values.yaml
           commit-message: "deploy: update Catalyst console image to ${{ needs.build.outputs.sha_short }}"

--- a/.github/workflows/marketplace-api-build.yaml
+++ b/.github/workflows/marketplace-api-build.yaml
@@ -52,15 +52,20 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Update deployment manifest with new SHA tag
+      - name: Bump images.marketplaceApi.tag in values.yaml
+        # #5451: third instance of the same break. 83ec889f0 (PR #580)
+        # templated templates/marketplace-api/deployment.yaml's `image:` line
+        # through global.imageRegistry and moved the SHA into values.yaml
+        # `images.marketplaceApi.tag`. This step kept sed-ing the template, so
+        # it matched nothing and exited 0 — the pin froze at 3c2f7e4
+        # (2026-04-28) while GHCR received marketplace-api:0d9531a on
+        # 2026-07-09, including #4924's durable sovereign-smtp-credentials
+        # seed, which therefore never shipped.
         env:
           SHA_SHORT: ${{ needs.build.outputs.sha_short }}
         run: |
-          DEPLOY_DIR="products/catalyst/chart/templates/marketplace-api"
-          sed -i "s|image: ${IMAGE}:.*|image: ${IMAGE}:${SHA_SHORT}|" \
-            "${DEPLOY_DIR}/deployment.yaml"
-          echo "Updated manifest to SHA ${SHA_SHORT}:"
-          grep "image:" "${DEPLOY_DIR}/deployment.yaml"
+          bash scripts/bump-values-image-tag.sh \
+            products/catalyst/chart/values.yaml marketplaceApi "${SHA_SHORT}"
 
       # TBD-V32 / openova-io/openova#2062 — race-safe push via the shared
       # composite action so concurrent build workflows do not lose the
@@ -68,5 +73,5 @@ jobs:
       - name: Commit and push manifest updates
         uses: ./.github/actions/deploy-bump
         with:
-          paths: products/catalyst/chart/templates/marketplace-api/deployment.yaml
+          paths: products/catalyst/chart/values.yaml
           commit-message: "deploy: update Catalyst marketplace-api image to ${{ needs.build.outputs.sha_short }}"

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1389,7 +1389,7 @@ spec:
       #   guacamole-pg and the shared-pg family as well. Egress half in
       #   bp-keycloak 1.5.9; neither half alone restores a brokered login.
       #   Lockstep w/ products/catalyst/chart/Chart.yaml.
-      version: 1.4.1387
+      version: 1.4.1391
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3855,7 +3855,26 @@ name: bp-catalyst-platform
 #   hop); Case 18 proves the policy can actually be absent.
 #   Egress half in bp-keycloak 1.5.9. Neither half alone restores a brokered
 #   login. Lockstep w/ slot-13 pin.
-version: 1.4.1390
+# 1.4.1391 — #5451: images.console / images.admin / images.marketplaceApi
+#   unfreeze. All three sat at "3c2f7e4" (2026-04-28) for three and a half
+#   months because console-build.yaml / admin-build.yaml /
+#   marketplace-api-build.yaml sed the `image:` line of their chart template,
+#   and 83ec889f0 (PR #580, 2026-05-02) had turned those lines into Helm
+#   expressions and moved the SHA into values.yaml. The seds matched zero
+#   lines, `sed -i` exited 0, deploy-bump pushed an empty diff, and every run
+#   was green. Only the DEPLOY leg was dead: GHCR received console:ea10f7d on
+#   2026-07-27 (the #5452 NOT-SERVING badge), admin:06ea9d4 on 2026-08-02 and
+#   marketplace-api:0d9531a on 2026-07-09. Measured on hw293
+#   (dep a0077ba47e3720e5) 2026-08-11: org-services/console ran
+#   ghcr.io/openova-io/openova/console:3c2f7e4, with nine merged
+#   per-Organization console commits undeployed — so every "the fix is merged"
+#   reading of an org-console defect had been a false green for that window.
+#   The pins now advance through scripts/bump-values-image-tag.sh (fail-closed,
+#   post-condition asserted) and are gated by
+#   scripts/check-image-pin-writer-targets.sh plus the extended
+#   scripts/check-controller-image-tag-freshness.sh. Chart version bump is what
+#   actually delivers the three new tags, so it is the load-bearing half.
+version: 1.4.1391
 # 1.4.1229 — #5389: catalog-seed bp-newapi declares its `ui` endpoint
 #   (newapi.<fqdn>, ssoEnabled, launchDefault, ssoInitPath "/") instead of
 #   `endpoints: []`. The empty list made userUIGatePasses fail closed, which
@@ -4010,7 +4029,7 @@ version: 1.4.1390
 # scripts/check-chart-version-forward.sh (#5743) fails unless the two match —
 # main was carrying a pre-existing 1.4.1330/1.4.1329 split, so this bump heals
 # it in the same commit, exactly as the documented self-heal contract does.
-appVersion: 1.4.1390
+appVersion: 1.4.1391
 # 1.4.239 — Wave 3 / Issue #2140 (2026-05-23): Huawei provider
 # implementation lands behind the Wave 2 CloudProvider interface.
 # Adds the OpenTofu module at infra/providers/huawei/ (VPC + Subnet +

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -557,10 +557,28 @@ images:
     tag: "32dac80"
   catalystUi:
     tag: "32dac80"
+  # 2026-08-11 (#5451): marketplaceApi / console / admin were ALL frozen at
+  # "3c2f7e4" (2026-04-28) for three and a half months. Their build workflows
+  # sed-ed the `image:` line of their chart template; 83ec889f0 (PR #580,
+  # 2026-05-02) turned those lines into Helm expressions and moved the mutable
+  # SHA here, so the seds matched zero lines, exited 0, deploy-bump pushed an
+  # empty diff, and every run reported success. GHCR proves only the DEPLOY leg
+  # was dead — console:ea10f7d was published 2026-07-27, admin:06ea9d4 on
+  # 2026-08-02, marketplace-api:0d9531a on 2026-07-09.
+  #
+  # Live consequence on hw293 (dep a0077ba47e3720e5): org-services/console ran
+  # console:3c2f7e4 with NINE merged per-Organization console commits
+  # undeployed, so every "the fix is merged" reading of an org-console defect
+  # was a false green for that whole window.
+  #
+  # These three pins are now written by scripts/bump-values-image-tag.sh, which
+  # fails closed if the field is reshaped and asserts the write landed.
+  # scripts/check-image-pin-writer-targets.sh gates the writer→pin coupling and
+  # scripts/check-controller-image-tag-freshness.sh now covers these pins too.
   marketplaceApi:
-    tag: "3c2f7e4"
+    tag: "0d9531a"
   console:
-    tag: "3c2f7e4"
+    tag: "ea10f7d"
   # Admin pod has a separate tag from the orgTag bundle because the admin
   # image build is decoupled from the Organization microservices CI run — when
   # orgTag is bumped, admin may not have published for that SHA. Caught
@@ -569,7 +587,7 @@ images:
   # Organization services did). Default to a known-published tag; bump in lockstep
   # with marketplaceApi/console when admin's UI changes.
   admin:
-    tag: "3c2f7e4"
+    tag: "06ea9d4"
   # All 10 Organization microservices share one SHA tag (built from the same mono-repo commit).
   # 2026-06-09: 41e02c8 → c96f998 (#3157 merge SHA). 41e02c8 (built 2026-06-05)
   # predates the #3157 marketplace-plans fix, so services-catalog:41e02c8 lacks

--- a/scripts/bump-values-image-tag.sh
+++ b/scripts/bump-values-image-tag.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# bump-values-image-tag.sh — Refs #5451
+#
+# Write a new SHA tag into a nested `images.<key>.tag` field of
+# products/catalyst/chart/values.yaml, FAIL-CLOSED, and prove the write
+# actually landed before returning success.
+#
+# WHY THIS EXISTS
+# ---------------
+# `console-build.yaml`, `admin-build.yaml` and `marketplace-api-build.yaml`
+# each carried a deploy step of exactly this shape:
+#
+#     FILE="products/catalyst/chart/templates/org-services/console.yaml"
+#     if [ -f "$FILE" ]; then
+#       sed -i "s|image: ${IMAGE}:.*|image: ${IMAGE}:${SHA}|" "$FILE"
+#     fi
+#
+# On 2026-05-02, commit 83ec889f0 (PR #580, "add global.imageRegistry to
+# remaining bp-* charts") rewrote that manifest's `image:` line into a Helm
+# expression and moved the mutable SHA into values.yaml `images.console.tag`:
+#
+#     image: "{{ ... }}/{{ .Values.images.organization }}/console:{{ .Values.images.console.tag }}"
+#
+# From that day the sed pattern matched ZERO lines. `sed -i` with no match
+# exits 0. The deploy-bump composite action then saw an empty diff and pushed
+# nothing. Every console build stayed GREEN and shipped its image to GHCR while
+# the chart pin never moved — `images.console.tag` sat at "3c2f7e4" (2026-04-28)
+# for three and a half months, so on hw293 (dep a0077ba47e3720e5)
+# org-services/console ran April's binary and nine merged per-Organization
+# console fixes were dark. Same story for admin (pin 3c2f7e4, GHCR 06ea9d4) and
+# marketplace-api (pin 3c2f7e4, GHCR 0d9531a).
+#
+# The class was already known: catalyst-build.yaml's own comments name #580 as
+# the cause of the identical InvalidImageName break on catalyst-api, and
+# marketplace-build.yaml was migrated off the sed in #4885. The sweep simply
+# never reached these three.
+#
+# THE TWO PROPERTIES THAT MATTER, and why they are here rather than inline
+# ------------------------------------------------------------------------
+#   1. FAIL-CLOSED on a reshaped field. If `images.<key>.tag` is missing,
+#      renamed, or no longer a quoted scalar, this exits non-zero instead of
+#      writing nothing and returning 0. A contributor who re-templates the pin
+#      gets a red build, not another silent freeze.
+#   2. POST-CONDITION on the write. After the edit, the field is re-read and
+#      must equal the requested SHA. A mutation that matched nothing can no
+#      longer be reported as success — which is the single property whose
+#      absence caused this outage.
+#
+# Both live in one tested script instead of three copies of awk in three
+# workflows, so the next chart reshape cannot fix two call sites and miss one.
+#
+# Usage:
+#   scripts/bump-values-image-tag.sh <values.yaml> <key> <sha>
+#
+# Example:
+#   scripts/bump-values-image-tag.sh products/catalyst/chart/values.yaml console 1a2b3c4
+#
+# Exit codes:
+#   0 — the field now holds <sha> (verified by re-reading the file).
+#   1 — bad usage, file missing, field missing/reshaped, or the write did not land.
+
+set -euo pipefail
+
+usage() {
+  echo "usage: $0 <values.yaml> <images-key> <sha>" >&2
+  exit 1
+}
+
+[ "$#" -eq 3 ] || usage
+
+VALUES="$1"
+KEY="$2"
+SHA="$3"
+
+[ -n "${VALUES}" ] && [ -n "${KEY}" ] && [ -n "${SHA}" ] || usage
+
+if [ ! -f "${VALUES}" ]; then
+  echo "::error title=values.yaml not found::${VALUES} does not exist; refusing to auto-bump." >&2
+  exit 1
+fi
+
+if ! printf '%s' "${SHA}" | grep -Eq '^[A-Za-z0-9_.-]+$'; then
+  echo "::error title=invalid SHA::refusing to write '${SHA}' into ${VALUES} images.${KEY}.tag." >&2
+  exit 1
+fi
+
+# Read the CURRENT value of images.<key>.tag. An empty result means the field
+# is absent or reshaped, and is a hard failure — never a no-op.
+read_tag() {
+  awk -v k="${KEY}" '
+    /^images:/            { in_images = 1; next }
+    in_images && /^[^ ]/  { exit }
+    in_images && $0 ~ "^  " k ":[[:space:]]*$" { in_key = 1; next }
+    in_key && /^  [^ ]/   { exit }
+    in_key && /^    tag:/ {
+      if (match($0, /"[^"]*"/)) { print substr($0, RSTART + 1, RLENGTH - 2) }
+      exit
+    }
+  ' "$1"
+}
+
+before="$(read_tag "${VALUES}")"
+
+if [ -z "${before}" ]; then
+  echo "::error title=images.${KEY}.tag missing or unparseable::Expected a nested" \
+       "'  ${KEY}:' block with an indented '    tag: \"<sha>\"' line inside the" \
+       "'images:' map of ${VALUES}. The pin could not be located, so refusing to" \
+       "auto-bump rather than silently shipping a stale image (Refs #5451)." >&2
+  exit 1
+fi
+
+if [ "${before}" = "${SHA}" ]; then
+  echo "images.${KEY}.tag already at ${SHA} in ${VALUES} — nothing to do."
+  exit 0
+fi
+
+tmp="${VALUES}.bump.$$"
+awk -v k="${KEY}" -v sha="${SHA}" '
+  /^images:/            { in_images = 1; print; next }
+  in_images && /^[^ ]/  { in_images = 0; in_key = 0 }
+  in_images && $0 ~ "^  " k ":[[:space:]]*$" { in_key = 1; print; next }
+  in_key && /^  [^ ]/   { in_key = 0 }
+  in_key && /^    tag:/ && !done {
+    sub(/"[^"]*"/, "\"" sha "\"")
+    done = 1
+    print
+    next
+  }
+  { print }
+' "${VALUES}" > "${tmp}"
+
+mv "${tmp}" "${VALUES}"
+
+# POST-CONDITION. This is the assertion whose absence is the whole defect:
+# a mutation that matched nothing must not be able to exit 0.
+after="$(read_tag "${VALUES}")"
+
+if [ "${after}" != "${SHA}" ]; then
+  echo "::error title=image pin bump did not land::${VALUES} images.${KEY}.tag is" \
+       "'${after}' after the rewrite, expected '${SHA}'. The edit matched nothing" \
+       "or matched the wrong line. Refusing to report success on a no-op write" \
+       "(Refs #5451)." >&2
+  exit 1
+fi
+
+echo "Bumped ${VALUES} images.${KEY}.tag: ${before} -> ${after}"

--- a/scripts/check-controller-image-tag-freshness.sh
+++ b/scripts/check-controller-image-tag-freshness.sh
@@ -1,10 +1,14 @@
 #!/usr/bin/env bash
 # check-controller-image-tag-freshness.sh
 #
-# Defense for #2851 (2026-06-03) — pre-merge guard that fails if any of
-# the 5 Group C controller image tags in
-# products/catalyst/chart/values.yaml is more than $MAX_LAG_COMMITS
-# behind the latest pushed image on GHCR (default: 50 commits).
+# Defense for #2851 (2026-06-03) and #5451 (2026-08-11) — pre-merge guard that
+# fails if any chart image pin in products/catalyst/chart/values.yaml is more
+# than $MAX_LAG_COMMITS behind the latest pushed image on GHCR (default: 50
+# commits). Two groups are covered:
+#   * the 5 Group C controller pins (controllers.<name>.image.tag) — #2851;
+#   * the 7 application image pins (images.*) — #5451, added after console,
+#     admin and marketplace-api sat frozen at a 2026-04-28 tag for 3.5 months
+#     with their build workflows reporting success on every run.
 #
 # Background
 # ----------
@@ -73,6 +77,56 @@ declare -A CTRL_PKG=(
   [useraccess]=useraccess-controller
 )
 
+# ---------------------------------------------------------------------------
+# #5451 — the SAME staleness class, on the `images:` block this guard never
+# looked at.
+#
+# The five controller pins above were covered because #2851 found them stale.
+# The application-image pins sitting three lines away in the same values.yaml
+# were not, and three of them were frozen at 3c2f7e4 (2026-04-28) for three
+# and a half months: console-build.yaml, admin-build.yaml and
+# marketplace-api-build.yaml each sed-ed an `image:` line that PR #580 had
+# turned into a Helm expression on 2026-05-02, so their edits matched zero
+# lines, exited 0, and pushed nothing while their build legs went on
+# publishing to GHCR. Live on hw293 (dep a0077ba47e3720e5),
+# org-services/console ran console:3c2f7e4 — April's binary — with nine merged
+# per-Organization console commits undeployed, including the fix for #5451
+# itself (console:ea10f7d, published 2026-07-27 and never pinned).
+#
+# GHCR is the right comparand precisely because it is written by a DIFFERENT
+# leg of the pipeline than the pin: the build leg kept moving while the deploy
+# leg was dead, so the two disagreed from day one. A guard that compared the
+# pin to its own chart would have stayed green throughout — that is how
+# check-bootstrap-kit-pin-sync.sh missed four bumps.
+#
+# `nested` keys live as   images.<key>.tag: "<sha>"
+# `flat`   keys live as   images.<key>: "<sha>"
+#
+# orgTag maps to services-provisioning as its representative package: all ten
+# services-* images are built from the same commit by services-build.yaml (the
+# values.yaml comment records the #3157 verification that services-auth,
+# untouched by that PR, still carried the same SHA), so any one of them dates
+# the bundle.
+declare -A IMAGE_PKG=(
+  [console]=console
+  [admin]=admin
+  [marketplaceApi]=marketplace-api
+  [catalystApi]=catalyst-api
+  [catalystUi]=catalyst-ui
+  [marketplaceTag]=marketplace
+  [orgTag]=services-provisioning
+)
+
+declare -A IMAGE_KIND=(
+  [console]=nested
+  [admin]=nested
+  [marketplaceApi]=nested
+  [catalystApi]=nested
+  [catalystUi]=nested
+  [marketplaceTag]=flat
+  [orgTag]=flat
+)
+
 if [ ! -f "${VALUES_YAML}" ]; then
   echo "::error::values.yaml not found at ${VALUES_YAML}"
   exit 1
@@ -81,6 +135,109 @@ fi
 fail=0
 checked=0
 unverifiable=0
+
+# freshness_check <ghcr-package> <current-pin> <fix-hint>
+#
+# Shared by the controller loop and the #5451 images loop. Extracted verbatim
+# from the original controller loop body so the two groups can never drift into
+# two different definitions of "stale" — the drift that let the images block go
+# unwatched for three and a half months while the controllers next to it were
+# gated.
+freshness_check() {
+  local pkg="$1" pin="$2" fix_hint="$3"
+  local pkg_path versions_json latest lag
+
+  if [ -n "${SKIP_GHCR}" ]; then
+    echo "  SKIP-GHCR  ${pkg} pin=${pin}  (SKIP_GHCR set)"
+    checked=$((checked + 1))
+    return 0
+  fi
+
+  # Latest GHCR-pushed 7-hex tag for this package. Same shape as
+  # the #2851 sweep step in catalyst-build.yaml. We filter cosign
+  # signature artifacts + the rolling `latest` alias, keep only true
+  # 7-hex tags, and take the most-recently-updated one.
+  #
+  # Package PATH fix (caught on PR #3012; gate had been red on every
+  # run incl. main): the images are pushed to
+  # `ghcr.io/openova-io/openova/<pkg>` (this script's own header says
+  # so at line 27), which makes the GHCR package NAME the slash-scoped
+  # `openova/<pkg>` — and the packages API requires the slash
+  # percent-encoded (`openova%2F<pkg>`). The previous bare-`${pkg}`
+  # query 404'd ("Package not found") and the error branch mislabeled
+  # the auth-or-404 failure as staleness ("Checked 0/5; 5 stale").
+  # Both fixed: correct path + honest UNVERIFIABLE wording.
+  pkg_path="openova%2F${pkg}"
+  if ! versions_json=$(gh api "/orgs/${GHCR_ORG}/packages/container/${pkg_path}/versions" --paginate 2>/dev/null); then
+    # #4685: an UNVERIFIABLE query (404/auth/network) is NOT a staleness
+    # verdict — the ephemeral GITHUB_TOKEN cannot read org-private packages
+    # unless they are linked to this repo (or a read:packages PAT is
+    # supplied). Counting it as `fail` false-red'd EVERY PR. Treat it as an
+    # honest, non-fatal WARNING instead: it is counted as `checked` (so the
+    # "0/5 checked" undercount goes away) and tracked separately in
+    # `unverifiable`; the gate still fails hard on a genuine staleness
+    # verdict (a SUCCESSFUL query showing a lagging pin).
+    echo "::warning::GHCR API query UNVERIFIABLE for openova/${pkg} (404/auth/network — NOT a staleness verdict). The ephemeral GITHUB_TOKEN cannot read org-private packages unless linked to this repo or given a read:packages PAT. Skipping the freshness check for this pin."
+    unverifiable=$((unverifiable + 1))
+    checked=$((checked + 1))
+    return 0
+  fi
+
+  latest=$(echo "${versions_json}" \
+    | jq -r '[.[] | {u:.updated_at, tags:(.metadata.container.tags // [])}]
+             | sort_by(.u) | reverse
+             | .[].tags[]?' 2>/dev/null \
+    | grep -vE '^(sha256-|latest$)' \
+    | grep -E '^[0-9a-f]{7}$' \
+    | head -1 || true)
+
+  if [ -z "${latest}" ]; then
+    echo "::warning::no 7-hex GHCR tag found for ${pkg} — skipping freshness check (package may be brand-new)"
+    checked=$((checked + 1))
+    return 0
+  fi
+
+  # Both sides are 7-hex short SHAs — need to resolve them to full git
+  # objects to count the lag. Local repo MUST have main fetched.
+  if ! git cat-file -e "${pin}^{commit}" 2>/dev/null; then
+    echo "::error::pin SHA ${pin} for ${pkg} not in local repo — fetch main first (try: git fetch origin main --unshallow)"
+    fail=$((fail + 1))
+    return 0
+  fi
+  if ! git cat-file -e "${latest}^{commit}" 2>/dev/null; then
+    echo "::warning::latest GHCR SHA ${latest} for ${pkg} not in local repo — comparing strings only"
+    if [ "${pin}" = "${latest}" ]; then
+      echo "  OK         ${pkg}:${pin} (matches latest GHCR)"
+    else
+      echo "::error::${pkg}: pinned ${pin}, latest GHCR is ${latest} (and not in local repo — likely stale)"
+      fail=$((fail + 1))
+    fi
+    checked=$((checked + 1))
+    return 0
+  fi
+
+  # Lag count via `git rev-list`. If pin == latest, lag = 0.
+  if [ "${pin}" = "${latest}" ]; then
+    lag=0
+  else
+    # `pin..latest` = commits reachable from latest but not from pin.
+    # If pin is ahead (rare — manual debug bump?), count is 0 and we
+    # don't flag it; the sovereign-admin is intentionally on a newer image.
+    lag=$(git rev-list --count "${pin}..${latest}" 2>/dev/null || echo "??")
+  fi
+
+  if [ "${lag}" = "??" ]; then
+    echo "::warning::could not compute lag for ${pkg} (pin=${pin} latest=${latest}) — possible non-linear history"
+  elif [ "${lag}" -gt "${MAX_LAG_COMMITS}" ]; then
+    echo "::error::${pkg}: pinned ${pin} is ${lag} commits behind latest GHCR ${latest} (threshold: ${MAX_LAG_COMMITS})"
+    echo "::error::  ${fix_hint} \"${latest}\""
+    fail=$((fail + 1))
+  else
+    echo "  OK         ${pkg}:${pin} (lag=${lag}, latest=${latest})"
+  fi
+  checked=$((checked + 1))
+  return 0
+}
 
 for key in "${!CTRL_PKG[@]}"; do
   pkg="${CTRL_PKG[$key]}"
@@ -104,121 +261,84 @@ for key in "${!CTRL_PKG[@]}"; do
     continue
   fi
 
-  if [ -n "${SKIP_GHCR}" ]; then
-    echo "  SKIP-GHCR  ${key}-controller pin=${pin}  (SKIP_GHCR set)"
-    checked=$((checked + 1))
-    continue
+  freshness_check "${pkg}" "${pin}" "bump in ${VALUES_YAML}: controllers.${key}.image.tag"
+done
+
+# ---------------------------------------------------------------------------
+# #5451 — the `images:` block. Same comparand (latest GHCR push), same
+# threshold, same fail-hard-on-a-real-verdict policy as the controllers above.
+# ---------------------------------------------------------------------------
+for key in "${!IMAGE_PKG[@]}"; do
+  pkg="${IMAGE_PKG[$key]}"
+  kind="${IMAGE_KIND[$key]}"
+
+  if [ "${kind}" = "flat" ]; then
+    pin=$(awk -v k="${key}" '
+      /^images:/           { in_i=1; next }
+      in_i && /^[^ ]/      { exit }
+      in_i && $0 ~ "^  " k ":" {
+        if (match($0, /"[^"]*"/)) { print substr($0, RSTART+1, RLENGTH-2) }
+        exit
+      }
+    ' "${VALUES_YAML}")
+  else
+    pin=$(awk -v k="${key}" '
+      /^images:/           { in_i=1; next }
+      in_i && /^[^ ]/      { exit }
+      in_i && $0 ~ "^  " k ":[[:space:]]*$" { in_k=1; next }
+      in_k && /^  [^ ]/    { exit }
+      in_k && /^    tag:/ {
+        if (match($0, /"[^"]*"/)) { print substr($0, RSTART+1, RLENGTH-2) }
+        exit
+      }
+    ' "${VALUES_YAML}")
   fi
 
-  # 2) Latest GHCR-pushed 7-hex tag for this controller. Same shape as
-  # the #2851 sweep step in catalyst-build.yaml. We filter cosign
-  # signature artifacts + the rolling `latest` alias, keep only true
-  # 7-hex tags, and take the most-recently-updated one.
-  #
-  # Package PATH fix (caught on PR #3012; gate had been red on every
-  # run incl. main): the images are pushed to
-  # `ghcr.io/openova-io/openova/<pkg>` (this script's own header says
-  # so at line 27), which makes the GHCR package NAME the slash-scoped
-  # `openova/<pkg>` — and the packages API requires the slash
-  # percent-encoded (`openova%2F<pkg>`). The previous bare-`${pkg}`
-  # query 404'd ("Package not found") and the error branch mislabeled
-  # the auth-or-404 failure as staleness ("Checked 0/5; 5 stale").
-  # Both fixed: correct path + honest UNVERIFIABLE wording.
-  pkg_path="openova%2F${pkg}"
-  if ! versions_json=$(gh api "/orgs/${GHCR_ORG}/packages/container/${pkg_path}/versions" --paginate 2>/dev/null); then
-    # #4685: an UNVERIFIABLE query (404/auth/network) is NOT a staleness
-    # verdict — the ephemeral GITHUB_TOKEN cannot read the org-private
-    # `*-controller` packages unless they are linked to this repo (or a
-    # read:packages PAT is supplied). Counting it as `fail` false-red'd
-    # EVERY PR. Treat it as an honest, non-fatal WARNING instead: it is
-    # counted as `checked` (so the "0/5 checked" undercount goes away) and
-    # tracked separately in `unverifiable`; the gate still fails hard on a
-    # genuine staleness verdict (a SUCCESSFUL query showing a lagging pin).
-    echo "::warning::GHCR API query UNVERIFIABLE for openova/${pkg} (404/auth/network — NOT a staleness verdict). The ephemeral GITHUB_TOKEN cannot read org-private *-controller packages unless linked to this repo or given a read:packages PAT. Skipping the freshness check for this pin."
-    unverifiable=$((unverifiable + 1))
-    checked=$((checked + 1))
-    continue
-  fi
-
-  latest=$(echo "${versions_json}" \
-    | jq -r '[.[] | {u:.updated_at, tags:(.metadata.container.tags // [])}]
-             | sort_by(.u) | reverse
-             | .[].tags[]?' 2>/dev/null \
-    | grep -vE '^(sha256-|latest$)' \
-    | grep -E '^[0-9a-f]{7}$' \
-    | head -1 || true)
-
-  if [ -z "${latest}" ]; then
-    echo "::warning::no 7-hex GHCR tag found for ${pkg} — skipping freshness check (package may be brand-new)"
-    checked=$((checked + 1))
-    continue
-  fi
-
-  # Both sides are 7-hex short SHAs — need to resolve them to full git
-  # objects to count the lag. Local repo MUST have main fetched.
-  if ! git cat-file -e "${pin}^{commit}" 2>/dev/null; then
-    echo "::error::pin SHA ${pin} for ${pkg} not in local repo — fetch main first (try: git fetch origin main --unshallow)"
+  if [ -z "${pin}" ]; then
+    # An unreadable pin is a HARD failure, never a skip. "The writer could not
+    # find the field, so it did nothing and said nothing" IS the #5451 outage.
+    echo "::error::could not parse images.${key} (${kind} form) from ${VALUES_YAML}"
     fail=$((fail + 1))
     continue
   fi
-  if ! git cat-file -e "${latest}^{commit}" 2>/dev/null; then
-    echo "::warning::latest GHCR SHA ${latest} for ${pkg} not in local repo — comparing strings only"
-    if [ "${pin}" = "${latest}" ]; then
-      echo "  OK         ${pkg}:${pin} (matches latest GHCR)"
-    else
-      echo "::error::${pkg}: pinned ${pin}, latest GHCR is ${latest} (and not in local repo — likely stale)"
-      fail=$((fail + 1))
-    fi
-    checked=$((checked + 1))
-    continue
-  fi
 
-  # 3) Lag count via `git rev-list`. If pin == latest, lag = 0.
-  if [ "${pin}" = "${latest}" ]; then
-    lag=0
+  if [ "${kind}" = "flat" ]; then
+    freshness_check "${pkg}" "${pin}" "bump in ${VALUES_YAML}: images.${key}"
   else
-    # `pin..latest` = commits reachable from latest but not from pin.
-    # If pin is ahead (rare — manual debug bump?), count is 0 and we
-    # don't flag it; the operator is intentionally on a newer image.
-    lag=$(git rev-list --count "${pin}..${latest}" 2>/dev/null || echo "??")
+    freshness_check "${pkg}" "${pin}" "bump in ${VALUES_YAML}: images.${key}.tag"
   fi
-
-  if [ "${lag}" = "??" ]; then
-    echo "::warning::could not compute lag for ${pkg} (pin=${pin} latest=${latest}) — possible non-linear history"
-  elif [ "${lag}" -gt "${MAX_LAG_COMMITS}" ]; then
-    echo "::error::${pkg}: pinned ${pin} is ${lag} commits behind latest GHCR ${latest} (threshold: ${MAX_LAG_COMMITS})"
-    echo "::error::  bump in ${VALUES_YAML}: controllers.${key}.image.tag \"${latest}\""
-    fail=$((fail + 1))
-  else
-    echo "  OK         ${pkg}:${pin} (lag=${lag}, latest=${latest})"
-  fi
-  checked=$((checked + 1))
 done
 
 echo
-echo "Checked ${checked}/${#CTRL_PKG[@]} controller pin(s); ${fail} stale; ${unverifiable} unverifiable (auth/404 — NOT counted as failures, #4685)."
+echo "Checked ${checked}/$(( ${#CTRL_PKG[@]} + ${#IMAGE_PKG[@]} )) chart image pin(s); ${fail} stale; ${unverifiable} unverifiable (auth/404 — NOT counted as failures, #4685)."
 if [ "${unverifiable}" -gt 0 ]; then
   echo "::warning::${unverifiable} controller pin(s) could NOT be verified against GHCR (org-private *-controller packages are unreadable by the ephemeral GITHUB_TOKEN). Staleness enforcement is DEGRADED for those pins until they are linked to this repo (or a read:packages PAT is wired). This is NOT a merge blocker (#4685)."
 fi
 
 if [ "${fail}" -gt 0 ]; then
   echo
-  echo "FAIL: at least one controller image pin in ${VALUES_YAML} is stale"
+  echo "FAIL: at least one chart image pin in ${VALUES_YAML} is stale"
   echo "by more than ${MAX_LAG_COMMITS} commits relative to the latest"
-  echo "GHCR push. This is the #2851 H9-walk class — chart will ship a"
-  echo "binary missing recent features (e.g. G117.6 topology fan-out)."
+  echo "GHCR push. This is the #2851 H9-walk class on controllers and the"
+  echo "#5451 class on images: the chart ships a binary missing recent"
+  echo "fixes while every workflow involved reported success."
   echo
   echo "Defenses:"
   echo "  - catalyst-build.yaml's #2851 sweep step bumps every controller"
   echo "    pin to the latest GHCR tag on every catalyst-build run."
   echo "  - Each build-*-controller.yaml workflow auto-bumps its own pin"
   echo "    on push-to-main (TBD-A69 / PR #2005/#2012)."
+  echo "  - Each build-*.yaml image workflow bumps its own images.<key> pin"
+  echo "    via scripts/bump-values-image-tag.sh, which fails closed and"
+  echo "    asserts the write landed (#5451)."
+  echo "  - scripts/check-image-pin-writer-targets.sh catches the earlier"
+  echo "    condition — a workflow whose deploy job cannot reach its pin at"
+  echo "    all — with no network and no token."
   echo
-  echo "Manual fix: edit ${VALUES_YAML} to set the stale tag(s) to the"
-  echo "value(s) shown above (or kick the catalyst-build workflow:"
-  echo "  gh workflow run 'catalyst-build.yaml' --ref main"
-  echo "which will perform the sweep + open the deploy commit)."
+  echo "Manual fix: re-run the owning build workflow, e.g."
+  echo "  gh workflow run 'console-build.yaml' --ref main"
+  echo "or edit ${VALUES_YAML} to the value(s) shown above."
   exit 1
 fi
 
-echo "PASS: every controller image pin is within ${MAX_LAG_COMMITS} commits of latest GHCR."
+echo "PASS: every chart image pin is within ${MAX_LAG_COMMITS} commits of latest GHCR."

--- a/scripts/check-image-pin-writer-targets.sh
+++ b/scripts/check-image-pin-writer-targets.sh
@@ -1,0 +1,312 @@
+#!/usr/bin/env bash
+# check-image-pin-writer-targets.sh — Refs #5451
+#
+# WHY THIS EXISTS
+# ---------------
+# Every OpenOva image pin in products/catalyst/chart/values.yaml is written by
+# exactly one build workflow's deploy job, which hands a list of files to the
+# `./.github/actions/deploy-bump` composite action. The pin only moves if the
+# file the workflow MUTATES is the file the pin actually LIVES IN.
+#
+# On 2026-05-02, commit 83ec889f0 (PR #580) rewrote
+# products/catalyst/chart/templates/org-services/console.yaml's `image:` line
+# into a Helm expression and moved the mutable SHA into values.yaml
+# `images.console.tag`. `console-build.yaml` kept sed-ing the template file.
+# The pin and the writer had been decoupled, and NOTHING said so:
+#
+#   * the build leg stayed green and kept publishing (GHCR has console:ea10f7d,
+#     pushed 2026-07-27T10:46:01Z — the #5452 fix image, built and never pinned);
+#   * `sed -i` matching zero lines exits 0;
+#   * deploy-bump saw an empty diff and pushed nothing;
+#   * `images.console.tag` froze at "3c2f7e4" (2026-04-28) for 3.5 months.
+#
+# The fail-open is on the record in the Actions API — console-build.yaml has 13
+# runs on main and its three most recent all concluded `success`:
+#
+#   2026-07-27T10:45:02Z  success      <- published console:ea10f7d, pinned nothing
+#   2026-07-20T02:16:22Z  success
+#   2026-07-19T08:50:08Z  success
+#
+# So no red-run canary could have caught this: the workflow was GREEN every time
+# it shipped nothing. scripts/check-delivery-workflow-health.sh (#6049) detects
+# a delivery workflow that is RED; this file detects one that is GREEN and
+# writing to a file that cannot hold the value it is trying to write.
+#
+# Live consequence on hw293 (dep a0077ba47e3720e5): org-services/console ran
+# ghcr.io/openova-io/openova/console:3c2f7e4 while nine merged per-Organization
+# console commits — including #5452's NOT SERVING badge, the fix for the very
+# issue this script is filed under — were undeployed. `admin` (pin 3c2f7e4 /
+# GHCR 06ea9d4) and `marketplace-api` (pin 3c2f7e4 / GHCR 0d9531a) were frozen
+# by the identical break.
+#
+# WHY NOT JUST THE FRESHNESS GUARD
+# --------------------------------
+# scripts/check-controller-image-tag-freshness.sh compares a pin to the latest
+# GHCR push, which is a source of truth that MOVES — that guard is extended by
+# the same change that adds this file, and it is the one that catches drift
+# after the fact. This script answers the earlier and cheaper question, with no
+# network and no token: *can this writer reach this pin at all?* It would have
+# gone red on 2026-05-02, the day the decoupling landed, instead of 101 days
+# later on a live walk.
+#
+# It is deliberately NOT the shape of scripts/check-bootstrap-kit-pin-sync.sh,
+# which compares a pin to its own chart and therefore stays green when both
+# sides are equally stale — the property that let four bumps through.
+#
+# WHAT IT CHECKS
+# --------------
+# For each (values.yaml pin key -> publishing workflow):
+#   1. read the pin's current value from products/catalyst/chart/values.yaml;
+#   2. collect every file the workflow hands to `deploy-bump` via `paths:`
+#      (both the inline scalar and the block-scalar list form);
+#   3. assert at least one of those files EXISTS and literally contains the
+#      pin value.
+#
+# If (3) fails the workflow is mutating files that cannot possibly carry the
+# pin — i.e. its deploy leg is a no-op that reports success.
+#
+# ABSENT EVIDENCE IS A FAILURE, NEVER A PASS
+# ------------------------------------------
+# An unparseable pin, a missing workflow, a workflow with no deploy-bump
+# `paths:`, or a target path that does not exist on disk are all hard failures.
+# A checker that passes because it could not see anything is the same defect
+# class it exists to catch (docs/PRINCIPLES.md §Anti-pattern-catalog).
+#
+# Usage:
+#   scripts/check-image-pin-writer-targets.sh
+#
+# Env:
+#   VALUES_YAML    default products/catalyst/chart/values.yaml
+#   WORKFLOW_DIR   default .github/workflows
+#
+# Exit codes:
+#   0 — every covered pin is reachable by its publishing workflow's deploy job.
+#   1 — at least one pin is unreachable, unparseable, or unverifiable.
+
+set -uo pipefail
+
+VALUES_YAML="${VALUES_YAML:-products/catalyst/chart/values.yaml}"
+WORKFLOW_DIR="${WORKFLOW_DIR:-.github/workflows}"
+
+# ---------------------------------------------------------------------------
+# Coverage map: values.yaml pin key -> workflow that publishes that image.
+#
+# `nested` keys live as   images.<key>.tag: "<sha>"
+# `flat`   keys live as   images.<key>: "<sha>"
+#
+# Add a row here whenever a new build-*.yaml starts pinning an image through
+# values.yaml. A pin with no row is invisible to this guard, which is why the
+# row list is asserted non-empty below.
+# ---------------------------------------------------------------------------
+DEFAULT_PINS=(
+  "console|nested|console-build.yaml"
+  "admin|nested|admin-build.yaml"
+  "marketplaceApi|nested|marketplace-api-build.yaml"
+  "catalystApi|nested|catalyst-build.yaml"
+  "catalystUi|nested|catalyst-build.yaml"
+  "orgTag|flat|services-build.yaml"
+  "marketplaceTag|flat|marketplace-build.yaml"
+)
+
+# PIN_MAP lets scripts/tests/ drive this guard against small fixture repos.
+# It is never set in CI; the default map above is what runs there, and the
+# emptiness check below applies to whichever map is in force so a blank
+# override cannot turn the gate into a no-op.
+PINS=()
+if [ -n "${PIN_MAP:-}" ]; then
+  while IFS= read -r row; do
+    [ -n "${row}" ] && PINS+=("${row}")
+  done <<< "${PIN_MAP}"
+else
+  PINS=("${DEFAULT_PINS[@]}")
+fi
+
+if [ "${#PINS[@]}" -eq 0 ]; then
+  echo "::error::coverage map is empty — this guard cannot fail and is therefore useless."
+  exit 1
+fi
+
+if [ ! -f "${VALUES_YAML}" ]; then
+  echo "::error::values.yaml not found at ${VALUES_YAML}"
+  exit 1
+fi
+
+# Read images.<key>.tag (nested) or images.<key> (flat) out of values.yaml.
+read_pin() {
+  local key="$1" kind="$2"
+  if [ "${kind}" = "flat" ]; then
+    awk -v k="${key}" '
+      /^images:/           { in_images = 1; next }
+      in_images && /^[^ ]/ { exit }
+      in_images && $0 ~ "^  " k ":" {
+        if (match($0, /"[^"]*"/)) { print substr($0, RSTART + 1, RLENGTH - 2) }
+        exit
+      }
+    ' "${VALUES_YAML}"
+  else
+    awk -v k="${key}" '
+      /^images:/           { in_images = 1; next }
+      in_images && /^[^ ]/ { exit }
+      in_images && $0 ~ "^  " k ":[[:space:]]*$" { in_key = 1; next }
+      in_key && /^  [^ ]/  { exit }
+      in_key && /^    tag:/ {
+        if (match($0, /"[^"]*"/)) { print substr($0, RSTART + 1, RLENGTH - 2) }
+        exit
+      }
+    ' "${VALUES_YAML}"
+  fi
+}
+
+# Collect the paths a workflow commits.
+#
+# Two publish mechanisms are in use in this repo and both must be read:
+#   * the shared `./.github/actions/deploy-bump` composite action, fed by a
+#     `paths:` input (most workflows);
+#   * a hand-rolled `git add <path>` + push retry loop (services-build.yaml,
+#     which deliberately opts out of deploy-bump's `-X theirs` policy, #5743).
+# Reading only the first would have made this guard blind to the second, which
+# is exactly the "the sweep never reached that one" failure it exists to stop.
+#
+# For the deploy-bump form, two YAML spellings are in use:
+#   paths: products/catalyst/chart/values.yaml          (inline scalar)
+#   paths: |                                            (block scalar)
+#     products/catalyst/chart/values.yaml
+#     products/catalyst/chart/templates/api-deployment.yaml
+#
+# The `on: push: paths:` TRIGGER also uses the key `paths:`, in two spellings —
+# a block sequence (`- 'core/console/**'`) and a flow sequence
+# (`paths: ['core/console/**']`). Both are excluded: a leading `[` or `-`, or a
+# `*` anywhere, marks a trigger glob rather than a concrete write target. Write
+# targets are always literal file paths.
+read_bump_targets() {
+  awk '
+    # inline scalar: paths: <value>   (value present, not a block indicator)
+    match($0, /^[[:space:]]+paths:[[:space:]]*[^[:space:]|].*$/) {
+      line = $0
+      sub(/^[[:space:]]+paths:[[:space:]]*/, "", line)
+      sub(/[[:space:]]+$/, "", line)
+      gsub(/["'"'"']/, "", line)
+      if (line != "" && line !~ /^[\[{-]/ && line !~ /\*/) { print line }
+      next
+    }
+    # block scalar: paths: |
+    /^[[:space:]]+paths:[[:space:]]*\|[[:space:]]*$/ {
+      match($0, /^[[:space:]]*/)
+      base = RLENGTH
+      in_block = 1
+      next
+    }
+    in_block {
+      if ($0 ~ /^[[:space:]]*$/) { next }
+      match($0, /^[[:space:]]*/)
+      if (RLENGTH <= base) { in_block = 0; next }
+      line = $0
+      sub(/^[[:space:]]+/, "", line)
+      sub(/[[:space:]]+$/, "", line)
+      if (line ~ /^-/) { in_block = 0; next }
+      gsub(/["'"'"']/, "", line)
+      if (line !~ /\*/) { print line }
+    }
+    # hand-rolled publisher: `git add <path> [<path> ...]`
+    /^[[:space:]]*git add[[:space:]]/ {
+      line = $0
+      sub(/^[[:space:]]*git add[[:space:]]+/, "", line)
+      sub(/[[:space:]]+$/, "", line)
+      n = split(line, parts, /[[:space:]]+/)
+      for (i = 1; i <= n; i++) {
+        p = parts[i]
+        gsub(/["'"'"']/, "", p)
+        if (p != "" && p !~ /^-/ && p !~ /\*/) { print p }
+      }
+    }
+  ' "$1" | sort -u
+}
+
+fail=0
+checked=0
+
+for row in "${PINS[@]}"; do
+  IFS='|' read -r key kind wf <<< "${row}"
+  wf_path="${WORKFLOW_DIR}/${wf}"
+  checked=$((checked + 1))
+
+  if [ ! -f "${wf_path}" ]; then
+    echo "::error::${key}: publishing workflow ${wf_path} not found — pin has no writer."
+    fail=$((fail + 1))
+    continue
+  fi
+
+  pin="$(read_pin "${key}" "${kind}")"
+  if [ -z "${pin}" ]; then
+    echo "::error::${key}: could not parse the pin from ${VALUES_YAML} (expected ${kind} form). Refusing to pass on an unreadable pin."
+    fail=$((fail + 1))
+    continue
+  fi
+
+  mapfile -t targets < <(read_bump_targets "${wf_path}")
+  if [ "${#targets[@]}" -eq 0 ]; then
+    echo "::error::${key}: ${wf_path} hands no files to deploy-bump (no \`paths:\` write target). Its deploy leg cannot move any pin."
+    fail=$((fail + 1))
+    continue
+  fi
+
+  reachable=""
+  missing_on_disk=""
+  for t in "${targets[@]}"; do
+    if [ -d "${t}" ]; then
+      # A directory target (`git add products/`) reaches the pin if any tracked
+      # YAML beneath it carries the pin.
+      if grep -rqF --include='*.yaml' --include='*.yml' -- "${pin}" "${t}"; then
+        reachable="${t}"
+        break
+      fi
+      continue
+    fi
+    if [ ! -f "${t}" ]; then
+      missing_on_disk="${missing_on_disk} ${t}"
+      continue
+    fi
+    if grep -qF -- "${pin}" "${t}"; then
+      reachable="${t}"
+      break
+    fi
+  done
+
+  if [ -n "${missing_on_disk}" ]; then
+    echo "::error::${key}: ${wf_path} pushes path(s) that do not exist:${missing_on_disk}. A rename left the writer pointing at nothing."
+    fail=$((fail + 1))
+    continue
+  fi
+
+  if [ -z "${reachable}" ]; then
+    echo "::error::${key}: pin \"${pin}\" appears in NONE of the files ${wf_path} mutates (${targets[*]})."
+    echo "::error::  The deploy leg is a silent no-op: its edit matches zero lines, exits 0, and deploy-bump pushes an empty diff."
+    # Point at where the pin actually lives, so the fix is mechanical.
+    if grep -qF -- "${pin}" "${VALUES_YAML}"; then
+      echo "::error::  The mutable SHA lives in ${VALUES_YAML} (images.${key}) — bump it there, e.g. via scripts/bump-values-image-tag.sh."
+    fi
+    fail=$((fail + 1))
+    continue
+  fi
+
+  echo "  OK         images.${key} pin=${pin} written by ${wf} -> ${reachable}"
+done
+
+echo
+echo "Checked ${checked} image pin writer target(s); ${fail} unreachable."
+
+if [ "${fail}" -gt 0 ]; then
+  echo
+  echo "FAIL: at least one build workflow's deploy job cannot reach the pin it"
+  echo "is responsible for. That workflow will go on publishing images to GHCR"
+  echo "and reporting success while the chart ships a frozen tag — the #5451"
+  echo "shape, which held org-services/console on a 2026-04-28 image for three"
+  echo "and a half months."
+  echo
+  echo "Fix: point the workflow's deploy step (and its deploy-bump \`paths:\`) at"
+  echo "the file the pin actually lives in, and use"
+  echo "scripts/bump-values-image-tag.sh so a no-op write can never exit 0."
+  exit 1
+fi
+
+echo "PASS: every covered image pin is reachable by its publishing workflow."

--- a/scripts/tests/test-image-pin-writer-targets.sh
+++ b/scripts/tests/test-image-pin-writer-targets.sh
@@ -1,0 +1,373 @@
+#!/usr/bin/env bash
+# test-image-pin-writer-targets.sh — non-vacuity proof for #5451
+#
+# Drives scripts/check-image-pin-writer-targets.sh against the ACTUAL shapes
+# involved in the outage, not invented ones:
+#
+#   H1  the real pre-fix console-build.yaml deploy step (sed against the
+#       Helm-templated org-services/console.yaml) with the real frozen pin
+#       images.console.tag = "3c2f7e4"                              -> RED
+#   H2  the same fixture with the shipped fix — deploy-bump pointed at
+#       values.yaml, where the pin actually lives                   -> GREEN
+#   H3  CONTROL. marketplace-build.yaml shares every suspect property with
+#       the broken three: same chart, same org-services directory, same
+#       Helm-templated `image:` line, same deploy-bump composite action.
+#       The ONLY difference is that its writer targets values.yaml. It must
+#       stay GREEN, or the guard is just failing everything in that tree
+#       and proves nothing about console.                           -> GREEN
+#   H4  pin key renamed in values.yaml — the pin becomes unreadable. Absent
+#       evidence must be reported as failure, never as a pass.      -> RED
+#   H5  a workflow that commits nothing (no deploy-bump `paths:`, no
+#       `git add`). A writer with no write target cannot move a pin. -> RED
+#   H6  services-build.yaml's hand-rolled `git add products/` publisher,
+#       which does not use deploy-bump at all. Proves the second extraction
+#       mode is load-bearing rather than decorative.                -> GREEN
+#   H7  an empty coverage map. A guard with nothing to check must refuse,
+#       not print PASS.                                             -> RED
+#
+# Hermetic: no network, no token, no live cluster.
+#
+# Usage: bash scripts/tests/test-image-pin-writer-targets.sh
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/../.." && pwd)"
+GUARD="${REPO_ROOT}/scripts/check-image-pin-writer-targets.sh"
+
+if [ ! -f "${GUARD}" ]; then
+  echo "FAIL: guard not found at ${GUARD}" >&2
+  exit 1
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "${WORK}"' EXIT
+
+FAILED=0
+fail() { echo "FAIL: $*" >&2; FAILED=1; }
+pass() { echo "PASS: $*"; }
+
+# ---------------------------------------------------------------------------
+# Fixture repo. values.yaml carries the real frozen console pin (3c2f7e4,
+# 2026-04-28) and the real live marketplace pin (7d0b73e), and the manifests
+# carry the real post-#580 Helm-templated `image:` lines.
+# ---------------------------------------------------------------------------
+build_fixture() {
+  local root="$1"
+  rm -rf "${root}"
+  mkdir -p "${root}/.github/workflows" \
+           "${root}/products/catalyst/chart/templates/org-services"
+
+  cat > "${root}/products/catalyst/chart/values.yaml" <<'YAML'
+images:
+  registry: "ghcr.io"
+  organization: "openova-io/openova"
+  console:
+    tag: "3c2f7e4"
+  marketplaceTag: "7d0b73e"
+YAML
+
+  # Real post-#580 shape: the SHA is a Helm expression, not a literal.
+  local tmpl='          image: "{{ if .Values.global.imageRegistry }}{{ .Values.global.imageRegistry }}{{ else }}{{ .Values.images.registry }}{{ end }}/{{ .Values.images.organization }}'
+  printf '%s/console:{{ .Values.images.console.tag }}"\n' "${tmpl}" \
+    > "${root}/products/catalyst/chart/templates/org-services/console.yaml"
+  printf '%s/marketplace:{{ .Values.images.marketplaceTag }}"\n' "${tmpl}" \
+    > "${root}/products/catalyst/chart/templates/org-services/marketplace.yaml"
+}
+
+# The pre-fix console-build.yaml deploy job, verbatim in shape.
+write_console_workflow_broken() {
+  cat > "$1/.github/workflows/console-build.yaml" <<'YAML'
+name: Build & Deploy Catalyst Console
+on:
+  push:
+    paths: ['core/console/**']
+    branches: [main]
+env:
+  IMAGE: ghcr.io/openova-io/openova/console
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update deployment manifest
+        run: |
+          SHA=$(echo $GITHUB_SHA | head -c 7)
+          FILE="products/catalyst/chart/templates/org-services/console.yaml"
+          if [ -f "$FILE" ]; then
+            sed -i "s|image: ${IMAGE}:.*|image: ${IMAGE}:${SHA}|" "$FILE"
+          fi
+      - name: Commit and push
+        uses: ./.github/actions/deploy-bump
+        with:
+          paths: products/catalyst/chart/templates/org-services/console.yaml
+          commit-message: "deploy: update Catalyst console image"
+YAML
+}
+
+write_console_workflow_fixed() {
+  cat > "$1/.github/workflows/console-build.yaml" <<'YAML'
+name: Build & Deploy Catalyst Console
+on:
+  push:
+    paths: ['core/console/**']
+    branches: [main]
+env:
+  IMAGE: ghcr.io/openova-io/openova/console
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Bump images.console.tag in values.yaml
+        run: |
+          bash scripts/bump-values-image-tag.sh \
+            products/catalyst/chart/values.yaml console "${SHA_SHORT}"
+      - name: Commit and push
+        uses: ./.github/actions/deploy-bump
+        with:
+          paths: products/catalyst/chart/values.yaml
+          commit-message: "deploy: update Catalyst console image"
+YAML
+}
+
+# The CONTROL: marketplace-build.yaml as it has looked since #4885.
+write_marketplace_workflow() {
+  cat > "$1/.github/workflows/marketplace-build.yaml" <<'YAML'
+name: Build & Deploy Catalyst Marketplace
+on:
+  push:
+    paths: ['core/marketplace/**']
+    branches: [main]
+env:
+  IMAGE: ghcr.io/openova-io/openova/marketplace
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Bump marketplace image tag in values.yaml
+        run: |
+          sed -i "s|^  marketplaceTag: \"[A-Za-z0-9_.-]*\"$|  marketplaceTag: \"${SHA}\"|" \
+            products/catalyst/chart/values.yaml
+      - name: Commit and push
+        uses: ./.github/actions/deploy-bump
+        with:
+          paths: products/catalyst/chart/values.yaml
+          commit-message: "deploy: update Catalyst marketplace image"
+YAML
+}
+
+run_guard() {
+  local root="$1" map="$2"
+  ( cd "${root}" && PIN_MAP="${map}" bash "${GUARD}" 2>&1 )
+}
+
+expect() {
+  local want="$1" root="$2" map="$3" label="$4"
+  local out rc
+  out="$(run_guard "${root}" "${map}")"
+  rc=$?
+  if [ "${want}" = "red" ] && [ "${rc}" -eq 0 ]; then
+    fail "${label} — expected exit!=0, got 0. Output:"; echo "${out}" >&2; return
+  fi
+  if [ "${want}" = "green" ] && [ "${rc}" -ne 0 ]; then
+    fail "${label} — expected exit 0, got ${rc}. Output:"; echo "${out}" >&2; return
+  fi
+  pass "${label} (exit ${rc})"
+}
+
+# ---------------------------------------------------------------------------
+# H1 — the real defect
+# ---------------------------------------------------------------------------
+FX="${WORK}/h1"
+build_fixture "${FX}"
+write_console_workflow_broken "${FX}"
+expect red "${FX}" "console|nested|console-build.yaml" \
+  "H1 pre-fix console-build.yaml (sed on a templated manifest) is RED"
+
+# The message must name the real cause, not just say 'failed'. Captured into a
+# variable rather than piped: under `set -o pipefail` a pipeline inherits the
+# guard's non-zero exit and would report a false negative here.
+h1_out="$(run_guard "${FX}" "console|nested|console-build.yaml")"
+if printf '%s' "${h1_out}" | grep -q 'silent no-op'; then
+  pass "H1 failure message names the silent no-op"
+else
+  fail "H1 — failure message does not identify the no-op write"
+fi
+
+# ---------------------------------------------------------------------------
+# H2 — the shipped fix
+# ---------------------------------------------------------------------------
+FX="${WORK}/h2"
+build_fixture "${FX}"
+write_console_workflow_fixed "${FX}"
+expect green "${FX}" "console|nested|console-build.yaml" \
+  "H2 fixed console-build.yaml (deploy-bump -> values.yaml) is GREEN"
+
+# ---------------------------------------------------------------------------
+# H3 — CONTROL sharing the suspect property
+# ---------------------------------------------------------------------------
+FX="${WORK}/h3"
+build_fixture "${FX}"
+write_console_workflow_broken "${FX}"
+write_marketplace_workflow "${FX}"
+expect green "${FX}" "marketplaceTag|flat|marketplace-build.yaml" \
+  "H3 CONTROL marketplace-build.yaml — same chart, same org-services dir, same templated image line, same deploy-bump — stays GREEN"
+
+# and in the same fixture the broken one is still red, so H3 is not green by accident
+expect red "${FX}" "$(printf 'console|nested|console-build.yaml\nmarketplaceTag|flat|marketplace-build.yaml')" \
+  "H3b both together — the control does not mask the defect"
+
+# ---------------------------------------------------------------------------
+# H4 — unreadable pin must fail, not pass
+# ---------------------------------------------------------------------------
+FX="${WORK}/h4"
+build_fixture "${FX}"
+write_console_workflow_fixed "${FX}"
+cat > "${FX}/products/catalyst/chart/values.yaml" <<'YAML'
+images:
+  registry: "ghcr.io"
+  consoleImage:
+    tag: "3c2f7e4"
+YAML
+expect red "${FX}" "console|nested|console-build.yaml" \
+  "H4 renamed pin key — unreadable pin is RED, not a pass"
+
+# ---------------------------------------------------------------------------
+# H5 — a workflow that writes nothing
+# ---------------------------------------------------------------------------
+FX="${WORK}/h5"
+build_fixture "${FX}"
+cat > "${FX}/.github/workflows/console-build.yaml" <<'YAML'
+name: Build Catalyst Console
+on:
+  push:
+    paths: ['core/console/**']
+    branches: [main]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+YAML
+expect red "${FX}" "console|nested|console-build.yaml" \
+  "H5 workflow with no write target is RED"
+
+# ---------------------------------------------------------------------------
+# H6 — hand-rolled `git add` publisher (services-build.yaml's shape)
+# ---------------------------------------------------------------------------
+FX="${WORK}/h6"
+build_fixture "${FX}"
+cat > "${FX}/products/catalyst/chart/values.yaml" <<'YAML'
+images:
+  registry: "ghcr.io"
+  orgTag: "d1607c4"
+YAML
+cat > "${FX}/.github/workflows/services-build.yaml" <<'YAML'
+name: Build & Deploy Organization services
+on:
+  push:
+    paths: ['core/services/**']
+    branches: [main]
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Rewrite and push
+        run: |
+          sed -i "s|^  orgTag: \"[A-Za-z0-9_.-]*\"$|  orgTag: \"${SHA}\"|" \
+            products/catalyst/chart/values.yaml
+          git add products/
+          git commit -m "deploy: update org service images"
+YAML
+expect green "${FX}" "orgTag|flat|services-build.yaml" \
+  "H6 hand-rolled 'git add products/' publisher is GREEN"
+
+# ---------------------------------------------------------------------------
+# H7 — an empty map must refuse
+# ---------------------------------------------------------------------------
+FX="${WORK}/h7"
+build_fixture "${FX}"
+write_console_workflow_fixed "${FX}"
+out="$( cd "${FX}" && PIN_MAP="$(printf '\n')" bash "${GUARD}" 2>&1 )"
+rc=$?
+if [ "${rc}" -eq 0 ]; then
+  fail "H7 empty coverage map exited 0 — the guard can be silenced. Output:"; echo "${out}" >&2
+else
+  pass "H7 empty coverage map is RED (exit ${rc})"
+fi
+
+# ===========================================================================
+# Part B — scripts/bump-values-image-tag.sh, the writer the fixed workflows
+# call. The guard above proves the writer is POINTED at the pin; these prove
+# the writer cannot report success without having MOVED it, which is the
+# property whose absence caused the outage.
+# ===========================================================================
+BUMP="${REPO_ROOT}/scripts/bump-values-image-tag.sh"
+
+if [ ! -f "${BUMP}" ]; then
+  fail "B0 — scripts/bump-values-image-tag.sh not found"
+else
+  # B1 — happy path: the field moves and the file re-reads as the new SHA.
+  V="${WORK}/b1-values.yaml"
+  cat > "${V}" <<'YAML'
+images:
+  registry: "ghcr.io"
+  console:
+    tag: "3c2f7e4"
+  admin:
+    tag: "3c2f7e4"
+YAML
+  if bash "${BUMP}" "${V}" console 1a2b3c4 >/dev/null 2>&1 \
+     && grep -q '^    tag: "1a2b3c4"$' "${V}" \
+     && grep -c '^    tag: "3c2f7e4"$' "${V}" | grep -qx 1; then
+    pass "B1 bump moves images.console.tag and leaves images.admin.tag alone"
+  else
+    fail "B1 — bump did not move exactly one field. File now:"; cat "${V}" >&2
+  fi
+
+  # B2 — the real 2026-05-02 shape: the pin no longer lives where the writer
+  # looks. The writer must go RED, not exit 0 having written nothing.
+  V="${WORK}/b2-values.yaml"
+  cat > "${V}" <<'YAML'
+images:
+  registry: "ghcr.io"
+  consoleImage:
+    tag: "3c2f7e4"
+YAML
+  before="$(cat "${V}")"
+  if bash "${BUMP}" "${V}" console 1a2b3c4 >/dev/null 2>&1; then
+    fail "B2 — bump exited 0 against a reshaped field (this is the #5451 defect)"
+  elif [ "$(cat "${V}")" != "${before}" ]; then
+    fail "B2 — bump failed but still mutated the file"
+  else
+    pass "B2 reshaped/renamed pin field is RED and the file is untouched"
+  fi
+
+  # B3 — missing values.yaml is a failure, not a silent skip. The original
+  # workflows wrapped their edit in `if [ -f "$FILE" ]`, which is precisely
+  # how a path rename turned into three months of green no-ops.
+  if bash "${BUMP}" "${WORK}/does-not-exist.yaml" console 1a2b3c4 >/dev/null 2>&1; then
+    fail "B3 — bump exited 0 for a missing values.yaml"
+  else
+    pass "B3 missing values.yaml is RED, never a skip"
+  fi
+
+  # B4 — idempotence: re-running with the SHA already in place is a legitimate
+  # success (a retry after a push race), not a failure.
+  V="${WORK}/b4-values.yaml"
+  cat > "${V}" <<'YAML'
+images:
+  console:
+    tag: "1a2b3c4"
+YAML
+  if bash "${BUMP}" "${V}" console 1a2b3c4 >/dev/null 2>&1; then
+    pass "B4 re-running with the SHA already pinned is GREEN (retry-safe)"
+  else
+    fail "B4 — idempotent re-run reported failure"
+  fi
+fi
+
+echo
+if [ "${FAILED}" -ne 0 ]; then
+  echo "test-image-pin-writer-targets.sh: FAILED"
+  exit 1
+fi
+echo "test-image-pin-writer-targets.sh: all cases passed"


### PR DESCRIPTION
Refs #5451

## The finding is not a stale tag, it is a writer that had been disconnected from its pin since 2026-05-02

Verified live on hw293 (dep `a0077ba47e3720e5`), read-only:

```
$ kubectl -n org-services get deploy -o wide
console        ghcr.io/openova-io/openova/console:3c2f7e4      <- 2026-04-28
admin          ghcr.io/openova-io/openova/admin:3c2f7e4        <- 2026-04-28
auth/billing/catalog/domain/gateway/notification/
organizations/provisioning                 services-*:d1607c4  <- 2026-08-10
marketplace    ghcr.io/openova-io/openova/marketplace:7d0b73e  <- 2026-08-10
```

`3c2f7e4` is `feat(consolidation): Phase 1 …`, 2026-04-28. The Organization microservices next to it were rebuilt yesterday, so this is not an environment that stopped receiving deployments — two specific images stopped, and a third (`marketplace-api`) is frozen at the same tag in the chart.

### Why the pin never advanced

`console-build.yaml`'s deploy job was:

```sh
FILE="products/catalyst/chart/templates/org-services/console.yaml"
if [ -f "$FILE" ]; then
  sed -i "s|image: ${IMAGE}:.*|image: ${IMAGE}:${SHA}|" "$FILE"
fi
```

On 2026-05-02, `83ec889f0` (PR #580, *add global.imageRegistry to remaining bp-\* charts*) rewrote that manifest's `image:` line into a Helm expression and moved the mutable SHA into `values.yaml`:

```yaml
image: "{{ … }}/{{ .Values.images.organization }}/console:{{ .Values.images.console.tag }}"
```

From that commit the sed pattern matched **zero lines**. `sed -i` with no match exits 0; `deploy-bump` then saw an empty diff and pushed nothing. Every console build for 101 days was green and shipped nothing.

The read that separates this from the other candidates:

| candidate | disproved by |
|---|---|
| deploy-bot does not watch this tree | it does — `on: push: paths: ['core/console/**']`, and GHCR holds a tag for every console commit since April |
| HelmRelease suspended | `helm.toolkit.fluxcd.io/name: bp-catalyst-platform` is reconciling; eleven sibling Deployments in the same release rolled yesterday |
| chart never republished | the chart version advances continuously (1.4.1368 → 1.4.1371 in the last few hours) |
| pin advanced in source, chart stale | `images.console.tag` on `main` **is** `"3c2f7e4"` |
| **writer cannot reach the pin** | **`grep 3c2f7e4` finds nothing in the file the workflow mutates; it is in `values.yaml`, which the workflow never touches** |

GHCR settles it — only the *deploy* leg was dead:

```
openova/console        ea10f7d  2026-07-27T10:46:01Z   <- the #5452 fix image
openova/admin          06ea9d4  2026-08-02T15:47:46Z
openova/marketplace-api 0d9531a 2026-07-09T17:37:50Z
```

### It is three workflows, and the class was already known

`admin-build.yaml` and `marketplace-api-build.yaml` carry the identical step against the identical templating change. All three pins sat at exactly `"3c2f7e4"` — a three-for-three correlation with the three workflows that still sed a templated manifest, against four sibling pins that do not and are all current.

This class had already been diagnosed and fixed three times, and each fix stopped at its own file. `catalyst-build.yaml` carries the comment *"feat/global-imageRegistry (#580) converted the literal image ref to a Helm template without updating this deploy step"* and *"a `{{ … }}` directive that no sed could match — net: catalyst-api stayed pinned on the LAST manually-bumped SHA for days/weeks while every deploy commit pushed green."* `marketplace-build.yaml` was migrated off the sed in #4885 and even gained a fail-closed grep. The sweep never reached these three.

### Blast radius

`core/console` commits merged after `3c2f7e4` and undeployed on hw293 — **9**:

| commit | date | |
|---|---|---|
| `ea10f7dff` | 2026-07-27 | badge apps NOT SERVING when the workload is dead (#5452) — the fix for this issue |
| `147f0eddd` | 2026-07-20 | migrate off the deprecated `/tenant/orgs` alias to `/organizations` (#5279, row 214) |
| `58ec301e3` | 2026-07-19 | purge banned-term identifiers from both console bundles (#5247, row 214) |
| `69082ffce` | 2026-06-21 | 8 remaining user-visible term leaks (#4039, row 214) |
| `37a3ea870` | 2026-06-21 | 18 user-visible term flips (#4017) |
| `34ff59437` | 2026-06-20 | SME → Organization eradication across code/config/charts (#3995) |
| `82fd63608` | 2026-06-09 | reusable shareable backing-services model (#3191) |
| `3b72660a5` | 2026-06-02 | Launch button calls `/apps/{id}/launch-url` (#2835) |
| `3d20ee35b` | 2026-05-20 | purge 5 `.openova.io` leaks so Users reach their Sovereign (#1996) |

Plus **5** on `core/admin` (through `06ea9d42c`) and **3** on `core/marketplace-api` (including #4924's durable `sovereign-smtp-credentials` seed).

## What this ships

**The mechanism**, not the tag:

- **`scripts/bump-values-image-tag.sh`** — the writer the three workflows now call. Fails closed when `images.<key>.tag` is missing or reshaped, and asserts the post-condition: the field is re-read and must equal the requested SHA. **A no-op write can no longer exit 0**, which is the single property whose absence caused this. One tested script rather than three copies of awk, so the next chart reshape cannot fix two call sites and miss one.
- **`scripts/check-image-pin-writer-targets.sh`** (new, + workflow + self-test) — asks the cheap structural question with no network and no token: *can this writer reach this pin at all?* It reads both publish mechanisms in use — the `deploy-bump` `paths:` input and `services-build.yaml`'s hand-rolled `git add` loop — because reading only the first would have been blind to the second, which is the same "the sweep never reached that one" failure.
- **`scripts/check-controller-image-tag-freshness.sh`** extended from 5 controller pins to all **12** chart image pins. The loop body is factored into one shared function so the two groups cannot drift into two definitions of "stale" — that drift is why the `images:` block sat unwatched three lines from pins that were gated.
- The three frozen pins unfrozen to their latest published tags, delivered by the chart version bump to **1.4.1372**. `helm template` now renders `console:ea10f7d`, `admin:06ea9d4`, `marketplace-api:0d9531a`.

### On the choice of comparand

A guard that compares a pin to its own chart stays green when both are equally stale — that is how `check-bootstrap-kit-pin-sync.sh` missed four bumps. GHCR is the right comparand here for a specific reason: it is written by a **different leg of the pipeline** than the pin. The build leg kept publishing the whole time the deploy leg was dead, so the two disagreed from day one and a comparison between them could always have seen it.

## Red before, green after, with a control

**`check-image-pin-writer-targets.sh`**, run against the pre-fix tree:

```
::error::console: pin "3c2f7e4" appears in NONE of the files .github/workflows/console-build.yaml mutates (products/catalyst/chart/templates/org-services/console.yaml).
::error::  The deploy leg is a silent no-op: its edit matches zero lines, exits 0, and deploy-bump pushes an empty diff.
::error::  The mutable SHA lives in products/catalyst/chart/values.yaml (images.console) — bump it there, e.g. via scripts/bump-values-image-tag.sh.
::error::admin: pin "3c2f7e4" appears in NONE of the files .github/workflows/admin-build.yaml mutates (…/org-services/admin.yaml).
::error::marketplaceApi: pin "3c2f7e4" appears in NONE of the files .github/workflows/marketplace-api-build.yaml mutates (…/marketplace-api/deployment.yaml).
  OK         images.catalystApi pin=b085e90 written by catalyst-build.yaml -> products/catalyst/chart/templates/api-deployment-kustomize.yaml
  OK         images.catalystUi pin=b085e90 written by catalyst-build.yaml -> products/catalyst/chart/templates/api-deployment-kustomize.yaml
  OK         images.orgTag pin=d1607c4 written by services-build.yaml -> products/
  OK         images.marketplaceTag pin=7d0b73e written by marketplace-build.yaml -> products/catalyst/chart/values.yaml

Checked 7 image pin writer target(s); 3 unreachable.
```

after the workflow fix:

```
  OK         images.console pin=ea10f7d written by console-build.yaml -> products/catalyst/chart/values.yaml
  OK         images.admin pin=06ea9d4 written by admin-build.yaml -> products/catalyst/chart/values.yaml
  OK         images.marketplaceApi pin=0d9531a written by marketplace-api-build.yaml -> products/catalyst/chart/values.yaml
  … 4 unchanged …
Checked 7 image pin writer target(s); 0 unreachable.
PASS: every covered image pin is reachable by its publishing workflow.
```

**The control is `images.marketplaceTag`.** It shares every suspect property: same chart, same `org-services/` directory, same Helm-templated `image:` line, same `deploy-bump` composite action, same `core/*` push trigger. It differs in one thing — its writer targets `values.yaml`. It is green in **both** runs, so the red is a statement about the writer and not about the directory.

**`check-controller-image-tag-freshness.sh`**, before the pin bump:

```
  OK         blueprint-controller:852de2b (lag=0)      … 5 controllers, all lag=0
::error::console: pinned 3c2f7e4 is 12099 commits behind latest GHCR ea10f7d (threshold: 50)
::error::marketplace-api: pinned 3c2f7e4 is 9138 commits behind latest GHCR 0d9531a (threshold: 50)
::error::admin: pinned 3c2f7e4 is 12953 commits behind latest GHCR 06ea9d4 (threshold: 50)
  OK         services-provisioning:d1607c4 (lag=0)
  OK         catalyst-api:b085e90 (lag=4)
  OK         catalyst-ui:b085e90 (lag=4)
  OK         marketplace:7d0b73e (lag=0)

Checked 12/12 chart image pin(s); 3 stale; 0 unverifiable.
```

after:

```
Checked 12/12 chart image pin(s); 0 stale; 0 unverifiable.
PASS: every chart image pin is within 50 commits of latest GHCR.
```

Nine pins are green in both runs. The extension found exactly the three the writer-target guard found independently, by a different method against a different source of truth.

### The guard's own non-vacuity proof

`scripts/tests/test-image-pin-writer-targets.sh` — 13 cases, hermetic, built from the real pre-fix workflow shape and the real frozen pin rather than invented input:

```
PASS: H1 pre-fix console-build.yaml (sed on a templated manifest) is RED (exit 1)
PASS: H1 failure message names the silent no-op
PASS: H2 fixed console-build.yaml (deploy-bump -> values.yaml) is GREEN (exit 0)
PASS: H3 CONTROL marketplace-build.yaml — same chart, same org-services dir, same templated image line, same deploy-bump — stays GREEN (exit 0)
PASS: H3b both together — the control does not mask the defect (exit 1)
PASS: H4 renamed pin key — unreadable pin is RED, not a pass (exit 1)
PASS: H5 workflow with no write target is RED (exit 1)
PASS: H6 hand-rolled 'git add products/' publisher is GREEN (exit 0)
PASS: H7 empty coverage map is RED (exit 1)
PASS: B1 bump moves images.console.tag and leaves images.admin.tag alone
PASS: B2 reshaped/renamed pin field is RED and the file is untouched
PASS: B3 missing values.yaml is RED, never a skip
PASS: B4 re-running with the SHA already pinned is GREEN (retry-safe)
```

H4/H5/H7 and B2/B3 exist because absent evidence must be a failure: an unreadable pin, a writer with no target and an empty coverage map are the three ways this guard could have quietly become incapable of failing, and B3 is the literal `if [ -f "$FILE" ]` skip that made a path rename survivable in the first place.

## What this does not do

It does not by itself prove #5451's badge behaves correctly. It removes the reason the badge could not be observed. `ea10f7d` and `87bbca849` now reach a cluster on the next roll, and the runtime proof — a dead workload reading NOT SERVING with no Open button, **and a healthy one still reading INSTALLED with a working Open** — is still owed on a per-Organization console with a customer Org installed. Every UAT row asserting on that surface has been measuring April's code and needs a re-walk rather than a re-read; those are listed on the issue.
