### PR TITLE
fix(catalyst): a usable secondary kubeconfig is not thereby a DELIVERY — the third bridge state (#6107)

### DIFF
--- a/core/controllers/organization/internal/controller/provisioning_postconditions.go
+++ b/core/controllers/organization/internal/controller/provisioning_postconditions.go
@@ -203,7 +203,30 @@ func (r *Reconciler) verifyProvisioned(ctx context.Context, org *orgapi.Organiza
 			"console Gateway listeners %s/%s in every region — %s (the console ELB pool forwards customer TLS to every region's nodes, so a region with no listener resets the handshake for %q on the share of connections it receives)",
 			names.HTTPSName, names.HTTPName, u, names.WildcardHost))
 	}
+	// #6107 — UNREACHABLE IS NOT INDISTINGUISHABLE FROM WIRED.
+	//
+	// This loop used to append to Unverifiable, and `complete()` is
+	// `len(Missing) == 0`, so a region the fan-out could not reach did not
+	// hold the Organization back at all. Measured on hw293: the bridge Secret
+	// carried a well-formed credential naming an endpoint in NEITHER region,
+	// every write to it timed out, the region landed in Unreachable — and all
+	// six Organizations read Ready/Reconciled for hours while region B held
+	// zero per-Org listeners. Reporting provisioned there is a verdict from
+	// absent evidence: this pass did not write the listener in that region and
+	// could not read one back.
+	//
+	// Missing is a requeue too, so a genuine apiserver blip clears on the next
+	// pass rather than sticking. What it no longer does is pass silently.
 	for _, u := range res.Unreachable {
+		out.Missing = append(out.Missing, fmt.Sprintf(
+			"console Gateway listeners %s/%s in every region — %s (unreached: this pass neither wrote the pair there nor read one back, so %q is unverified on the share of connections the console ELB sends to that region; requeueing clears it if the region merely blipped)",
+			names.HTTPSName, names.HTTPName, u, names.WildcardHost))
+	}
+	// The DENOMINATOR failing is a different claim and keeps its old routing:
+	// "I could not count the regions" genuinely is unverifiable, and turning
+	// it into a missing artifact would red-flag every Organization on a
+	// Sovereign whose witness read errored once.
+	for _, u := range res.Undecidable {
 		out.Unverifiable = append(out.Unverifiable, fmt.Sprintf(
 			"console Gateway listeners for %q in every region — %s", names.WildcardHost, u))
 	}

