### PR TITLE
fix(wizard): the retired fabricated ORG_DEFAULTS come back on rehydration (UAT W1/W2)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/entities/deployment/model.ts
+++ b/products/catalyst/bootstrap/ui/src/entities/deployment/model.ts
@@ -343,6 +343,53 @@ export const ORG_DEFAULTS = {
 }
 
 /**
+ * RETIRED_ORG_DEFAULTS_5401 — the fabricated identity ORG_DEFAULTS used to
+ * ship, kept ONLY so the persist `migrate` below can recognise and drop it.
+ *
+ * Emptying ORG_DEFAULTS fixes INITIAL_WIZARD_STATE and nothing else. The
+ * wizard store is `persist`-wrapped, `partialize()` strips only the four
+ * credential fields, and `merge()` returns `{ ...current, ...persisted }` —
+ * so the persisted payload WINS over INITIAL_WIZARD_STATE. Every browser that
+ * ran the wizard against the pre-fix bundle still holds these six values in
+ * `localStorage['openova-catalyst-wizard']` and rehydrates them verbatim,
+ * which makes the #5401 fix invisible on exactly the machines most likely to
+ * walk UAT rows W1/W2 — an operator's own browser, which has run the wizard
+ * before.
+ *
+ * W2 is the sharper half: `orgHeadquarters: 'Frankfurt, Germany'` is matched by
+ * StepProvider's `getHqHint()` against
+ * `/germany|frankfurt|berlin|munich|hamburg|cologne/i`, which derives provider
+ * 'hetzner' + regions ['fsn1','nbg1','hel1'] and renders the
+ * "★ Pre-selected based on HQ" banner — cloud provider and region derived from
+ * a fabricated value, which is precisely what W2 forbids.
+ *
+ * The migration is deliberately VALUE-MATCHED, not a blanket wipe: a field is
+ * dropped only when it is still verbatim-identical to the retired default, so
+ * an operator who had already typed their real identity keeps it. See the
+ * CONTROL cases in `store.org-defaults-rehydrate-5401.test.ts`.
+ *
+ * Do not "clean this up" by deleting it — removing this constant silently
+ * restores the fabricated company on every returning operator's browser.
+ */
+export const RETIRED_ORG_DEFAULTS_5401: Readonly<Record<string, string>> = {
+  orgName: 'Acme Financial',
+  orgDomain: 'acme.io',
+  orgEmail: 'platform@acme.io',
+  orgIndustry: 'Financial Services',
+  orgSize: '2,000–10,000',
+  orgHeadquarters: 'Frankfurt, Germany',
+}
+
+/**
+ * Persist schema version for `localStorage['openova-catalyst-wizard']`.
+ *
+ * 1 — #5401: drop the retired fabricated ORG_DEFAULTS (and any
+ *     provider/region derivation computed from the fabricated HQ) from
+ *     payloads written by the pre-fix bundle.
+ */
+export const WIZARD_PERSIST_VERSION = 1
+
+/**
  * Pool domains a Sovereign operator can pick when sovereignDomainMode='pool'.
  *
  * The first entry, omani.works, is OpenOva's primary pool domain — registered in the

--- a/products/catalyst/bootstrap/ui/src/entities/deployment/store.org-defaults-rehydrate-5401.test.ts
+++ b/products/catalyst/bootstrap/ui/src/entities/deployment/store.org-defaults-rehydrate-5401.test.ts
@@ -1,0 +1,202 @@
+/**
+ * store.org-defaults-rehydrate-5401.test.ts — UAT rows W1 + W2, issue #5401.
+ *
+ * #5401 retired the fabricated ORG_DEFAULTS (`Acme Financial` / `acme.io` /
+ * `platform@acme.io` / `Frankfurt, Germany` / …) by emptying them in
+ * `model.ts`. That fix reaches INITIAL_WIZARD_STATE only.
+ *
+ * The wizard store is `persist`-wrapped and `partialize()` strips ONLY the
+ * four credential fields, so every Organization identity field is written to
+ * localStorage under `openova-catalyst-wizard`. `merge()` then returns
+ * `{ ...current, ...persisted }` — the persisted payload WINS over
+ * INITIAL_WIZARD_STATE.
+ *
+ * So any browser that ran the wizard against the pre-fix bundle rehydrates the
+ * fabricated company verbatim, and the #5401 fix is invisible on exactly the
+ * machines most likely to walk these rows (an operator's own browser, which has
+ * run the wizard before). Concretely:
+ *
+ *   W1 — "step 1 does NOT pre-fill a fabricated company into the Organisation
+ *         identity fields": `orgName` rehydrates to 'Acme Financial'.
+ *   W2 — "the wizard does NOT derive cloud provider/region from a fabricated
+ *         value": `orgHeadquarters` rehydrates to 'Frankfurt, Germany', which
+ *         StepProvider's `getHqHint()` matches against
+ *         `/germany|frankfurt|berlin|munich|hamburg|cologne/i` — deriving
+ *         provider 'hetzner' + regions ['fsn1','nbg1','hel1'] AND rendering the
+ *         "★ Pre-selected based on HQ" banner, from a fabricated value.
+ *
+ * The fix is a persist `version` bump + `migrate` that drops the retired
+ * identity fields from legacy payloads so INITIAL_WIZARD_STATE's empty values
+ * win. An operator's OWN typed identity must survive — that is the control
+ * below, and it is what makes this a migration rather than a blanket wipe.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useWizardStore } from './store'
+import { INITIAL_WIZARD_STATE } from './model'
+
+const PERSIST_KEY = 'openova-catalyst-wizard'
+
+/**
+ * The exact ORG_DEFAULTS shipped by the pre-#5401 bundle (image tag fad88bd,
+ * `model.ts:320-324` at that commit). This is the payload a returning
+ * operator's browser actually holds.
+ */
+const RETIRED_ORG_DEFAULTS = {
+  orgName: 'Acme Financial',
+  orgDomain: 'acme.io',
+  orgEmail: 'platform@acme.io',
+  orgIndustry: 'Financial Services',
+  orgSize: '2,000–10,000',
+  orgHeadquarters: 'Frankfurt, Germany',
+}
+
+/**
+ * Seed localStorage with a legacy (pre-version-bump) persist payload.
+ *
+ * `version: 0` is the REAL shape, verified empirically against zustand 5
+ * rather than assumed: the pre-fix persist options declared no `version`, and
+ * zustand's default option is `version: 0`, which it writes into every payload.
+ * An earlier draft of this test seeded no `version` key at all and the fix
+ * appeared not to work — zustand calls `migrate` ONLY when the stored version
+ * is `typeof === 'number'` (middleware.js:392), so a version-less payload
+ * silently skips migration and every assertion here failed for the wrong
+ * reason.
+ */
+function seedLegacyPayload(state: Record<string, unknown>): void {
+  window.localStorage.setItem(PERSIST_KEY, JSON.stringify({ state, version: 0 }))
+}
+
+beforeEach(() => {
+  window.localStorage.clear()
+  useWizardStore.setState({ ...INITIAL_WIZARD_STATE })
+  window.localStorage.clear()
+})
+
+describe('wizard store — retired ORG_DEFAULTS must not survive rehydration (#5401, UAT W1/W2)', () => {
+  it('W1: a legacy payload does NOT rehydrate the fabricated Organisation identity', async () => {
+    seedLegacyPayload({
+      ...RETIRED_ORG_DEFAULTS,
+      // A field from the SAME payload that must survive — this is the vacuity
+      // check: if the payload were not being read at all, this assertion fails
+      // and the org-field assertions below would be passing on nothing.
+      sovereignSubdomain: 'legacy-payload-was-read',
+    })
+
+    await useWizardStore.persist.rehydrate()
+    const s = useWizardStore.getState()
+
+    // VACUITY CHECK — prove the seeded payload really was rehydrated.
+    expect(s.sovereignSubdomain).toBe('legacy-payload-was-read')
+
+    // The actual assertion: no fabricated company comes back.
+    expect(s.orgName).toBe('')
+    expect(s.orgDomain).toBe('')
+    expect(s.orgEmail).toBe('')
+    expect(s.orgIndustry).toBe('')
+    expect(s.orgSize).toBe('')
+  })
+
+  it('W2: a legacy payload does NOT rehydrate an HQ that drives provider/region derivation', async () => {
+    seedLegacyPayload({
+      ...RETIRED_ORG_DEFAULTS,
+      sovereignSubdomain: 'legacy-payload-was-read',
+    })
+
+    await useWizardStore.persist.rehydrate()
+    const s = useWizardStore.getState()
+
+    expect(s.sovereignSubdomain).toBe('legacy-payload-was-read')
+    // 'Frankfurt, Germany' is what StepProvider's getHqHint() matches to
+    // derive provider 'hetzner' + regions ['fsn1','nbg1','hel1'].
+    expect(s.orgHeadquarters).toBe('')
+    expect(/germany|frankfurt|berlin|munich|hamburg|cologne/i.test(s.orgHeadquarters)).toBe(false)
+  })
+
+  it("W2: a legacy payload's provider/region DERIVATION from the fabricated HQ is dropped too", async () => {
+    // StepProvider's first-visit effect early-returns when regionProviders is
+    // already populated, so a derivation computed from the fabricated HQ would
+    // be frozen in and never recomputed against the operator's real HQ.
+    seedLegacyPayload({
+      ...RETIRED_ORG_DEFAULTS,
+      sovereignSubdomain: 'legacy-payload-was-read',
+      provider: 'hetzner',
+      regionProviders: { 0: 'hetzner', 1: 'hetzner' },
+      regionCloudRegions: { 0: 'fsn1', 1: 'nbg1' },
+    })
+
+    await useWizardStore.persist.rehydrate()
+    const s = useWizardStore.getState()
+
+    expect(s.sovereignSubdomain).toBe('legacy-payload-was-read')
+    expect(s.regionProviders).toEqual({})
+    expect(s.regionCloudRegions).toEqual({})
+    expect(s.provider).toBeNull()
+  })
+
+  /**
+   * FORWARD-COMPAT — a payload already at the new version must be handed
+   * through untouched (migrate must not run on it). This one can only be green
+   * AFTER the fix: pre-fix the store declares no `version`, so zustand sees a
+   * version mismatch with no `migrate` to call and drops the payload entirely.
+   * It is therefore NOT a control — the control is the legacy-payload case
+   * below, which is green before AND after.
+   */
+  it('an operator’s OWN typed identity in a current-version payload survives rehydration', async () => {
+    window.localStorage.setItem(
+      PERSIST_KEY,
+      JSON.stringify({
+        state: {
+          orgName: 'Omantel',
+          orgDomain: 'omantel.biz',
+          orgEmail: 'platform@omantel.biz',
+          orgIndustry: 'Telecommunications',
+          orgSize: '10,000+',
+          orgHeadquarters: 'Muscat, Oman',
+          provider: 'huawei',
+          regionProviders: { 0: 'huawei' },
+          regionCloudRegions: { 0: 'me-east-1' },
+        },
+        // Written by the post-fix bundle, so no migration is owed.
+        version: 1,
+      }),
+    )
+
+    await useWizardStore.persist.rehydrate()
+    const s = useWizardStore.getState()
+
+    expect(s.orgName).toBe('Omantel')
+    expect(s.orgDomain).toBe('omantel.biz')
+    expect(s.orgEmail).toBe('platform@omantel.biz')
+    expect(s.orgIndustry).toBe('Telecommunications')
+    expect(s.orgSize).toBe('10,000+')
+    expect(s.orgHeadquarters).toBe('Muscat, Oman')
+    expect(s.provider).toBe('huawei')
+    expect(s.regionProviders).toEqual({ 0: 'huawei' })
+    expect(s.regionCloudRegions).toEqual({ 0: 'me-east-1' })
+  })
+
+  /**
+   * CONTROL 2 — a LEGACY payload whose org identity is the operator's own
+   * (they overwrote the fabricated defaults before the fix landed) must also
+   * survive. Only values that are still verbatim-identical to the retired
+   * defaults may be dropped.
+   */
+  it('CONTROL: a legacy payload the operator had already overwritten survives', async () => {
+    seedLegacyPayload({
+      orgName: 'Omantel',
+      orgDomain: 'omantel.biz',
+      orgEmail: 'platform@omantel.biz',
+      orgIndustry: 'Telecommunications',
+      orgSize: '10,000+',
+      orgHeadquarters: 'Muscat, Oman',
+    })
+
+    await useWizardStore.persist.rehydrate()
+    const s = useWizardStore.getState()
+
+    expect(s.orgName).toBe('Omantel')
+    expect(s.orgHeadquarters).toBe('Muscat, Oman')
+    expect(s.orgIndustry).toBe('Telecommunications')
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/entities/deployment/store.ts
+++ b/products/catalyst/bootstrap/ui/src/entities/deployment/store.ts
@@ -10,6 +10,8 @@ import {
   type TopologyTemplate,
   type ProvisionResult,
   type MarketplaceBrand,
+  RETIRED_ORG_DEFAULTS_5401,
+  WIZARD_PERSIST_VERSION,
 } from './model'
 import { parseDeploymentID } from '@/shared/types/deployment'
 import {
@@ -701,6 +703,54 @@ export const useWizardStore = create<WizardStore>()(
       }),
       {
         name: 'openova-catalyst-wizard',
+        version: WIZARD_PERSIST_VERSION,
+        /**
+         * #5401 / UAT rows W1 + W2 — retire the fabricated ORG_DEFAULTS from
+         * payloads written by the pre-fix bundle.
+         *
+         * Emptying ORG_DEFAULTS in model.ts only changes INITIAL_WIZARD_STATE.
+         * `merge()` below returns `{ ...current, ...persisted }`, so a payload
+         * from the old bundle overrides that fix and re-seeds
+         * `orgName: 'Acme Financial'` (W1) and
+         * `orgHeadquarters: 'Frankfurt, Germany'` (W2) on every returning
+         * operator's browser. Without this migration the fix is only visible on
+         * a browser profile that has never run the wizard.
+         *
+         * VALUE-MATCHED, not a blanket wipe: a field is dropped only when it is
+         * still verbatim-identical to the retired default, so an operator who
+         * had already typed their own identity keeps it.
+         *
+         * Deleting the key (rather than writing '') is deliberate — `merge()`
+         * spreads the persisted payload OVER `current`, so an absent key lets
+         * INITIAL_WIZARD_STATE's empty value win, while an explicit '' would
+         * work only by coincidence of the two being equal today.
+         */
+        migrate: (persisted, fromVersion) => {
+          const p = { ...(persisted as Partial<WizardState>) } as Record<string, unknown>
+          // `fromVersion` is `undefined` for payloads written before this
+          // option existed — zustand persists no `version` key at all then.
+          if (fromVersion == null || fromVersion < 1) {
+            let hqWasFabricated = false
+            for (const [key, retired] of Object.entries(RETIRED_ORG_DEFAULTS_5401)) {
+              if (p[key] === retired) {
+                if (key === 'orgHeadquarters') hqWasFabricated = true
+                delete p[key]
+              }
+            }
+            // The DERIVATION is as much a fabricated value as its input.
+            // StepProvider's first-visit effect early-returns when
+            // regionProviders is already populated, so a provider/region set
+            // derived from 'Frankfurt, Germany' would be frozen in and never
+            // recomputed against the operator's real HQ. Drop it so the step
+            // re-derives once they state who they actually are.
+            if (hqWasFabricated) {
+              delete p.provider
+              delete p.regionProviders
+              delete p.regionCloudRegions
+            }
+          }
+          return p as unknown as WizardState
+        },
         // Per credential hygiene (docs/INVIOLABLE-PRINCIPLES.md #10), the
         // private key from /api/v1/sshkey/generate is held in memory ONLY
         // for the duration of the StepCredentials view. We strip it from


### PR DESCRIPTION
## Problem

UAT rows **W1** and **W2** have been red for the entire two-day window and nothing has moved them. Both were parked as `DEPLOY-GATED (MOTHERSHIP)`. That parking is correct as far as it goes — but it is only the top layer, and underneath it the #5401 fix is **half-landed**.

**Layer 1 — the delivery gate (measured, not taken from the ledger).** The mothership `catalyst-ui` Deployment reports `ready=1 updated=1 available=1`, which reads as a completed roll. It is not:

```
catalyst-ui-7d86f8f454-t56xm   catalyst-ui:fad88bd   Running   (2026-08-03)
catalyst-ui-86ccd58b99-f7wn5   catalyst-ui:5f40184   Pending   (2026-08-11)
```

```
FailedScheduling  0/1 nodes are available: 1 Too many pods.
```

The node's `allocatable.pods` is `110` and it is running exactly `110`. `maxSurge: 25%` of 1 replica rounds **up** to 1, so a second pod is created; `maxUnavailable: 25%` of 1 rounds **down** to 0, so the old pod may never be evicted to make room. New pod cannot schedule, old pod cannot leave — the rollout is deadlocked, and `fad88bd` keeps serving the wizard.

`fad88bd` is a precise red/green control on the real artifact:

| image | `ORG_DEFAULTS` |
|---|---|
| `fad88bd` (serving) | `name: 'Acme Financial', domain: 'acme.io', email: 'platform@acme.io', industry: 'Financial Services', size: '2,000–10,000', headquarters: 'Frankfurt, Germany'` |
| `5f40184` (Pending) | all empty |

So both rows are **merged-but-undeployed**, and one object — `ORG_DEFAULTS` in `model.ts` — is the writer for both.

**Layer 2 — what this PR fixes.** Clearing that gate is *not sufficient*, because #5401 only reaches `INITIAL_WIZARD_STATE`:

- the store is `persist`-wrapped, and `partialize()` strips only the four credential fields, so every Organization identity field is written to `localStorage['openova-catalyst-wizard']`;
- `merge()` returns `{ ...current, ...persisted }` — the persisted payload **wins** over `INITIAL_WIZARD_STATE`;
- there is no `version` and no `migrate`, so nothing ever retires the old values.

Any browser that ran the wizard against the pre-fix bundle rehydrates the fabricated company verbatim. The fix is invisible on exactly the machines most likely to walk these rows — an operator's own browser, which has run the wizard before.

- **W1** — `orgName` rehydrates to `Acme Financial`.
- **W2** — `orgHeadquarters` rehydrates to `Frankfurt, Germany`, which `StepProvider`'s `getHqHint()` matches against `/germany|frankfurt|berlin|munich|hamburg|cologne/i`, deriving provider `hetzner` + regions `['fsn1','nbg1','hel1']` **and** rendering the "Pre-selected based on HQ" banner. Cloud provider and region derived from a fabricated value is precisely what W2 forbids.

## Remediation

Bump the persist schema to `version: 1` and add a `migrate()` that drops the retired identity fields from legacy payloads so `INITIAL_WIZARD_STATE`'s empty values win.

When the retired HQ is the field being dropped, the provider/region **derivation** goes with it: `StepProvider`'s first-visit effect early-returns when `regionProviders` is already populated, so a derivation computed from `Frankfurt, Germany` would otherwise be frozen in and never recomputed against the operator's real HQ.

The migration is **value-matched, not a blanket wipe** — a field is dropped only when it is still verbatim-identical to the retired default, so an operator who had already typed their own identity keeps it.

## Expected

A returning operator's browser lands on step 1 with empty Organisation identity fields, and step 3 derives nothing from a fabricated HQ.

## Tests — red before, green after, with a control and a vacuity check

`store.org-defaults-rehydrate-5401.test.ts`, 5 cases.

RED (fix stashed, corrected fixture):

```
 × W1: a legacy payload does NOT rehydrate the fabricated Organisation identity
 × W2: a legacy payload does NOT rehydrate an HQ that drives provider/region derivation
 × W2: a legacy payload's provider/region DERIVATION from the fabricated HQ is dropped too
 × an operator’s OWN typed identity in a current-version payload survives rehydration
 ✓ CONTROL: a legacy payload the operator had already overwritten survives
 Tests  4 failed | 1 passed (5)
```

```
AssertionError: expected 'Frankfurt, Germany' to be '' // Object.is equality
 ❯ store.org-defaults-rehydrate-5401.test.ts:103:31
```

GREEN (fix applied):

```
 ✓ W1: a legacy payload does NOT rehydrate the fabricated Organisation identity
 ✓ W2: a legacy payload does NOT rehydrate an HQ that drives provider/region derivation
 ✓ W2: a legacy payload's provider/region DERIVATION from the fabricated HQ is dropped too
 ✓ an operator’s OWN typed identity in a current-version payload survives rehydration
 ✓ CONTROL: a legacy payload the operator had already overwritten survives
 Tests  5 passed (5)
```

- **CONTROL** — green **before and after**: a legacy payload the operator had already overwritten survives untouched. It shares the suspect property (same fields, same persist key, same merge path), so a blanket "always blank the org fields" change would turn it red. This is what makes the change a migration rather than a wipe.
- **VACUITY CHECK** — each red case also asserts that a non-org field from the same payload arrives, so the org assertions cannot pass on a payload that was never read.

## Method note — the fixture shape was verified, not assumed

The fixture uses `version: 0` because that is the **real** pre-fix payload shape, confirmed empirically against zustand 5:

```
PRE-FIX PAYLOAD SHAPE: {"state":{...},"version":0}
```

A first draft seeded no `version` key at all, and every case failed for the wrong reason — zustand calls `migrate` **only** when the stored version is `typeof === 'number'` (`middleware.js:392`), so a version-less payload silently skips migration. Guessing the subject would have produced a confident false negative about the fix.

## Gates

- Full `ui` suite: **247 files / 2228 tests passed**.
- `tsc -b --noEmit` exit 0; `eslint` exit 0 on all three changed files.

Refs #5401
