### PR TITLE
fix(catalyst-api, console): report an Organization isolation from the AUTHORED boundary, not the declared one (UAT row 101)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/org_isolation_observed_backing_6145_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_isolation_observed_backing_6145_test.go
@@ -1,0 +1,347 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/store"
+)
+
+// org_isolation_observed_backing_6145_test.go — #6145 (UAT row 101).
+//
+// MEASURED on hw293.omantel.biz (dep a0077ba47e3720e5), 2026-08-11:
+//
+//	Organization  plan  real backing                     console said
+//	g7freea       s     NO vcluster StatefulSet;         Isolation: Vcluster
+//	                    bp-keycloak/bp-agenity run in
+//	                    the host `g7freea` namespace
+//	hw293walkone  m     statefulset/vcluster 1/1         Isolation: Vcluster
+//
+// Two Organizations with materially different backings reported the SAME
+// isolation. That is the row-101 assertion failing: the field is not derived
+// from the backing.
+//
+// MECHANISM, at the line. The persisted provision record on the Sovereign
+// carried the DECLARED value, not a derived one:
+//
+//	/var/lib/catalyst/deployments/org-tenant/84f0cb06-….json
+//	  "subdomain": "g7freea", "plan_slug": "s", "isolation": "vcluster"
+//
+// organization_provisioning.go orgTenantRecordToResponse copies that field
+// verbatim (`Isolation: rec.Isolation`), and mergeOrgResponses gives the local
+// store row priority over the CR-derived row on a slug/id collision — so the
+// declared value wins over the tier-derived one the CR read path already
+// computes correctly. The console was NOT defaulting: `isolation` was present
+// on the wire with the value "vcluster".
+//
+// WHY OBSERVED AND NOT DECLARED. `isolation` renders on the Organization
+// identity card as a statement about infrastructure. The only component that
+// AUTHORS the boundary is the org-controller, and it records what it authored:
+// `status.vcluster{name,phase}` is stamped only for a vCluster-backed Org
+// (#5489 vclusterStatusFor). A read path that republishes a declared field is
+// reporting an intention as a fact. So the read path now prefers the
+// controller's own observation and falls back to the tier gate only while the
+// Organization has not been reconciled yet.
+//
+// WHAT THESE TESTS PIN.
+//   - RED case: a store record that declares `vcluster` beside plan `s`, with a
+//     reconciled CR that authored no vCluster, must report `namespace`.
+//   - CONTROL: an Organization with the SAME declared `vcluster` and a CR that
+//     really did author one must still report `vcluster` — the fix is not
+//     "everything is namespace".
+//   - VACUITY: the observation helper must be able to return each value, and
+//     must not answer from key PRESENCE (the live g7freea CR carries
+//     `status.vcluster: {}` — an empty block).
+
+// orgCRWithVCluster builds an Organization CR whose status carries the block
+// the org-controller stamps ONLY for a vCluster-backed Org.
+func orgCRWithVCluster(t *testing.T, slug, planSlug string) *unstructured.Unstructured {
+	t.Helper()
+	cr := orgReadyCR(slug, slug, "omani.homes", "owner@"+slug+".test", "")
+	spec, _, _ := unstructured.NestedMap(cr.Object, "spec")
+	spec["planSlug"] = planSlug
+	cr.Object["spec"] = spec
+	cr.Object["status"] = map[string]any{
+		"observedGeneration": int64(2),
+		"vcluster": map[string]any{
+			"name":        slug,
+			"hostCluster": "hw293.omantel.biz",
+			"phase":       "Ready",
+		},
+		"conditions": []any{
+			map[string]any{"type": "Ready", "status": "True", "reason": "Reconciled"},
+		},
+	}
+	return cr
+}
+
+// orgCRHostNamespace builds an Organization CR shaped EXACTLY like the walked
+// g7freea: reconciled (observedGeneration 2, Ready=True) with an EMPTY
+// status.vcluster block, which is how the org-controller records "no vCluster
+// was authored for this Organization".
+func orgCRHostNamespace(t *testing.T, slug, planSlug string) *unstructured.Unstructured {
+	t.Helper()
+	cr := orgReadyCR(slug, slug, "omani.homes", "owner@"+slug+".test", "")
+	spec, _, _ := unstructured.NestedMap(cr.Object, "spec")
+	spec["planSlug"] = planSlug
+	cr.Object["spec"] = spec
+	cr.Object["status"] = map[string]any{
+		"observedGeneration": int64(2),
+		// The live CR carries the key with an empty value — see the header.
+		"vcluster": map[string]any{},
+		"conditions": []any{
+			map[string]any{
+				"type": "Ready", "status": "True", "reason": "Reconciled",
+				"message": "host namespace Active + Keycloak group + Gitea Org reconciled (namespace-isolated tier — no vCluster authored)",
+			},
+		},
+	}
+	return cr
+}
+
+// seedDeclaredRecord writes the provision record the BSS/free-subdomain door
+// persisted on hw293: plan `s`, isolation DECLARED as `vcluster`.
+func seedDeclaredRecord(t *testing.T, st *store.OrganizationProvisionStore, id, slug, planSlug, declared string) {
+	t.Helper()
+	rec := store.OrganizationProvisionRecord{
+		OrganizationID:  id,
+		State:           store.STSTenantRegistered,
+		Subdomain:       slug,
+		DomainMode:      store.OrganizationDomainFreeSubdomain,
+		ParentDomain:    "omani.homes",
+		AdminEmail:      "owner@" + slug + ".test",
+		CompanyName:     slug,
+		OTECHFQDN:       "otech.example",
+		VClusterName:    slug,
+		TenantNamespace: slug,
+		Kind:            "customer",
+		Tier:            "org",
+		BillingMode:     "real",
+		Isolation:       declared,
+		PlanSlug:        planSlug,
+	}
+	if err := st.Save(&rec); err != nil {
+		t.Fatalf("seed record %s: %v", slug, err)
+	}
+}
+
+// listOrgsBySlug drives GET /api/v1/organizations and indexes the rows.
+func listOrgsBySlug(t *testing.T, h *Handler) map[string]orgTenantResponse {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/organizations", nil)
+	w := httptest.NewRecorder()
+	h.HandleListOrganizations(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: want 200 got %d body=%s", w.Code, w.Body.String())
+	}
+	var got struct {
+		Items []orgTenantResponse `json:"items"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v body=%s", err, w.Body.String())
+	}
+	out := make(map[string]orgTenantResponse, len(got.Items))
+	for _, it := range got.Items {
+		out[it.Subdomain] = it
+	}
+	return out
+}
+
+// TestOrgDirectory_IsolationComesFromObservedBacking_6145 is the row-101
+// measurement, both arms in ONE directory read so the two rows are produced by
+// the same code on the same request — which is what makes "they reported the
+// same value" a defect rather than a coincidence.
+func TestOrgDirectory_IsolationComesFromObservedBacking_6145(t *testing.T) {
+	h, st := newOrgHandlerWithSeededCRs(t,
+		orgCRHostNamespace(t, "g7freea", "s"),
+		orgCRWithVCluster(t, "hw293walkone", "m"),
+	)
+	// BOTH records declare `vcluster` — that is the suspect property the
+	// control shares. On hw293 both rows rendered `Isolation: Vcluster`.
+	seedDeclaredRecord(t, st, "84f0cb06-1e9b-43a6-8c4e-1c7a0540779d", "g7freea", "s", "vcluster")
+	seedDeclaredRecord(t, st, "tid-hw293walkone", "hw293walkone", "m", "vcluster")
+
+	rows := listOrgsBySlug(t, h)
+
+	free, ok := rows["g7freea"]
+	if !ok {
+		t.Fatalf("g7freea missing from the directory: %+v", rows)
+	}
+	walk, ok := rows["hw293walkone"]
+	if !ok {
+		t.Fatalf("hw293walkone missing from the directory: %+v", rows)
+	}
+
+	// RED before the fix: the declared value survives the read path.
+	if free.Isolation != "namespace" {
+		t.Errorf("g7freea isolation = %q, want %q — the org-controller authored NO vCluster for it "+
+			"(status.vcluster empty, Ready message \"no vCluster authored\"), and on hw293 the host "+
+			"namespace really did run bp-keycloak/bp-agenity directly. Reporting %q republishes the "+
+			"DECLARED field from the provision record as though it were a fact about the cluster (#6145)",
+			free.Isolation, "namespace", free.Isolation)
+	}
+	// CONTROL: shares the suspect property (declared `vcluster`, same door,
+	// same mapper) and must stay green.
+	if walk.Isolation != "vcluster" {
+		t.Errorf("hw293walkone isolation = %q, want %q — this Organization HAS a vCluster "+
+			"(status.vcluster.name/phase stamped, statefulset/vcluster 1/1 on hw293). A fix that "+
+			"answers \"namespace\" here has over-corrected into reporting every Org as namespace",
+			walk.Isolation, "vcluster")
+	}
+	// The two must DIFFER — that difference is the whole row.
+	if free.Isolation == walk.Isolation {
+		t.Errorf("both Organizations report isolation=%q despite materially different backings; "+
+			"the field is still not derived from the backing", free.Isolation)
+	}
+
+	// A namespace-backed Org must not carry a vcluster_name either: the name
+	// would assert an object nobody authored (#5489/#5501 contract).
+	if free.VClusterName != "" {
+		t.Errorf("g7freea vcluster_name = %q, want empty — no vCluster exists to name", free.VClusterName)
+	}
+	if walk.VClusterName != "hw293walkone" {
+		t.Errorf("hw293walkone vcluster_name = %q, want %q", walk.VClusterName, "hw293walkone")
+	}
+	// The vcluster timeline step is a claim about the same object.
+	if free.Steps.VCluster != "" {
+		t.Errorf("g7freea steps.vcluster = %q, want empty — a host-namespace Org has no vCluster step",
+			free.Steps.VCluster)
+	}
+}
+
+// TestOrgDetail_IsolationComesFromObservedBacking_6145 pins the SAME contract
+// on GET /api/v1/organizations/{id}, the slug/UUID-addressed detail read that
+// openova-MCP and the console share. A fix applied only to the list leaves the
+// identical lie on the second surface.
+func TestOrgDetail_IsolationComesFromObservedBacking_6145(t *testing.T) {
+	h, st := newOrgHandlerWithSeededCRs(t, orgCRHostNamespace(t, "g7freea", "s"))
+	seedDeclaredRecord(t, st, "84f0cb06-1e9b-43a6-8c4e-1c7a0540779d", "g7freea", "s", "vcluster")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/organizations/84f0cb06-1e9b-43a6-8c4e-1c7a0540779d", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", "84f0cb06-1e9b-43a6-8c4e-1c7a0540779d")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+	w := httptest.NewRecorder()
+	h.HandleGetOrganization(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: want 200 got %d body=%s", w.Code, w.Body.String())
+	}
+	var got orgTenantResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Isolation != "namespace" {
+		t.Errorf("org-detail isolation = %q, want %q — the store record declares vcluster, the "+
+			"reconciled CR authored none, and the detail read republished the declaration",
+			got.Isolation, "namespace")
+	}
+	if got.VClusterName != "" {
+		t.Errorf("org-detail vcluster_name = %q, want empty", got.VClusterName)
+	}
+}
+
+// TestObservedIsolationFromCR_VacuityAndValueNotKey_6145 is the VACUITY CHECK
+// for the observation helper: it must be able to answer each of the three
+// outcomes, and it must read the VALUE of status.vcluster rather than the
+// presence of the key. The live g7freea CR carries `status.vcluster: {}`, so a
+// helper that tested key presence would report "vcluster" for the very
+// Organization this row is about — and every assertion above would pass while
+// measuring nothing.
+func TestObservedIsolationFromCR_VacuityAndValueNotKey_6145(t *testing.T) {
+	t.Parallel()
+
+	statusOf := func(status map[string]any) *unstructured.Unstructured {
+		obj := map[string]any{
+			"apiVersion": "orgs.openova.io/v1",
+			"kind":       "Organization",
+			"metadata":   map[string]any{"name": "probe"},
+			"spec":       map[string]any{"slug": "probe", "planSlug": "s"},
+		}
+		if status != nil {
+			obj["status"] = status
+		}
+		return &unstructured.Unstructured{Object: obj}
+	}
+
+	cases := []struct {
+		name   string
+		status map[string]any
+		want   string
+	}{
+		{
+			// The exact live shape. Key PRESENT, value EMPTY.
+			name: "reconciled with an empty status.vcluster block (the live g7freea shape)",
+			status: map[string]any{
+				"observedGeneration": int64(2),
+				"vcluster":           map[string]any{},
+				"conditions":         []any{map[string]any{"type": "Ready", "status": "True"}},
+			},
+			want: "namespace",
+		},
+		{
+			name: "reconciled with no vcluster key at all",
+			status: map[string]any{
+				"observedGeneration": int64(1),
+				"conditions":         []any{map[string]any{"type": "Ready", "status": "True"}},
+			},
+			want: "namespace",
+		},
+		{
+			name: "vCluster authored and Ready",
+			status: map[string]any{
+				"observedGeneration": int64(2),
+				"vcluster":           map[string]any{"name": "walkone", "phase": "Ready"},
+			},
+			want: "vcluster",
+		},
+		{
+			// Mid-provision: the block exists with a phase before the vCluster
+			// is up. Still POSITIVE evidence that one was authored.
+			name: "vCluster authored, still Pending",
+			status: map[string]any{
+				"observedGeneration": int64(1),
+				"vcluster":           map[string]any{"name": "walkone", "phase": "Pending"},
+			},
+			want: "vcluster",
+		},
+		{
+			// The over-correction guard: an unreconciled CR must NOT read as
+			// namespace. It looks identical to a namespace-backed one, and
+			// answering "namespace" here would report every freshly created
+			// M-plan Organization as host-namespace-backed.
+			name:   "no status at all — unobserved",
+			status: nil,
+			want:   "",
+		},
+		{
+			name:   "status present but the controller has not reconciled it",
+			status: map[string]any{"conditions": []any{}},
+			want:   "",
+		},
+	}
+
+	seen := map[string]bool{}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := observedIsolationFromCR(statusOf(tc.status)); got != tc.want {
+				t.Fatalf("observedIsolationFromCR() = %q, want %q", got, tc.want)
+			}
+		})
+		seen[tc.want] = true
+	}
+
+	// Vacuity: the table above is only a guard if it actually exercised all
+	// three outcomes. A helper hardwired to any single answer fails here.
+	for _, want := range []string{"namespace", "vcluster", ""} {
+		if !seen[want] {
+			t.Fatalf("the table never exercised outcome %q — the guard cannot distinguish a working "+
+				"helper from one that returns a constant", want)
+		}
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/org_list_from_cr.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_list_from_cr.go
@@ -40,25 +40,87 @@ import (
 // out-of-cluster catalyst-api) so callers transparently fall back to the
 // local store. A list error is surfaced so the caller can decide whether to
 // degrade to store-only (it does) rather than 5xx the whole console.
-func (h *Handler) orgResponsesFromCRs(ctx context.Context) ([]orgTenantResponse, error) {
+func (h *Handler) orgResponsesFromCRs(ctx context.Context) ([]orgTenantResponse, observedIsolationIndex, error) {
 	deps, err := h.sovereignDepsFor()
 	if err != nil || deps == nil || deps.dyn == nil {
 		// Out-of-cluster / CI: no apiserver to read CRs from. The caller
 		// falls back to the local provision store.
-		return nil, nil
+		return nil, nil, nil
 	}
 	list, err := deps.dyn.Resource(organizationGVR()).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		// CRD not installed on an older Sovereign, transient apiserver
 		// blip, RBAC gap — degrade to store-only rather than erroring the
 		// directory. The caller logs + falls back.
-		return nil, err
+		return nil, nil, err
 	}
 	out := make([]orgTenantResponse, 0, len(list.Items))
+	observed := make(observedIsolationIndex, len(list.Items)*2)
 	for i := range list.Items {
-		out = append(out, orgCRToResponse(&list.Items[i], h.orgTenantDeps.OTECHFQDN))
+		resp := orgCRToResponse(&list.Items[i], h.orgTenantDeps.OTECHFQDN)
+		out = append(out, resp)
+		observed.record(&list.Items[i], resp)
 	}
-	return out, nil
+	return out, observed, nil
+}
+
+// observedIsolationIndex maps each merge key of a CR-derived row (see
+// orgMergeKeys) to the boundary primitive the org-controller was OBSERVED to
+// have authored for it. Entries exist ONLY for Organizations whose CR carries
+// that observation — an unreconciled CR contributes nothing, so a caller can
+// never mistake "not looked at yet" for a measurement (#6145).
+type observedIsolationIndex map[string]string
+
+func (idx observedIsolationIndex) record(obj *unstructured.Unstructured, resp orgTenantResponse) {
+	observed := observedIsolationFromCR(obj)
+	if observed == "" {
+		return
+	}
+	for _, k := range orgMergeKeys(resp) {
+		idx[k] = observed
+	}
+}
+
+// lookup returns the observed isolation for a row, matching on either of the
+// row's merge keys (Organization id / subdomain).
+func (idx observedIsolationIndex) lookup(r orgTenantResponse) string {
+	for _, k := range orgMergeKeys(r) {
+		if v, ok := idx[k]; ok && v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// applyObservedIsolation replaces a row's DECLARED boundary with the one the
+// org-controller was observed to have authored, and re-derives the two other
+// fields that are claims about the SAME object — the vCluster's name and the
+// vCluster timeline step. Re-deriving them here is what keeps the payload
+// internally consistent: `isolation: "namespace"` beside `vcluster_name:
+// "g7freea"` is the shape #5489/#5501 already removed once, and overwriting
+// only the label would reintroduce it from the store side.
+//
+// A no-op when nothing was observed, or when the observation agrees with the
+// row — so a correctly recorded Organization is byte-unchanged.
+func applyObservedIsolation(r orgTenantResponse, observed string) orgTenantResponse {
+	if observed == "" || observed == r.Isolation {
+		return r
+	}
+	r.Isolation = observed
+	if observed == "namespace" {
+		// Nothing was authored, so there is no vCluster to name and no
+		// vCluster step to report.
+		r.VClusterName = ""
+		r.Steps.VCluster = ""
+		return r
+	}
+	// vcluster: name it after the same slug the org-controller reports
+	// (status.vcluster.name == the slug, #5501). A row with no slug to derive
+	// from keeps whatever name it already carried rather than losing it.
+	if name := vclusterNameFor(observed, r.Subdomain); name != "" {
+		r.VClusterName = name
+	}
+	return r
 }
 
 // orgCRFromSlug fetches a single Organization CR by name (the slug). Returns
@@ -79,6 +141,27 @@ func (h *Handler) orgCRFromSlug(ctx context.Context, slug string) (*orgTenantRes
 	}
 	resp := orgCRToResponse(obj, h.orgTenantDeps.OTECHFQDN)
 	return &resp, true
+}
+
+// observedIsolationForSlug reads the canonical Organization CR for slug and
+// reports the boundary the org-controller was observed to have authored, or ""
+// when there is no in-cluster client, no such CR, or the controller has not
+// reconciled it. Same fail-open-to-unknown contract as observeOrgBoundary: an
+// unreadable substrate yields no measurement rather than a wrong one.
+func (h *Handler) observedIsolationForSlug(ctx context.Context, slug string) string {
+	slug = strings.ToLower(strings.TrimSpace(slug))
+	if slug == "" {
+		return ""
+	}
+	deps, err := h.sovereignDepsFor()
+	if err != nil || deps == nil || deps.dyn == nil {
+		return ""
+	}
+	obj, err := deps.dyn.Resource(organizationGVR()).Get(ctx, slug, metav1.GetOptions{})
+	if err != nil || obj == nil {
+		return ""
+	}
+	return observedIsolationFromCR(obj)
 }
 
 // orgCRToResponse maps an Organization CR (orgs.openova.io/v1) onto the
@@ -133,7 +216,17 @@ func orgCRToResponse(obj *unstructured.Unstructured, otechFQDN string) orgTenant
 	// paid-plan internal Org "namespace" while the org-controller rendered it a
 	// real vCluster (UAT row 100). `kind` is a billing dimension; it is not read
 	// here.
+	//
+	// #6145 (UAT row 101) — the tier gate is now the FALLBACK, not the answer.
+	// It is a second copy of the switch that decides what to author, so it
+	// reports intent; `status.vcluster` reports what the org-controller
+	// actually authored. Prefer the measurement and fall back to the gate only
+	// while the Organization has not been reconciled yet, so a CR minted
+	// seconds ago still badges its plan's boundary instead of blanking.
 	isolation := isolationForTier(planSlug)
+	if observed := observedIsolationFromCR(obj); observed != "" {
+		isolation = observed
+	}
 
 	// tenantPublic.parentDomain carries the org-pool apex; subdomain
 	// defaults to the slug. Empty parent → single-domain back-compat
@@ -215,6 +308,54 @@ func orgCRToResponse(obj *unstructured.Unstructured, otechFQDN string) orgTenant
 	return orgTenantRecordToResponse(rec)
 }
 