--- a/core/controllers/organization/internal/controller/tenant_console_tls.go
+++ b/core/controllers/organization/internal/controller/tenant_console_tls.go
@@ -378,6 +378,9 @@ func (r *Reconciler) reconcileTenantConsoleTLS(ctx context.Context, org *orgapi.
 	for _, u := range res.Unreachable {
 		errs = append(errs, "unreachable secondary region: "+u)
 	}
+	for _, u := range res.Undecidable {
+		errs = append(errs, "undecidable secondary-region count: "+u)
+	}
 	if len(errs) > 0 {
 		sort.Strings(errs)
 		return changed, fmt.Errorf("console listener for %q: %s", names.WildcardHost, strings.Join(errs, "; "))
@@ -634,6 +637,9 @@ func (r *Reconciler) teardownTenantConsoleTLS(ctx context.Context, org *orgapi.O
 	}
 	for _, u := range res.Unreachable {
 		errs = append(errs, "unreachable secondary region: "+u)
+	}
+	for _, u := range res.Undecidable {
+		errs = append(errs, "undecidable secondary-region count: "+u)
 	}
 	if len(errs) > 0 {
 		sort.Strings(errs)

--- a/core/controllers/organization/internal/controller/tenant_console_tls_regions.go
+++ b/core/controllers/organization/internal/controller/tenant_console_tls_regions.go
@@ -150,10 +150,33 @@ type consoleRegionResolution struct {
 	// until the credential is replaced, so it is reported as a missing
 	// artifact, not as a transient.
 	Unwired []string
-	// Unreachable — regions whose kubeconfig IS wired but whose client could
-	// not be built or used this pass. TRANSIENT: an apiserver blip must not
-	// red-flag every Organization on the Sovereign, so it only requeues.
+	// Unreachable — a region this Sovereign is KNOWN to have and whose
+	// kubeconfig IS wired, but which could not be reached this pass.
+	//
+	// #6107 changed what this means for the completeness verdict. It used to
+	// feed Unverifiable, on the reasoning that "an apiserver blip must not
+	// red-flag every Organization at once". The reasoning is sound about
+	// blips and wrong about verdicts: a region we could not reach is a region
+	// where this pass neither wrote the listener nor read it back, so
+	// reporting the Organization as provisioned on that basis publishes a
+	// verdict from absent evidence. On hw293 that is exactly what happened —
+	// the bridge Secret named an endpoint in neither region, every write to it
+	// timed out, the region landed here, and all six Organizations read
+	// Ready/Reconciled while region B carried zero per-Org listeners for
+	// hours. It now feeds Missing.
+	//
+	// Nothing is destroyed by that: Missing means not-complete means requeue,
+	// so a genuine blip clears itself on the next pass. What it costs is a
+	// status flap during a real outage, which is the honest reading — the
+	// customer door in that region genuinely is unverified while it lasts.
 	Unreachable []string
+	// Undecidable — the pass could not establish how many regions there ARE.
+	// This is the denominator failing, not an artifact: an unreadable witness
+	// or an unreadable bridge Secret leaves the expected count unknown, and
+	// "I cannot count the regions" is a different claim from "I know a region
+	// exists and could not reach it". Only this one is a requeue-and-say-so
+	// (Unverifiable); the other is a region with no listener.
+	Undecidable []string
 }
 
 // regionClientCache memoizes the per-region clients between reconciles, keyed
@@ -235,15 +258,9 @@ func consoleRegionKeyFromSecretKey(k string) string {
 // kubeconfig bridge and can fail to install, #6004). It is therefore decidable
 // in the exact window in which the ClusterMesh witness is not.
 func (r *Reconciler) configuredRegionRemoteCount() (int, bool) {
-	raw := strings.TrimSpace(r.ConfiguredRegions)
-	if raw == "" {
-		return 0, false
-	}
 	seen := map[string]bool{}
-	for _, part := range strings.Split(raw, ",") {
-		if k := strings.TrimSpace(part); k != "" {
-			seen[k] = true
-		}
+	for _, k := range r.configuredRegionList() {
+		seen[k] = true
 	}
 	if len(seen) == 0 {
 		return 0, false
@@ -252,6 +269,26 @@ func (r *Reconciler) configuredRegionRemoteCount() (int, bool) {
 	// so the remote count is one fewer. A malformed single-entry list yields
 	// zero remotes, which is the pre-#6027 behaviour.
 	return len(seen) - 1, true
+}
+
+// configuredRegionList is the parsed CATALYST_CONFIGURED_REGIONS value — the
+// same witness configuredRegionRemoteCount takes its COUNT from, exposed as
+// the NAMES so the shared delivery contract can decide whether a bridge-Secret
+// key names a region this Sovereign actually declares (#6107). One parse, one
+// witness: a second copy of this split is how the count and the names would
+// drift apart.
+func (r *Reconciler) configuredRegionList() []string {
+	raw := strings.TrimSpace(r.ConfiguredRegions)
+	if raw == "" {
+		return nil
+	}
+	out := make([]string, 0, 2)
+	for _, part := range strings.Split(raw, ",") {
+		if k := strings.TrimSpace(part); k != "" {
+			out = append(out, k)
+		}
+	}
+	return out
 }
 
 // clusterMeshRemoteClusters extracts the REMOTE cluster names from a Cilium
@@ -332,10 +369,10 @@ func (r *Reconciler) consoleRegionTargets(ctx context.Context) consoleRegionReso
 		// two are indistinguishable HERE, which is precisely why this is no
 		// longer the only witness — see configuredRegionRemoteCount.
 	default:
-		// Cannot decide completeness this pass. Report it as transient so
-		// the Org requeues rather than being declared complete on an
-		// unverified region set.
-		res.Unreachable = append(res.Unreachable, fmt.Sprintf(
+		// The DENOMINATOR is unknown this pass — not an artifact verdict.
+		// Report it as undecidable so the Org requeues rather than being
+		// declared complete on an unverified region set.
+		res.Undecidable = append(res.Undecidable, fmt.Sprintf(
 			"ClusterMesh witness %s/%s unreadable, so the expected region count is unknown: %s",
 			r.clusterMeshSecretNamespace(), r.clusterMeshSecretName(), err))
 	}
@@ -350,7 +387,9 @@ func (r *Reconciler) consoleRegionTargets(ctx context.Context) consoleRegionReso
 	bridge := &corev1.Secret{}
 	err := r.Get(ctx, client.ObjectKey{Namespace: bridgeNS, Name: bridgeName}, bridge)
 	if err != nil && !apierrors.IsNotFound(err) {
-		res.Unreachable = append(res.Unreachable, fmt.Sprintf(
+		// Denominator again: without the Secret this pass cannot say which
+		// regions are wired, so it must not claim any verdict about them.
+		res.Undecidable = append(res.Undecidable, fmt.Sprintf(
 			"secondary-region kubeconfig Secret %s/%s unreadable: %s", bridgeNS, bridgeName, err))
 		return res
 	}
@@ -381,7 +420,26 @@ func (r *Reconciler) consoleRegionTargets(ctx context.Context) consoleRegionReso
 			// This is STRUCTURAL, not transient: the verdict is a property of
 			// the bytes, so no amount of requeueing can change it, which is
 			// precisely the struct's own definition of Unwired.
-			if defects := kubeconfig.Defects(string(v)); len(defects) > 0 {
+			//
+			// #6107 second rung — USABILITY IS NOT DELIVERY. The bytes
+			// contract passes on a document that names a host in neither
+			// region: on hw293 this key held 219 bytes (sha256
+			// 881231f95cd49646…) pointing at `https://212.72.24.6:6443` while
+			// region A answered on .43 and region B on .25. So the shared
+			// contract is asked its DELIVERY question, which additionally
+			// checks that the region key is one the Sovereign declares.
+			//
+			// This controller passes no endpoint oracle, deliberately. It has
+			// no cheap probe, and a component that cannot dial is not entitled
+			// to a reachability verdict — inventing one would be the
+			// verdict-from-absent-evidence pattern this file exists to refuse.
+			// The endpoint is proven by catalyst-api, which owns the producer
+			// side and already dials; here an unreachable endpoint surfaces
+			// through Unreachable, which now holds the Organization back.
+			if defects := kubeconfig.DeliveryDefects(string(v), kubeconfig.Delivery{
+				RegionKey:       region,
+				DeclaredRegions: r.configuredRegionList(),
+			}); len(defects) > 0 {
 				unusable = append(unusable, fmt.Sprintf("%s (missing: %s)",
 					region, kubeconfig.DescribeDefects(defects)))
 				continue

--- a/core/controllers/organization/internal/controller/tenant_console_tls_regions_unreached_6107_test.go
+++ b/core/controllers/organization/internal/controller/tenant_console_tls_regions_unreached_6107_test.go
@@ -1,0 +1,321 @@
+// tenant_console_tls_regions_unreached_6107_test.go — #6107, the REPORTING
+// defect underneath the routing defect.
+//
+// THE DEFECT
+// ----------
+// consoleRegionResolution has always had two buckets for a region that did not
+// get its listener, and they route to opposite verdicts:
+//
+//	Unwired      -> out.Missing        -> complete() == false  (holds the Org)
+//	Unreachable  -> out.Unverifiable   -> complete() == true   (does not)
+//
+// `complete()` is `len(Missing) == 0`, so a region in Unreachable was, as far
+// as every status surface is concerned, indistinguishable from a region that
+// was written successfully.
+//
+// hw293 (dep a0077ba47e3720e5) is what that costs. Its bridge Secret carried a
+// well-formed, credentialled kubeconfig — 219 bytes, sha256 881231f95cd49646…
+// — naming `https://212.72.24.6:6443`, which is NEITHER region (A answers on
+// .43, B on .25) and answers nothing at all. So:
+//
+//   - the shared usability contract passed it, and the region counted as WIRED
+//     (`expectedRemotes > len(regions)` became 1 > 1, i.e. no shortfall);
+//   - every write to it timed out and the region landed in Unreachable;
+//   - all six Organizations read Ready/Reconciled for hours while region B's
+//     `cilium-gateway-console` carried ZERO per-Org listeners — catalyst-api's
+//     own emitter said so in the same log, `regions_declared=2
+//     regions_written=1`, on every one of them.
+//
+// Reporting an Organization provisioned there is a verdict published from
+// absent evidence: the pass neither wrote the pair in that region nor read one
+// back.
+//
+// THE FIX, AND WHY IT IS NOT "EVERYTHING IS INCOMPLETE"
+// -----------------------------------------------------
+// Unreachable now feeds Missing — but the DENOMINATOR failures that used to
+// share that bucket move to their own, Undecidable, and keep feeding
+// Unverifiable. The two are different claims:
+//
+//	"I know this region exists and could not reach it"  -> no listener there
+//	"I could not work out how many regions there are"   -> genuinely unknown
+//
+// Only the first is a missing artifact. Folding the second in would red-flag
+// every Organization on a Sovereign whose witness read errored once, which is
+// the over-correction the previous routing was (correctly) worried about — it
+// just applied that worry to the wrong bucket.
+//
+// Missing is still a requeue, so a genuine apiserver blip clears on the next
+// pass. What it no longer does is pass silently for hours.
+//
+// Refs #5246 #5511 #6015 #6027 #6107.
+package controller
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// deliveredRegionKubeconfig is a document that passes the bytes contract
+// completely — five sections, resolvable current-context, bearer-shaped
+// credential — for the region key the fixture declares. It carries no secret:
+// its credential is the literal string `not-a-real-token`.
+//
+// It is what a MIS-delivery looks like from this controller's side. The
+// controller has no cheap endpoint probe and deliberately claims no
+// reachability verdict of its own; what it sees is a credential that resolves
+// and a region it cannot reach, which is exactly the state under test.
+const deliveredRegionKubeconfig = `apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://212.72.24.6:6443
+    insecure-skip-tls-verify: true
+  name: c
+contexts:
+- name: c
+  context:
+    cluster: c
+    user: c
+current-context: c
+users:
+- name: c
+  user:
+    token: not-a-real-token
+`
+
+// seedDeliveredBridgeSecret writes the bridge Secret with a USABLE value under
+// the fixture's declared secondary region key — i.e. the region WILL be
+// counted as wired, which is what makes Unreachable (not Unwired) the bucket
+// under test.
+func seedDeliveredBridgeSecret(t *testing.T, f multiRegionFixture) {
+	t.Helper()
+	bridge := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      consoleSecondaryKubeconfigSecretDefaultName,
+			Namespace: consoleSecondaryKubeconfigSecretDefaultNamespace,
+		},
+		Data: map[string][]byte{secondaryRegionKey + ".yaml": []byte(deliveredRegionKubeconfig)},
+	}
+	if err := f.r.Create(context.Background(), bridge); err != nil {
+		t.Fatalf("seed bridge Secret: %v", err)
+	}
+}
+
+// errOnGetClient fails Get for ONE object key and delegates everything else,
+// so a single witness can be made unreadable without disturbing the rest of
+// the fixture.
+type errOnGetClient struct {
+	client.Client
+	failNS, failName string
+	err              error
+}
+
+func (c errOnGetClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	if key.Namespace == c.failNS && key.Name == c.failName {
+		return c.err
+	}
+	return c.Client.Get(ctx, key, obj, opts...)
+}
+
+// TestVerifyProvisioned_UnreachedSecondaryRegionHoldsTheOrgBack_6107 is the
+// RED case. Before this change verifyProvisioned put the region in
+// Unverifiable and complete() returned true.
+func TestVerifyProvisioned_UnreachedSecondaryRegionHoldsTheOrgBack_6107(t *testing.T) {
+	ctx := context.Background()
+
+	f := newMultiRegionFixture(t, false, false, regionGatewayListeners(9443, 9080))
+	f.r.ConfiguredRegions = hw293ConfiguredRegions
+	seedDeliveredBridgeSecret(t, f)
+	// The endpoint is in neither region, so no client can be used against it.
+	// The builder failing is this fixture's stand-in for that dial timing out.
+	f.r.RegionClientBuilder = func([]byte) (client.Client, error) {
+		return nil, errors.New("dial tcp 212.72.24.6:6443: i/o timeout")
+	}
+
+	res := f.r.consoleRegionTargets(ctx)
+
+	// Precondition — the region must land in Unreachable, not Unwired. If it
+	// were Unwired this case would pass for the reason #6107's first rung
+	// already covers, and would assert nothing new.
+	if len(res.Unwired) != 0 {
+		t.Fatalf("precondition: the value is usable, so the region must be WIRED; unwired=%v", res.Unwired)
+	}
+	if len(res.Unreachable) == 0 {
+		t.Fatalf("precondition: a region whose client cannot be built must land in Unreachable; got targets=%d", len(res.Targets))
+	}
+	if len(res.Undecidable) != 0 {
+		t.Fatalf("a region-level failure was filed as a DENOMINATOR failure: %v", res.Undecidable)
+	}
+
+	// Write the host-region listener so nothing else can be the cause.
+	if _, err := f.r.ensureConsoleOrgListener(ctx, f.r.Client, f.names); err != nil {
+		t.Fatalf("write the host-region listener: %v", err)
+	}
+	syncGatewayStatus(t, f.r.Client)
+
+	got := f.r.verifyProvisioned(ctx, f.org)
+	if got.complete() {
+		t.Fatalf("Organization reads FULLY PROVISIONED while a declared secondary region was never reached — "+
+			"this pass neither wrote the per-Org pair there nor read one back, and the console EIP round-robins "+
+			"both regions, so a share of customer TLS to %q resets. missing=%v unverifiable=%v",
+			f.names.WildcardHost, got.Missing, got.Unverifiable)
+	}
+	joined := strings.Join(got.Missing, " | ")
+	if !strings.Contains(joined, secondaryRegionKey) {
+		t.Fatalf("the Missing entry does not name the region that was not reached: %q", joined)
+	}
+	if !strings.Contains(joined, "unreached") {
+		t.Fatalf("the Missing entry does not distinguish an UNREACHED region from an absent artifact: %q", joined)
+	}
+}
+
+// TestVerifyProvisioned_ReachedSecondaryRegionStaysComplete_6107 is the
+// CONTROL that shares the suspect property. Same fixture, same declared
+// region, same non-empty bridge value — and a region client that works. The
+// Organization must still read complete, or the fix has over-corrected into
+// "everything is incomplete".
+func TestVerifyProvisioned_ReachedSecondaryRegionStaysComplete_6107(t *testing.T) {
+	ctx := context.Background()
+
+	f := newMultiRegionFixture(t, false, false, regionGatewayListeners(9443, 9080))
+	f.r.ConfiguredRegions = hw293ConfiguredRegions
+	seedDeliveredBridgeSecret(t, f)
+	f.r.RegionClientBuilder = func([]byte) (client.Client, error) { return f.region, nil }
+
+	res := f.r.consoleRegionTargets(ctx)
+	if len(res.Unwired) != 0 || len(res.Unreachable) != 0 || len(res.Undecidable) != 0 {
+		t.Fatalf("a usable credential at a declared region reported a gap: unwired=%v unreachable=%v undecidable=%v",
+			res.Unwired, res.Unreachable, res.Undecidable)
+	}
+	if len(res.Targets) != 2 {
+		t.Fatalf("targets = %d, want 2 (host + the wired secondary)", len(res.Targets))
+	}
+
+	if _, err := f.r.reconcileTenantConsoleTLS(ctx, f.org); err != nil {
+		t.Fatalf("the up-path failed against a reachable secondary region: %v", err)
+	}
+	syncGatewayStatus(t, f.r.Client)
+	syncGatewayStatus(t, f.region)
+
+	got := f.r.verifyProvisioned(ctx, f.org)
+	if !got.complete() {
+		t.Fatalf("an Organization whose listener pair reached EVERY declared region reads incomplete — "+
+			"the fix has over-corrected. missing=%v unverifiable=%v", got.Missing, got.Unverifiable)
+	}
+}
+
+// TestVerifyProvisioned_AbsentKeyStillMissing_6107 is the CONTROL for the case
+// the previous rungs were built on: a genuinely ABSENT secondary key still
+// lands in Missing with the #6027 shortfall wording. Widening Unreachable must
+// not have swallowed it.
+func TestVerifyProvisioned_AbsentKeyStillMissing_6107(t *testing.T) {
+	ctx := context.Background()
+
+	f := newMultiRegionFixture(t, false, false, regionGatewayListeners(9443, 9080))
+	f.r.ConfiguredRegions = hw293ConfiguredRegions
+
+	res := f.r.consoleRegionTargets(ctx)
+	if len(res.Unwired) == 0 {
+		t.Fatal("a declared secondary region with no bridge key must still be UNWIRED")
+	}
+	joined := strings.Join(res.Unwired, " | ")
+	if !strings.Contains(joined, "wired region keys: none") {
+		t.Fatalf("the #6027 shortfall wording was lost: %q", joined)
+	}
+	if got := f.r.verifyProvisioned(ctx, f.org); got.complete() {
+		t.Fatalf("an Organization with no credential for a declared region reads complete: missing=%v", got.Missing)
+	}
+}
+
+// TestVerifyProvisioned_UndecidableCountIsUnverifiable_6107 is the
+// ANTI-OVER-CORRECTION control, and the reason Undecidable exists as its own
+// field. A witness this pass could not READ leaves the expected region count
+// unknown — a claim about the denominator, not about any artifact. It must
+// requeue and say so, never red-flag every Organization on the Sovereign.
+func TestVerifyProvisioned_UndecidableCountIsUnverifiable_6107(t *testing.T) {
+	ctx := context.Background()
+
+	f := newMultiRegionFixture(t, false, false, regionGatewayListeners(9443, 9080))
+	// Single-region topology: with the mesh witness readable there would be no
+	// remote at all, so anything reported here comes from the unreadable
+	// witness and nothing else.
+	f.r.ConfiguredRegions = "hw-me-east-215-a-rtz-prod"
+	f.r.Client = errOnGetClient{
+		Client:   f.r.Client,
+		failNS:   consoleClusterMeshSecretDefaultNamespace,
+		failName: consoleClusterMeshSecretDefaultName,
+		err:      errors.New("etcdserver: request timed out"),
+	}
+
+	res := f.r.consoleRegionTargets(ctx)
+	if len(res.Undecidable) == 0 {
+		t.Fatal("an unreadable region witness must be reported as an UNDECIDABLE count")
+	}
+	if len(res.Unreachable) != 0 {
+		t.Fatalf("a denominator failure was filed as an unreached REGION, which now holds every Org back: %v", res.Unreachable)
+	}
+
+	if _, err := f.r.ensureConsoleOrgListener(ctx, f.r.Client, f.names); err != nil {
+		t.Fatalf("write the host-region listener: %v", err)
+	}
+	syncGatewayStatus(t, f.r.Client)
+
+	got := f.r.verifyProvisioned(ctx, f.org)
+	if len(got.Unverifiable) == 0 {
+		t.Fatal("the undecidable count never reached the postcondition report")
+	}
+	for _, m := range got.Missing {
+		if strings.Contains(m, "request timed out") {
+			t.Fatalf("a witness read error was turned into a MISSING artifact — every Organization on the Sovereign would red-flag on one bad Get: %q", m)
+		}
+	}
+	if !got.complete() {
+		t.Fatalf("an unreadable witness held the Organization back as if an artifact were absent: missing=%v", got.Missing)
+	}
+}
+
+// TestVerifyProvisioned_UnreachedVacuity_6107 is the VACUITY CHECK. Every
+// green assertion above would also hold against an implementation that never
+// produced a Missing entry for a region. This flips ONE input — whether the
+// region client builds — inside one fixture shape, and requires the verdict to
+// change.
+func TestVerifyProvisioned_UnreachedVacuity_6107(t *testing.T) {
+	ctx := context.Background()
+
+	verdict := func(buildFails bool) provisioningPostconditions {
+		f := newMultiRegionFixture(t, false, false, regionGatewayListeners(9443, 9080))
+		f.r.ConfiguredRegions = hw293ConfiguredRegions
+		seedDeliveredBridgeSecret(t, f)
+		if buildFails {
+			f.r.RegionClientBuilder = func([]byte) (client.Client, error) {
+				return nil, errors.New("dial tcp 212.72.24.6:6443: i/o timeout")
+			}
+		} else {
+			f.r.RegionClientBuilder = func([]byte) (client.Client, error) { return f.region, nil }
+		}
+		if _, err := f.r.reconcileTenantConsoleTLS(ctx, f.org); err != nil && !buildFails {
+			t.Fatalf("up-path failed on the reachable arm: %v", err)
+		}
+		syncGatewayStatus(t, f.r.Client)
+		syncGatewayStatus(t, f.region)
+		return f.r.verifyProvisioned(ctx, f.org)
+	}
+
+	reachable := verdict(false)
+	unreached := verdict(true)
+	if !reachable.complete() {
+		t.Fatalf("control arm is not complete, so the comparison proves nothing: missing=%v", reachable.Missing)
+	}
+	if unreached.complete() {
+		t.Fatal("VACUITY: flipping the region client from working to failing changed nothing — the new assertion cannot fail")
+	}
+	if len(unreached.Missing) == len(reachable.Missing) {
+		t.Fatalf("VACUITY: both arms report %d missing artifacts", len(reachable.Missing))
+	}
+}

--- a/core/controllers/pkg/kubeconfig/delivery.go
+++ b/core/controllers/pkg/kubeconfig/delivery.go
@@ -1,0 +1,359 @@
+// delivery.go — the SECOND question a secondary region's kubeconfig has to
+// answer, because the first one is demonstrably not enough.
+//
+// WHAT kubeconfig.go ALREADY ANSWERS, AND WHY IT WAS NOT SUFFICIENT
+// -----------------------------------------------------------------
+// Defects answers "can these bytes produce a working client?". That closed the
+// 95-byte credential-less shell (#6054/#6112/#6116) and every hop now shares
+// the one implementation, so a document accepted by the producer cannot be
+// rejected by the reader.
+//
+// It did not close the state measured on hw293 (dep a0077ba47e3720e5) on
+// 2026-08-11, and that state is why those merged fixes are INERT there:
+//
+//	Secret catalyst/cutover-secondary-kubeconfigs
+//	  me-east-215-b-1.yaml  219 bytes  sha256 881231f95cd49646…
+//	  server: https://212.72.24.6:6443
+//
+// Five top-level sections, a resolvable current-context, a bearer credential.
+// `Defects` returns EMPTY on it. And `212.72.24.6` is neither of this
+// deployment's two regions — region A's apiserver answers on `212.72.24.43`
+// and region B's on `212.72.24.25`, each proven by its own serving
+// certificate's SANs (`…-me-east-215-a-cp1-…` / `…-me-east-215-b-cp1-…`,
+// both issued by this Sovereign's own `k3s-server-ca`). `212.72.24.6` answers
+// nothing at all: no ICMP, no :443, and a 12-second timeout on :6443.
+//
+// Those 219 bytes are, to the byte, this repository's own unit-test control
+// fixture `completeKubeconfigSameCluster` (220 bytes with its trailing
+// newline, 219 without; sha256 of the stripped form matches the live value
+// exactly). The fixture was built to be maximally usable-by-the-contract while
+// pointing at a deliberately fake host — which is precisely what makes it the
+// perfect counterexample: **a document engineered to satisfy "usable" is not
+// thereby a delivery.** Presence stood in for usability once; usability then
+// stood in for delivery. Same substitution, one rung further in.
+//
+// WHAT "DELIVERED" MUST ADDITIONALLY MEAN
+// ---------------------------------------
+// Two properties, both of which the hw293 value fails and a genuine peer-region
+// credential passes:
+//
+//  1. ATTRIBUTION — the region the document is filed under must be one this
+//     deployment DECLARES. The declared set is `CATALYST_CONFIGURED_REGIONS`
+//     (`catalyst-system/sovereign-fqdn` key `configuredRegions`), live on
+//     hw293 as `hw-me-east-215-a-rtz-prod,hw-me-east-215-b-rtz-prod`. It is
+//     written by the IaC at provision time, so it is independent of both
+//     ClusterMesh (absent until the mesh establishes — NotFound on hw293) and
+//     the cutover chart that owns the bridge Secret.
+//
+//  2. PROOF — the endpoint the document names must have been PROVEN to answer,
+//     by whatever oracle the calling component legitimately has. This package
+//     performs no I/O and never will: it takes the oracle as a function and
+//     asks it. A caller with no oracle passes nil and gets exactly the
+//     pre-existing bytes-only verdict, so nothing regresses for a consumer
+//     that cannot probe.
+//
+// WHY ATTRIBUTION IS ON THE REGION KEY AND NOT ON THE ENDPOINT
+// ------------------------------------------------------------
+// The obvious form of check 1 — "is the server host one of the declared
+// regions?" — is NOT decidable from local state, and saying so is more useful
+// than shipping a check that cannot fire. The declared witness names CLOUD
+// REGIONS (`hw-me-east-215-b-rtz-prod`) while a kubeconfig names an IP
+// (`212.72.24.25`), and no in-cluster object on hw293 maps one to the other:
+// region A's node list contains only region-A nodes, `cilium-clustermesh` is
+// NotFound, and `sovereign-fqdn` carries the LOCAL control-plane IP only. A
+// host-versus-declared-region comparison would therefore reject every genuine
+// delivery — the exact over-correction this contract must not make.
+//
+// So the endpoint is bound by PROOF (check 2) rather than by name, and the
+// NAME is bound where names actually exist (check 1). Between them the hw293
+// value has nowhere to hide: the endpoint answers nothing, so no oracle can
+// prove it.
+//
+// Refs #5488 #6015 #6027 #6054 #6104 #6107 #6112 #6116.
+package kubeconfig
+
+import (
+	"net"
+	"net/url"
+	"sort"
+	"strings"
+
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// Defect names this file can add, on top of the section names Defects
+// returns. They are deliberately not section names: an operator reading
+// "users" knows to look at a `users:` block, and must not be sent looking for
+// an `endpoint:` block that does not exist in the format.
+const (
+	// DefectEndpoint — the document declares no server URL that can be
+	// parsed, so there is nothing to prove and nothing to dial.
+	DefectEndpoint = "endpoint-absent"
+	// DefectRegionUndeclared — the region key this document is filed under
+	// is not one the deployment declares.
+	DefectRegionUndeclared = "region-undeclared"
+	// DefectEndpointUnproven — the caller's oracle could not prove the
+	// endpoint belongs to a live apiserver of this deployment.
+	DefectEndpointUnproven = "endpoint-unproven"
+)
+
+// Delivery carries the context a delivery verdict needs beyond the bytes.
+// Every field is optional: a zero Delivery makes DeliveryDefects behave
+// exactly like Defects, which is what keeps this additive for callers that
+// legitimately know less.
+type Delivery struct {
+	// RegionKey is the key the document is filed under — the `<regionKey>`
+	// half of the bridge Secret's `<regionKey>.yaml` data key, or of the
+	// on-disk `<depID>-<regionKey>.yaml` file name. Empty skips attribution.
+	RegionKey string
+
+	// DeclaredRegions is the deployment's own region list, normally
+	// CATALYST_CONFIGURED_REGIONS. Empty skips attribution: a Sovereign with
+	// no witness must behave exactly as it did before this file existed,
+	// never worse.
+	DeclaredRegions []string
+
+	// EndpointProven is the caller's oracle, given the server URL as written
+	// in the document. Nil skips the proof — a consumer that cannot dial is
+	// not thereby entitled to a verdict about reachability, and inventing one
+	// would be reporting from absent evidence.
+	EndpointProven func(endpoint string) bool
+}
+
+// DeliveryDefects reports why raw is not a credible DELIVERY of the named
+// region's credential: everything Defects reports, plus attribution and proof.
+// An empty slice means the document is usable AND is a delivery.
+//
+// Ordering is stable (sorted) so a log line or a condition message diffs
+// cleanly between passes.
+func DeliveryDefects(raw string, d Delivery) []string {
+	defects := Defects(raw)
+
+	// A document that cannot build a client is already disqualified; adding
+	// attribution/proof findings on top would bury the primary cause under
+	// consequences of it. Report the bytes verdict alone.
+	if len(defects) > 0 {
+		return defects
+	}
+
+	extra := map[string]struct{}{}
+
+	endpoint := Endpoint(raw)
+	if endpoint == "" {
+		extra[DefectEndpoint] = struct{}{}
+	}
+
+	if d.RegionKey != "" && len(d.DeclaredRegions) > 0 && !RegionDeclared(d.RegionKey, d.DeclaredRegions) {
+		extra[DefectRegionUndeclared] = struct{}{}
+	}
+
+	// The proof runs only when there IS an endpoint to prove and an oracle to
+	// ask. Both guards matter: asking an oracle about "" would make every
+	// caller's prober answer a question about nothing.
+	if endpoint != "" && d.EndpointProven != nil && !d.EndpointProven(endpoint) {
+		extra[DefectEndpointUnproven] = struct{}{}
+	}
+
+	if len(extra) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(extra))
+	for k := range extra {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// Endpoint returns the server URL of the cluster the document's current
+// context names. When the current context cannot be resolved to a cluster it
+// falls back to the first cluster carrying a non-empty server, which is the
+// same relaxation kubeconfigServerHost has always made on the self-heal path.
+// Empty when the document is unparseable or declares no server.
+func Endpoint(raw string) string {
+	cfg, err := clientcmd.Load([]byte(raw))
+	if err != nil || cfg == nil {
+		return ""
+	}
+	if ctx, ok := cfg.Contexts[strings.TrimSpace(cfg.CurrentContext)]; ok && ctx != nil {
+		if c, ok := cfg.Clusters[strings.TrimSpace(ctx.Cluster)]; ok && c != nil {
+			if s := strings.TrimSpace(c.Server); s != "" {
+				return s
+			}
+		}
+	}
+	// Deterministic fallback — map iteration order must not decide which
+	// endpoint a message names.
+	names := make([]string, 0, len(cfg.Clusters))
+	for name := range cfg.Clusters {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		if c := cfg.Clusters[name]; c != nil {
+			if s := strings.TrimSpace(c.Server); s != "" {
+				return s
+			}
+		}
+	}
+	return ""
+}
+
+// EndpointHostPort renders a DOCUMENT's endpoint as host:port, supplying
+// defaultPort when the URL carries none. Empty when there is no parseable
+// endpoint. Takes raw kubeconfig bytes, like every other function in this
+// package — see HostPort for the URL-in variant.
+func EndpointHostPort(raw, defaultPort string) string {
+	return HostPort(Endpoint(raw), defaultPort)
+}
+
+// HostPort renders a SERVER URL as host:port, supplying defaultPort when the
+// URL carries none. Empty when the URL is unparseable or names no host.
+//
+// It exists as its own function because Delivery.EndpointProven is handed the
+// server URL, not the document: an oracle that had to re-parse the whole
+// kubeconfig to find the host it was just told about would be re-deriving what
+// the caller already computed — and a caller that mistakenly fed a URL to a
+// raw-bytes function would get a silent empty string and a probe that always
+// answers "unreachable", i.e. a check that fails closed for the wrong reason.
+func HostPort(serverURL, defaultPort string) string {
+	serverURL = strings.TrimSpace(serverURL)
+	if serverURL == "" {
+		return ""
+	}
+	u, err := url.Parse(serverURL)
+	if err != nil || u.Hostname() == "" {
+		return ""
+	}
+	port := u.Port()
+	if port == "" {
+		port = defaultPort
+	}
+	if port == "" {
+		return u.Hostname()
+	}
+	return net.JoinHostPort(u.Hostname(), port)
+}
+
+// RegionDeclared reports whether regionKey names one of declared.
+//
+// The two vocabularies do not match literally and never have: kubeconfigs are
+// keyed by the secondary control plane's own region key (`me-east-215-b-1`,
+// where the trailing ordinal counts control planes within the region) while
+// the declared list names cloud regions (`hw-me-east-215-b-rtz-prod`). The
+// match is therefore on dash-delimited TOKENS, not on raw substrings:
+// `me-east-215-b-1` reduces to the token run [me east 215 b], which appears
+// contiguously in [hw me east 215 b rtz prod].
+//
+// Token containment rather than string containment is deliberate. `strings.
+// Contains` would let `me-east-21` match `me-east-215`, i.e. a neighbouring
+// region would be accepted as this one — a mis-delivery of exactly the class
+// this function exists to catch, waved through by the check meant to catch it.
+//
+// Containment is tested BOTH ways so neither vocabulary has to be the longer
+// one; a future provider whose region key is the more specific string is
+// handled without a second rule.
+//
+// Containment alone is still too generous at the short end — `me-east-2`
+// reduces to [me east], which IS a run inside [hw me east 215 b rtz prod],
+// and accepting it would attribute a truncated key to a region it merely
+// shares a prefix with. So a match must ALSO be substantial: either the run is
+// at least minRegionRunTokens long, or it is the declared identifier exactly
+// (which is what keeps a genuinely short provider key like `fsn1-1` against a
+// declared `fsn1` attributable).
+func RegionDeclared(regionKey string, declared []string) bool {
+	key := regionKeyRun(regionKey)
+	if len(key) == 0 {
+		return false
+	}
+	for _, d := range declared {
+		dt := regionTokens(d)
+		if len(dt) == 0 {
+			continue
+		}
+		if !containsRun(dt, key) && !containsRun(key, dt) {
+			continue
+		}
+		if len(key) >= minRegionRunTokens || equalRun(key, dt) {
+			return true
+		}
+	}
+	return false
+}
+
+// minRegionRunTokens is how many tokens a region key must contribute before
+// mere containment counts as attribution. Two is not enough: [me east] is a
+// run inside most of a region list. Three is the shortest run that names a
+// region rather than a family of them, and anything shorter still attributes
+// when it matches a declared identifier exactly.
+const minRegionRunTokens = 3
+
+// regionKeyRun tokenizes a region key and drops a trailing control-plane
+// ordinal (`me-east-215-b-1` → [me east 215 b]). Tokenizing FIRST is what
+// makes the strip separator-agnostic: `me_east_215_b_1` reduces identically,
+// where a `-`-only trim would have left the ordinal attached and the key
+// unattributable. A key that is a bare number keeps it — stripping would leave
+// nothing to match on, and an empty run must never attribute.
+func regionKeyRun(regionKey string) []string {
+	t := regionTokens(regionKey)
+	if len(t) > 1 && allDigits(t[len(t)-1]) {
+		t = t[:len(t)-1]
+	}
+	return t
+}
+
+func allDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// equalRun reports token-sequence equality.
+func equalRun(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// regionTokens lowercases and splits a region identifier on any run of
+// non-alphanumeric characters, so `hw-me-east-215-b-rtz-prod`,
+// `hw_me_east_215_b`, and `HW.ME.EAST.215.B` all tokenize the same way.
+func regionTokens(s string) []string {
+	return strings.FieldsFunc(strings.ToLower(strings.TrimSpace(s)), func(r rune) bool {
+		return !(r >= 'a' && r <= 'z') && !(r >= '0' && r <= '9')
+	})
+}
+
+// containsRun reports whether needle appears as a CONTIGUOUS run inside
+// haystack. An empty needle never matches — "nothing is contained in
+// everything" would make attribution vacuous.
+func containsRun(haystack, needle []string) bool {
+	if len(needle) == 0 || len(needle) > len(haystack) {
+		return false
+	}
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		match := true
+		for j := range needle {
+			if haystack[i+j] != needle[j] {
+				match = false
+				break
+			}
+		}
+		if match {
+			return true
+		}
+	}
+	return false
+}

--- a/core/controllers/pkg/kubeconfig/delivery_test.go
+++ b/core/controllers/pkg/kubeconfig/delivery_test.go
@@ -1,0 +1,376 @@
+// delivery_test.go — the THIRD bridge state, pinned.
+//
+// Every case asserts on a VALUE the shared contract produced, and every
+// assertion is paired with a control that shares the suspect property and must
+// answer the other way, so nothing here can pass by having widened a rule.
+//
+// Refs #5488 #6027 #6107.
+package kubeconfig
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+	"testing"
+)
+
+// hw293DeliveredValue is the live artefact, reproduced byte-for-byte from
+// `catalyst/cutover-secondary-kubeconfigs` key `me-east-215-b-1.yaml` on
+// hw293 (dep a0077ba47e3720e5) as read 2026-08-11: 219 bytes, sha256 prefix
+// 881231f95cd49646.
+//
+// It carries no secret. Its "credential" is the literal string `fake-token`,
+// which is the whole point of the case: the document is credentialled in every
+// sense the contract could check from the bytes, and it is still not a
+// delivery. The trailing newline is absent in the live value, so the fixture
+// is built by trimming one — see TestHw293DeliveredValue_MatchesLiveDigest,
+// which fails if this fixture ever drifts from the measured artefact.
+const hw293DeliveredValue = `apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://212.72.24.6:6443
+  name: c
+contexts:
+- name: c
+  context:
+    cluster: c
+    user: c
+current-context: c
+users:
+- name: c
+  user:
+    token: fake-token`
+
+// hw293LiveBytes / hw293LiveDigest are what `kubectl get secret -o json` +
+// base64-decode reported for that key. Pinning both is what makes this a
+// regression fixture rather than a story about one.
+const (
+	hw293LiveBytes  = 219
+	hw293LiveDigest = "881231f95cd49646"
+)
+
+// hw293DeclaredRegions is the live `catalyst-system/sovereign-fqdn` key
+// `configuredRegions`, injected as CATALYST_CONFIGURED_REGIONS.
+var hw293DeclaredRegions = []string{"hw-me-east-215-a-rtz-prod", "hw-me-east-215-b-rtz-prod"}
+
+// genuineRegionBValue is the CONTROL. It shares every property that made the
+// live value pass: same five sections, same resolvable current-context, same
+// bearer-shaped credential, same brevity. The ONE difference is that its
+// endpoint is region B's real apiserver — `212.72.24.25`, the address whose
+// serving certificate names `…-me-east-215-b-cp1-…` — so an oracle can prove
+// it. If the new rule were rejecting on document shape, on the token, or on
+// terseness, this control would be refused too.
+const genuineRegionBValue = `apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://212.72.24.25:6443
+  name: c
+contexts:
+- name: c
+  context:
+    cluster: c
+    user: c
+current-context: c
+users:
+- name: c
+  user:
+    token: fake-token`
+
+// provenEndpoints is an oracle that proves exactly the endpoints a real
+// deployment would answer on. It stands in for catalyst-api's TCP probe.
+func provenEndpoints(allowed ...string) func(string) bool {
+	set := map[string]bool{}
+	for _, a := range allowed {
+		set[a] = true
+	}
+	return func(endpoint string) bool { return set[endpoint] }
+}
+
+// TestHw293DeliveredValue_MatchesLiveDigest pins the fixture to the measured
+// artefact. Without it every assertion below is about a document of this
+// test's own invention.
+func TestHw293DeliveredValue_MatchesLiveDigest(t *testing.T) {
+	if got := len(hw293DeliveredValue); got != hw293LiveBytes {
+		t.Fatalf("fixture drifted from the live Secret value: %d bytes, want %d", got, hw293LiveBytes)
+	}
+	sum := sha256.Sum256([]byte(hw293DeliveredValue))
+	if got := hex.EncodeToString(sum[:])[:len(hw293LiveDigest)]; got != hw293LiveDigest {
+		t.Fatalf("fixture sha256 prefix = %s, want %s (the live value)", got, hw293LiveDigest)
+	}
+}
+
+// TestHw293DeliveredValue_PassesTheBytesContract states the defect in the
+// contract's own terms: the document that left region B credential-less is
+// USABLE. This is not a bug in Defects — it is the reason Defects alone could
+// not be the whole answer, and if it ever starts failing here the premise of
+// delivery.go has changed and its header must change with it.
+func TestHw293DeliveredValue_PassesTheBytesContract(t *testing.T) {
+	if d := Defects(hw293DeliveredValue); len(d) != 0 {
+		t.Fatalf("premise broken: the live value now has bytes-level defects %v — delivery.go's rationale needs rewriting", d)
+	}
+	if !Usable(hw293DeliveredValue) {
+		t.Fatal("premise broken: the live value is no longer Usable")
+	}
+	if got := Endpoint(hw293DeliveredValue); got != "https://212.72.24.6:6443" {
+		t.Fatalf("Endpoint = %q, want the live value's server URL", got)
+	}
+	if got := EndpointHostPort(hw293DeliveredValue, "6443"); got != "212.72.24.6:6443" {
+		t.Fatalf("EndpointHostPort = %q, want 212.72.24.6:6443", got)
+	}
+}
+
+// TestDeliveryDefects_Hw293 is the RED case: the live value must be refused as
+// a delivery, and the reason must name the endpoint proof rather than
+// something vague.
+func TestDeliveryDefects_Hw293(t *testing.T) {
+	// The oracle proves only the two real regions, exactly as a live probe
+	// would: 212.72.24.6 answers nothing (no ICMP, no :443, 12s timeout on
+	// :6443, measured 2026-08-11).
+	oracle := provenEndpoints("https://212.72.24.43:6443", "https://212.72.24.25:6443")
+
+	got := DeliveryDefects(hw293DeliveredValue, Delivery{
+		RegionKey:       "me-east-215-b-1",
+		DeclaredRegions: hw293DeclaredRegions,
+		EndpointProven:  oracle,
+	})
+	if len(got) == 0 {
+		t.Fatal("the live hw293 value was accepted as a DELIVERY — a well-formed, credentialled document pointing at neither region is a mis-delivery, not a delivery")
+	}
+	if DescribeDefects(got) != DefectEndpointUnproven {
+		t.Fatalf("defects = %v, want exactly [%s]: the region key IS declared and the bytes ARE usable, so the endpoint proof must be the sole discriminator",
+			got, DefectEndpointUnproven)
+	}
+
+	// CONTROL — same everything, real endpoint. Must be a delivery.
+	if got := DeliveryDefects(genuineRegionBValue, Delivery{
+		RegionKey:       "me-east-215-b-1",
+		DeclaredRegions: hw293DeclaredRegions,
+		EndpointProven:  oracle,
+	}); len(got) != 0 {
+		t.Fatalf("the CONTROL — a genuinely usable kubeconfig at a declared region — was refused: %v", got)
+	}
+}
+
+// TestDeliveryDefects_NoOracleIsNoVerdict pins the non-regression guarantee: a
+// consumer that cannot probe gets exactly the bytes-only answer it got before
+// this file existed. A package that invented a reachability verdict without an
+// oracle would be reporting from absent evidence.
+func TestDeliveryDefects_NoOracleIsNoVerdict(t *testing.T) {
+	if got := DeliveryDefects(hw293DeliveredValue, Delivery{
+		RegionKey:       "me-east-215-b-1",
+		DeclaredRegions: hw293DeclaredRegions,
+	}); len(got) != 0 {
+		t.Fatalf("with no oracle the verdict must match Defects (empty), got %v", got)
+	}
+	if got := DeliveryDefects(hw293DeliveredValue, Delivery{}); len(got) != 0 {
+		t.Fatalf("a zero Delivery must behave exactly like Defects, got %v", got)
+	}
+}
+
+// TestDeliveryDefects_BytesVerdictWins — an unusable document reports its
+// SECTIONS, never the downstream consequences of being unusable. Burying
+// "users" under "endpoint-absent" would make the operator chase the wrong
+// thing.
+func TestDeliveryDefects_BytesVerdictWins(t *testing.T) {
+	const stub = `apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://212.72.24.6:6443
+  name: c`
+	got := DescribeDefects(DeliveryDefects(stub, Delivery{
+		RegionKey:       "nowhere-9",
+		DeclaredRegions: hw293DeclaredRegions,
+		EndpointProven:  provenEndpoints(),
+	}))
+	const want = "contexts,current-context,users"
+	if got != want {
+		t.Fatalf("defects = %q, want %q — the bytes verdict must not be diluted by attribution findings", got, want)
+	}
+}
+
+// TestDeliveryDefects_Attribution covers check 1 on its own, with the endpoint
+// proof satisfied so attribution is the only thing under test.
+func TestDeliveryDefects_Attribution(t *testing.T) {
+	oracle := provenEndpoints("https://212.72.24.25:6443")
+
+	// A key from a topology this Sovereign does not have.
+	if got := DescribeDefects(DeliveryDefects(genuineRegionBValue, Delivery{
+		RegionKey:       "nbg1-1",
+		DeclaredRegions: hw293DeclaredRegions,
+		EndpointProven:  oracle,
+	})); got != DefectRegionUndeclared {
+		t.Fatalf("defects = %q, want %q for a region key the deployment does not declare", got, DefectRegionUndeclared)
+	}
+
+	// CONTROL — the declared key attributes cleanly.
+	if got := DeliveryDefects(genuineRegionBValue, Delivery{
+		RegionKey:       "me-east-215-b-1",
+		DeclaredRegions: hw293DeclaredRegions,
+		EndpointProven:  oracle,
+	}); len(got) != 0 {
+		t.Fatalf("the declared region key was refused: %v", got)
+	}
+
+	// CONTROL — no witness means no verdict, never a worse one. A Sovereign
+	// with an empty CATALYST_CONFIGURED_REGIONS behaves as it did before.
+	if got := DeliveryDefects(genuineRegionBValue, Delivery{
+		RegionKey:      "nbg1-1",
+		EndpointProven: oracle,
+	}); len(got) != 0 {
+		t.Fatalf("with no declared-region witness the attribution check must not fire, got %v", got)
+	}
+}
+
+// TestRegionDeclared covers the token matcher directly, including the
+// off-by-one neighbour that string containment would have accepted.
+func TestRegionDeclared(t *testing.T) {
+	cases := []struct {
+		name     string
+		key      string
+		declared []string
+		want     bool
+	}{
+		{"live hw293 secondary", "me-east-215-b-1", hw293DeclaredRegions, true},
+		{"live hw293 primary", "me-east-215-a-1", hw293DeclaredRegions, true},
+		{"no ordinal suffix", "me-east-215-b", hw293DeclaredRegions, true},
+		{"underscore separators", "me_east_215_b_1", hw293DeclaredRegions, true},
+		{"uppercase", "ME-EAST-215-B-1", hw293DeclaredRegions, true},
+		{"declared is the shorter run", "hw-me-east-215-b-rtz-prod-1", []string{"me-east-215-b"}, true},
+		// The reason this is token containment and not strings.Contains: a
+		// NEIGHBOURING region must not be accepted as this one.
+		{"neighbouring region", "me-east-21-b-1", hw293DeclaredRegions, false},
+		{"prefix of a declared token", "me-east-2", hw293DeclaredRegions, false},
+		{"foreign provider region", "nbg1-1", hw293DeclaredRegions, false},
+		{"empty key", "", hw293DeclaredRegions, false},
+		// A bare number is a run inside the declared list ([215] sits in
+		// [hw me east 215 b rtz prod]) and must NOT attribute on that alone.
+		{"bare number does not attribute", "215", hw293DeclaredRegions, false},
+		// The short-key escape hatch: a one-token provider region attributes
+		// when it EQUALS the declared identifier, so Hetzner-shaped keys keep
+		// working under the minimum-run rule.
+		{"short provider key equal to declared", "fsn1-1", []string{"fsn1", "hel1"}, true},
+		{"short provider key not declared", "nbg1-1", []string{"fsn1", "hel1"}, false},
+		{"no declared regions", "me-east-215-b-1", nil, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := RegionDeclared(tc.key, tc.declared); got != tc.want {
+				t.Fatalf("RegionDeclared(%q, %v) = %v, want %v", tc.key, tc.declared, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestEndpoint_CurrentContextWins — the endpoint reported must be the one the
+// client would actually dial. A document with two clusters where the
+// current-context names the second would otherwise be described by the first,
+// and an operator would chase an address the process never used.
+func TestEndpoint_CurrentContextWins(t *testing.T) {
+	const twoClusters = `apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://212.72.24.43:6443
+  name: a
+- cluster:
+    server: https://212.72.24.25:6443
+  name: b
+contexts:
+- name: cb
+  context:
+    cluster: b
+    user: u
+current-context: cb
+users:
+- name: u
+  user:
+    token: fake-token`
+	if got := Endpoint(twoClusters); got != "https://212.72.24.25:6443" {
+		t.Fatalf("Endpoint = %q, want the current context's cluster server", got)
+	}
+	if got := Endpoint("not: [a kubeconfig"); got != "" {
+		t.Fatalf("Endpoint on unparseable input = %q, want empty", got)
+	}
+	if got := EndpointHostPort(`apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://cp.example.internal
+  name: c`, "6443"); got != "cp.example.internal:6443" {
+		t.Fatalf("EndpointHostPort without an explicit port = %q, want the default applied", got)
+	}
+}
+
+// TestOracleReceivesTheServerURL pins the argument the oracle is handed, and
+// TestHostPort pins the URL-in helper it needs. Both exist because the first
+// wiring of this seam fed a server URL to EndpointHostPort — a raw-bytes
+// function — which returned "" and made the probe answer "unreachable" for
+// EVERY document, including genuine ones. That is a check failing closed for a
+// reason unrelated to what it claims to measure, and no assertion in the
+// package caught it: the oracle was a test stub that never looked at its
+// argument.
+func TestOracleReceivesTheServerURL(t *testing.T) {
+	var seen []string
+	DeliveryDefects(genuineRegionBValue, Delivery{
+		RegionKey:       "me-east-215-b-1",
+		DeclaredRegions: hw293DeclaredRegions,
+		EndpointProven: func(endpoint string) bool {
+			seen = append(seen, endpoint)
+			return true
+		},
+	})
+	if len(seen) != 1 || seen[0] != "https://212.72.24.25:6443" {
+		t.Fatalf("oracle was called with %v, want exactly [https://212.72.24.25:6443] — the SERVER URL, not the document and not a host", seen)
+	}
+}
+
+func TestHostPort(t *testing.T) {
+	cases := []struct{ in, def, want string }{
+		{"https://212.72.24.25:6443", "6443", "212.72.24.25:6443"},
+		{"https://cp.example.internal", "6443", "cp.example.internal:6443"},
+		{"https://[2001:db8::1]:6443", "6443", "[2001:db8::1]:6443"},
+		{"", "6443", ""},
+		{"::not a url::", "6443", ""},
+	}
+	for _, tc := range cases {
+		if got := HostPort(tc.in, tc.def); got != tc.want {
+			t.Errorf("HostPort(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestDeliveryDefects_CanFail is the VACUITY CHECK. Every assertion above is
+// an equality against a value; this one proves the new machinery is capable of
+// producing a non-empty verdict at all, from a document that differs from the
+// accepted control ONLY in its endpoint. Without it, an implementation that
+// returned nil unconditionally would pass every green assertion in the file.
+func TestDeliveryDefects_CanFail(t *testing.T) {
+	oracle := provenEndpoints("https://212.72.24.25:6443")
+	accepted := DeliveryDefects(genuineRegionBValue, Delivery{
+		RegionKey:       "me-east-215-b-1",
+		DeclaredRegions: hw293DeclaredRegions,
+		EndpointProven:  oracle,
+	})
+	refused := DeliveryDefects(
+		strings.Replace(genuineRegionBValue, "212.72.24.25", "212.72.24.6", 1),
+		Delivery{
+			RegionKey:       "me-east-215-b-1",
+			DeclaredRegions: hw293DeclaredRegions,
+			EndpointProven:  oracle,
+		})
+	if len(accepted) != 0 {
+		t.Fatalf("control refused: %v", accepted)
+	}
+	if len(refused) == 0 {
+		t.Fatal("VACUITY: flipping the endpoint (the single byte-level difference) changed nothing — the new assertion cannot fail")
+	}
+	if DescribeDefects(refused) == DescribeDefects(accepted) {
+		t.Fatal("VACUITY: accepted and refused describe identically")
+	}
+	if DescribeDefects(nil) != "none" {
+		t.Fatal("DescribeDefects must name the empty case explicitly")
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/cutover_secondary_kubeconfigs.go
+++ b/products/catalyst/bootstrap/api/internal/handler/cutover_secondary_kubeconfigs.go
@@ -81,6 +81,7 @@ package handler
 import (
 	"context"
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"sort"
@@ -90,6 +91,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openova-io/openova/core/controllers/pkg/kubeconfig"
 )
 
 // envCutoverSecondaryKubeconfigsSecret overrides the Secret name (runtime-
@@ -481,36 +484,49 @@ func (h *Handler) materializeSecondaryKubeconfigsSecret(ctx context.Context, dep
 		// non-empty values, and not annotated for a different deployment)
 		// — a chain whose region-B legs would silently no-op still aborts
 		// below.
-		if n, ok := h.acceptMaterializedSecondaryKubeconfigsSecret(ctx, deps, name, expected, res.depID); ok {
+		n, ok, refusal := h.acceptMaterializedSecondaryKubeconfigsSecret(ctx, deps, name, expected, res)
+		if ok {
 			return n, nil
 		}
-
 		sort.Strings(missing)
 		secretRef := deps.ns + "/" + name
+		// abort carries the #6107 refusal into the ERROR, not only into a log
+		// line. Every message below ends with "no already-materialized Secret
+		// satisfies the expected count", which is true and useless when the
+		// Secret is right there: an operator reads it, finds the object, sees a
+		// parseable credential with a token in it, and has been told nothing
+		// about why the platform will not use it.
+		abort := func(format string, args ...any) (int, error) {
+			msg := fmt.Sprintf(format, args...)
+			if refusal != "" {
+				msg += " — " + refusal
+			}
+			return 0, fmt.Errorf("%s", msg)
+		}
 		switch {
 		case res.depID == "" && len(res.ambiguousPrefixes) > 0:
 			// #5488 task 3 — ambiguous on-disk fallback: never silently
 			// pick one of several deployment prefixes.
-			return 0, fmt.Errorf(
+			return abort(
 				"cutover: the resolved deployment record carries an EMPTY deployment id (degraded record after a catalyst-api restart, #5488) and %d distinct deployment prefixes exist on disk in %s (%s) — refusing to guess which one is this Sovereign's; expected %d secondary region(s) and no already-materialized %s Secret satisfies them. Recovery: re-import the deployment record (POST /api/v1/internal/deployments/import from the mothership) so the record can name its own id, then re-fire the cutover (#5359 fail-loud contract preserved)",
 				len(res.ambiguousPrefixes), secondaryKubeconfigsDir(), strings.Join(res.ambiguousPrefixes, ", "), expected, secretRef)
 		case res.depID == "":
 			// #5488 task 1 — the empty-ID record is its own diagnosable
 			// condition, not "0 readable".
-			return 0, fmt.Errorf(
+			return abort(
 				"cutover: the resolved deployment record carries an EMPTY deployment id (degraded record after a catalyst-api restart, #5488) while its spec expects %d secondary region(s) — the on-disk <depID>-<regionKey>.yaml kubeconfig paths in %s cannot be derived from a blank id, and no already-materialized %s Secret satisfies the expected count. Recovery: re-import the deployment record (POST /api/v1/internal/deployments/import from the mothership) or re-POST the secondary kubeconfig(s) via /sovereign/secondary-kubeconfig, then re-fire the cutover (#5359 fail-loud contract preserved)",
 				expected, secondaryKubeconfigsDir(), secretRef)
 		case len(paths) == 0:
 			// #5488 task 2 — an empty candidate map is "we never looked",
 			// not "the files were unreadable". Say so instead of printing
 			// an empty missing list.
-			return 0, fmt.Errorf(
+			return abort(
 				"cutover: deployment %s expects %d secondary region(s) but no candidate kubeconfig paths resolved (the in-memory secondary-kubeconfig map is empty — typical after a catalyst-api restart — and no %s-<regionKey>.yaml files were found in %s), and no already-materialized %s Secret satisfies the expected count — refusing to start a cutover whose region-B pivot legs would silently no-op (#5359)",
 				res.depID, expected, res.depID, secondaryKubeconfigsDir(), secretRef)
 		default:
 			// Original #5359 contract: candidate paths existed but the
 			// files are genuinely missing/unreadable/unusable — name each.
-			return 0, fmt.Errorf(
+			return abort(
 				"cutover: deployment %s expects %d secondary region(s) but only %d kubeconfig(s) are USABLE (rejected: %s) — refusing to start a cutover whose region-B pivot legs would silently no-op (#5359)",
 				res.depID, expected, len(data), strings.Join(missing, ", "))
 		}
@@ -608,39 +624,188 @@ func (h *Handler) materializeSecondaryKubeconfigsSecret(ctx context.Context, dep
 //     is foreign and is NOT accepted.
 //
 // Returns (key count, true) on acceptance.
-func (h *Handler) acceptMaterializedSecondaryKubeconfigsSecret(ctx context.Context, deps *cutoverDeps, name string, expected int, depID string) (int, bool) {
+//
+// #6107 — WHY A USABLE KEY COUNT IS NOT ENOUGH, MEASURED
+// -------------------------------------------------------
+// This arm accepted the hw293 (dep a0077ba47e3720e5) Secret every 60 seconds
+// for hours, on the record:
+//
+//	03:06:40 … "accepting as-is" … keys=1 expected=1
+//	03:07:40 … "accepting as-is" … keys=1 expected=1
+//	03:08:40 … "accepting as-is" … keys=1 expected=1
+//
+// Its single key `me-east-215-b-1.yaml` held 219 bytes (sha256
+// 881231f95cd49646…) that pass the shared usability contract completely — five
+// sections, a resolvable current-context, a bearer credential — and name
+// `https://212.72.24.6:6443`, which is NEITHER of this deployment's regions
+// (A answers on .43, B on .25, each proven by its own apiserver certificate's
+// SANs) and answers nothing at all. Those bytes are, to the byte, this
+// repository's own test control fixture `completeKubeconfigSameCluster`.
+//
+// Three consequences followed, and the third is the one that made #6112 and
+// #6116 inert on that Sovereign:
+//
+//  1. The chroot's kubeconfigs dir was EMPTY — region B had never been
+//     delivered at all — so nothing this function could have produced existed.
+//  2. Acceptance short-circuited the producer: materializeSecondaryKubeconfigs-
+//     Secret returns here BEFORE its write, so the mis-delivered value is
+//     STICKY. A correct delivery landing later cannot displace it, because the
+//     pass that would write it never reaches the write.
+//  3. Downstream, every Organization read fully provisioned while region B
+//     held zero per-Org console listeners.
+//
+// So acceptance now requires CORROBORATION — evidence, from outside the Secret
+// itself, that the Secret is what this process would have written:
+//
+//   - PROVENANCE: at least one secondary kubeconfig file exists on disk for a
+//     candidate deployment prefix. This arm exists because a restart wipes the
+//     process-local PATH MAP while the FILES remain (the hw291 #5488 case,
+//     where the on-disk fallback globbed a leading dash and matched nothing).
+//     It was never meant to substitute for a delivery that never happened. An
+//     empty directory is not a lost path map; it is an undelivered region.
+//   - or PROOF: every counted key names an endpoint that answers on the
+//     apiserver port. A credential whose endpoint has never been reached is
+//     not evidence that a prior run materialized anything.
+//
+// Either suffices, which is what keeps this from over-correcting: a genuine
+// post-restart recovery still passes on its files alone (no dial), and a
+// Sovereign whose files were legitimately reaped still passes on a reachable
+// endpoint. Only the state with NEITHER — no files and a dead endpoint — is
+// refused, and that is exactly hw293.
+// The third return is the operator-facing reason the Secret was NOT accepted,
+// empty when there was nothing to refuse (no Secret, or acceptance). The
+// caller appends it to whichever abort message it selects: a refusal that
+// exists only in a log line leaves the ERROR saying "no already-materialized
+// Secret satisfies the expected count" about an object that is plainly sitting
+// in the namespace, which is the state an operator would then go looking for
+// and find.
+func (h *Handler) acceptMaterializedSecondaryKubeconfigsSecret(ctx context.Context, deps *cutoverDeps, name string, expected int, res secondaryKubeconfigResolution) (int, bool, string) {
 	if expected <= 0 {
-		return 0, false // single-region never needs recovery.
+		return 0, false, "" // single-region never needs recovery.
 	}
+	depID := res.depID
 	existing, err := deps.core.CoreV1().Secrets(deps.ns).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
-		return 0, false
+		return 0, false, ""
 	}
 	if depID != "" {
 		if ann := strings.TrimSpace(existing.Annotations["catalyst.openova.io/deployment-id"]); ann != "" && ann != depID {
-			return 0, false // materialized for a different deployment.
+			return 0, false, fmt.Sprintf(
+				"the already-materialized %s/%s Secret is annotated for deployment %q, not this one",
+				deps.ns, name, ann) // materialized for a different deployment.
 		}
 	}
+
+	// PROVENANCE — did this process lose track of files that exist, or was the
+	// region simply never delivered? `paths` is the union of the in-memory map
+	// and the on-disk `<prefix>-<regionKey>.yaml` files, and ambiguousPrefixes
+	// records the case where files exist but could not be attributed to a
+	// deployment. Either means there is something on disk to have lost.
+	corroborated := len(res.paths) > 0 || len(res.ambiguousPrefixes) > 0
+
 	// USABILITY, not presence (#6027). `len(v) > 0` accepted the 95-byte
 	// hw293 stub here exactly as it did on the read path — and this arm is
 	// the one that runs when the process cannot re-derive its own on-disk
 	// paths, i.e. precisely when nothing else would catch it. A key that
 	// cannot build a client does not count toward the expected total.
-	n := 0
-	for _, v := range existing.Data {
-		if len(v) > 0 && secondaryKubeconfigUsable(string(v)) {
-			n++
+	//
+	// DELIVERY, not usability (#6107). When provenance is absent the endpoint
+	// must be proven instead, through the shared contract so the producer and
+	// every reader ask one question. `regionsFromEnv()` is the same declared-
+	// region witness the count is taken from.
+	declared := regionsFromEnv()
+	n, refused := 0, []string{}
+	for key, v := range existing.Data {
+		if len(v) == 0 {
+			continue
 		}
+		delivery := kubeconfig.Delivery{
+			RegionKey:       strings.TrimSuffix(strings.TrimSuffix(key, ".yaml"), ".yml"),
+			DeclaredRegions: declared,
+		}
+		if !corroborated {
+			delivery.EndpointProven = h.secondaryEndpointProven
+		}
+		if defects := kubeconfig.DeliveryDefects(string(v), delivery); len(defects) > 0 {
+			refused = append(refused, fmt.Sprintf("%s (%d bytes, endpoint %s, %s)",
+				key, len(v), describeEndpoint(string(v)), kubeconfig.DescribeDefects(defects)))
+			continue
+		}
+		n++
 	}
 	if n < expected {
-		return 0, false
+		sort.Strings(refused)
+		reason := fmt.Sprintf(
+			"the already-materialized %s/%s Secret is present but is NOT a delivery (#6107): %d of %d key(s) qualify, on-disk corroboration=%v, declared regions=[%s], refused: %s",
+			deps.ns, name, n, expected, corroborated, strings.Join(declared, ","), describeRefusals(refused))
+		// LOUD, not silent. The pre-#6107 arm returned false here with no log
+		// line at all, so a Sovereign in this state showed only the caller's
+		// generic shortfall message and nothing about the Secret that was
+		// sitting there looking complete.
+		h.log.Warn("cutover: the already-materialized secondary-kubeconfigs Secret is NOT a delivery — refusing to accept it as one (#6107). A credential that parses and carries a token but names an endpoint this deployment never answered on is a MIS-delivery: accepting it makes the value sticky, because acceptance returns before the write that would replace it",
+			"secret", deps.ns+"/"+name,
+			"usableKeys", n,
+			"expected", expected,
+			"onDiskCorroboration", corroborated,
+			"declaredRegions", strings.Join(declared, ","),
+			"refused", describeRefusals(refused),
+			"deploymentID", depID,
+			"remedy", "deliver the peer region's kubeconfig (POST /api/v1/sovereign/secondary-kubeconfig) so this Sovereign materializes the Secret from a file it holds")
+		return 0, false, reason
 	}
 	h.log.Info("cutover: secondary kubeconfigs Secret already materialized by a prior run — accepting as-is (#5488 recovery: process-local paths unresolvable after a catalyst-api restart)",
 		"secret", deps.ns+"/"+name,
 		"keys", n,
 		"expected", expected,
+		"onDiskCorroboration", corroborated,
 		"deploymentID", depID)
-	return n, true
+	return n, true, ""
+}
+
+// describeRefusals renders the per-key refusal list, naming the empty case
+// rather than rendering nothing at all — "refused: " with no tail reads as a
+// message that lost its content.
+func describeRefusals(refused []string) string {
+	if len(refused) == 0 {
+		return "none"
+	}
+	return strings.Join(refused, "; ")
+}
+
+// secondaryEndpointProven is the endpoint oracle this component legitimately
+// has: a TCP connect to the apiserver port, the same probe #4000's self-heal
+// already uses to decide whether a kubeconfig needs healing at all. It is a
+// method so a test can replace it through h.secondaryEndpointProbe without
+// dialling anything.
+//
+// A dial is affordable here precisely because this path is rare: it runs only
+// when the producer could NOT build the Secret from its own files, at most
+// once per materializer tick, and only for the keys of one Secret.
+func (h *Handler) secondaryEndpointProven(endpoint string) bool {
+	probe := h.secondaryEndpointProbe
+	if probe == nil {
+		probe = hostReachable
+	}
+	hostPort := kubeconfig.HostPort(endpoint, secondaryHealPort)
+	if hostPort == "" {
+		return false
+	}
+	host, _, err := net.SplitHostPort(hostPort)
+	if err != nil {
+		return false
+	}
+	return probe(host)
+}
+
+// describeEndpoint renders a document's server URL for an operator-facing log
+// line, naming the empty case rather than printing "". The URL is not a
+// secret: it is the address half of the credential, and an operator cannot act
+// on a refusal that will not say where the refused document pointed.
+func describeEndpoint(raw string) string {
+	if e := kubeconfig.Endpoint(raw); e != "" {
+		return e
+	}
+	return "none"
 }
 
 // reapSecondaryCutoverEgressPolicies is the #5014 backstop's region-B

--- a/products/catalyst/bootstrap/api/internal/handler/cutover_secondary_kubeconfigs_5488_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/cutover_secondary_kubeconfigs_5488_test.go
@@ -126,8 +126,18 @@ func writeKubeconfigFile5488(t *testing.T, dir, stem string) {
 // in-memory paths map, and nothing derivable on disk — the exact hw291
 // post-restart state. Before the #5488 fallback change this returned the
 // "(missing/unreadable: )" abort; reverting the change makes this fail.
+//
+// #6107 — with nothing on disk there is no PROVENANCE corroboration, so
+// acceptance now rests on the other one: the endpoint the Secret's credential
+// names must answer. hw291's did; hw293's did not, and that is the whole
+// difference between this case and
+// TestSecondaryKubeconfigSecret_6107_MisDeliveredEndpointIsNotRecovery. The
+// probe is injected so no unit test dials, and it is the SUBJECT of this
+// case's twin below (…_NoCorroborationAndDeadEndpoint), which flips only this
+// one input and must abort.
 func TestMaterializeSecondaryKubeconfigs_5488_AcceptsAlreadyMaterializedSecret(t *testing.T) {
 	h, deps, _ := newFixture5488(t, "", 2)
+	h.secondaryEndpointProbe = func(string) bool { return true }
 	seedMaterializedSecret5488(t, deps, "", "me-east-215-b-1.yaml")
 
 	n, err := h.materializeSecondaryKubeconfigsSecret(context.Background(), deps)

--- a/products/catalyst/bootstrap/api/internal/handler/handler.go
+++ b/products/catalyst/bootstrap/api/internal/handler/handler.go
@@ -100,6 +100,14 @@ type Handler struct {
 	secondaryKubeconfigSecretState   string
 	secondaryKubeconfigSecretStateMu sync.Mutex
 
+	// secondaryEndpointProbe (#6107) — the endpoint oracle the #5488 recovery
+	// arm consults when it has no on-disk corroboration for an
+	// already-materialized Secret. Nil uses hostReachable, the same TCP probe
+	// #4000's self-heal makes; tests inject a pure function so no unit test
+	// ever dials. Takes the host (no port) and answers whether an apiserver
+	// responds there.
+	secondaryEndpointProbe func(host string) bool
+
 	// orphanReleaseWG tracks the releaseOrphanedReservation goroutines that
 	// restoreFromStore fires (#489). Those goroutines outlive the call that
 	// spawned them: after pdm.Release returns they clear the dep's PDM

--- a/products/catalyst/bootstrap/api/internal/handler/secondary_kubeconfig_misdelivery_6107_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/secondary_kubeconfig_misdelivery_6107_test.go
@@ -1,0 +1,330 @@
+// secondary_kubeconfig_misdelivery_6107_test.go — the THIRD bridge state.
+//
+// THE MEASURED ARTEFACT (hw293, dep a0077ba47e3720e5, 2026-08-11)
+// ---------------------------------------------------------------
+//
+//	/var/lib/catalyst/kubeconfigs/                    EMPTY — region B was never delivered
+//	Secret catalyst/cutover-secondary-kubeconfigs
+//	  annotations: deployment-id=a0077ba47e3720e5, materialized=2026-08-11T01:46:02Z
+//	  me-east-215-b-1.yaml   219 bytes   sha256 881231f95cd49646…
+//	  server: https://212.72.24.6:6443
+//	catalyst-system/sovereign-fqdn  configuredRegions=
+//	  hw-me-east-215-a-rtz-prod,hw-me-east-215-b-rtz-prod
+//
+//	catalyst-api, every 60 seconds, for hours:
+//	  03:06:40 "accepting as-is" keys=1 expected=1
+//	  03:07:40 "accepting as-is" keys=1 expected=1
+//	  03:08:40 "accepting as-is" keys=1 expected=1
+//	and, in the same log, for all six Organizations:
+//	  "this Sovereign DECLARES more regions than carry a per-Org console
+//	   listener" regions_declared=2 regions_written=1 regions=host
+//
+// `212.72.24.6` is neither region. Region A's apiserver answers on
+// `212.72.24.43` and region B's on `212.72.24.25`; each proves its own
+// identity through its serving certificate's SANs
+// (`…-me-east-215-a-cp1-…` / `…-me-east-215-b-cp1-…`, one shared k3s CA).
+// `212.72.24.6` answers nothing: no ICMP, no :443, 12s timeout on :6443.
+//
+// WHY THE MERGED FIXES WERE INERT HERE
+// ------------------------------------
+// #6054 stopped a credential-less shell being RECEIVED. #6112/#6116 stopped
+// one being FORWARDED and CREATED. #6121 gave writer and reader one usability
+// contract. Every one of them measures the same thing: can these bytes build a
+// client. This value can. It is not a delivery all the same, and the arm that
+// let it stand is the #5488 recovery arm — which short-circuits
+// materializeSecondaryKubeconfigsSecret BEFORE its write. So the mis-delivered
+// value is STICKY: a correct delivery landing later cannot displace it,
+// because the pass that would write it returns before the write. That is what
+// makes this the state in which the merged fixes cannot act.
+//
+// WHAT IS ASSERTED, AND THE CONTROLS
+// ----------------------------------
+// Acceptance now requires CORROBORATION — provenance (files on disk) OR proof
+// (the endpoint answers) — and every case below flips exactly one of those
+// inputs against a control that must answer the other way:
+//
+//   - MisDeliveredEndpointIsNotRecovery — the live state. REFUSED.
+//   - ProvenEndpointIsRecovery — CONTROL, same document shape, live endpoint.
+//     ACCEPTED, so the rule is not "refuse everything".
+//   - OnDiskProvenanceNeedsNoProbe — CONTROL, the genuine hw291 #5488 case.
+//     ACCEPTED without the oracle being consulted at all.
+//   - AbsentSecretStillAborts — CONTROL, the #5359/#5488 message is unchanged
+//     for the case it was written for.
+//   - MisDeliveryIsReportedNotMaterialized — the operator-visible consequence:
+//     the level-triggered loop must settle on `incomplete:` naming the refused
+//     endpoint, not on `materialized:1`. Its second half is the convergence
+//     control — a real delivery still lands.
+//   - VacuityOfTheEndpointProof — flipping only the endpoint changes the
+//     verdict.
+//
+// Refs #5359 #5488 #6015 #6027 #6104 #6107 #6112 #6116.
+package handler
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	fakek8s "k8s.io/client-go/kubernetes/fake"
+
+	"github.com/openova-io/openova/core/controllers/pkg/kubeconfig"
+)
+
+// hw293DeliveredValue is the live Secret value, byte-for-byte. It is
+// `completeKubeconfigSameCluster` without its trailing newline — 219 bytes
+// against the fixture's 220 — which is exactly how the live artefact reads.
+// The equality is asserted, not assumed, by TestHw293_DeliveredValueIsThe
+// ControlFixture below: the document a live Sovereign accepted as its region-B
+// credential is this repository's own "usable" control.
+var hw293DeliveredValue = strings.TrimSuffix(completeKubeconfigSameCluster, "\n")
+
+// hw293DeadEndpointHost is the host that value names. Nothing answers there.
+const hw293DeadEndpointHost = "212.72.24.6"
+
+// hw293RegionBHost is region B's real apiserver, proven by its certificate.
+const hw293RegionBHost = "212.72.24.25"
+
+// genuineRegionBKubeconfig is the CONTROL document: identical in every
+// property that made the live value pass the usability contract — five
+// sections, resolvable current-context, bearer-shaped credential, same
+// brevity — and differing ONLY in the endpoint it names.
+var genuineRegionBKubeconfig = strings.Replace(
+	hw293DeliveredValue, hw293DeadEndpointHost, hw293RegionBHost, 1)
+
+// hw293MisdeliveryFixture is recordlessChrootFixture WITHOUT the on-disk
+// primary kubeconfig: on the live Sovereign the kubeconfigs directory was
+// empty, which is precisely why there was no provenance to corroborate the
+// Secret with. Returns the handler, the fake clientset, the deps, and a
+// pointer to a counter the injected oracle increments.
+func hw293MisdeliveryFixture(t *testing.T, endpointAnswers bool) (*Handler, *fakek8s.Clientset, *cutoverDeps, *int) {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("CATALYST_K8SCACHE_KUBECONFIGS_DIR", dir)
+	t.Setenv("SOVEREIGN_FQDN", "hw293.omantel.biz")
+	t.Setenv("CATALYST_CONFIGURED_REGIONS", "hw-me-east-215-a-rtz-prod,hw-me-east-215-b-rtz-prod")
+
+	h := NewWithPDM(silentLogger(), &fakePDM{}) // record-less, as measured
+	fake := fakek8s.NewSimpleClientset()
+	deps := &cutoverDeps{core: fake, ns: cutoverTestNS}
+	h.SetCutoverDepsFactory(func() (*cutoverDeps, error) { return deps, nil })
+	h.secondaryKubeconfigSecretInterval = 5 * time.Millisecond
+
+	probes := 0
+	h.secondaryEndpointProbe = func(host string) bool {
+		probes++
+		// The oracle answers for the real region only, exactly as a live TCP
+		// probe did. A stub that ignored its argument would make every case
+		// below pass for the wrong reason.
+		return endpointAnswers && host == hw293RegionBHost
+	}
+	return h, fake, deps, &probes
+}
+
+func seedBridgeSecret6107(t *testing.T, fake *fakek8s.Clientset, value string) {
+	t.Helper()
+	if _, err := fake.CoreV1().Secrets(cutoverTestNS).Create(context.Background(), &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        cutoverSecondaryKubeconfigsSecretName(),
+			Namespace:   cutoverTestNS,
+			Annotations: map[string]string{"catalyst.openova.io/deployment-id": "a0077ba47e3720e5"},
+		},
+		Data: map[string][]byte{"me-east-215-b-1.yaml": []byte(value)},
+	}, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("seed bridge Secret: %v", err)
+	}
+}
+
+// TestHw293_DeliveredValueIsTheControlFixture pins the premise. If this fails,
+// the fixture no longer reproduces the live artefact and every case below is
+// about a document of this test's own invention.
+func TestHw293_DeliveredValueIsTheControlFixture(t *testing.T) {
+	if got := len(hw293DeliveredValue); got != 219 {
+		t.Fatalf("live-value fixture is %d bytes, want 219 (the measured Secret value)", got)
+	}
+	if d := secondaryKubeconfigDefects(hw293DeliveredValue); len(d) != 0 {
+		t.Fatalf("premise broken: the live value now fails the bytes contract (%v) — this whole file exists because it PASSES it", d)
+	}
+	if got := kubeconfig.Endpoint(hw293DeliveredValue); got != "https://"+hw293DeadEndpointHost+":6443" {
+		t.Fatalf("live-value endpoint = %q, want the measured server URL", got)
+	}
+	// The control differs in the endpoint and NOTHING else.
+	if len(genuineRegionBKubeconfig) != len(hw293DeliveredValue)+1 {
+		t.Fatalf("control must differ from the live value only by the endpoint host (%d vs %d bytes)",
+			len(genuineRegionBKubeconfig), len(hw293DeliveredValue))
+	}
+}
+
+// TestSecondaryKubeconfigSecret_6107_MisDeliveredEndpointIsNotRecovery is the
+// RED case. Before this change it returned (1, nil) — "accepting as-is".
+func TestSecondaryKubeconfigSecret_6107_MisDeliveredEndpointIsNotRecovery(t *testing.T) {
+	h, fake, deps, probes := hw293MisdeliveryFixture(t, true)
+	seedBridgeSecret6107(t, fake, hw293DeliveredValue)
+
+	if n, ok, _ := h.acceptMaterializedSecondaryKubeconfigsSecret(context.Background(), deps,
+		cutoverSecondaryKubeconfigsSecretName(), 1, secondaryKubeconfigResolution{depID: "a0077ba47e3720e5"}); ok {
+		t.Fatalf("the live hw293 Secret satisfied the #5488 recovery check (n=%d) — a well-formed, credentialled document naming an endpoint this deployment never answered on is a MIS-delivery, and accepting it makes it permanent", n)
+	}
+	if *probes == 0 {
+		t.Fatal("the endpoint oracle was never consulted, so the refusal cannot have been about the endpoint")
+	}
+
+	// End to end: the whole materialization pass must abort, not report 1.
+	n, err := h.materializeSecondaryKubeconfigsSecret(context.Background(), deps)
+	if err == nil {
+		t.Fatalf("materialization reported success (n=%d) over a mis-delivered credential — the region-B legs and the per-Org console listener would both silently no-op", n)
+	}
+}
+
+// TestSecondaryKubeconfigSecret_6107_ProvenEndpointIsRecovery is the CONTROL
+// that shares the suspect property: the same document shape, the same absence
+// of on-disk provenance, the same declared region — and a live endpoint. It
+// must still be accepted, or the fix has over-corrected into "nothing is ever
+// recoverable".
+func TestSecondaryKubeconfigSecret_6107_ProvenEndpointIsRecovery(t *testing.T) {
+	h, fake, deps, probes := hw293MisdeliveryFixture(t, true)
+	seedBridgeSecret6107(t, fake, genuineRegionBKubeconfig)
+
+	n, ok, _ := h.acceptMaterializedSecondaryKubeconfigsSecret(context.Background(), deps,
+		cutoverSecondaryKubeconfigsSecretName(), 1, secondaryKubeconfigResolution{depID: "a0077ba47e3720e5"})
+	if !ok || n != 1 {
+		t.Fatalf("a genuinely usable credential at a DECLARED region was refused: n=%d ok=%v", n, ok)
+	}
+	if *probes == 0 {
+		t.Fatal("acceptance without consulting the oracle means the proof is decorative")
+	}
+}
+
+// TestSecondaryKubeconfigSecret_6107_OnDiskProvenanceNeedsNoProbe is the other
+// CONTROL: the genuine #5488 condition (hw291) — the files ARE on disk, the
+// process merely lost its path map. Acceptance rests on provenance, and the
+// oracle must not be consulted at all, so a peer region that is briefly down
+// during a restart cannot flip a correct Secret to refused.
+func TestSecondaryKubeconfigSecret_6107_OnDiskProvenanceNeedsNoProbe(t *testing.T) {
+	// endpointAnswers=false: even a DEAD endpoint must be accepted here,
+	// which is what proves provenance alone is sufficient.
+	h, fake, deps, probes := hw293MisdeliveryFixture(t, false)
+	seedBridgeSecret6107(t, fake, hw293DeliveredValue)
+
+	res := secondaryKubeconfigResolution{
+		depID: "a0077ba47e3720e5",
+		paths: map[string]string{"me-east-215-b-1": "/var/lib/catalyst/kubeconfigs/a0077ba47e3720e5-me-east-215-b-1.yaml"},
+	}
+	n, ok, _ := h.acceptMaterializedSecondaryKubeconfigsSecret(context.Background(), deps,
+		cutoverSecondaryKubeconfigsSecretName(), 1, res)
+	if !ok || n != 1 {
+		t.Fatalf("the hw291 #5488 condition (files on disk, path map lost) was refused: n=%d ok=%v", n, ok)
+	}
+	if *probes != 0 {
+		t.Fatalf("the oracle was consulted %d time(s) despite on-disk provenance — a peer region that blips during a restart would then flip a correct Secret to refused", *probes)
+	}
+
+	// And the ambiguous-prefix shape counts as provenance too: files exist,
+	// they just could not be attributed to a deployment.
+	ambiguous := secondaryKubeconfigResolution{ambiguousPrefixes: []string{"aaa111", "bbb222"}}
+	if _, ok, _ := h.acceptMaterializedSecondaryKubeconfigsSecret(context.Background(), deps,
+		cutoverSecondaryKubeconfigsSecretName(), 1, ambiguous); !ok {
+		t.Fatal("ambiguous on-disk prefixes are files this process could not attribute, not an undelivered region — the Secret must still win")
+	}
+}
+
+// TestSecondaryKubeconfigSecret_6107_AbsentSecretStillAborts is the CONTROL
+// for the case #5488 was actually written for: a genuinely ABSENT Secret still
+// produces the original diagnosable abort, not the new mis-delivery message.
+// Without it, "refuse more things" could be mistaken for a fix.
+func TestSecondaryKubeconfigSecret_6107_AbsentSecretStillAborts(t *testing.T) {
+	h, _, deps, _ := hw293MisdeliveryFixture(t, true)
+
+	_, err := h.materializeSecondaryKubeconfigsSecret(context.Background(), deps)
+	if err == nil {
+		t.Fatal("a Sovereign declaring 2 regions with no kubeconfig and no Secret must abort")
+	}
+	if !strings.Contains(err.Error(), "#5359") {
+		t.Errorf("the absent-Secret abort lost its #5359 contract reference: %s", err)
+	}
+	if strings.Contains(err.Error(), "MIS-delivery") {
+		t.Errorf("an ABSENT Secret was described as a mis-delivered one: %s", err)
+	}
+}
+
+// TestSecondaryKubeconfigSecret_6107_MisDeliveryIsReportedNotMaterialized is
+// the operator-visible consequence, and it is what makes the refusal worth
+// shipping rather than merely correct.
+//
+// The level-triggered materializer reports one state per pass, and it logs
+// only on a CHANGE — so whatever it settles on is what an operator sees for as
+// long as the condition lasts. While the arm accepted, it settled on
+// `materialized:1`: a Sovereign whose region B held no credential at all
+// reported, once, that the peer-region credential was in place, and then went
+// quiet. That is the same substitution one layer up in the reporting stack.
+//
+// The second half is the convergence CONTROL: refusing must not wedge the
+// Sovereign. The moment a real file is delivered, the same loop materializes
+// it and the state moves to `materialized:1` with region B's real endpoint in
+// the Secret.
+func TestSecondaryKubeconfigSecret_6107_MisDeliveryIsReportedNotMaterialized(t *testing.T) {
+	h, fake, _, _ := hw293MisdeliveryFixture(t, true)
+	seedBridgeSecret6107(t, fake, hw293DeliveredValue)
+
+	h.reconcileSecondaryKubeconfigsSecret(context.Background())
+	h.secondaryKubeconfigSecretStateMu.Lock()
+	state := h.secondaryKubeconfigSecretState
+	h.secondaryKubeconfigSecretStateMu.Unlock()
+	if !strings.HasPrefix(state, "incomplete:") {
+		t.Fatalf("the materializer settled on %q over a mis-delivered credential — a Sovereign whose region B holds no usable credential reported that one was in place, and the loop logs only on a state CHANGE, so that is what an operator sees until something else moves", state)
+	}
+	if !strings.Contains(state, hw293DeadEndpointHost) {
+		t.Errorf("the reported state does not name the endpoint that was refused, so an operator cannot act on it: %q", state)
+	}
+
+	// CONVERGENCE CONTROL — the refusal must not wedge the Sovereign.
+	dir := os.Getenv("CATALYST_K8SCACHE_KUBECONFIGS_DIR")
+	for stem, body := range map[string]string{
+		"a0077ba47e3720e5":                 genuineRegionBKubeconfig,
+		"a0077ba47e3720e5-me-east-215-b-1": genuineRegionBKubeconfig,
+	} {
+		if err := os.WriteFile(filepath.Join(dir, stem+".yaml"), []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	h.reconcileSecondaryKubeconfigsSecret(context.Background())
+	h.secondaryKubeconfigSecretStateMu.Lock()
+	state = h.secondaryKubeconfigSecretState
+	h.secondaryKubeconfigSecretStateMu.Unlock()
+	if state != "materialized:1" {
+		t.Fatalf("after a real delivery landed the materializer state is %q, want materialized:1 — the refusal wedged convergence", state)
+	}
+	sec, err := getBridgeSecret(t, fake)
+	if err != nil {
+		t.Fatalf("get bridge Secret: %v", err)
+	}
+	if got := kubeconfig.Endpoint(string(sec.Data["me-east-215-b-1.yaml"])); got != "https://"+hw293RegionBHost+":6443" {
+		t.Fatalf("materialized endpoint = %q, want region B's real apiserver", got)
+	}
+}
+
+// TestSecondaryKubeconfigSecret_6107_VacuityOfTheEndpointProof is the VACUITY
+// CHECK. Every green assertion above would also pass against an arm that
+// accepted unconditionally. This one flips ONE input — the endpoint host, one
+// substring of one fixture — and requires the verdict to change.
+func TestSecondaryKubeconfigSecret_6107_VacuityOfTheEndpointProof(t *testing.T) {
+	verdict := func(value string) bool {
+		h, fake, deps, _ := hw293MisdeliveryFixture(t, true)
+		seedBridgeSecret6107(t, fake, value)
+		_, ok, _ := h.acceptMaterializedSecondaryKubeconfigsSecret(context.Background(), deps,
+			cutoverSecondaryKubeconfigsSecretName(), 1, secondaryKubeconfigResolution{depID: "a0077ba47e3720e5"})
+		return ok
+	}
+	accepted := verdict(genuineRegionBKubeconfig)
+	refused := verdict(hw293DeliveredValue)
+	if !accepted {
+		t.Fatal("the control was refused — the gate cannot pass")
+	}
+	if refused {
+		t.Fatal("VACUITY: swapping the endpoint host changed nothing — the gate cannot fail")
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/secondary_kubeconfig_secret_materializer_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/secondary_kubeconfig_secret_materializer_test.go
@@ -227,6 +227,12 @@ func TestSecondaryKubeconfigSecret_StubIsRefused(t *testing.T) {
 func TestSecondaryKubeconfigSecret_StubInSecretIsNotAcceptedAsRecovery(t *testing.T) {
 	h, fake, _ := materializerFixture(t, 2) // 2 regions expected, NOTHING on disk
 	deps := &cutoverDeps{core: fake, ns: cutoverTestNS}
+	// This test isolates the CREDENTIAL axis, so the endpoint axis is held
+	// satisfied: the probe proves whatever host the fixtures name. Endpoint
+	// proof has its own test — TestSecondaryKubeconfigSecret_6107_* — and
+	// leaving it unproven here would let this case pass for the wrong reason.
+	h.secondaryEndpointProbe = func(string) bool { return true }
+	res := secondaryKubeconfigResolution{depID: "dep5359"}
 
 	if _, err := fake.CoreV1().Secrets(cutoverTestNS).Create(context.Background(), &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{Name: cutoverSecondaryKubeconfigsSecretName(), Namespace: cutoverTestNS},
@@ -235,8 +241,8 @@ func TestSecondaryKubeconfigSecret_StubInSecretIsNotAcceptedAsRecovery(t *testin
 		t.Fatalf("seed: %v", err)
 	}
 
-	if n, ok := h.acceptMaterializedSecondaryKubeconfigsSecret(context.Background(), deps,
-		cutoverSecondaryKubeconfigsSecretName(), 1, "dep5359"); ok {
+	if n, ok, _ := h.acceptMaterializedSecondaryKubeconfigsSecret(context.Background(), deps,
+		cutoverSecondaryKubeconfigsSecretName(), 1, res); ok {
 		t.Fatalf("a Secret whose only key is the 95-byte stub satisfied the recovery check (n=%d) — the count was of keys, not of credentials", n)
 	}
 
@@ -246,8 +252,8 @@ func TestSecondaryKubeconfigSecret_StubInSecretIsNotAcceptedAsRecovery(t *testin
 	if _, err := fake.CoreV1().Secrets(cutoverTestNS).Update(context.Background(), sec, metav1.UpdateOptions{}); err != nil {
 		t.Fatalf("update: %v", err)
 	}
-	if n, ok := h.acceptMaterializedSecondaryKubeconfigsSecret(context.Background(), deps,
-		cutoverSecondaryKubeconfigsSecretName(), 1, "dep5359"); !ok || n != 1 {
+	if n, ok, _ := h.acceptMaterializedSecondaryKubeconfigsSecret(context.Background(), deps,
+		cutoverSecondaryKubeconfigsSecretName(), 1, res); !ok || n != 1 {
 		t.Fatalf("the complete control was refused by the recovery check: n=%d ok=%v", n, ok)
 	}
 }


### PR DESCRIPTION
## The third bridge state — verified on hw293 before writing a line of code

The region-B kubeconfig chain was closed at four hops (receive #6054, produce
#6104, deliver #6112/#6116, read #6121) and the degradation on
`hw293.omantel.biz` (dep `a0077ba47e3720e5`) persisted anyway, through a state
none of them cover. Read-only measurement, 2026-08-11:

| what | measured |
|---|---|
| `catalyst-system/sovereign-fqdn` `configuredRegions` | `hw-me-east-215-a-rtz-prod,hw-me-east-215-b-rtz-prod` |
| region A apiserver | `212.72.24.43:6443` -> HTTP 401, cert SAN `…-me-east-215-a-cp1-e83482` |
| region B apiserver | `212.72.24.25:6443` -> HTTP 401, cert SAN `…-me-east-215-b-cp1-b9b630` |
| chroot `/var/lib/catalyst/kubeconfigs/` | **EMPTY** — region B was never delivered |
| `catalyst/cutover-secondary-kubeconfigs` | 1 key `me-east-215-b-1.yaml`, **219 bytes**, sha256 `881231f95cd49646…`, `deployment-id=a0077ba47e3720e5` |
| that key's `server:` | `https://212.72.24.6:6443` |
| `212.72.24.6` | no ICMP, no :443, **12s timeout on :6443** |
| `kube-system/cilium-clustermesh` | NotFound (the #6027 witness window) |
| all 6 Organizations | `Ready=True / Reconciled` |

catalyst-api, every 60 seconds, for hours:

```
03:06:40 "cutover: secondary kubeconfigs Secret already materialized by a prior run - accepting as-is (#5488 recovery...)" keys=1 expected=1
03:07:40 ...same... keys=1 expected=1
03:08:40 ...same... keys=1 expected=1
```

and, in the same log, on every Organization:

```
"org-console-tls: this Sovereign DECLARES more regions than carry a per-Org console listener"
  regions_declared=2 regions_written=1 regions=host
```

**Those 219 bytes are, to the byte, this repository's own unit-test control
fixture `completeKubeconfigSameCluster`** — 220 bytes with its trailing
newline, 219 without, and the sha256 of the stripped form matches the live
value exactly. That fixture was built to be maximally usable-by-the-contract
while pointing at a deliberately fake host, which makes it the perfect
counterexample: a document engineered to satisfy "usable" is not thereby a
delivery.

## Why the merged fixes are inert here

Every hop in the chain measures the same thing — *can these bytes build a
client*. This value can. Presence stood in for usability once (#6054/#6112);
usability then stood in for delivery. Same substitution, one rung further in.

And the arm that let it stand is the #5488 recovery arm, which short-circuits
`materializeSecondaryKubeconfigsSecret` **before its write**. So the
mis-delivered value is sticky: the pass that would replace it returns before
the write. That is precisely the state in which #6112 and #6116 cannot act.

Downstream, `kubeconfig.Defects` returned empty -> the region counted as WIRED
-> the shortfall check became `1 > 1` (false) -> the write timed out -> the
region landed in `Unreachable` -> `Unverifiable` -> and `complete()` is
`len(Missing) == 0`. Six Organizations green over a region with zero listeners.

## What changed

**1. One contract, extended — `core/controllers/pkg/kubeconfig/delivery.go`.**
`DeliveryDefects(raw, Delivery{RegionKey, DeclaredRegions, EndpointProven})` is
`Defects` plus two properties the hw293 value fails and a genuine credential
passes: the region key must be one the deployment DECLARES
(`CATALYST_CONFIGURED_REGIONS`), and the endpoint must be PROVEN by whatever
oracle the calling component legitimately has. The package performs no I/O and
takes the oracle as a function; a caller with no oracle passes nil and gets
exactly the pre-existing bytes-only verdict, so nothing regresses.

The obvious form of the endpoint check — "is the server host one of the
declared regions?" — is **not decidable from local state**, and shipping a
check that cannot fire would be worse than saying so. The declared witness
names cloud regions (`hw-me-east-215-b-rtz-prod`) while a kubeconfig names an
IP (`212.72.24.25`), and nothing in-cluster maps one to the other on hw293:
region A's node list holds only region-A nodes, `cilium-clustermesh` is
NotFound, and `sovereign-fqdn` carries the LOCAL control-plane IP only. A
host-versus-region-name comparison would reject every genuine delivery. So the
endpoint is bound by proof, and the NAME is bound where names actually exist.

**2. The recovery arm requires CORROBORATION — `cutover_secondary_kubeconfigs.go`.**
`keys=1 expected=1` no longer means accept. Acceptance needs evidence from
outside the Secret itself, either of:

- **provenance** — at least one secondary kubeconfig file exists on disk for a
  candidate prefix. The arm exists because a restart wipes the process-local
  *path map* while the *files* remain (hw291). An empty directory is not a lost
  path map; it is an undelivered region.
- **proof** — every counted key names an endpoint that answers on the apiserver
  port, via the same TCP probe #4000's self-heal already makes, behind an
  injectable seam so no unit test dials.

Either suffices, which is what keeps this from over-correcting: a genuine
post-restart recovery still passes on its files alone with no dial at all, and
a Sovereign whose files were legitimately reaped still passes on a reachable
endpoint. Only "no files AND a dead endpoint" is refused — exactly hw293.

**3. The failure is loud in the ERROR, not just in a log line.** The refusal
now carries into the abort message. Every previous message ended with "no
already-materialized Secret satisfies the expected count", which is true and
useless when the Secret is right there: an operator reads it, finds the object,
sees a parseable credential with a token in it, and has been told nothing.

**4. `Unreachable` stops being indistinguishable from `wired` —
`provisioning_postconditions.go`.** A region we KNOW exists and could not reach
now feeds `Missing`. A region we could not COUNT feeds a new, separate bucket
`Undecidable` -> `Unverifiable`. Those are different claims:

```
"I know this region exists and could not reach it"  -> no listener there
"I could not work out how many regions there are"   -> genuinely unknown
```

Only the first is a missing artifact. `Missing` is still a requeue, so a
genuine apiserver blip clears on the next pass — what it no longer does is pass
silently for hours. The old routing's worry about red-flagging every
Organization on one bad read was right; it was applied to the wrong bucket, and
`Undecidable` is where it belongs.

## Red then green

`-count=1` throughout. "Before" is the same test files against the pre-fix
behaviour (new API present, unconsumed).

**catalyst-api — BEFORE:**

```
=== RUN   TestSecondaryKubeconfigSecret_6107_MisDeliveredEndpointIsNotRecovery
    the live hw293 Secret satisfied the #5488 recovery check (n=1) - a well-formed,
    credentialled document naming an endpoint this deployment never answered on is a
    MIS-delivery, and accepting it makes it permanent
--- FAIL: TestSecondaryKubeconfigSecret_6107_MisDeliveredEndpointIsNotRecovery (0.00s)
=== RUN   TestSecondaryKubeconfigSecret_6107_ProvenEndpointIsRecovery
    acceptance without consulting the oracle means the proof is decorative
--- FAIL: TestSecondaryKubeconfigSecret_6107_ProvenEndpointIsRecovery (0.00s)
=== RUN   TestSecondaryKubeconfigSecret_6107_OnDiskProvenanceNeedsNoProbe
--- PASS: TestSecondaryKubeconfigSecret_6107_OnDiskProvenanceNeedsNoProbe (0.00s)
=== RUN   TestSecondaryKubeconfigSecret_6107_AbsentSecretStillAborts
--- PASS: TestSecondaryKubeconfigSecret_6107_AbsentSecretStillAborts (0.00s)
=== RUN   TestSecondaryKubeconfigSecret_6107_VacuityOfTheEndpointProof
    VACUITY: swapping the endpoint host changed nothing - the gate cannot fail
--- FAIL: TestSecondaryKubeconfigSecret_6107_VacuityOfTheEndpointProof (0.00s)
FAIL
FAIL	github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/handler	0.028s
```

**org-controller — BEFORE:**

```
=== RUN   TestVerifyProvisioned_UnreachedSecondaryRegionHoldsTheOrgBack_6107
    Organization reads FULLY PROVISIONED while a declared secondary region was never
    reached - this pass neither wrote the per-Org pair there nor read one back, and the
    console EIP round-robins both regions, so a share of customer TLS to
    "*.uatco.omani.homes" resets. missing=[] unverifiable=[console Gateway listeners for
    "*.uatco.omani.homes" in every region - region "me-east-215-b" kubeconfig in
    catalyst/cutover-secondary-kubeconfigs did not yield a client: dial tcp
    212.72.24.6:6443: i/o timeout (unreached)]
--- FAIL: TestVerifyProvisioned_UnreachedSecondaryRegionHoldsTheOrgBack_6107 (0.00s)
=== RUN   TestVerifyProvisioned_ReachedSecondaryRegionStaysComplete_6107
--- PASS: TestVerifyProvisioned_ReachedSecondaryRegionStaysComplete_6107 (0.01s)
=== RUN   TestVerifyProvisioned_AbsentKeyStillMissing_6107
--- PASS: TestVerifyProvisioned_AbsentKeyStillMissing_6107 (0.00s)
=== RUN   TestVerifyProvisioned_UndecidableCountIsUnverifiable_6107
--- PASS: TestVerifyProvisioned_UndecidableCountIsUnverifiable_6107 (0.01s)
=== RUN   TestVerifyProvisioned_UnreachedVacuity_6107
    VACUITY: flipping the region client from working to failing changed nothing - the
    new assertion cannot fail
--- FAIL: TestVerifyProvisioned_UnreachedVacuity_6107 (0.01s)
FAIL
FAIL	github.com/openova-io/openova/core/controllers/organization/internal/controller	0.058s
```

Note the three PASS lines in each block: the controls are green in BOTH
directions, which is what makes the four FAILs mean something.

**AFTER — all green:**

```
--- PASS: TestHw293Stub_ShapeIsPinned (0.00s)
--- PASS: TestHw293_DeliveredValueIsTheControlFixture (0.00s)
--- PASS: TestSecondaryKubeconfigSecret_6107_MisDeliveredEndpointIsNotRecovery (0.00s)
--- PASS: TestSecondaryKubeconfigSecret_6107_ProvenEndpointIsRecovery (0.00s)
--- PASS: TestSecondaryKubeconfigSecret_6107_OnDiskProvenanceNeedsNoProbe (0.00s)
--- PASS: TestSecondaryKubeconfigSecret_6107_AbsentSecretStillAborts (0.00s)
--- PASS: TestSecondaryKubeconfigSecret_6107_MisDeliveryIsReportedNotMaterialized (0.00s)
--- PASS: TestSecondaryKubeconfigSecret_6107_VacuityOfTheEndpointProof (0.00s)
PASS
ok  	github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/handler	0.033s

--- PASS: TestConsoleRegionTargets_UnusableSecondaryKubeconfigIsUnwired_6107 (0.01s)
--- PASS: TestConsoleRegionTargets_CompleteSecondaryKubeconfigStaysWired_6107 (0.00s)
--- PASS: TestConsoleRegionTargets_AbsentKeyKeepsTheNoneWording_6107 (0.00s)
--- PASS: TestVerifyProvisioned_UnreachedSecondaryRegionHoldsTheOrgBack_6107 (0.00s)
--- PASS: TestVerifyProvisioned_ReachedSecondaryRegionStaysComplete_6107 (0.01s)
--- PASS: TestVerifyProvisioned_AbsentKeyStillMissing_6107 (0.00s)
--- PASS: TestVerifyProvisioned_UndecidableCountIsUnverifiable_6107 (0.00s)
--- PASS: TestVerifyProvisioned_UnreachedVacuity_6107 (0.01s)
PASS
ok  	github.com/openova-io/openova/core/controllers/organization/internal/controller	0.061s

--- PASS: TestHw293DeliveredValue_MatchesLiveDigest (0.00s)
--- PASS: TestHw293DeliveredValue_PassesTheBytesContract (0.00s)
--- PASS: TestDeliveryDefects_Hw293 (0.00s)
--- PASS: TestDeliveryDefects_NoOracleIsNoVerdict (0.00s)
--- PASS: TestDeliveryDefects_BytesVerdictWins (0.00s)
--- PASS: TestDeliveryDefects_Attribution (0.00s)
--- PASS: TestRegionDeclared (0.00s)
--- PASS: TestEndpoint_CurrentContextWins (0.00s)
--- PASS: TestOracleReceivesTheServerURL (0.00s)
--- PASS: TestHostPort (0.00s)
--- PASS: TestDeliveryDefects_CanFail (0.00s)
PASS
ok  	github.com/openova-io/openova/core/controllers/pkg/kubeconfig	0.010s
```

Whole-module regression, `-count=1`: `products/catalyst/bootstrap/api ./...`
20 packages ok / 0 FAIL; `core/controllers ./...` all ok.

## Controls, and the vacuity checks

- **CONTROL** `…_ProvenEndpointIsRecovery` — same document shape, same absence
  of on-disk provenance, same declared region, live endpoint -> still ACCEPTED.
  The rule is not "refuse everything".
- **CONTROL** `…_OnDiskProvenanceNeedsNoProbe` — the genuine hw291 #5488
  condition. Accepted with a DEAD endpoint, and the oracle is asserted never to
  have been consulted, so a peer region that blips during a restart cannot flip
  a correct Secret to refused.
- **CONTROL** `…_AbsentSecretStillAborts` — a genuinely absent Secret still
  produces the original #5359 abort, not the mis-delivery one.
- **CONTROL** `…_ReachedSecondaryRegionStaysComplete_6107` — a usable
  kubeconfig at a declared region still counts as wired and the Org still reads
  complete. This is the guard against over-correcting into "everything is
  incomplete".
- **CONTROL** `…_AbsentKeyStillMissing_6107` — a genuinely absent key still
  lands in `Missing` with the #6027 `wired region keys: none` wording.
- **CONTROL** `…_UndecidableCountIsUnverifiable_6107` — an unreadable witness
  stays `Unverifiable` and the Org stays complete, so one bad `Get` cannot
  red-flag every Organization on the Sovereign.
- **CONTROL** `TestRegionDeclared/neighbouring_region` — `me-east-21-b-1` must
  NOT attribute to `hw-me-east-215-b-rtz-prod`. Attribution matches
  dash-delimited token RUNS, not substrings, precisely so the check meant to
  catch a mis-delivery cannot wave one through.
- **VACUITY, all three packages** — each flips exactly ONE input (the endpoint
  host substring; whether the region client builds) and requires the verdict to
  change. `TestOracleReceivesTheServerURL` exists because the first wiring of
  this seam fed a server URL to a raw-bytes function, which returned `""` and
  made the probe answer "unreachable" for *every* document — a check failing
  closed for a reason unrelated to what it claims to measure, and the stub
  oracle never looked at its argument, so nothing caught it.

## Discipline

Everything on hw293 and the mothership was `get` / `describe` / `logs` /
`exec ... cat` only. No `apply`, `patch`, `delete`, `create`, `scale`, `edit`
or `rollout`. The extracted kubeconfig was shredded. No kubeconfig bytes,
token, key or cookie appear anywhere in this branch — byte lengths and sha256
prefixes only. No NodePorts. No `openova.io` in any test.

Refs #6107 #5488 #6027 #6015 #6054 #6104 #6112 #6116

🤖 Generated with [Claude Code](https://claude.com/claude-code)
