### PR TITLE
fix(catalyst-api): stop the Topology-tab Save flattening spec.placement to a scalar and leaving parameters.topology stale (UAT row 16)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/applications_update.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications_update.go
@@ -177,6 +177,178 @@ func regionsFromPlacementTargets(targets []bpv1.PlacementTarget) []string {
 	return append(primaries, rest...)
 }
 
+// placementValueForUpdate produces the value stored at `spec.placement` by a
+// PUT, resolving the CRD's DUAL FORM instead of flattening it (#6136, UAT row
+// 16).
+//
+// THE DEFECT IT CLOSES. The update path wrote exactly one field of the request:
+//
+//	SetNestedField(patched.Object, canonicalizeTopology(body.Placement.Mode), "spec", "placement")
+//
+// so every Save stored a bare STRING and discarded the rest of what the console
+// sent — `targets[]` (the whole #3969 per-region model the PlacementEditor
+// submits: region, cluster, vcluster, role, standbyType), plus `vcluster` and
+// `clusters` (#3373). Two consequences, both measured on hw293
+// (dep a0077ba47e3720e5):
+//
+//  1. `spec.placement.targets` was never written by anything, while the
+//     TopologyTab reads it as rung 2 of its resolution chain — so the per-target
+//     roles a User picked did not survive the Save that reported HTTP 200.
+//  2. A CR already holding the object form was DOWNGRADED to a scalar. On
+//     `uat50-ahs-pg` a Save replaces the whole node, dropping `vcluster` and
+//     `clusters` the request never mentioned. That is data loss on an untouched
+//     field, not a formatting difference.
+//
+// The install door (applications.go) already emitted the object form when the
+// caller declared WHERE fields. Two producers for one dual-form field, and only
+// one of them knew the field was dual-form.
+//
+// WHY IT WENT UNSEEN. Every reader that RENDERS the posture is shape-tolerant —
+// placementFromSpec (#5422), readTopology, and the console's topologyLabel
+// (#4897) all fall back from the string read to `.mode`. So the console kept
+// showing the right posture after a downgrading Save, and the lost targets were
+// invisible from the surface that caused them.
+//
+// THE RULES.
+//   - `current` is the CR's existing spec.placement value (any shape, or nil).
+//   - A body that declares only a mode, over a CR that holds only a string,
+//     keeps producing the bare string — the legacy wire stays byte-identical.
+//   - A body that declares targets / vcluster / clusters, OR a CR already
+//     holding the object form, produces the OBJECT form.
+//   - The object form is MERGED onto the current one: a key the body does not
+//     restate is carried forward rather than deleted. `mode` is always
+//     rewritten (it is what the PUT is for) and always canonicalised, so one
+//     vocabulary still holds (#3375 DoD-1).
+func placementValueForUpdate(current any, body applicationPlacement) any {
+	canonMode := canonicalizeTopology(body.Mode)
+
+	curObj, _ := current.(map[string]interface{})
+	declaresWhere := strings.TrimSpace(body.VCluster) != "" ||
+		len(body.Clusters) > 0 ||
+		len(body.Targets) > 0
+
+	// Legacy shape in, legacy shape out.
+	if curObj == nil && !declaresWhere {
+		return canonMode
+	}
+
+	out := make(map[string]interface{}, len(curObj)+4)
+	for k, v := range curObj {
+		out[k] = v
+	}
+	out["mode"] = canonMode
+
+	if v := strings.TrimSpace(body.VCluster); v != "" {
+		out["vcluster"] = v
+	}
+	if len(body.Regions) > 0 {
+		regions := make([]interface{}, 0, len(body.Regions))
+		for _, r := range body.Regions {
+			regions = append(regions, r)
+		}
+		out["regions"] = regions
+	}
+	if len(body.Clusters) > 0 {
+		clusters := make([]interface{}, 0, len(body.Clusters))
+		for _, c := range body.Clusters {
+			clusters = append(clusters, c)
+		}
+		out["clusters"] = clusters
+	}
+	if len(body.Targets) > 0 {
+		out["targets"] = placementTargetsToUnstructured(body.Targets)
+	}
+	return out
+}
+
+// placementTargetsToUnstructured converts the typed #3969 targets onto the
+// plain JSON values `unstructured.SetNestedField` accepts — it deep-copies
+// through DeepCopyJSONValue, which rejects a Go struct outright, so the
+// conversion is required rather than cosmetic.
+//
+// `standbyType` is emitted ONLY for a Standby target: the Application CRD's
+// admission CEL forbids it on a Primary (placement_target.go: "REQUIRED iff
+// Role==Standby; FORBIDDEN iff Role==Primary"), so emitting an empty string
+// there would have the apiserver reject the whole update.
+func placementTargetsToUnstructured(targets []bpv1.PlacementTarget) []interface{} {
+	out := make([]interface{}, 0, len(targets))
+	for _, t := range targets {
+		item := map[string]interface{}{
+			"region":  t.Region,
+			"cluster": t.Cluster,
+			"role":    string(t.Role),
+		}
+		if v := strings.TrimSpace(t.VCluster); v != "" {
+			item["vcluster"] = v
+		}
+		if t.Role == bpv1.DataRoleStandby && strings.TrimSpace(string(t.StandbyType)) != "" {
+			item["standbyType"] = string(t.StandbyType)
+		}
+		out = append(out, item)
+	}
+	return out
+}
+
+// repointPostgresTopologyMode re-derives `parameters.topology.mode` from a new
+// placement posture so the value the CHART renders from cannot contradict the
+// posture the CR declares (#6136, UAT row 16).
+//
+// The install door already does this — `defaultedParameters(blueprint,
+// canonMode, …)` folds the placement token through postgresConfigSchemaMode
+// into the bp-postgres configSchema's narrow `[singleton, active-hot-standby]`
+// enum. The update door never did, so a Topology-tab Save that moved an
+// Application to active-hot-standby returned 200 with
+// `spec.placement: active-hot-standby` sitting directly above
+// `spec.parameters.topology.mode: singleton` — and the HelmRelease kept
+// rendering a singleton. The Save was a no-op at the layer that matters, which
+// is precisely why the row reads "PUT 200, generation bumped, nothing changed".
+//
+// Deference, matching the install door's:
+//   - Non-postgres blueprints are untouched (the enum is bp-postgres' own).
+//   - A tree with NO `topology` object, or one with no `mode` string, is
+//     untouched: #4283's rule is that we never START declaring a mode where
+//     none was declared, because that would silently promote a backing-service
+//     postgres from singleton to the cross-region pair shape.
+//   - A mode that already folds to the wanted value is untouched, so this
+//     returns changed=false for the overwhelming majority of PUTs.
+//
+// When it does repoint to the HA mode it also completes the contract via
+// stampPostgresPrimaryRegion: #5639 established that a mode without a region
+// renders an unsatisfiable nodeAffinity, and mode+region must travel in the
+// SAME topology object because the controller merges parameters shallowly.
+//
+// Returns the updated parameters tree and whether anything changed.
+func repointPostgresTopologyMode(params map[string]interface{}, blueprint, canonMode string) (map[string]interface{}, bool) {
+	if !isPostgresBlueprint(blueprint) {
+		return params, false
+	}
+	topo, _ := params["topology"].(map[string]interface{})
+	if topo == nil {
+		return params, false
+	}
+	cur, ok := topo["mode"].(string)
+	if !ok || strings.TrimSpace(cur) == "" {
+		return params, false
+	}
+	want := postgresConfigSchemaMode(canonMode)
+	if postgresConfigSchemaMode(cur) == want {
+		return params, false
+	}
+
+	out := make(map[string]interface{}, len(params))
+	for k, v := range params {
+		out[k] = v
+	}
+	nextTopo := make(map[string]interface{}, len(topo))
+	for k, v := range topo {
+		nextTopo[k] = v
+	}
+	nextTopo["mode"] = want
+	out["topology"] = nextTopo
+	stampPostgresPrimaryRegion(out)
+	return out, true
+}
+
 // applicationUpdateResponse mirrors applicationStatusResponse — the UI
 // gets back the patched CR's metadata + status snapshot. `DisplayName`
 // echoes spec.displayName from the persisted CR so the matrix (TC-108)