+// observedIsolationFromCR reports the boundary primitive the org-controller
+// was OBSERVED to have authored for this Organization — "vcluster",
+// "namespace", or "" when the controller has not reconciled the object yet.
+//
+// #6145 (UAT row 101). `isolation` renders on the Organization identity card
+// as a statement about infrastructure, so it has to be MEASURED. Until this
+// function existed every producer of the field answered from intent: the BSS
+// door persisted the request's declaration (organization_provisioning.go
+// resolveOrgShape) and the CR read path mirrored the tier gate
+// (isolationForTier). On hw293 that produced `Isolation: Vcluster` for
+// `g7freea`, an Organization whose bp-keycloak/bp-agenity StatefulSets ran in
+// the host namespace with no vCluster anywhere on the cluster.
+//
+// The org-controller is the only component that authors the boundary, and it
+// records what it authored: `vclusterStatusFor`
+// (core/controllers/organization/internal/controller/organization_controller.go)
+// stamps `status.vcluster{name,hostCluster,phase}` for a vCluster-backed Org
+// and the ZERO VALUE for a host-namespace one (#5489). So:
+//
+//   - a non-empty name OR phase is POSITIVE evidence a vCluster was authored;
+//   - their absence is evidence of a host namespace ONLY once the controller
+//     has actually processed the object, which `status.observedGeneration`
+//     reports. An untouched CR is byte-identical to a namespace-backed one,
+//     and answering "namespace" for it would report every freshly created
+//     M-plan Organization as host-namespace-backed. That case returns "" and
+//     the caller falls back to the tier gate.
+//
+// The read is on the VALUE, never the key. The walked g7freea CR carries
+// `status.vcluster: {}` — an EMPTY block — so `NestedMap(...)` finding the key
+// says nothing at all, and a presence test would report "vcluster" for exactly
+// the Organization this row is about.
+func observedIsolationFromCR(obj *unstructured.Unstructured) string {
+	if obj == nil {
+		return ""
+	}
+	if vc, found, _ := unstructured.NestedMap(obj.Object, "status", "vcluster"); found {
+		name, _ := vc["name"].(string)
+		phase, _ := vc["phase"].(string)
+		if strings.TrimSpace(name) != "" || strings.TrimSpace(phase) != "" {
+			return "vcluster"
+		}
+	}
+	if gen, found, _ := unstructured.NestedInt64(obj.Object, "status", "observedGeneration"); found && gen > 0 {
+		return "namespace"
+	}
+	return ""
+}
+
 // orgStateFromCR maps the Organization CR status to a provision state for the
 // console timeline. Ready (vcluster phase Ready OR a Ready=True condition) →
 // STSDone; an explicit Failed phase → STSFailed; everything else (Pending /
