### PR TITLE
fix(catalyst): catalyst-ui could not roll at all, and Available=True hid it for 8 days (#6157)

### DIFF
--- a/.github/workflows/check-single-replica-rollout-strategy.yaml
+++ b/.github/workflows/check-single-replica-rollout-strategy.yaml
@@ -1,0 +1,43 @@
+name: single-replica-rollout-strategy-guard
+# Regression guard (#6157, 2026-08-11). A Deployment with a literal
+# `replicas: 1` and no `strategy:` block inherits the default RollingUpdate,
+# whose maxUnavailable rounds DOWN to 0 at one replica. maxUnavailable=0
+# forbids retiring the old Pod before the new one is Ready, so every roll
+# needs a spare Pod slot — and on a node at its Pod ceiling that slot never
+# appears. The rollout then deadlocks silently: the Deployment keeps
+# reporting Available=True while serving a stale image.
+#
+# That is exactly how the mothership console served an 8-day-old bundle from
+# 2026-08-03 to 2026-08-11 (13 ReplicaSets created and scaled back to 0 in a
+# single day, every `deploy: update catalyst images to ...` commit a no-op at
+# the serving layer). `catalyst-api`, same chart and same saturated node, had
+# `strategy: Recreate` and rolled fine — the control.
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'products/catalyst/chart/templates/**'
+      - 'scripts/check-single-replica-rollout-strategy.py'
+      - '.github/workflows/check-single-replica-rollout-strategy.yaml'
+  pull_request:
+    paths:
+      - 'products/catalyst/chart/templates/**'
+      - 'scripts/check-single-replica-rollout-strategy.py'
+      - '.github/workflows/check-single-replica-rollout-strategy.yaml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  guard:
+    name: replicas=1 Deployments must declare a rollout strategy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Guard — no un-rollable single-replica Deployment (#6157)
+        run: python3 scripts/check-single-replica-rollout-strategy.py

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1374,6 +1374,20 @@ spec:
       #   provisioned. Env injection ships inside this umbrella, so the
       #   witness reaches the controller only once this pin advances. Lockstep
       #   w/ products/catalyst/chart/Chart.yaml.
+      # 1.4.1385 (#6157, Refs #6114 #6061 #6153): catalyst-ui could not roll at
+      #   all. ui-deployment.yaml declared `replicas: 1` with no `strategy:`,
+      #   inheriting RollingUpdate 25%/25%; at one replica maxSurge rounds UP
+      #   (-> 1) and maxUnavailable rounds DOWN (-> 0), and maxUnavailable=0
+      #   forbids retiring the old Pod until the new one is Ready — so the roll
+      #   needs a SECOND Pod slot, which never appears on a node at its Pod
+      #   ceiling. The mothership served an 8-day-old console bundle this way
+      #   while reporting Available=True. CONTROL: catalyst-api, same chart and
+      #   node, rolled 5s earlier on `strategy: Recreate`. Both ui siblings now
+      #   declare Recreate + `kustomize.toolkit.fluxcd.io/force: enabled`.
+      #   Relevant to Sovereigns because a worker node near its Pod ceiling has
+      #   the identical latent deadlock, and because every front-end fix
+      #   (e.g. #6061's Topology tab) is delivered by this Deployment.
+      #   Lockstep w/ products/catalyst/chart/Chart.yaml.
       # 1.4.1384 (#6106, Refs #6089, UAT rows 30/31/33/34/35/37/39/219): the
       #   catalyst-system INGRESS half of the catalyst-pin backchannel fix. The
       #   #6089 split moved Keycloak's tokenUrl/userInfoUrl/jwksUrl from the
@@ -1389,7 +1403,7 @@ spec:
       #   guacamole-pg and the shared-pg family as well. Egress half in
       #   bp-keycloak 1.5.9; neither half alone restores a brokered login.
       #   Lockstep w/ products/catalyst/chart/Chart.yaml.
-      version: 1.4.1384
+      version: 1.4.1385
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3820,6 +3820,27 @@ name: bp-catalyst-platform
 #   RENDER-TIME failure, not a runtime surprise (#4466's belt-and-suspenders
 #   against the b9f9590b self-reap). Lockstep w/ slot-13 pin.
 #
+# 1.4.1385 — #6157 (Refs #6114 #6061 #6153): catalyst-ui could not roll at
+#   all. ui-deployment.yaml declared `replicas: 1` with no `strategy:`, so it
+#   inherited RollingUpdate 25%/25%; at one replica Kubernetes rounds maxSurge
+#   UP (-> 1) and maxUnavailable DOWN (-> 0), and maxUnavailable=0 forbids
+#   retiring the old Pod before the new one is Ready. The roll therefore needs
+#   a SECOND Pod slot, which never appears on a node at its Pod ceiling. The
+#   mothership (single node, 110/110 Pods) served a 2026-08-02 console bundle
+#   until 2026-08-11 — 13 ReplicaSets created and scaled back to 0 in one day
+#   without landing a Pod, so every image bump was a no-op at the serving
+#   layer while the Deployment reported Available=True (Progressing=False /
+#   ProgressDeadlineExceeded). CONTROL: catalyst-api, same chart, same node,
+#   same saturated capacity, same image tag, rolled 5s earlier — it declares
+#   `strategy: Recreate`. Both ui siblings now declare Recreate plus
+#   `kustomize.toolkit.fluxcd.io/force: enabled` (mandatory on the Kustomize
+#   sibling, which the mothership actually applies and whose live object
+#   carries the default RollingUpdate block, else the flip fails admission
+#   with `spec.strategy.rollingUpdate: Forbidden`). Front-end delivery only —
+#   no Go image roll — but a Sovereign whose nodes are near their Pod ceiling
+#   had the same latent deadlock. Guard:
+#   scripts/check-single-replica-rollout-strategy.py. Lockstep w/ slot-13 pin.
+#
 # 1.4.1384 — #6106 (Refs #6089, UAT rows 30/31/33/34/35/37/39/219): the
 #   catalyst-system INGRESS half of the catalyst-pin OIDC backchannel. #6089
 #   repointed the sovereign realm's tokenUrl/userInfoUrl/jwksUrl at
@@ -3855,7 +3876,7 @@ name: bp-catalyst-platform
 #   hop); Case 18 proves the policy can actually be absent.
 #   Egress half in bp-keycloak 1.5.9. Neither half alone restores a brokered
 #   login. Lockstep w/ slot-13 pin.
-version: 1.4.1384
+version: 1.4.1385
 # 1.4.1229 — #5389: catalog-seed bp-newapi declares its `ui` endpoint
 #   (newapi.<fqdn>, ssoEnabled, launchDefault, ssoInitPath "/") instead of
 #   `endpoints: []`. The empty list made userUIGatePasses fail closed, which
@@ -4010,7 +4031,7 @@ version: 1.4.1384
 # scripts/check-chart-version-forward.sh (#5743) fails unless the two match —
 # main was carrying a pre-existing 1.4.1330/1.4.1329 split, so this bump heals
 # it in the same commit, exactly as the documented self-heal contract does.
-appVersion: 1.4.1384
+appVersion: 1.4.1385
 # 1.4.239 — Wave 3 / Issue #2140 (2026-05-23): Huawei provider
 # implementation lands behind the Wave 2 CloudProvider interface.
 # Adds the OpenTofu module at infra/providers/huawei/ (VPC + Subnet +

--- a/products/catalyst/chart/templates/ui-deployment-kustomize.yaml
+++ b/products/catalyst/chart/templates/ui-deployment-kustomize.yaml
@@ -19,8 +19,33 @@ metadata:
   labels:
     app.kubernetes.io/name: catalyst-ui
     app.kubernetes.io/component: frontend
+  annotations:
+    # REQUIRED here, not merely mirrored from the Helm sibling: this is
+    # the file contabo-mkt (the mothership) actually applies, and its
+    # live catalyst-ui Deployment already carries the default
+    # RollingUpdate block. Applying `strategy: Recreate` over it fails
+    # validating admission with
+    #   spec.strategy.rollingUpdate: Forbidden:
+    #     may not be specified when strategy `type` is 'Recreate'
+    # unless Flux is told to force-replace the object. See the identical
+    # block in api-deployment-kustomize.yaml, docs/CHART-AUTHORING.md
+    # §"Strategy flips on existing Deployments", and the CI fixture
+    # tests/integration/strategy-flip.yaml.
+    kustomize.toolkit.fluxcd.io/force: enabled
 spec:
   replicas: 1
+  # Recreate, not the default RollingUpdate (#6157). For `replicas: 1`
+  # Kubernetes rounds maxSurge UP (25% -> 1) and maxUnavailable DOWN
+  # (25% -> 0); maxUnavailable=0 forbids retiring the old Pod before the
+  # new one is Ready, so the roll needs a second Pod slot. On the
+  # mothership's single node at its 110-Pod ceiling that slot never
+  # appears, so from 2026-08-03 to 2026-08-11 the new Pod stayed Pending
+  # ("Too many pods") and the console served an 8-day-old bundle while
+  # the Deployment reported Available=True. Kept byte-identical in
+  # intent to the Helm sibling (ui-deployment.yaml) so contabo and
+  # Sovereigns roll the same way.
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app.kubernetes.io/name: catalyst-ui

--- a/products/catalyst/chart/templates/ui-deployment.yaml
+++ b/products/catalyst/chart/templates/ui-deployment.yaml
@@ -5,8 +5,46 @@ metadata:
   labels:
     app.kubernetes.io/name: catalyst-ui
     app.kubernetes.io/component: frontend
+  annotations:
+    # Companion to `strategy: Recreate` below. Applying Recreate over a
+    # Deployment that already carries the default RollingUpdate block
+    # fails validating admission with
+    #   spec.strategy.rollingUpdate: Forbidden:
+    #     may not be specified when strategy `type` is 'Recreate'
+    # because strategic-merge merges the new `type` in without dropping
+    # the residual maxSurge/maxUnavailable keys. This annotation is the
+    # durable remediation — see the identical block in
+    # api-deployment.yaml, docs/CHART-AUTHORING.md §"Strategy flips on
+    # existing Deployments", and tests/integration/strategy-flip.yaml.
+    # Do NOT use an inline `$patch: replace` instead: it breaks fresh
+    # installs and Flux's SSA path strips it anyway.
+    kustomize.toolkit.fluxcd.io/force: enabled
 spec:
   replicas: 1
+  # Recreate, not the default RollingUpdate (#6157).
+  #
+  # For `replicas: 1` Kubernetes rounds maxSurge UP (25% -> 1) and
+  # maxUnavailable DOWN (25% -> 0). maxUnavailable=0 forbids retiring
+  # the old Pod until the new one is Ready, so the roll requires a
+  # SECOND Pod slot to exist at the same time. On a node at its Pod
+  # ceiling that slot never appears, the new Pod stays Pending
+  # ("Too many pods"), and the old Pod serves forever:
+  #
+  #   Available=True    reason=MinimumReplicasAvailable   <- hides it
+  #   Progressing=False reason=ProgressDeadlineExceeded
+  #
+  # That deadlock ran unnoticed on the mothership from 2026-08-03 to
+  # 2026-08-11 — 13 ReplicaSets created and scaled back to 0 in a single
+  # day without ever landing a Pod, so every `deploy: update catalyst
+  # images to ...` commit was a no-op at the serving layer while the
+  # console kept serving an 8-day-old bundle.
+  #
+  # catalyst-api (same chart, also replicas: 1) already uses Recreate
+  # and rolled cleanly on the same saturated node in the same minute.
+  # A single-replica stateless frontend has no HA to preserve, so
+  # RollingUpdate buys nothing here and costs the ability to roll.
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app.kubernetes.io/name: catalyst-ui

--- a/scripts/check-single-replica-rollout-strategy.py
+++ b/scripts/check-single-replica-rollout-strategy.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Guard: a literal `replicas: 1` Deployment must declare an explicit rollout strategy.
+
+Why this guard exists (#6157)
+-----------------------------
+On 2026-08-03 the mothership's `catalyst-ui` Deployment stopped rolling, and
+nobody noticed until 2026-08-11 — eight days and 13 no-op ReplicaSets later.
+
+`ui-deployment.yaml` declared `replicas: 1` and no `strategy:` block, so it
+inherited the default RollingUpdate with maxSurge/maxUnavailable of 25%/25%.
+For `replicas: 1` Kubernetes rounds maxSurge UP (-> 1) and maxUnavailable
+DOWN (-> 0). maxUnavailable=0 forbids retiring the old Pod until the new one
+is Ready, so the roll requires a SECOND Pod slot to exist simultaneously.
+
+The mothership is a single node at its 110-Pod ceiling. That slot never
+appeared, the new Pod stayed Pending ("Too many pods"), and the old Pod served
+an eight-day-old console bundle. The Deployment reported:
+
+    Available=True    reason=MinimumReplicasAvailable    <- why nobody noticed
+    Progressing=False reason=ProgressDeadlineExceeded
+
+Meanwhile `catalyst-api` — same chart, same node, same saturated capacity,
+same target image, rolled five seconds earlier — succeeded, because it
+declares `strategy: type: Recreate`. That is the control: the only difference
+between the two was the rollout strategy.
+
+Scope, and why it is a ratchet
+------------------------------
+CORE is hard-gated: the console + API Deployments must declare
+`type: Recreate` AND carry `kustomize.toolkit.fluxcd.io/force: enabled` (the
+documented remediation for the RollingUpdate -> Recreate flip collision — see
+docs/CHART-AUTHORING.md and tests/integration/strategy-flip.yaml).
+
+KNOWN_GAP records the pre-existing instances of the same shape that this guard
+does NOT fix. They are real latent deadlocks on any capacity-bound Sovereign
+node, but they are not the confirmed live defect and were not changed here.
+The list is a ratchet: a NEW literal-`replicas: 1` Deployment with no strategy
+fails the guard, so the class cannot grow. Fixing one means deleting its line
+from KNOWN_GAP — the guard fails if a listed file has quietly been fixed, so
+the list cannot rot into a lie.
+
+Deployments whose replica count is templated (e.g. the controllers'
+`{{ .Values.controllers.X.replicas | default 1 }}`) are deliberately OUT of
+scope: an operator can scale those above 1, where the strategy tradeoff is a
+genuine availability decision rather than a guaranteed deadlock.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+TEMPLATES = Path("products/catalyst/chart/templates")
+
+# Must declare Recreate + the Flux force annotation. Hard failure.
+CORE = {
+    "api-deployment.yaml",
+    "api-deployment-kustomize.yaml",
+    "ui-deployment.yaml",
+    "ui-deployment-kustomize.yaml",
+}
+
+# Pre-existing same-shape Deployments this change did not fix (#6157 follow-up).
+# Paths are relative to TEMPLATES. Removing a file from this set is the ONLY
+# correct way to retire an entry — see the module docstring.
+KNOWN_GAP = {
+    "marketplace-api/deployment.yaml",
+    "org-services/admin.yaml",
+    "org-services/auth.yaml",
+    "org-services/billing.yaml",
+    "org-services/catalog.yaml",
+    "org-services/console.yaml",
+    "org-services/domain.yaml",
+    "org-services/gateway.yaml",
+    "org-services/marketplace.yaml",
+    "org-services/notification.yaml",
+    "org-services/organization.yaml",
+    "org-services/provisioning.yaml",
+}
+
+LITERAL_REPLICAS_1 = re.compile(r"^  replicas: 1\s*$", re.M)
+STRATEGY = re.compile(r"^  strategy:\s*$", re.M)
+RECREATE = re.compile(r"^  strategy:\s*\n\s+type: Recreate\s*$", re.M)
+FORCE_ANNOTATION = re.compile(
+    r"^\s*kustomize\.toolkit\.fluxcd\.io/force:\s*enabled\s*$", re.M
+)
+
+
+def main() -> int:
+    if not TEMPLATES.is_dir():
+        print(f"FAIL: {TEMPLATES} not found — run from the repo root", file=sys.stderr)
+        return 2
+
+    failures: list[str] = []
+    seen_gap: set[str] = set()
+    checked = 0
+
+    for path in sorted(TEMPLATES.rglob("*.yaml")):
+        text = path.read_text(encoding="utf-8")
+        if not LITERAL_REPLICAS_1.search(text):
+            continue
+        if "kind: Deployment" not in text:
+            continue
+
+        checked += 1
+        rel = path.relative_to(TEMPLATES).as_posix()
+        name = path.name
+        has_strategy = bool(STRATEGY.search(text))
+
+        if name in CORE:
+            if not RECREATE.search(text):
+                failures.append(
+                    f"{rel}: CORE Deployment with `replicas: 1` must declare "
+                    f"`strategy:\\n    type: Recreate` (found strategy block: {has_strategy}). "
+                    f"maxUnavailable rounds to 0 at replicas=1, so the roll needs a spare "
+                    f"Pod slot and deadlocks on a full node (#6157)."
+                )
+            if not FORCE_ANNOTATION.search(text):
+                failures.append(
+                    f"{rel}: missing `kustomize.toolkit.fluxcd.io/force: enabled`, which "
+                    f"must accompany the Recreate strategy. Applying Recreate over an "
+                    f"existing RollingUpdate object fails admission with "
+                    f"`spec.strategy.rollingUpdate: Forbidden` without it."
+                )
+            continue
+
+        if rel in KNOWN_GAP:
+            seen_gap.add(rel)
+            if has_strategy:
+                failures.append(
+                    f"{rel}: now declares a rollout strategy but is still listed in "
+                    f"KNOWN_GAP. Delete it from that set in {Path(__file__).name} so the "
+                    f"ratchet keeps telling the truth."
+                )
+            continue
+
+        if not has_strategy:
+            failures.append(
+                f"{rel}: NEW Deployment with a literal `replicas: 1` and no `strategy:`. "
+                f"At replicas=1 maxUnavailable rounds to 0, so this cannot roll on a node "
+                f"at its Pod ceiling — it will serve a stale image while reporting "
+                f"Available=True (#6157). Declare `strategy: type: Recreate` (plus the "
+                f"`kustomize.toolkit.fluxcd.io/force: enabled` annotation), or add an "
+                f"explicit rollingUpdate with maxUnavailable >= 1."
+            )
+
+    stale = KNOWN_GAP - seen_gap
+    if stale:
+        failures.append(
+            "KNOWN_GAP lists files that no longer match the guarded shape "
+            f"(moved, renamed, or deleted): {sorted(stale)}. Update the set."
+        )
+
+    if failures:
+        print(f"FAIL — {len(failures)} rollout-strategy problem(s):\n", file=sys.stderr)
+        for f in failures:
+            print(f"  - {f}\n", file=sys.stderr)
+        return 1
+
+    print(
+        f"ok — {checked} literal `replicas: 1` Deployment(s) checked: "
+        f"{len(CORE)} core on Recreate + force-annotation, "
+        f"{len(seen_gap)} known-gap held flat (#6157)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What this fixes

The mothership console served a **2026-08-02 bundle until 2026-08-11**. Thirteen ReplicaSets were created and scaled back to 0 in a single day without ever landing a Pod — every `deploy: update catalyst images to ...` commit in that window was a **no-op at the serving layer**.

`ui-deployment.yaml` declared `replicas: 1` and no `strategy:`, so it inherited the default RollingUpdate 25%/25%. At one replica Kubernetes rounds maxSurge **up** (→ 1) and maxUnavailable **down** (→ 0). `maxUnavailable: 0` forbids retiring the old Pod until the new one is Ready, so the roll needs a *second* Pod slot. The mothership is a single node at its 110-Pod ceiling:

```
Warning  FailedScheduling  (x23 over 129m)  default-scheduler
  0/1 nodes are available: 1 Too many pods.
```

The slot never appeared, so the new Pod stayed Pending and the old Pod served forever. Kubernetes already knew:

```
Available=True    reason=MinimumReplicasAvailable    <- why nobody noticed
Progressing=False reason=ProgressDeadlineExceeded
```

## Control — why this is the strategy, not the capacity

`catalyst-api` is in the same chart, on the same node, at the same saturated capacity, rolled to the same image tag **five seconds earlier**:

| Deployment | replicas | strategy | outcome |
|---|---|---|---|
| `catalyst-api` | 1 | **Recreate** | Pod created `04:20:59Z` on `c99f71b` — **rolled** |
| `catalyst-ui` | 1 | RollingUpdate (maxUnavailable→0) | Pod **Pending** `04:20:54Z`, serving `fad88bd` from 2026-08-03 — **never rolled** |

The only difference between the two is the rollout strategy.

## Impact, measured against the served bundle

Not assumed — checked with `git merge-base --is-ancestor` against the bundle actually being served:

- **#6061** (Topology tab returned before it ever read `status.targets`) — `NOT-IN` served `fad88bd`, `IN` desired `c99f71b`.
- **#6153** (wizard fabricated `ORG_DEFAULTS` on rehydration, UAT rows W1/W2) — `NOT-IN` either.

Both are front-end fixes that ride `catalyst-ui`. This is also why UAT evidence that re-established "the running artifact" from **catalyst-api**'s `/api/v1/version` was reading the **wrong artifact** for every console-rendered row — the console rolls independently.

## The change

`strategy: type: Recreate` on both siblings, plus `kustomize.toolkit.fluxcd.io/force: enabled`. The annotation is **mandatory** on the Kustomize sibling — that is the file the mothership actually applies, and its live object already carries the default RollingUpdate block, so the flip would otherwise fail admission with `spec.strategy.rollingUpdate: Forbidden` (the documented `docs/CHART-AUTHORING.md` §"Strategy flips on existing Deployments" collision, fixture at `tests/integration/strategy-flip.yaml`).

A single-replica stateless frontend has no availability to preserve across a roll, so RollingUpdate buys nothing here and costs the ability to roll at all.

## Guard

`scripts/check-single-replica-rollout-strategy.py`, wired to CI on any change under `products/catalyst/chart/templates/`.

**RED** (pre-fix tree, chart files reverted):
```
FAIL — 4 rollout-strategy problem(s)
  ui-deployment.yaml / ui-deployment-kustomize.yaml: CORE Deployment with
  `replicas: 1` must declare `strategy: type: Recreate` … (+ force annotation)
EXIT=1
```

**RED** (ratchet control — a new un-strategied `replicas: 1` Deployment):
```
FAIL — 1 rollout-strategy problem(s)
  org-services/_ratchet-probe.yaml: NEW Deployment with a literal
  `replicas: 1` and no `strategy:` …
EXIT=1
```

**GREEN** (this tree):
```
ok — 16 literal `replicas: 1` Deployment(s) checked: 4 core on Recreate +
force-annotation, 12 known-gap held flat
EXIT=0
```

## Scope

The 12 `KNOWN_GAP` entries (`org-services/*`, `marketplace-api/`) are the same shape and are real latent deadlocks on any capacity-bound Sovereign node, but they are **not** the confirmed live defect and are not changed here. The guard **ratchets** them: the class cannot grow, and a listed file that gets fixed must be removed from the set or the guard fails — so the list cannot rot into a lie.

Deployments whose replica count is **templated** (the controllers' `{{ .Values.controllers.X.replicas | default 1 }}`) are deliberately out of scope: an operator can scale those above 1, where the strategy is a genuine availability decision rather than a guaranteed deadlock.

## Verification

- `helm template` renders `Recreate` + the annotation.
- `kubectl kustomize` over the mothership's own `resources[]` list renders the same — the actual apply path.
- The pre-existing mothership raw-kustomize plain-YAML guard (#5290/#5292) still **PASSes**.
- Read-only on live clusters throughout; no NodePort involved.

Refs #6157 #6114 #6061 #6153

🤖 Generated with [Claude Code](https://claude.com/claude-code)