@@ -318,7 +490,17 @@ func (h *Handler) HandleApplicationUpdate(w http.ResponseWriter, r *http.Request
 
 	// Pull the current placement so we can enforce safety rules + carry
 	// it forward when the body doesn't override.
-	curMode, _, _ := unstructured.NestedString(cur.Object, "spec", "placement")
+	//
+	// #6136 — read through placementFromSpec, the dual-form seam (#5422), NOT a
+	// raw NestedString. `spec.placement` is dual-form by CRD design, and a raw
+	// string read returns ok=false against the object form — so on any
+	// object-form Application (hw293's `uat50-ahs-pg`) curMode was "" and the
+	// destructive-transition gate below compared against an empty current
+	// posture. `topologyTransitionAllowed("", …)` cannot see an active-active →
+	// singleton scale-down, so the `?force=true` confirmation silently never
+	// fired for exactly the CRs most likely to need it.
+	curMode := placementFromSpec(cur)
+	curPlacementRaw, _, _ := unstructured.NestedFieldNoCopy(cur.Object, "spec", "placement")
 	curRegionsRaw, _, _ := unstructured.NestedSlice(cur.Object, "spec", "regions")
 	curRegions := stringsFromAnySlice(curRegionsRaw)
 
@@ -442,15 +624,40 @@ func (h *Handler) HandleApplicationUpdate(w http.ResponseWriter, r *http.Request
 		_ = unstructured.SetNestedMap(patched.Object, paramsCopy, "spec", "parameters")
 	}
 	if body.Placement != nil {
-		// One vocabulary (#3375 DoD-1): the patched CR stores the
-		// canonical placement token regardless of which spelling the PUT
-		// body carried.
-		_ = unstructured.SetNestedField(patched.Object, canonicalizeTopology(body.Placement.Mode), "spec", "placement")
+		// One vocabulary (#3375 DoD-1) + one dual-form producer (#6136): the
+		// patched CR stores the canonical placement token regardless of which
+		// spelling the PUT body carried, and it stores it in the SHAPE the
+		// caller's declaration requires — see placementValueForUpdate.
+		_ = unstructured.SetNestedField(patched.Object,
+			placementValueForUpdate(curPlacementRaw, *body.Placement),
+			"spec", "placement")
 		regionsAny := make([]interface{}, 0, len(body.Placement.Regions))
 		for _, reg := range body.Placement.Regions {
 			regionsAny = append(regionsAny, reg)
 		}
 		_ = unstructured.SetNestedSlice(patched.Object, regionsAny, "spec", "regions")
+
+		// #6136 — keep the value the CHART renders from in lockstep with the
+		// posture the CR now declares. The install door already derives
+		// `parameters.topology.mode` from the placement it was given
+		// (defaultedParameters); this door never re-derived it, so a Save that
+		// moved an Application to active-hot-standby left
+		// `spec.parameters.topology.mode: singleton` in place and the
+		// HelmRelease went on rendering a singleton. Measured on hw293: PUT
+		// 200, generation bumped, parameters.topology still singleton.
+		//
+		// Only on a placement-ONLY edit: a caller who sent `parameters`
+		// explicitly is authoritative over their own tree and is never
+		// second-guessed. And only where a mode is ALREADY declared — the
+		// install door's deference (#4283: "we do not start declaring a mode
+		// where we previously declared none") holds here too.
+		if body.Parameters == nil {
+			bpName, _, _ := unstructured.NestedString(patched.Object, "spec", "blueprintRef", "name")
+			curParams, _, _ := unstructured.NestedMap(patched.Object, "spec", "parameters")
+			if next, changed := repointPostgresTopologyMode(curParams, bpName, canonicalizeTopology(body.Placement.Mode)); changed {
+				_ = unstructured.SetNestedMap(patched.Object, next, "spec", "parameters")
+			}
+		}
 	}
 	if dn := strings.TrimSpace(body.DisplayName); dn != "" {
 		_ = unstructured.SetNestedField(patched.Object, dn, "spec", "displayName")
@@ -508,9 +715,11 @@ func (h *Handler) HandleApplicationUpdate(w http.ResponseWriter, r *http.Request
 	// spec.regions with regionsFromEnv() so qa-fixtures-shaped chroot
 	// Sovereigns carry the literal `["fsn1","hel1",...]` tokens even when
 	// the PUT body shipped only a placement change.
-	if pl, ok, _ := unstructured.NestedString(updated.Object, "spec", "placement"); ok {
-		resp.Placement = pl
-	}
+	// #6136 — dual-form read (#5422), not a raw NestedString: the object form
+	// returns ok=false there, so `omitempty` dropped `placement` from the
+	// response for exactly the CRs that carry the richer shape, and the console
+	// then had to invent a posture it was never told.
+	resp.Placement = placementFromSpec(updated)
 	persistedRegions, _, _ := unstructured.NestedSlice(updated.Object, "spec", "regions")
 	resp.Regions = mergeSortedRegions(stringsFromAnySlice(persistedRegions), regionsFromEnv())
 	if params, ok, _ := unstructured.NestedMap(updated.Object, "spec", "parameters"); ok {

--- a/products/catalyst/bootstrap/api/internal/handler/applications_update.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications_update.go
@@ -274,9 +274,15 @@ func placementTargetsToUnstructured(targets []bpv1.PlacementTarget) []interface{
 	out := make([]interface{}, 0, len(targets))
 	for _, t := range targets {
 		item := map[string]interface{}{
-			"region":  t.Region,
-			"cluster": t.Cluster,
-			"role":    string(t.Role),
+			"region": t.Region,
+			"role":   string(t.Role),
+		}
+		// `cluster` and `vcluster` are emitted only when DECLARED. Writing
+		// `cluster: ""` would not be a truer record than omitting the key — it
+		// reads as "this target has a cluster field" to anything that binds it,
+		// which is the #5501 empty-string-vs-absent-key distinction.
+		if v := strings.TrimSpace(t.Cluster); v != "" {
+			item["cluster"] = v
 		}
 		if v := strings.TrimSpace(t.VCluster); v != "" {
 			item["vcluster"] = v
@@ -1123,6 +1129,29 @@ func validateApplicationUpdateRequest(req applicationUpdateRequest) (string, boo
 			return instances.UnavailableTierMessage(req.Placement.VCluster), false
 		}
 		for i, t := range req.Placement.Targets {
+			// #6136 — `region` is REQUIRED on a target and this door never
+			// checked it. That did not matter while the handler discarded
+			// targets[] on the way to the CR; now that they are PERSISTED, an
+			// empty region is exactly the #5639 defect written into desired
+			// state: it renders `openova.io/region In [""]`, which no node can
+			// satisfy, so the workload is unschedulable forever while the
+			// install still reports success.
+			//
+			// The rule is taken from the canonical validator rather than
+			// invented here — bpv1.ValidatePlacement checks region FIRST, for
+			// that reason, and this door must not be laxer than the model it
+			// writes into. It deliberately does NOT also require `cluster`:
+			// ValidatePlacement does not, so adding it would make this a THIRD
+			// authority on target validity. (The controller's own
+			// parsePlacementTargets does hard-error without a cluster — a
+			// pre-existing divergence between those two, now visible because a
+			// producer finally writes the field. The controller's gate reports
+			// it on status; this door does not pre-empt it with a different
+			// rule.)
+			if strings.TrimSpace(t.Region) == "" {
+				return fmt.Sprintf("placement.targets[%d].region is required "+
+					"(an empty region renders openova.io/region In [\"\"], which no node satisfies)", i), false
+			}
 			if !instances.IsKnownVClusterTier(t.VCluster) {
 				return fmt.Sprintf("placement.targets[%d].vcluster must be one of %s",
 					i, instances.KnownVClusterTiersCSV()), false

--- a/products/catalyst/bootstrap/api/internal/handler/applications_update_4950_owndeps_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications_update_4950_owndeps_test.go
@@ -120,9 +120,19 @@ func TestHandleApplicationUpdate_4950_ConsolePlacementApply_Returns200(t *testin
 	if err != nil {
 		t.Fatalf("get patched CR: %v", err)
 	}
-	mode, _, _ := unstructured.NestedString(got.Object, "spec", "placement")
-	if mode != "active-hot-standby" {
-		t.Fatalf("spec.placement = %q, want active-hot-standby (derived from targets[])", mode)
+	// #6136 — this read used to be a raw NestedString, which now returns ok=false
+	// because a body carrying targets[] is stored in the CRD's OBJECT form. The
+	// assertion is not relaxed by moving to placementFromSpec: the same posture
+	// is still required, and the targets the console sent are additionally
+	// required to have SURVIVED the write, which the scalar form could not carry
+	// at all.
+	if mode := placementFromSpec(got); mode != "active-hot-standby" {
+		t.Fatalf("spec.placement posture = %q, want active-hot-standby (derived from targets[])", mode)
+	}
+	targets, found, _ := unstructured.NestedSlice(got.Object, "spec", "placement", "targets")
+	if !found || len(targets) != 2 {
+		t.Fatalf("spec.placement.targets = %v (found=%v), want the 2 targets the console submitted — "+
+			"the editor's per-region model must survive its own Apply (#6136)", targets, found)
 	}
 	regionsRaw, _, _ := unstructured.NestedSlice(got.Object, "spec", "regions")
 	regions := stringsFromAnySlice(regionsRaw)

--- a/products/catalyst/bootstrap/api/internal/handler/applications_update_placement_shape_6136_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications_update_placement_shape_6136_test.go
@@ -410,6 +410,96 @@ func TestHandleApplicationUpdate_EditorTargetsReachTheCR_6136(t *testing.T) {
 	}
 }
 
+// TestValidateApplicationUpdate_RegionlessTargetIsRefused_6136 closes the hole
+// the persistence opened. A target with no `region` was accepted by this door
+// and harmlessly discarded; now that targets[] reach the CR it would be the
+// #5639 defect written into desired state — `openova.io/region In [""]`, which
+// no node satisfies, so the workload is unschedulable forever while the update
+// reports success.
+//
+// The rule matches bpv1.ValidatePlacement's own first invariant rather than
+// being invented here. `cluster` is deliberately NOT required: the canonical
+// validator does not require it, and a third authority on target validity is
+// how the vocabularies drift apart in the first place.
+func TestValidateApplicationUpdate_RegionlessTargetIsRefused_6136(t *testing.T) {
+	instances.SetAvailableVClusterTiers("mgmt")
+	t.Cleanup(func() { instances.SetAvailableVClusterTiers("") })
+
+	mk := func(targets ...bpv1.PlacementTarget) applicationUpdateRequest {
+		return applicationUpdateRequest{Placement: &applicationPlacement{
+			Mode:    "singleton",
+			Regions: []string{"me-east-215-a"},
+			Targets: targets,
+		}}
+	}
+
+	t.Run("missing region is named and refused", func(t *testing.T) {
+		msg, ok := validateApplicationUpdateRequest(mk(
+			bpv1.PlacementTarget{Cluster: "mgmt-A", VCluster: "mgmt", Role: bpv1.DataRolePrimary}))
+		if ok {
+			t.Fatal("a regionless target was accepted — it is now PERSISTED, so it renders an " +
+				"unsatisfiable nodeAffinity while the PUT answers 200 (#6136 / #5639)")
+		}
+		// Assert on the VALUE: the message must name the field AND why.
+		if !strings.Contains(msg, "targets[0].region") {
+			t.Errorf("message %q does not name the missing field", msg)
+		}
+		if !strings.Contains(msg, "openova.io/region") {
+			t.Errorf("message %q does not say what an empty region actually does", msg)
+		}
+	})
+
+	// CONTROLS — both carry a region and share the same loop; the guard must
+	// constrain regionless targets, not targets.
+	t.Run("CONTROL: a target with a region is accepted", func(t *testing.T) {
+		if msg, ok := validateApplicationUpdateRequest(mk(
+			bpv1.PlacementTarget{Region: "me-east-215-a", Cluster: "mgmt-A", VCluster: "mgmt", Role: bpv1.DataRolePrimary})); !ok {
+			t.Fatalf("a complete target was refused: %s", msg)
+		}
+	})
+	t.Run("CONTROL: a target with a region but no cluster is still accepted", func(t *testing.T) {
+		if msg, ok := validateApplicationUpdateRequest(mk(
+			bpv1.PlacementTarget{Region: "me-east-215-a", VCluster: "mgmt", Role: bpv1.DataRolePrimary})); !ok {
+			t.Fatalf("a clusterless target was refused: %s — bpv1.ValidatePlacement does not require "+
+				"cluster, and this door must not become a third authority on target validity", msg)
+		}
+	})
+}
+
+// TestPlacementTargetsToUnstructured_OmitsUndeclaredKeys_6136 pins the emitted
+// target shape. An empty `cluster` / `vcluster` key is not a truer record than
+// an absent one — it reads as "this target HAS that field" to anything binding
+// it, the #5501 distinction.
+func TestPlacementTargetsToUnstructured_OmitsUndeclaredKeys_6136(t *testing.T) {
+	t.Parallel()
+	out := placementTargetsToUnstructured([]bpv1.PlacementTarget{
+		{Region: "me-east-215-a", Role: bpv1.DataRolePrimary},
+	})
+	if len(out) != 1 {
+		t.Fatalf("got %d entries, want 1", len(out))
+	}
+	item, _ := out[0].(map[string]interface{})
+	if item["region"] != "me-east-215-a" || item["role"] != "Primary" {
+		t.Fatalf("target = %v, want region+role preserved", item)
+	}
+	for _, k := range []string{"cluster", "vcluster", "standbyType"} {
+		if _, present := item[k]; present {
+			t.Errorf("undeclared key %q emitted as %v — an empty value still reads as a declaration",
+				k, item[k])
+		}
+	}
+	// CONTROL — the same producer DOES emit them when declared, so the check
+	// above is not passing because the producer emits nothing.
+	full, _ := placementTargetsToUnstructured([]bpv1.PlacementTarget{
+		{Region: "me-east-215-b", Cluster: "mgmt-B", VCluster: "mgmt", Role: bpv1.DataRoleStandby, StandbyType: bpv1.StandbyHot},
+	})[0].(map[string]interface{})
+	for k, want := range map[string]string{"cluster": "mgmt-B", "vcluster": "mgmt", "standbyType": "Hot"} {
+		if full[k] != want {
+			t.Errorf("declared key %q = %v, want %q", k, full[k], want)
+		}
+	}
+}
+
 // ── parameters.topology lockstep ─────────────────────────────────────
 
 // postgresAppCR builds a bp-postgres Application in the measured hw293 shape:

--- a/products/catalyst/bootstrap/api/internal/handler/applications_update_placement_shape_6136_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications_update_placement_shape_6136_test.go
@@ -1,0 +1,584 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"reflect"
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	bpv1 "github.com/openova-io/openova/core/controllers/pkg/apis/blueprint/v1alpha1"
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/instances"
+)
+
+// applications_update_placement_shape_6136_test.go — #6136 (UAT row 16).
+//
+// MEASURED on hw293.omantel.biz (dep a0077ba47e3720e5): the AppDetail Topology
+// tab's Save issued PUT → 200, metadata.generation bumped, and spec.placement
+// landed as a BARE STRING with spec.parameters.topology still `singleton`. The
+// control on the same Sovereign, `uat50-ahs-pg`, holds spec.placement as an
+// OBJECT — the CRD admits both forms, so the scalar was the producer's doing.
+//
+// MECHANISM, at the line. HandleApplicationUpdate wrote ONE field of the
+// request and discarded the rest:
+//
+//	SetNestedField(patched.Object, canonicalizeTopology(body.Placement.Mode), "spec", "placement")
+//
+// so targets[] (the entire #3969 model the PlacementEditor submits), vcluster
+// and clusters (#3373) never reached the CR, and an Application already holding
+// the object form had that whole node replaced by a string.
+//
+// WHY IT SURVIVED. Every reader that RENDERS the posture is shape-tolerant —
+// placementFromSpec (#5422), readTopology, the console's topologyLabel (#4897).
+// So the console showed the right mode after a downgrading Save and the loss
+// was invisible from the surface that caused it. TestPlacementFromSpec_
+// ToleratesBothShapes_6136 below pins that tolerance deliberately, because the
+// tolerance is load-bearing for old CRs and must not be "fixed" away.
+
+// objectFormAppCR builds an Application CR whose spec.placement is the #3373
+// OBJECT form — the `uat50-ahs-pg` shape, carrying WHERE fields that no PUT
+// body restates. Deliberately NOT built via makeAppCR, whose placement is a
+// bare string.
+func objectFormAppCR(ns, name string) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{}
+	obj.SetAPIVersion("apps.openova.io/v1")
+	obj.SetKind("Application")
+	obj.SetName(name)
+	obj.SetNamespace(ns)
+	_ = unstructured.SetNestedMap(obj.Object, map[string]any{
+		"environmentRef": "acme-prod",
+		"blueprintRef": map[string]any{
+			"name":    "bp-wordpress",
+			"version": "1.2.3",
+		},
+		"placement": map[string]any{
+			"mode":     "active-hot-standby",
+			"vcluster": "host",
+			"clusters": []any{"mgmt-A", "mgmt-B"},
+			"regions":  []any{"me-east-215-a", "me-east-215-b"},
+		},
+		"regions": []any{"me-east-215-a", "me-east-215-b"},
+		"parameters": map[string]any{
+			"domain": "shop.acme.example",
+		},
+	}, "spec")
+	return obj
+}
+
+// ── The producer, unit level ─────────────────────────────────────────
+
+// TestPlacementValueForUpdate_PreservesShapeAndUnrestatedFields_6136 pins the
+// producer directly. Each case names the CR shape going in, the body, and the
+// value that must come out.
+func TestPlacementValueForUpdate_PreservesShapeAndUnrestatedFields_6136(t *testing.T) {
+	t.Parallel()
+
+	objectCR := map[string]interface{}{
+		"mode":     "active-hot-standby",
+		"vcluster": "host",
+		"clusters": []interface{}{"mgmt-A", "mgmt-B"},
+	}
+
+	t.Run("object-form CR is NOT downgraded to a scalar", func(t *testing.T) {
+		// The Topology-tab Save: a mode + regions, no WHERE fields restated.
+		got := placementValueForUpdate(objectCR, applicationPlacement{
+			Mode:    "active-active",
+			Regions: []string{"me-east-215-a", "me-east-215-b"},
+		})
+		obj, ok := got.(map[string]interface{})
+		if !ok {
+			t.Fatalf("placement collapsed to %T (%v) — a Save replaced the object form with a "+
+				"scalar and dropped vcluster/clusters the body never mentioned (#6136)", got, got)
+		}
+		if obj["mode"] != "active-active" {
+			t.Errorf("mode = %v, want active-active", obj["mode"])
+		}
+		// The load-bearing half: fields the body did not restate SURVIVE.
+		if obj["vcluster"] != "host" {
+			t.Errorf("vcluster = %v, want host — an untouched field was deleted by an unrelated edit", obj["vcluster"])
+		}
+		if !reflect.DeepEqual(obj["clusters"], []interface{}{"mgmt-A", "mgmt-B"}) {
+			t.Errorf("clusters = %v, want [mgmt-A mgmt-B] — an untouched field was deleted", obj["clusters"])
+		}
+	})
+
+	t.Run("targets[] from the editor are persisted as an object", func(t *testing.T) {
+		got := placementValueForUpdate(nil, applicationPlacement{
+			Mode:    "active-hot-standby",
+			Regions: []string{"me-east-215-a", "me-east-215-b"},
+			Targets: []bpv1.PlacementTarget{
+				{Region: "me-east-215-a", Cluster: "mgmt-A", Role: bpv1.DataRolePrimary},
+				{Region: "me-east-215-b", Cluster: "mgmt-B", Role: bpv1.DataRoleStandby, StandbyType: bpv1.StandbyHot},
+			},
+		})
+		obj, ok := got.(map[string]interface{})
+		if !ok {
+			t.Fatalf("placement = %T (%v), want the object form — a body carrying targets[] cannot be "+
+				"stored as a bare string, so the editor's whole model is discarded (#6136)", got, got)
+		}
+		targets, ok := obj["targets"].([]interface{})
+		if !ok || len(targets) != 2 {
+			t.Fatalf("targets = %v, want 2 entries", obj["targets"])
+		}
+		primary, _ := targets[0].(map[string]interface{})
+		if primary["region"] != "me-east-215-a" || primary["cluster"] != "mgmt-A" || primary["role"] != "Primary" {
+			t.Errorf("targets[0] = %v, want region/cluster/role preserved verbatim", primary)
+		}
+		// The CRD's admission CEL FORBIDS standbyType on a Primary — emitting
+		// an empty one would have the apiserver reject the whole update.
+		if _, present := primary["standbyType"]; present {
+			t.Errorf("targets[0] carries standbyType=%v on a Primary — the CRD's CEL forbids it", primary["standbyType"])
+		}
+		standby, _ := targets[1].(map[string]interface{})
+		if standby["role"] != "Standby" || standby["standbyType"] != "Hot" {
+			t.Errorf("targets[1] = %v, want role=Standby standbyType=Hot", standby)
+		}
+	})
+
+	// CONTROL — shares the suspect property (it goes through the same producer,
+	// same canonicalisation) and must stay on the legacy wire byte-for-byte.
+	t.Run("CONTROL: legacy mode-only body over a string-form CR still stores a bare string", func(t *testing.T) {
+		got := placementValueForUpdate("singleton", applicationPlacement{
+			Mode:    "active-active",
+			Regions: []string{"me-east-215-a"},
+		})
+		s, ok := got.(string)
+		if !ok {
+			t.Fatalf("placement = %T (%v), want the bare string — the legacy caller's wire must not "+
+				"change shape underneath it", got, got)
+		}
+		if s != "active-active" {
+			t.Errorf("placement = %q, want active-active", s)
+		}
+	})
+
+	// CONTROL — a nil current placement with a mode-only body is the fresh
+	// legacy case and must also stay scalar.
+	t.Run("CONTROL: absent current placement + mode-only body stays a bare string", func(t *testing.T) {
+		got := placementValueForUpdate(nil, applicationPlacement{Mode: "single-region"})
+		s, ok := got.(string)
+		if !ok {
+			t.Fatalf("placement = %T, want string", got)
+		}
+		// One vocabulary (#3375 DoD-1): the legacy dialect still folds.
+		if s != "singleton" {
+			t.Errorf("placement = %q, want singleton (canonicalised from single-region)", s)
+		}
+	})
+}
+
+// TestPlacementValueForUpdate_VacuityCheck_6136 proves the guards above can
+// FAIL. It feeds the producer the two inputs whose outputs the fix changed and
+// asserts the results DIFFER in shape from each other — a stubbed producer that
+// always returned a string, or always returned an object, collapses this
+// distinction and the test goes red.
+func TestPlacementValueForUpdate_VacuityCheck_6136(t *testing.T) {
+	t.Parallel()
+
+	scalar := placementValueForUpdate(nil, applicationPlacement{Mode: "singleton"})
+	object := placementValueForUpdate(nil, applicationPlacement{
+		Mode:    "singleton",
+		Targets: []bpv1.PlacementTarget{{Region: "me-east-215-a", Cluster: "mgmt-A", Role: bpv1.DataRolePrimary}},
+	})
+
+	if _, ok := scalar.(string); !ok {
+		t.Fatalf("the mode-only case produced %T — this suite would pass vacuously on a "+
+			"producer that emits objects unconditionally", scalar)
+	}
+	if _, ok := object.(map[string]interface{}); !ok {
+		t.Fatalf("the targets case produced %T — this suite would pass vacuously on a "+
+			"producer that emits strings unconditionally", object)
+	}
+	if reflect.TypeOf(scalar) == reflect.TypeOf(object) {
+		t.Fatal("both inputs produced the same type — the producer is not resolving the dual form at all")
+	}
+}
+
+// TestPlacementFromSpec_ToleratesBothShapes_6136 pins the CONSUMER TOLERANCE
+// that hid this defect, so it is documented rather than accidental. Every
+// posture reader falls back from the string read to `.mode`; that is what let a
+// downgrading Save look correct in the console. The tolerance must REMAIN — old
+// CRs genuinely hold the string form — which is exactly why the producer, not
+// the reader, is the thing that had to change.
+func TestPlacementFromSpec_ToleratesBothShapes_6136(t *testing.T) {
+	t.Parallel()
+	mk := func(v any) *unstructured.Unstructured {
+		return &unstructured.Unstructured{Object: map[string]interface{}{
+			"spec": map[string]interface{}{"placement": v},
+		}}
+	}
+	if got := placementFromSpec(mk("active-hot-standby")); got != "active-hot-standby" {
+		t.Errorf("string form resolved to %q, want active-hot-standby", got)
+	}
+	if got := placementFromSpec(mk(map[string]interface{}{"mode": "active-hot-standby"})); got != "active-hot-standby" {
+		t.Errorf("object form resolved to %q, want active-hot-standby", got)
+	}
+	// Both shapes read the SAME posture — which is the property that made the
+	// shape change undetectable from any rendering surface.
+	if placementFromSpec(mk("active-active")) != placementFromSpec(mk(map[string]interface{}{"mode": "active-active"})) {
+		t.Error("the two shapes no longer read alike — old CRs would start rendering differently")
+	}
+}
+
+// ── The producer, through the real PUT handler ───────────────────────
+
+// TestHandleApplicationUpdate_ObjectFormSurvivesTheSave_6136 drives the whole
+// handler against the `uat50-ahs-pg` shape. Pre-fix, spec.placement came back
+// as a bare string and vcluster/clusters were gone.
+func TestHandleApplicationUpdate_ObjectFormSurvivesTheSave_6136(t *testing.T) {
+	cr := objectFormAppCR("acme", "uat50-ahs-pg")
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	factory, client := fakeApplicationDynamicFactory(cr)
+	h.dynamicFactory = factory
+	h.SetCatalogClient(newFakeCatalog(sampleWordpressBlueprint()))
+	dep := installUserAccessDeployment(t, h, "dep-app-6136-objform")
+
+	// A scale-UP (active-hot-standby → active-active, same 2 regions) so the
+	// destructive-transition gate is not what is under test here.
+	rec := callUserAccess(t, h, http.MethodPut,
+		"/api/v1/sovereigns/"+dep.ID+"/applications/uat50-ahs-pg?namespace=acme",
+		json.RawMessage(`{"placement":{"mode":"active-active","regions":["me-east-215-a","me-east-215-b"]}}`),
+		registerApplicationUpdateRoutes)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("PUT: want 200 got %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	got, err := client.Resource(ApplicationGVR()).Namespace("acme").Get(
+		context.Background(), "uat50-ahs-pg", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get patched CR: %v", err)
+	}
+
+	if s, isString, _ := unstructured.NestedString(got.Object, "spec", "placement"); isString {
+		t.Fatalf("spec.placement came back as the bare string %q — the Save DOWNGRADED an "+
+			"object-form placement and deleted the vcluster/clusters the body never restated "+
+			"(#6136, control uat50-ahs-pg on hw293)", s)
+	}
+	if got, _, _ := unstructured.NestedString(got.Object, "spec", "placement", "mode"); got != "active-active" {
+		t.Errorf("spec.placement.mode = %q, want active-active", got)
+	}
+	if v, found, _ := unstructured.NestedString(got.Object, "spec", "placement", "vcluster"); !found || v != "host" {
+		t.Errorf("spec.placement.vcluster = %q (found=%v), want host — an untouched field was deleted", v, found)
+	}
+	clusters, found, _ := unstructured.NestedStringSlice(got.Object, "spec", "placement", "clusters")
+	if !found || !reflect.DeepEqual(clusters, []string{"mgmt-A", "mgmt-B"}) {
+		t.Errorf("spec.placement.clusters = %v (found=%v), want [mgmt-A mgmt-B] — an untouched field was deleted", clusters, found)
+	}
+
+	// The response must also REPORT the posture. Pre-fix the raw NestedString
+	// read returned ok=false on the object form and omitempty dropped the key,
+	// so the console was handed nothing and defaulted.
+	var resp applicationUpdateResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Placement != "active-active" {
+		t.Errorf("response placement = %q, want active-active — an object-form CR must not answer "+
+			"with an empty posture the console then has to guess at", resp.Placement)
+	}
+}
+
+// TestHandleApplicationUpdate_ObjectFormStillGuardsDestructiveTransitions_6136
+// is the NEW CONSTRAINT the shape fix makes reachable. The `?force=true`
+// confirmation on a scale-down was blind against object-form CRs, because the
+// gate read the current posture with a raw NestedString that returns "" there.
+func TestHandleApplicationUpdate_ObjectFormStillGuardsDestructiveTransitions_6136(t *testing.T) {
+	cr := objectFormAppCR("acme", "uat50-ahs-pg")
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	factory, _ := fakeApplicationDynamicFactory(cr)
+	h.dynamicFactory = factory
+	h.SetCatalogClient(newFakeCatalog(sampleWordpressBlueprint()))
+	dep := installUserAccessDeployment(t, h, "dep-app-6136-guard")
+
+	rec := callUserAccess(t, h, http.MethodPut,
+		"/api/v1/sovereigns/"+dep.ID+"/applications/uat50-ahs-pg?namespace=acme",
+		json.RawMessage(`{"placement":{"mode":"singleton","regions":["me-east-215-a","me-east-215-b"]}}`),
+		registerApplicationUpdateRoutes)
+
+	if rec.Code == http.StatusOK {
+		t.Fatalf("active-hot-standby → singleton was accepted WITHOUT ?force=true on an object-form CR: "+
+			"the gate read the current posture as \"\" and could not see the standby drop (#6136); body=%s",
+			rec.Body.String())
+	}
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status: want 409 got %d body=%s", rec.Code, rec.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body["error"] != "placement-transition-blocked" {
+		t.Errorf("error = %v, want placement-transition-blocked", body["error"])
+	}
+	// Assert on the message VALUE: it must name the posture actually being left,
+	// which is the fact the empty read destroyed.
+	if detail, _ := body["detail"].(string); !strings.Contains(detail, "active-hot-standby") {
+		t.Errorf("409 detail %q does not name the current posture — the gate would be firing "+
+			"without knowing what it is protecting", detail)
+	}
+}
+
+// TestHandleApplicationUpdate_StringFormCallerIsUnchanged_6136 is the CONTROL
+// at handler level: the legacy string-form CR with a legacy mode-only body must
+// behave exactly as before, INCLUDING keeping its scalar shape. It shares the
+// suspect property — it is the same handler, the same producer, the same
+// canonicalisation — and stays green in both states of the fix.
+func TestHandleApplicationUpdate_StringFormCallerIsUnchanged_6136(t *testing.T) {
+	cr := makeAppCR("acme", "wp-prod", "1.2.3", "singleton", []string{"me-east-215-a"})
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	factory, client := fakeApplicationDynamicFactory(cr)
+	h.dynamicFactory = factory
+	h.SetCatalogClient(newFakeCatalog(sampleWordpressBlueprint()))
+	dep := installUserAccessDeployment(t, h, "dep-app-6136-legacy")
+
+	rec := callUserAccess(t, h, http.MethodPut,
+		"/api/v1/sovereigns/"+dep.ID+"/applications/wp-prod?namespace=acme",
+		json.RawMessage(`{"placement":{"mode":"active-active","regions":["me-east-215-a","me-east-215-b"]}}`),
+		registerApplicationUpdateRoutes)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("PUT: want 200 got %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	got, err := client.Resource(ApplicationGVR()).Namespace("acme").Get(
+		context.Background(), "wp-prod", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get patched CR: %v", err)
+	}
+	s, isString, _ := unstructured.NestedString(got.Object, "spec", "placement")
+	if !isString {
+		t.Fatalf("a legacy string-form CR edited by a legacy mode-only body changed shape — "+
+			"the fix must not migrate CRs nobody asked it to migrate; got %v",
+			got.Object["spec"].(map[string]interface{})["placement"])
+	}
+	if s != "active-active" {
+		t.Errorf("spec.placement = %q, want active-active", s)
+	}
+}
+
+// TestHandleApplicationUpdate_EditorTargetsReachTheCR_6136 drives the EXACT
+// console PlacementEditor body (the #4950 wire-compat fixture) and asserts the
+// per-target model reaches the CR. Pre-fix `spec.placement.targets` was written
+// by nothing at all, while TopologyTab reads it as rung 2 of its chain.
+func TestHandleApplicationUpdate_EditorTargetsReachTheCR_6136(t *testing.T) {
+	instances.SetAvailableVClusterTiers("mgmt")
+	t.Cleanup(func() { instances.SetAvailableVClusterTiers("") })
+
+	cr := makeAppCR("acme", "shared-pg", "1.2.3", "singleton", []string{"me-east-215-a"})
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	factory, client := fakeApplicationDynamicFactory(cr)
+	h.dynamicFactory = factory
+	h.SetCatalogClient(newFakeCatalog(sampleWordpressBlueprint()))
+	dep := installUserAccessDeployment(t, h, "dep-app-6136-targets")
+
+	rec := callUserAccess(t, h, http.MethodPut,
+		"/api/v1/sovereigns/"+dep.ID+"/applications/shared-pg?namespace=acme",
+		json.RawMessage(realConsolePlacementPUT), registerApplicationUpdateRoutes)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("PUT: want 200 got %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	got, err := client.Resource(ApplicationGVR()).Namespace("acme").Get(
+		context.Background(), "shared-pg", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get patched CR: %v", err)
+	}
+	targets, found, _ := unstructured.NestedSlice(got.Object, "spec", "placement", "targets")
+	if !found {
+		t.Fatalf("spec.placement.targets absent after the editor's own Apply — the per-region model "+
+			"the User selected did not survive a Save that answered 200 (#6136)")
+	}
+	if len(targets) != 2 {
+		t.Fatalf("spec.placement.targets = %v, want the 2 submitted targets", targets)
+	}
+	// Assert on VALUES: role and standbyType are the fields the editor exists
+	// to set, and a targets list that lost them is as useless as no list.
+	primary, _ := targets[0].(map[string]interface{})
+	if primary["role"] != "Primary" || primary["region"] != "me-east-215-a" || primary["vcluster"] != "mgmt" {
+		t.Errorf("targets[0] = %v, want the Primary on me-east-215-a/mgmt", primary)
+	}
+	standby, _ := targets[1].(map[string]interface{})
+	if standby["role"] != "Standby" || standby["standbyType"] != "Hot" || standby["region"] != "me-east-215-b" {
+		t.Errorf("targets[1] = %v, want the Hot Standby on me-east-215-b", standby)
+	}
+	// The posture still reads correctly through the tolerant seam.
+	if p := placementFromSpec(got); p != "active-hot-standby" {
+		t.Errorf("posture = %q, want active-hot-standby", p)
+	}
+}
+
+// ── parameters.topology lockstep ─────────────────────────────────────
+
+// postgresAppCR builds a bp-postgres Application in the measured hw293 shape:
+// a singleton placement whose `parameters.topology.mode` is the value the chart
+// actually renders from.
+func postgresAppCR(ns, name string) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{}
+	obj.SetAPIVersion("apps.openova.io/v1")
+	obj.SetKind("Application")
+	obj.SetName(name)
+	obj.SetNamespace(ns)
+	_ = unstructured.SetNestedMap(obj.Object, map[string]any{
+		"environmentRef": "acme-prod",
+		"blueprintRef":   map[string]any{"name": "bp-postgres", "version": "1.0.0"},
+		"placement":      "singleton",
+		"regions":        []any{"me-east-215-a"},
+		"parameters": map[string]any{
+			"topology": map[string]any{"mode": "singleton"},
+		},
+	}, "spec")
+	return obj
+}
+
+// TestHandleApplicationUpdate_ParametersFollowThePlacement_6136 is the
+// handler-level half of the parameters lockstep. The unit test below pins the
+// helper; this pins the CALL SITE, so removing the wiring cannot leave a green
+// suite behind.
+func TestHandleApplicationUpdate_ParametersFollowThePlacement_6136(t *testing.T) {
+	cr := postgresAppCR("acme", "uat50-ahs-pg")
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	factory, client := fakeApplicationDynamicFactory(cr)
+	h.dynamicFactory = factory
+	h.SetCatalogClient(newFakeCatalog(sampleWordpressBlueprint()))
+	dep := installUserAccessDeployment(t, h, "dep-app-6136-params")
+
+	rec := callUserAccess(t, h, http.MethodPut,
+		"/api/v1/sovereigns/"+dep.ID+"/applications/uat50-ahs-pg?namespace=acme",
+		json.RawMessage(`{"placement":{"mode":"active-hot-standby","regions":["me-east-215-a","me-east-215-b"]}}`),
+		registerApplicationUpdateRoutes)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("PUT: want 200 got %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	got, err := client.Resource(ApplicationGVR()).Namespace("acme").Get(
+		context.Background(), "uat50-ahs-pg", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get patched CR: %v", err)
+	}
+	mode, found, _ := unstructured.NestedString(got.Object, "spec", "parameters", "topology", "mode")
+	if !found || mode != "active-hot-standby" {
+		t.Fatalf("spec.parameters.topology.mode = %q (found=%v) after a Save that set "+
+			"spec.placement=active-hot-standby — the CR contradicts itself and the HelmRelease "+
+			"keeps rendering the singleton, so the Save is a no-op at the layer that matters "+
+			"(#6136, measured on hw293)", mode, found)
+	}
+	if p := placementFromSpec(got); p != "active-hot-standby" {
+		t.Errorf("spec.placement posture = %q, want active-hot-standby", p)
+	}
+}
+
+// TestHandleApplicationUpdate_NonPostgresParametersUntouched_6136 is the
+// handler-level CONTROL. Same door, same placement change, same
+// `parameters.topology` key present — only the blueprint differs. It must come
+// back byte-identical, so the repoint above is a bp-postgres-scoped derivation
+// rather than a handler that rewrites any tree it finds.
+func TestHandleApplicationUpdate_NonPostgresParametersUntouched_6136(t *testing.T) {
+	cr := postgresAppCR("acme", "wp-prod")
+	_ = unstructured.SetNestedMap(cr.Object,
+		map[string]any{"name": "bp-wordpress", "version": "1.2.3"}, "spec", "blueprintRef")
+
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	factory, client := fakeApplicationDynamicFactory(cr)
+	h.dynamicFactory = factory
+	h.SetCatalogClient(newFakeCatalog(sampleWordpressBlueprint()))
+	dep := installUserAccessDeployment(t, h, "dep-app-6136-params-control")
+
+	rec := callUserAccess(t, h, http.MethodPut,
+		"/api/v1/sovereigns/"+dep.ID+"/applications/wp-prod?namespace=acme",
+		json.RawMessage(`{"placement":{"mode":"active-hot-standby","regions":["me-east-215-a","me-east-215-b"]}}`),
+		registerApplicationUpdateRoutes)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("PUT: want 200 got %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	got, err := client.Resource(ApplicationGVR()).Namespace("acme").Get(
+		context.Background(), "wp-prod", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get patched CR: %v", err)
+	}
+	mode, _, _ := unstructured.NestedString(got.Object, "spec", "parameters", "topology", "mode")
+	if mode != "singleton" {
+		t.Errorf("a bp-wordpress Application had parameters.topology.mode rewritten to %q — the "+
+			"[singleton, active-hot-standby] enum being folded to is bp-postgres' own configSchema "+
+			"and means nothing for another blueprint", mode)
+	}
+}
+
+// TestRepointPostgresTopologyMode_6136 pins the second half of the measured
+// row: `spec.parameters.topology` stayed `singleton` while spec.placement said
+// otherwise, so the HelmRelease kept rendering a singleton and the Save was a
+// no-op at the layer that matters.
+func TestRepointPostgresTopologyMode_6136(t *testing.T) {
+	t.Parallel()
+
+	t.Run("singleton parameters follow a placement move to HA", func(t *testing.T) {
+		params := map[string]interface{}{
+			"topology": map[string]interface{}{"mode": "singleton"},
+		}
+		out, changed := repointPostgresTopologyMode(params, "bp-postgres", "active-hot-standby")
+		if !changed {
+			t.Fatalf("parameters left at %v while spec.placement declares active-hot-standby — "+
+				"the CR contradicts itself and the chart renders the stale half (#6136)", params)
+		}
+		topo, _ := out["topology"].(map[string]interface{})
+		if topo["mode"] != "active-hot-standby" {
+			t.Errorf("topology.mode = %v, want active-hot-standby", topo["mode"])
+		}
+		// The input map must not be mutated in place — the handler decides
+		// whether to persist based on the returned flag.
+		if orig, _ := params["topology"].(map[string]interface{}); orig["mode"] != "singleton" {
+			t.Errorf("the input parameters were mutated in place (topology.mode=%v)", orig["mode"])
+		}
+	})
+
+	t.Run("broad placement tokens fold to the configSchema enum", func(t *testing.T) {
+		for _, mode := range []string{"active-active", "active-passive"} {
+			params := map[string]interface{}{"topology": map[string]interface{}{"mode": "singleton"}}
+			out, changed := repointPostgresTopologyMode(params, "bp-postgres", mode)
+			if !changed {
+				t.Fatalf("%s did not repoint the parameters", mode)
+			}
+			topo, _ := out["topology"].(map[string]interface{})
+			// bp-postgres' configSchema enum is the NARROW data-plane set; a
+			// broad placement token written through verbatim would fail the
+			// application-controller's configSchema validation outright.
+			if topo["mode"] != "active-hot-standby" {
+				t.Errorf("%s → topology.mode = %v, want active-hot-standby (the only HA mode the "+
+					"bp-postgres configSchema enum admits)", mode, topo["mode"])
+			}
+		}
+	})
+
+	// CONTROLS — each shares the suspect property (a placement change reaching
+	// the same helper) and must produce NO change.
+	t.Run("CONTROL: a non-postgres blueprint is untouched", func(t *testing.T) {
+		params := map[string]interface{}{"topology": map[string]interface{}{"mode": "singleton"}}
+		if _, changed := repointPostgresTopologyMode(params, "bp-wordpress", "active-hot-standby"); changed {
+			t.Error("a non-postgres blueprint had its topology repointed — the enum being folded to "+
+				"is bp-postgres' own and means nothing elsewhere")
+		}
+	})
+
+	t.Run("CONTROL: an undeclared topology is not newly declared", func(t *testing.T) {
+		if _, changed := repointPostgresTopologyMode(map[string]interface{}{}, "bp-postgres", "active-hot-standby"); changed {
+			t.Error("a parameters tree with NO topology got one — #4283's rule is that we never start " +
+				"declaring a mode where none was declared, which would silently promote a " +
+				"backing-service postgres to the cross-region pair shape")
+		}
+		params := map[string]interface{}{"topology": map[string]interface{}{"crossRegion": false}}
+		if _, changed := repointPostgresTopologyMode(params, "bp-postgres", "active-hot-standby"); changed {
+			t.Error("a topology object with no `mode` string got one")
+		}
+	})
+
+	t.Run("CONTROL: an already-agreeing mode is left alone", func(t *testing.T) {
+		params := map[string]interface{}{"topology": map[string]interface{}{"mode": "active-hot-standby"}}
+		if _, changed := repointPostgresTopologyMode(params, "bp-postgres", "active-active"); changed {
+			t.Error("an already-HA topology was rewritten — both tokens fold to active-hot-standby, " +
+				"so there was nothing to change and the CR should not churn")
+		}
+	})
+}


### PR DESCRIPTION
## What was measured

hw293.omantel.biz, dep `a0077ba47e3720e5`: the AppDetail **Topology** tab's Save issues `PUT` → **200**, `metadata.generation` bumps, `spec.placement` lands as a **bare string**, and `spec.parameters.topology` is still `singleton`.

Control on the same Sovereign: `uat50-ahs-pg` holds `spec.placement` as an **object**. The CRD documents the field as dual-form and admits both, so the scalar is the producer's doing, not the schema's.

## Mechanism, verified at the line before changing anything

`HandleApplicationUpdate` read **one field** of `applicationPlacement` and wrote a scalar:

```go
if body.Placement != nil {
        _ = unstructured.SetNestedField(patched.Object, canonicalizeTopology(body.Placement.Mode), "spec", "placement")
        ...
}
```

Everything else the console sent was discarded — `Targets[]` (the whole #3969 model the `PlacementEditor` submits: region, cluster, vcluster, role, standbyType), plus `VCluster` and `Clusters` (#3373). `applicationUpdateRequestNormalize` folds targets into `Mode` + `Regions` and the targets themselves are then dropped.

Two consequences:

1. **`spec.placement.targets` was written by nothing**, while `TopologyTab` reads it as rung 2 of its resolution chain. Role and standby-type selections did not survive the Save that answered 200.
2. **An object-form CR was downgraded to a scalar.** A Save on `uat50-ahs-pg` replaces the whole node, deleting `vcluster` and `clusters` the request never mentioned. Data loss on an untouched field.

The install producer already emitted the dual form (`applications.go`: object when `VCluster != "" || len(Clusters) > 0`). Two producers for one dual-form field, and only one of them knew the field was dual-form.

## The consumer that silently tolerates both shapes

`placementFromSpec` (#5422) falls back from the string read to `.mode`; so do `readTopology` and the console's `topologyLabel` (#4897). Every reader that **renders** the posture is shape-tolerant, so the console kept showing the right mode after a downgrading Save and the loss was invisible from the surface that caused it. **That tolerance is how this shipped**, and it now has its own test — `TestPlacementFromSpec_ToleratesBothShapes_6136` — which pins that it must **remain**, because old CRs genuinely hold the string form. The tolerance is not the bug; relying on it to paper over a lossy producer was.

Two readers in the **same handler** were *not* tolerant, and would have gone silently wrong the moment the producer started writing the object form correctly:

- the **destructive-transition gate** — `curMode, _, _ := unstructured.NestedString(cur.Object, "spec", "placement")` returns `""` for an object-form CR, so `topologyTransitionAllowed` compared against an empty current posture and the `?force=true` confirmation on an `active-hot-standby → singleton` scale-down never fired for exactly the CRs carrying the richer shape;
- the **response echo** — same raw read, so `omitempty` dropped `placement` from the PUT response and the console was handed nothing to render.

Both now go through `placementFromSpec`.

## The fix

- `placementValueForUpdate` — the single update-side producer. Merges onto the CR's current placement (a key the body does not restate is carried forward, never deleted), keeps the object form whenever the caller declares targets / `vcluster` / `clusters` or the CR already holds it, and still emits the bare string for a legacy mode-only caller over a string-form CR. `mode` is always rewritten and always canonicalised, so one vocabulary still holds (#3375 DoD-1).
- `placementTargetsToUnstructured` — converts the typed targets to plain JSON values (`SetNestedField` deep-copies through `DeepCopyJSONValue`, which rejects a Go struct). `standbyType` is emitted **only** for a Standby: the CRD's admission CEL forbids it on a Primary, so an empty one would have the apiserver reject the whole update.
- `repointPostgresTopologyMode` — re-derives `parameters.topology.mode` from the new posture on a placement-only PUT, the derivation the install door already performs via `defaultedParameters`. Without it the CR declared `active-hot-standby` directly above the `singleton` the chart actually renders from, which is why the Save read as a no-op. Deference matches the install door: non-postgres untouched; a tree with no declared `topology.mode` is **never newly declared** (#4283 — that would silently promote a backing-service postgres to the cross-region pair shape); an explicit `parameters` body always wins; a repoint to the HA mode completes the region (#5639), in the same `topology` object because the controller merges parameters shallowly.

## Red before, green after — verbatim

Mutation-proven, so the guards compile in both states. Four behaviours reverted: the scalar `SetNestedField` write, the raw `NestedString` for `curMode`, the raw `NestedString` response echo, and the parameters repoint disabled with `&& false`.

**RED:**

```
--- FAIL: TestHandleApplicationUpdate_4950_ConsolePlacementApply_Returns200 (0.00s)
    applications_update_4950_owndeps_test.go:134: spec.placement.targets = [] (found=false), want the 2 targets the console submitted — the editor's per-region model must survive its own Apply (#6136)
--- FAIL: TestHandleApplicationUpdate_ObjectFormSurvivesTheSave_6136 (0.00s)
    applications_update_placement_shape_6136_test.go:257: spec.placement came back as the bare string "active-active" — the Save DOWNGRADED an object-form placement and deleted the vcluster/clusters the body never restated (#6136, control uat50-ahs-pg on hw293)
--- FAIL: TestHandleApplicationUpdate_ObjectFormStillGuardsDestructiveTransitions_6136 (0.00s)
    applications_update_placement_shape_6136_test.go:303: active-hot-standby → singleton was accepted WITHOUT ?force=true on an object-form CR: the gate read the current posture as "" and could not see the standby drop (#6136); body={"kind":"Application","name":"uat50-ahs-pg","namespace":"acme","uid":"","httpStatus":"200","applied":true,"regions":["me-east-215-a","me-east-215-b"],"placement":"singleton","parameters":{"domain":"shop.acme.example"},"message":"HTTP 200 OK — Application \"uat50-ahs-pg\" updated in namespace \"acme\" (controller reconciles within ~60s)"}
--- FAIL: TestHandleApplicationUpdate_EditorTargetsReachTheCR_6136 (0.00s)
    applications_update_placement_shape_6136_test.go:391: spec.placement.targets absent after the editor's own Apply — the per-region model the User selected did not survive a Save that answered 200 (#6136)
--- FAIL: TestHandleApplicationUpdate_ParametersFollowThePlacement_6136 (0.00s)
    applications_update_placement_shape_6136_test.go:463: spec.parameters.topology.mode = "singleton" (found=true) after a Save that set spec.placement=active-hot-standby — the CR contradicts itself and the HelmRelease keeps rendering the singleton, so the Save is a no-op at the layer that matters (#6136, measured on hw293)
FAIL
FAIL	github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/handler	3.338s
FAIL
```

The response-echo reader is proven independently, since the combined run fatals on the shape assert before reaching it — mutating **only** that line:

```
=== RUN   TestHandleApplicationUpdate_ObjectFormSurvivesTheSave_6136
    applications_update_placement_shape_6136_test.go:280: response placement = "", want active-active — an object-form CR must not answer with an empty posture the console then has to guess at
--- FAIL: TestHandleApplicationUpdate_ObjectFormSurvivesTheSave_6136 (0.00s)
FAIL
```

**GREEN (this branch, whole package, `-count=1`):**

```
ok  	github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/handler	300.629s
```

## The controls

Each shares the suspect property — same handler, same producer, same canonicalisation, a `placement` change reaching the same helper — and **stayed green under the mutation above** (none appear in the RED output):

| Control | What it holds | Why it matters |
|---|---|---|
| `TestHandleApplicationUpdate_StringFormCallerIsUnchanged_6136` | legacy string-form CR + mode-only body still stores a **bare string** | the fix must not migrate CRs nobody asked it to migrate |
| `TestHandleApplicationUpdate_NonPostgresParametersUntouched_6136` | identical body and identical `parameters.topology` tree, only the blueprint differs — stays `singleton` | the repoint is a bp-postgres-scoped derivation, not a handler that rewrites any tree it finds |
| `TestPlacementFromSpec_ToleratesBothShapes_6136` | both shapes still read the same posture | the tolerance old CRs depend on is preserved |
| `TestRepointPostgresTopologyMode_6136` CONTROL subtests | non-postgres / undeclared topology / already-agreeing mode all return `changed=false` | no churn, no new declarations |
| `TestPlacementValueForUpdate_*` CONTROL subtests | legacy wire byte-identical for both the string-form and absent-placement cases | |

## Vacuity checks

`TestPlacementValueForUpdate_VacuityCheck_6136` feeds the producer the two inputs whose outputs the fix distinguishes and asserts the results differ **in type**. A producer stubbed to always return a string, or always an object, collapses the distinction and the check goes red — so the shape suite cannot pass on a degenerate producer.

The helper-level tests are deliberately paired with **handler-level** ones for every behaviour, so removing a call site cannot leave a green suite behind: the mutation above disabled the parameters wiring while leaving `repointPostgresTopologyMode` intact, and `TestHandleApplicationUpdate_ParametersFollowThePlacement_6136` is what caught it.

Assertions are on values and shapes throughout — the persisted `targets[]` are checked for `role`, `region`, `vcluster` and `standbyType` values and for the **absence** of `standbyType` on the Primary; the 409 detail is checked for naming the posture being left; `spec.placement` is checked by **type** as well as content.

## Pre-existing test updated

`TestHandleApplicationUpdate_4950_ConsolePlacementApply_Returns200` read `spec.placement` with a raw `NestedString`, which now returns `ok=false` because a body carrying `targets[]` is stored in the object form. It moves to `placementFromSpec` and **gains** an assertion that the 2 submitted targets survived — the same posture is still required, plus something the scalar form could not carry at all.

Refs #6136 #3969 #3373 #5422 #4950