@@ -256,7 +397,15 @@ func orgStateFromCR(obj *unstructured.Unstructured) store.OrganizationProvisionS
 // Sovereign Org) are appended so the directory shows every real Organization.
 // Order: local rows first (newest-first as the store returns them), then the
 // CR-only remainder.
-func mergeOrgResponses(local, fromCR []orgTenantResponse) []orgTenantResponse {
+//
+// #6145 (UAT row 101) — "local wins" is right for the provisioning TIMELINE
+// and wrong for the boundary. The store record's `isolation` is whatever the
+// create door persisted at t=0; the CR's status is what the org-controller
+// authored. On hw293 the g7freea record said `isolation:"vcluster"` beside
+// `plan_slug:"s"` and won the collision, so the console reported a vCluster
+// for an Organization backed by the host namespace. A local row that collides
+// with an OBSERVED CR therefore adopts that observation before it wins.
+func mergeOrgResponses(local, fromCR []orgTenantResponse, observed observedIsolationIndex) []orgTenantResponse {
 	seen := make(map[string]struct{}, len(local)*2)
 	out := make([]orgTenantResponse, 0, len(local)+len(fromCR))
 
@@ -283,9 +432,9 @@ func mergeOrgResponses(local, fromCR []orgTenantResponse) []orgTenantResponse {
 
 	// Local first: it wins on collision. The BSS door authored the in-flight
 	// provisioning detail (7-step timeline, last_error, commit_sha) that the
-	// CR does not carry.
+	// CR does not carry — but NOT the boundary, which is measured (#6145).
 	for _, r := range local {
-		add(r)
+		add(applyObservedIsolation(r, observed.lookup(r)))
 	}
 	for _, r := range fromCR {
 		add(r)

--- a/products/catalyst/bootstrap/api/internal/handler/org_list_from_cr_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_list_from_cr_test.go
@@ -51,14 +51,34 @@ func newOrgHandlerWithSeededCRs(t *testing.T, crs ...*unstructured.Unstructured)
 }
 
 // orgCR builds a minimal Ready Organization CR (orgs.openova.io/v1) shaped
-// like the one both doors mint.
+// like the one both doors mint, on the default host-namespace plan `s`.
 func orgReadyCR(slug, displayName, parentDomain, ownerEmail, phase string) *unstructured.Unstructured {
+	return orgReadyCRWithPlan(slug, displayName, parentDomain, ownerEmail, phase, "s")
+}
+
+// orgReadyCRWithPlan builds the same CR on an explicit plan, and — this is the
+// part that matters (#6145) — stamps the status the org-controller would
+// ACTUALLY write for that plan.
+//
+// This fixture used to put `status.vcluster.phase` on every CR regardless of
+// plan. No such object exists: `vclusterStatusFor`
+// (core/controllers/organization/internal/controller/organization_controller.go)
+// is gated on the same tier switch that decides whether a vCluster is authored
+// at all, so a plan-`s` Organization gets the ZERO block (#5489) and reports
+// readiness through the top-level Ready condition instead — exactly what the
+// walked hw293 `g7freea` CR carries (`status.vcluster: {}` + Ready=True with
+// "namespace-isolated tier — no vCluster authored").
+//
+// A fixture that describes an impossible object teaches the tests a shape the
+// production system cannot produce, and any measurement taken from it is a
+// measurement of the fixture.
+func orgReadyCRWithPlan(slug, displayName, parentDomain, ownerEmail, phase, planSlug string) *unstructured.Unstructured {
 	spec := map[string]any{
 		"slug":         slug,
 		"displayName":  displayName,
 		"kind":         "customer",
 		"tier":         "org",
-		"planSlug":     "s",
+		"planSlug":     planSlug,
 		"billingMode":  "real",
 		"sovereignRef": "otech.example",
 		"owners": []any{
@@ -83,9 +103,28 @@ func orgReadyCR(slug, displayName, parentDomain, ownerEmail, phase string) *unst
 		"spec": spec,
 	}
 	if phase != "" {
-		obj["status"] = map[string]any{
-			"vcluster": map[string]any{"phase": phase},
+		status := map[string]any{"observedGeneration": int64(1)}
+		if isolationForTier(planSlug) == "vcluster" {
+			status["vcluster"] = map[string]any{
+				"name":        slug,
+				"hostCluster": "otech.example",
+				"phase":       phase,
+			}
+		} else {
+			// Host-namespace tier: no vcluster block is ever written, and the
+			// Ready condition is the boundary signal boundaryPhaseFromCR reads.
+			ready := "False"
+			if phase == "Ready" {
+				ready = "True"
+			}
+			status["conditions"] = []any{map[string]any{
+				"type":    "Ready",
+				"status":  ready,
+				"reason":  "Reconciled",
+				"message": "host namespace Active (namespace-isolated tier — no vCluster authored)",
+			}}
 		}
+		obj["status"] = status
 	}
 	return &unstructured.Unstructured{Object: obj}
 }

--- a/products/catalyst/bootstrap/api/internal/handler/org_merge_key_5833_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_merge_key_5833_test.go
@@ -47,7 +47,7 @@ func TestMergeOrgResponses_CustomDomainOrgDoesNotDoubleCount(t *testing.T) {
 		orgResp("tnt-uatco", "uatco"), // the CR always carries the slug
 	}
 
-	got := mergeOrgResponses(local, fromCR)
+	got := mergeOrgResponses(local, fromCR, nil)
 	if len(got) != 2 {
 		t.Fatalf("merge produced %d rows for 2 Organizations: %v\n"+
 			"The directory now disagrees with `kubectl get organizations` about how many "+
@@ -62,7 +62,7 @@ func TestMergeOrgResponses_LocalRowWinsOnCollision(t *testing.T) {
 	local := []orgTenantResponse{{OrganizationID: "tnt-1", Subdomain: "acme", CompanyName: "from-store"}}
 	fromCR := []orgTenantResponse{{OrganizationID: "tnt-1", Subdomain: "acme", CompanyName: "from-cr"}}
 
-	got := mergeOrgResponses(local, fromCR)
+	got := mergeOrgResponses(local, fromCR, nil)
 	if len(got) != 1 {
 		t.Fatalf("expected 1 row, got %d", len(got))
 	}
@@ -79,6 +79,7 @@ func TestMergeOrgResponses_CROnlyOrgStillAppears(t *testing.T) {
 	got := mergeOrgResponses(
 		[]orgTenantResponse{orgResp("tnt-1", "acme")},
 		[]orgTenantResponse{orgResp("tnt-1", "acme"), orgResp("tnt-2", "funnelco")},
+		nil,
 	)
 	if len(got) != 2 {
 		t.Fatalf("expected 2 rows, got %d: %v — a funnel-created Org went missing, which is "+
@@ -92,6 +93,7 @@ func TestMergeOrgResponses_FallsBackToSubdomainWhenIDAbsent(t *testing.T) {
 	got := mergeOrgResponses(
 		[]orgTenantResponse{orgResp("", "legacy")},
 		[]orgTenantResponse{orgResp("", "legacy")},
+		nil,
 	)
 	if len(got) != 1 {
 		t.Fatalf("expected 1 row, got %d — the subdomain fallback is gone, so a legacy store "+
@@ -103,7 +105,7 @@ func TestMergeOrgResponses_FallsBackToSubdomainWhenIDAbsent(t *testing.T) {
 // operator's own store authored would be worse than showing it — but it also
 // must not be silently treated as deduped.
 func TestMergeOrgResponses_UnidentifiableRowIsKept(t *testing.T) {
-	got := mergeOrgResponses([]orgTenantResponse{orgResp("", "")}, nil)
+	got := mergeOrgResponses([]orgTenantResponse{orgResp("", "")}, nil, nil)
 	if len(got) != 1 {
 		t.Fatalf("expected the unidentifiable row to survive, got %d rows", len(got))
 	}
@@ -142,6 +144,7 @@ func TestMergeOrgResponses_SameSlugDifferentIDsIsOneOrg(t *testing.T) {
 	got := mergeOrgResponses(
 		[]orgTenantResponse{orgResp("uuid-acme", "acme")},
 		[]orgTenantResponse{orgResp("cr-acme", "acme")},
+		nil,
 	)
 	if len(got) != 1 {
 		t.Fatalf("expected 1 row, got %d: %v — keying on the id alone splits one Organization "+

--- a/products/catalyst/bootstrap/api/internal/handler/org_vcluster_fabrication_5489_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_vcluster_fabrication_5489_test.go
@@ -7,8 +7,6 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/store"
 )
 
@@ -110,10 +108,11 @@ func TestOrgResponseFromCR_NamespaceTier_NoVClusterFields(t *testing.T) {
 // direction: a vcluster-tier CR (customer + plan m) keeps the exact pre-fix
 // shape — vc-<slug> name + a rendered vCluster step.
 func TestOrgResponseFromCR_VclusterTier_KeepsVClusterFields(t *testing.T) {
-	cr := orgReadyCR("acme", "ACME Corp", "", "ceo@acme.com", "Ready")
-	if err := unstructured.SetNestedField(cr.Object, "m", "spec", "planSlug"); err != nil {
-		t.Fatalf("set planSlug: %v", err)
-	}
+	// #6145 — built on plan `m` UP FRONT rather than patched afterwards, so the
+	// fixture's status is the one the org-controller stamps for a vcluster
+	// tier (a real status.vcluster block). Patching the plan after the status
+	// was written produced a CR whose plan and status disagreed.
+	cr := orgReadyCRWithPlan("acme", "ACME Corp", "", "ceo@acme.com", "Ready", "m")
 	h, _ := newOrgHandlerWithSeededCRs(t, cr)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/organizations", nil)

--- a/products/catalyst/bootstrap/api/internal/handler/organization_provisioning.go
+++ b/products/catalyst/bootstrap/api/internal/handler/organization_provisioning.go
@@ -1017,14 +1017,14 @@ func (h *Handler) HandleListOrganizations(w http.ResponseWriter, r *http.Request
 		}
 	}
 
-	fromCR, err := h.orgResponsesFromCRs(r.Context())
+	fromCR, observed, err := h.orgResponsesFromCRs(r.Context())
 	if err != nil {
 		// CRD absent / apiserver blip / RBAC gap — degrade to store-only
 		// rather than 5xx-ing the directory. Loud log, soft fall-through.
 		h.log.Warn("org-tenant: list Organization CRs failed — directory degrades to local store only", "err", err)
 	}
 
-	out := mergeOrgResponses(local, fromCR)
+	out := mergeOrgResponses(local, fromCR, observed)
 
 	// #6081 (UAT row 218) — an Org-scoped session sees its OWN row and nothing
 	// else.
@@ -1095,7 +1095,14 @@ func (h *Handler) HandleGetOrganization(w http.ResponseWriter, r *http.Request) 
 	// 1) Local provision store keyed by the BSS-door UUID.
 	if deps.Store != nil {
 		if rec, ok := deps.Store.Get(id); ok {
-			writeJSON(w, http.StatusOK, orgTenantRecordToResponse(rec))
+			resp := orgTenantRecordToResponse(rec)
+			// #6145 (UAT row 101) — the record carries the boundary the create
+			// door DECLARED; the Organization CR carries the one the
+			// org-controller authored. Detail must report the measurement for
+			// the same reason the directory does, or the two surfaces disagree
+			// about the same Organization.
+			resp = applyObservedIsolation(resp, h.observedIsolationForSlug(r.Context(), rec.Subdomain))
+			writeJSON(w, http.StatusOK, resp)
 			return
 		}
 	}

--- a/products/catalyst/bootstrap/api/internal/handler/sovereign_seed_reconciler.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sovereign_seed_reconciler.go
@@ -187,7 +187,7 @@ func (h *Handler) runSeedReconcilePass(ctx context.Context) {
 	// source of truth both the BSS door and the marketplace funnel write) and
 	// self-heal each Org's per-slug bearer path. Global seeds above already
 	// ran, so a list failure here never starves them.
-	orgs, err := h.orgResponsesFromCRs(ctx)
+	orgs, _, err := h.orgResponsesFromCRs(ctx)
 	if err != nil {
 		if h.log != nil {
 			h.log.Warn("[SEED-RECONCILE] list Organizations failed; per-Org mcp-bearer self-heal skipped this pass — retry next tick",

--- a/products/catalyst/bootstrap/ui/src/lib/organizations.api.test.ts
+++ b/products/catalyst/bootstrap/ui/src/lib/organizations.api.test.ts
@@ -124,6 +124,9 @@ describe('subOrgRowFromRecord', () => {
   // Legacy rows that predate the B1 spec fields (empty kind/tier/billing/
   // isolation) fall back to the kind-derived customer defaults so they
   // still badge sensibly rather than rendering blanks.
+  //
+  // #6145 (UAT row 101) — with ONE exception, asserted below: `isolation` no
+  // longer falls back. This case used to expect 'vcluster' here.
   it('falls back to customer defaults when spec fields are empty (legacy row)', () => {
     const row = subOrgRowFromRecord({
       ...record,
@@ -135,6 +138,27 @@ describe('subOrgRowFromRecord', () => {
     expect(row.kind).toBe('customer')
     expect(row.tier).toBe('org')
     expect(row.billingMode).toBe('real')
-    expect(row.isolation).toBe('vcluster')
+  })
+
+  // #6145 (UAT row 101). kind/tier/billingMode degrade into a milder version of
+  // themselves when the feed is silent; `isolation` would invent a dedicated
+  // Kubernetes control plane. On hw293 the host-namespace-backed Organization
+  // `g7freea` and the really-vcluster-backed `hw293walkone` both rendered
+  // `Isolation: Vcluster`, and a mapper that substitutes 'vcluster' is the
+  // second way that same wrong value reaches the card.
+  it('reports NO isolation when the feed does not measure one', () => {
+    const row = subOrgRowFromRecord({ ...record, isolation: '' })
+    expect(row.isolation).not.toBe('vcluster')
+    expect(row.isolation).toBe('')
+  })
+
+  // CONTROL for the same change: a feed that DOES report a boundary is passed
+  // through untouched, in both directions. Without this the assertion above is
+  // satisfied by a mapper that blanks the field for everyone.
+  it('passes a measured isolation through verbatim', () => {
+    expect(subOrgRowFromRecord({ ...record, isolation: 'vcluster' }).isolation).toBe('vcluster')
+    expect(subOrgRowFromRecord({ ...record, isolation: 'namespace' }).isolation).toBe('namespace')
+    // Unrecognized values are not measurements either.
+    expect(subOrgRowFromRecord({ ...record, isolation: 'bogus' }).isolation).toBe('')
   })
 })

--- a/products/catalyst/bootstrap/ui/src/lib/organizations.api.ts
+++ b/products/catalyst/bootstrap/ui/src/lib/organizations.api.ts
@@ -71,8 +71,13 @@ export interface OrgRow {
    *  sovereign-root row is the CLUSTER itself — isolated within nothing —
    *  so it carries 'cluster'. #5489: it previously claimed 'vcluster', a
    *  hardcoded literal with no backing object; on hw291 the directory
-   *  advertised a vCluster while `kubectl get vclusters -A` returned none. */
-  isolation: OrgIsolation | 'cluster'
+   *  advertised a vCluster while `kubectl get vclusters -A` returned none.
+   *
+   *  '' when the feed does not report one (#6145). The catalyst-api derives
+   *  this field from the boundary the org-controller was OBSERVED to have
+   *  authored (status.vcluster), so an empty value means "not measured" — and
+   *  the renderers show an em dash rather than guessing. */
+  isolation: OrgIsolation | 'cluster' | ''
   status: OrgStatus
   /** True for the sovereign-root row (parentOrg empty). The Enter-org
    *  button is hidden on this row (#3378 §5: "you are already inside it"). */
@@ -232,13 +237,24 @@ function normalizeBillingMode(raw: string | undefined, kind: OrgKind): OrgBillin
 
 /**
  * normalizeIsolation — coerce the roster-feed `isolation` onto the
- * OrgIsolation union, falling back to the kind-derived default when empty
- * or unrecognized.
+ * OrgIsolation union, or '' when the feed does not say.
+ *
+ * #6145 (UAT row 101). This used to fall back to `kindDefaults(kind).isolation`
+ * — 'vcluster' for every customer Org — so a feed that omitted the field made
+ * the identity card assert a dedicated Kubernetes control plane for an
+ * Organization nobody had measured. That is not a "safe default": every other
+ * badge on this card degrades into a milder version of itself, while this one
+ * invents infrastructure. The same reasoning already removed the parent row's
+ * hardcoded 'vcluster' (#5489) and the record mapper's fabricated plan (#4292).
+ *
+ * Unknown renders as an em dash. `kindDefaults` survives for the CREATE form,
+ * where pre-selecting a boundary the User can still change is a default rather
+ * than a claim.
  */
-function normalizeIsolation(raw: string | undefined, kind: OrgKind): OrgIsolation {
+function normalizeIsolation(raw: string | undefined): OrgIsolation | '' {
   const v = String(raw ?? '').trim().toLowerCase()
   if (v === 'namespace' || v === 'vcluster') return v
-  return kindDefaults(kind).isolation
+  return ''
 }
 
 /**
@@ -263,7 +279,7 @@ export function subOrgRowFromRecord(t: OrgRecord): OrgRow {
     // detail page omits the field rather than naming a plan nobody bought.
     plan: String(t.planSlug ?? '').trim(),
     billingMode: normalizeBillingMode(t.billingMode, kind),
-    isolation: normalizeIsolation(t.isolation, kind),
+    isolation: normalizeIsolation(t.isolation),
     status: t.status,
     isParent: false,
     ownerEmail: t.ownerEmail,

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/organizations/OrganizationDetailPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/organizations/OrganizationDetailPage.tsx
@@ -111,7 +111,14 @@ export function OrganizationDetailPage({ org, initialOrgsOverride }: Organizatio
                   <Field label="Plan" value={target.plan} testid="org-detail-plan" enumValue />
                 ) : null}
                 <Field label="Billing mode" value={target.billingMode} testid="org-detail-billing" enumValue />
-                <Field label="Isolation" value={target.isolation} testid="org-detail-isolation" enumValue />
+                {/* #6145 (UAT row 101) — the boundary the org-controller was
+                    OBSERVED to have authored, not the one the create door was
+                    asked for. An unmeasured Organization renders an em dash;
+                    the mapper no longer substitutes 'vcluster', which is how
+                    g7freea (host-namespace-backed, no vCluster on the cluster)
+                    came to render the same value as a really-vcluster-backed
+                    Organization on hw293. */}
+                <Field label="Isolation" value={target.isolation || '—'} testid="org-detail-isolation" enumValue />
                 <Field label="Status" value={target.status} testid="org-detail-status" enumValue />
                 {target.ownerEmail ? <Field label="Owner" value={target.ownerEmail} testid="org-detail-owner" /> : null}
                 {target.consoleHost ? (

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/organizations/OrganizationsDirectoryPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/organizations/OrganizationsDirectoryPage.tsx
@@ -279,7 +279,9 @@ function OrgDirectoryRow({ org }: { org: OrgRow }) {
         className="px-3 py-2 align-middle text-xs text-[var(--color-text)]"
         data-testid={`organizations-cell-isolation-${org.id}`}
       >
-        {org.isolation}
+        {/* #6145 (UAT row 101) — em dash when the feed reports no measured
+            boundary. The mapper used to substitute 'vcluster' here. */}
+        {org.isolation || '—'}
       </td>
       <td className="px-3 py-2 align-middle">
         <StatusBadge status={org.status} orgId={org.id} />


### PR DESCRIPTION
## The measurement — hw293.omantel.biz, dep `a0077ba47e3720e5`, 2026-08-11

| Organization | plan | real backing | Organization-detail card |
|---|---|---|---|
| `g7freea` | `s` | **no vcluster StatefulSet**; `bp-keycloak`, `bp-keycloak-postgresql`, `bp-agenity` run in the host `g7freea` namespace | **Isolation: Vcluster** |
| `hw293walkone` | `m` | `statefulset/vcluster` **1/1** | **Isolation: Vcluster** |

```
$ kubectl get statefulsets -A | grep -E 'g7freea|hw293walkone'
g7freea        bp-agenity               1/1   72m
g7freea        bp-keycloak              1/1   72m
g7freea        bp-keycloak-postgresql   1/1   72m
hw293walkone   vcluster                 1/1   14h
```

Two Organizations with materially different real backings reporting one value is the proof that the field is not derived from the backing — UAT row 101.

## Which of the two candidate mechanisms is actually firing

Not the console default. **The producer emits `vcluster` outright.** The record persisted on the Sovereign:

```
/var/lib/catalyst/deployments/org-tenant/84f0cb06-1e9b-43a6-8c4e-1c7a0540779d.json
  "subdomain": "g7freea", "plan_slug": "s", "isolation": "vcluster", "vcluster_name": "g7freea"
```

and two hops carry it to the card:

- `organization_provisioning.go:636` — `orgTenantRecordToResponse` copies `Isolation: rec.Isolation` verbatim; the field is `json:"isolation,omitempty"`, so a non-empty value is present on the wire and the console's `normalizeIsolation` fallback is never reached.
- `org_list_from_cr.go` `mergeOrgResponses` — local store rows win a slug/id collision, displacing the CR-derived row whose `isolation := isolationForTier(planSlug)` (`org_list_from_cr.go:136`) already answers `namespace` for plan `s`.

Upstream the value came from `resolveOrgShape` (`organization_provisioning.go:390-395`), where an explicit request `isolation` overrode the tier gate. **PR #6138 (#6135, row G7) already corrects that door, and this PR does not touch it.** They are complementary: #6138 stops the lie being minted; existing records — `g7freea`, `g7doora`, `uat107org` on hw293 right now — keep rendering it, because nothing rewrites a record accepted before the 422 landed. Coordination comment posted on #6138 rather than a rival change.

## Decision — report the OBSERVED backing

`isolation` renders on the identity card as a statement about infrastructure, so it must be measured.

- The `Organization` CRD has **no** `spec.isolation`. Live on hw293 every Organization CR reports `ISO: <none>`. A declared isolation has no downstream consumer: `gitops.boundaryIsVcluster(planSlug)` authors the boundary from the plan alone. A declared value can therefore only agree with the plan or lie about it.
- The org-controller records what it authored — `vclusterStatusFor` stamps `status.vcluster{name,hostCluster,phase}` for a vCluster-backed Organization and the zero value otherwise (#5489):

```
$ kubectl get organization hw293walkone -o jsonpath='{.status.vcluster}'
{"hostCluster":"hw293.omantel.biz","name":"hw293walkone","phase":"Ready"}
$ kubectl get organization g7freea -o jsonpath='{.status.vcluster}'
{}
   Ready: "host namespace Active + Keycloak group + Gitea Org reconciled
           (namespace-isolated tier — no vCluster authored)"
```

- `isolationForTier` is a hand-copied mirror of that gate: it reports intent. It stays as the FALLBACK for an Organization the controller has not reconciled yet, because an untouched CR is byte-identical to a namespace-backed one and answering `namespace` there would report every freshly created M-plan Organization as host-namespace-backed.

## The change

- `observedIsolationFromCR` — asserts on the **VALUE** of `status.vcluster` (name/phase), never key presence. The live `g7freea` CR carries `status.vcluster: {}`, so a presence test reports `vcluster` for exactly the Organization this row is about. Absence counts as evidence only once `status.observedGeneration > 0`.
- `orgCRToResponse` prefers the observation over the tier gate.
- `mergeOrgResponses` — a local row colliding with an OBSERVED CR adopts that observation before it wins, and re-derives `vcluster_name` + the `vcluster` timeline step, so the payload can never say `isolation: namespace` beside `vcluster_name: g7freea` (the #5489/#5501 shape, reintroduced from the store side).
- `HandleGetOrganization` applies the same overlay — detail and directory cannot disagree about one Organization.
- Console `normalizeIsolation` stops substituting `vcluster` for an absent field. That default fabricated a dedicated Kubernetes control plane out of silence; unmeasured now renders an em dash. `kindDefaults` survives for the CREATE form, where pre-selecting a boundary the User can still change is a default rather than a claim.

## Red → green, with the control

RED (helper present, not yet wired):

```
$ go test ./internal/handler/ -run '6145' -count=1 -v
=== RUN   TestOrgDirectory_IsolationComesFromObservedBacking_6145
    org_isolation_observed_backing_6145_test.go:183: g7freea isolation = "vcluster", want "namespace" — …
    org_isolation_observed_backing_6145_test.go:199: both Organizations report isolation="vcluster" despite materially different backings; the field is still not derived from the backing
    org_isolation_observed_backing_6145_test.go:206: g7freea vcluster_name = "g7freea", want empty — no vCluster exists to name
    org_isolation_observed_backing_6145_test.go:213: g7freea steps.vcluster = "pending", want empty — a host-namespace Org has no vCluster step
--- FAIL: TestOrgDirectory_IsolationComesFromObservedBacking_6145 (0.00s)
=== RUN   TestOrgDetail_IsolationComesFromObservedBacking_6145
    org_isolation_observed_backing_6145_test.go:240: org-detail isolation = "vcluster", want "namespace" — …
    org_isolation_observed_backing_6145_test.go:245: org-detail vcluster_name = "g7freea", want empty
--- FAIL: TestOrgDetail_IsolationComesFromObservedBacking_6145 (0.00s)
--- PASS: TestObservedIsolationFromCR_VacuityAndValueNotKey_6145 (0.00s)
FAIL
```

GREEN:

```
$ go test ./internal/handler/ -run '6145' -count=1 -v
--- PASS: TestOrgDirectory_IsolationComesFromObservedBacking_6145 (0.00s)
--- PASS: TestOrgDetail_IsolationComesFromObservedBacking_6145 (0.00s)
--- PASS: TestObservedIsolationFromCR_VacuityAndValueNotKey_6145 (0.00s)
    --- PASS: …/reconciled_with_an_empty_status.vcluster_block_(the_live_g7freea_shape) (0.00s)
    --- PASS: …/reconciled_with_no_vcluster_key_at_all (0.00s)
    --- PASS: …/vCluster_authored_and_Ready (0.00s)
    --- PASS: …/vCluster_authored,_still_Pending (0.00s)
    --- PASS: …/no_status_at_all_—_unobserved (0.00s)
    --- PASS: …/status_present_but_the_controller_has_not_reconciled_it (0.00s)
PASS
```

**CONTROL, in the same directory read.** `hw293walkone` shares the suspect property — the same declared `vcluster`, the same door, the same mapper — and must still report `vcluster`, with `vcluster_name: hw293walkone`. It is green in both runs above, which is what makes this a correction rather than "everything is namespace". A second control: `mergeOrgResponses` with an empty observation index is byte-unchanged, pinned by the six pre-existing `org_merge_key_5833_test.go` cases.

**VACUITY.** `TestObservedIsolationFromCR_VacuityAndValueNotKey_6145` fails if the table stops exercising all three outcomes (`vcluster` / `namespace` / unobserved), so a helper hardwired to any constant goes red. Its first case is the exact live shape — key present, value empty — which is the case a key-presence test would get wrong. The over-correction guard is in the same table: an unreconciled CR must answer `""`, not `namespace`.

TypeScript, same shape:

```
$ npx vitest run src/lib/organizations.api.test.ts     # with the old fallback restored
 FAIL  > subOrgRowFromRecord > reports NO isolation when the feed does not measure one
AssertionError: expected 'vcluster' not to be 'vcluster'
 FAIL  > subOrgRowFromRecord > passes a measured isolation through verbatim
AssertionError: expected 'vcluster' to be ''
 Test Files  1 failed (1)   Tests  2 failed | 8 passed (10)

$ npx vitest run src/lib/organizations.api.test.ts     # after
 Test Files  1 passed (1)   Tests  10 passed (10)
```

Plus `npx vitest run src/pages/sovereign/organizations` → 8 files / 34 tests passed, and `npx tsc --noEmit` clean. Full `internal/handler` package green (2814 tests).

## One fixture corrected, because the new assertion caught it

`orgReadyCR` (the shared CR fixture) stamped `status.vcluster.phase` on every CR including the plan-`s` ones. The org-controller never writes that: `vclusterStatusFor` is gated on the same tier switch that decides whether a vCluster is authored at all, so a plan-`s` Organization gets the zero block. The fixture described an object the production system cannot produce, and `TestOrgResponseFromCR_NamespaceTier_NoVClusterFields` went red against it the moment isolation started being measured rather than mirrored. The fixture now mirrors `vclusterStatusFor`, and the vcluster-tier control builds its CR on plan `m` UP FRONT instead of patching the plan after the status was written.

## Noted, not addressed here

`TestCompliance_ResourceFindings` flaked once in a full-package run taken under CPU contention. `compliance_test.go:770` waits only for `…Found`, which the FIRST of its two published PolicyReports already satisfies, so the assertion at `compliance_test.go:788` (`expected 2 findings`) can read the cache one report early. It shares no code with this diff, and it passes both in isolation and in an uncontended full run of the same package on `origin/main` (2807 tests, zero failures).

## Surfaces checked

All four front-end trees grepped for `isolation`: `core/console/` (0 hits), `core/marketplace/` (0), `products/catalyst/console/` (0), `products/catalyst/bootstrap/ui/` — the only two renderers, `OrganizationDetailPage.tsx:114` and `OrganizationsDirectoryPage.tsx:282`. `products/openova-mcp/` also 0.

Live-cluster work for this change was read-only throughout (`kubectl get` / `exec … cat` only).

Refs #6145 #6135 #5489 #5501 #4292
