### PR TITLE
fix(agenity): read the Anthropic credential more than once (Refs #6163)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1389,7 +1389,7 @@ spec:
       #   guacamole-pg and the shared-pg family as well. Egress half in
       #   bp-keycloak 1.5.9; neither half alone restores a brokered login.
       #   Lockstep w/ products/catalyst/chart/Chart.yaml.
-      version: 1.4.1396
+      version: 1.4.1398
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1389,7 +1389,7 @@ spec:
       #   guacamole-pg and the shared-pg family as well. Egress half in
       #   bp-keycloak 1.5.9; neither half alone restores a brokered login.
       #   Lockstep w/ products/catalyst/chart/Chart.yaml.
-      version: 1.4.1395
+      version: 1.4.1396
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/agenity/README.md
+++ b/products/agenity/README.md
@@ -142,6 +142,17 @@ Sovereign via either:
 - a per-Sovereign overlay setting `sovereign.anthropic.{apiKey,credentialsJson}`
   on bp-catalyst-platform.
 
+**Rotation takes effect without a pod roll (#6163).** `seedAnthropicToken`
+reads `catalyst-system/sovereign-anthropic-credentials` **live** on every seed
+pass and falls back to the process env. Before that it read only
+`CATALYST_ANTHROPIC_API_KEY` / `CATALYST_ANTHROPIC_CREDENTIALS_JSON`, which are
+`secretKeyRef` env vars — materialised **once, at container start** — so the
+ten-minute self-heal loop re-wrote the credential the process booted with,
+forever, and an operator who rotated the Secret after an OAuth expiry changed
+nothing until the next catalyst-api roll. The seed log line now carries
+`credentialSource`; `process-env` on a Sovereign that HAS the Secret means the
+live read failed.
+
 Until it is supplied the dashboard still renders, but the seed **loud-skips**
 (catalyst-api logs `anthropic seed: SKIPPED — platform Anthropic credential
 unset`) and the agent reports *"runtime offline · 0 workers"* / *"no Claude
@@ -173,7 +184,26 @@ ESO refreshes `agenity-anthropic-token` within `refreshInterval` (1h, or force
 an immediate sync by annotating the ExternalSecret with
 `force-sync=$(date +%s)`); the init container then seeds
 `~/.claude/.credentials.json` from `credentialsJson` and the next agent spawn
-authenticates. This path is **shared per-Sovereign** (not per-Org-namespaced) —
+authenticates.
+
+> **The init container waits for a late credential — it no longer no-ops
+> (#6163).** `seed-claude-creds` used to read the mounted Secret once at pod
+> start and, on a miss, print `no credentials.json key in Secret — key-only
+> mode` and exit 0. Measured on hw293, a workspace held that line for **eight
+> hours** after the openbao path was seeded, with the Pod reporting `Running`
+> throughout. It now polls the mount for
+> `anthropic.credentialWait.deadlineSeconds` (default 180s) — kubelet
+> re-projects a mounted Secret on its own sync period, so a credential seeded
+> after pod start arrives with no restart — and on timeout exits non-zero, so
+> the kubelet retries with backoff and the gap is visible in `kubectl get pod`
+> rather than only in a log. Set
+> `anthropic.credentialWait.onTimeout: continue` to start the workspace anyway.
+> Note that the old "key-only mode" wording was never accurate here: this init
+> container renders only when `anthropic.credentialsKey` is set, i.e. only when
+> OAuth mode was requested — a real key-only install sets `credentialsKey: ""`
+> and gets no init container at all.
+
+This path is **shared per-Sovereign** (not per-Org-namespaced) —
 a single seed serves every Org's agenity install on that Sovereign. The
 preferred durable seam is the platform credential the catalyst-api producer
 auto-seeds (above); this `bao kv put` is a one-off / hot re-seed.

--- a/products/agenity/blueprint.yaml
+++ b/products/agenity/blueprint.yaml
@@ -18,7 +18,12 @@ spec:
   # Keycloak backchannel + upstream) — the per-Org namespace is default-deny
   # and the gate's ingress-only CNP left the OAuth callback 500ing on a DNS
   # timeout. Lockstep with products/agenity/chart + the catalog-seed pin.
-  version: 0.5.22
+  # 0.5.24 (#6163): the seed-claude-creds init container stops being a
+  # ONE-SHOT reader of the Anthropic credential — it now waits for a
+  # late-arriving credential, retries across kubelet restarts, and fails
+  # loudly instead of announcing "key-only mode" and exiting 0 forever.
+  # Lockstep with products/agenity/chart + the catalog-seed pin.
+  version: 0.5.24
   card:
     title: Agenity
     summary: |

--- a/products/agenity/chart/Chart.yaml
+++ b/products/agenity/chart/Chart.yaml
@@ -188,7 +188,25 @@ type: application
 # same gateway bp-wordpress-tenant + the org console route attach to, #4054).
 # The old default rendered Accepted=False/InvalidHTTPRoute and the host 404'd
 # until the parentRef was hand-overridden. appVersion (image) unchanged.
-version: 0.5.22
+version: 0.5.24
+# 0.5.24 (#6163): the seed-claude-creds init container stops being a ONE-SHOT
+# reader of the Anthropic credential. It read the mounted Secret once at pod
+# start and, on a miss, printed `no credentials.json key in Secret — key-only
+# mode` and exited 0 — forever. Measured on hw293: a workspace held that line
+# for EIGHT HOURS after the Sovereign's openbao path was seeded, because a
+# one-shot reader cannot notice a credential that arrives later, and the Pod
+# reported Running the whole time (which is what let UAT row R19 — "the init
+# container validates the token and exits 0" — read green over a workspace
+# that could not authenticate). "key-only mode" was never true either: this
+# container renders ONLY under `if .Values.anthropic.credentialsKey`, i.e.
+# only when OAuth mode was requested, so the miss branch could only ever mean
+# "the credential you asked for did not arrive". It now WAITS on the mount
+# (kubelet re-projects a Secret on its own sync period, so a credential seeded
+# after pod start lands with no restart), RETRIES across kubelet init-container
+# restarts, and FAILS LOUDLY into `kubectl get pod` when it never arrives.
+# New values anthropic.credentialWait.{deadlineSeconds,pollSeconds,onTimeout}
+# (180 / 5 / fail); onTimeout=continue restores the old start-anyway shape.
+# Template + values change; appVersion (image) UNCHANGED.
 # 0.5.22 (#5617): the per-Org oidc-gate companion gains its EGRESS
 # CiliumNetworkPolicy (templates/oidc-gate.yaml `oidc-gate-<cid>-egress`).
 # The gate shipped an ingress-only gateway CNP into a DEFAULT-DENY per-Org

--- a/products/agenity/chart/templates/statefulset.yaml
+++ b/products/agenity/chart/templates/statefulset.yaml
@@ -72,9 +72,47 @@ spec:
         # on the chepherd host. Materialize it from the Secret's full
         # credentials.json blob into a shared emptyDir mounted at
         # /home/chepherd/.claude (writable so claude-code can rotate the OAuth
-        # pair). No-op when the Secret lacks the credentials key (key-only
-        # mode). Runs as uid 1000 to match the chepherd user the agent forks
+        # pair). Runs as uid 1000 to match the chepherd user the agent forks
         # as. The Secret is mounted read-only at /creds.
+        #
+        # ── WHY THIS WAITS INSTEAD OF NO-OPPING (#6163) ─────────────────────
+        # This container used to read /creds ONCE, and on a miss print
+        #   "no credentials.json key in Secret — key-only mode"
+        # and exit 0. Measured on hw293: it printed that line and the
+        # workspace then held it for EIGHT HOURS after the Sovereign's
+        # OpenBao path was seeded — a one-shot reader cannot pick up a
+        # later-arriving credential, so every workspace provisioned before
+        # the seed was stranded until someone hand-deleted the Pod.
+        #
+        # "key-only mode" was also never true here. This whole init
+        # container renders only under `if .Values.anthropic.credentialsKey`
+        # — i.e. only when the installer ASKED for OAuth mode. An install
+        # that genuinely wants a bare `sk-ant-api03` key sets
+        # credentialsKey: "" and gets no init container and an
+        # ANTHROPIC_API_KEY env instead (see the container env below). So
+        # the miss branch could only ever mean "the OAuth credential you
+        # asked for did not arrive", and it announced a supported operating
+        # mode instead. The pod then reached Running with an agent that
+        # 401s on every message, which is exactly what let R19 —
+        # "the init container validates the token and exits 0" — read green
+        # over a workspace that could not talk to Claude.
+        #
+        # The shape now: WAIT (the Secret volume is refreshed by kubelet on
+        # its own sync period, so a credential seeded AFTER this pod started
+        # lands in /creds with no restart — the wait costs nothing and fixes
+        # the common case), then RETRY (on timeout we exit non-zero; the
+        # kubelet restarts the init container with backoff, so the wait
+        # resumes forever until the credential exists), and FAIL LOUDLY
+        # (Init:Error / CrashLoopBackOff puts the gap in `kubectl get pod`,
+        # the one place an operator already looks, instead of on line 3 of a
+        # log nobody reads).
+        #
+        # Why failing is right even though the dashboard then does not
+        # serve: a workspace whose entire purpose is chatting with Claude is
+        # not "serving" when it cannot authenticate. Rendering the shell is
+        # not the product. `anthropic.credentialWait.onTimeout: continue`
+        # restores the old degraded behaviour for anyone who disagrees, and
+        # is deliberately not the default.
         - name: seed-claude-creds
           image: {{ include "agenity.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -84,8 +122,29 @@ spec:
             - |
               set -e
               mkdir -p /claudehome/.claude/projects
-              if [ -s /creds/{{ .Values.anthropic.credentialsKey }} ]; then
-                cp /creds/{{ .Values.anthropic.credentialsKey }} /claudehome/.claude/.credentials.json
+              CREDS_PATH=/creds/{{ .Values.anthropic.credentialsKey }}
+              # Bounded wait for a LATER-ARRIVING credential (#6163). Poll the
+              # mount rather than reading it once: kubelet re-projects a mounted
+              # Secret on its own sync period, so the file materialises in this
+              # container's filesystem the moment the ExternalSecret resolves —
+              # no pod restart, no operator action. deadlineSeconds<=0 disables
+              # the wait entirely (single read, original behaviour).
+              WAIT_DEADLINE={{ .Values.anthropic.credentialWait.deadlineSeconds | int }}
+              WAIT_POLL={{ .Values.anthropic.credentialWait.pollSeconds | int }}
+              [ "$WAIT_POLL" -ge 1 ] || WAIT_POLL=1
+              WAITED=0
+              while [ ! -s "$CREDS_PATH" ] && [ "$WAITED" -lt "$WAIT_DEADLINE" ]; do
+                if [ "$WAITED" -eq 0 ]; then
+                  echo "waiting up to ${WAIT_DEADLINE}s for the Anthropic credential at ${CREDS_PATH} — a credential seeded into openbao AFTER this pod started still arrives here (kubelet re-projects the mounted Secret), so this wait is what stops a workspace being stranded credential-less for the life of the pod (#6163)."
+                fi
+                sleep "$WAIT_POLL"
+                WAITED=$(( WAITED + WAIT_POLL ))
+              done
+              if [ "$WAITED" -gt 0 ] && [ -s "$CREDS_PATH" ]; then
+                echo "Anthropic credential arrived after ~${WAITED}s of waiting."
+              fi
+              if [ -s "$CREDS_PATH" ]; then
+                cp "$CREDS_PATH" /claudehome/.claude/.credentials.json
                 chmod 600 /claudehome/.claude/.credentials.json
                 echo "seeded ~/.claude/.credentials.json ($(wc -c < /claudehome/.claude/.credentials.json) bytes)"
                 # ── OAuth-expiry pre-flight (#4111) ──────────────────────────
@@ -112,7 +171,22 @@ spec:
                   *)        echo "could not parse claude-code OAuth expiry from credentials.json (non-fatal)." ;;
                 esac
               else
-                echo "no credentials.json key in Secret — key-only mode"
+                # The credential never arrived. Say the true thing (#6163):
+                # this install ASKED for OAuth mode (anthropic.credentialsKey
+                # is set, which is the only reason this container exists), so
+                # the miss is a missing credential and never "key-only mode".
+                echo "🛑 AGENITY CREDENTIAL MISSING (#6163): no non-empty '{{ .Values.anthropic.credentialsKey }}' in Secret {{ .Values.anthropic.secretName }} after waiting ${WAIT_DEADLINE}s. The workspace agent CANNOT authenticate to Anthropic and every chat message would fail 401. This is NOT key-only mode — key-only mode is anthropic.credentialsKey=\"\", which renders no init container at all. Fix: seed the Sovereign's openbao catalyst/anthropic/token (catalyst-api CATALYST_ANTHROPIC_CREDENTIALS_JSON, or the operator-rotatable Secret catalyst-system/sovereign-anthropic-credentials) and let the {{ .Values.anthropic.secretName }} ExternalSecret sync."
+                {{- if eq .Values.anthropic.credentialWait.onTimeout "fail" }}
+                # Exit non-zero on purpose. The kubelet restarts this init
+                # container with backoff, so the wait above resumes and the pod
+                # proceeds by itself the moment the credential exists — and
+                # until then the gap is visible in `kubectl get pod` as
+                # Init:Error/CrashLoopBackOff rather than only in a log line
+                # under a pod that reports Running.
+                exit 1
+                {{- else }}
+                echo "anthropic.credentialWait.onTimeout={{ .Values.anthropic.credentialWait.onTimeout }} — starting the workspace anyway. The dashboard will render and every chat message will fail; do not read a Running pod as a working agent."
+                {{- end }}
               fi
               # Onboarding stub so claude-code does not re-run the first-run
               # /login flow AND does not block on the two interactive first-run

--- a/products/agenity/chart/tests/seed-claude-creds-credential-wait.sh
+++ b/products/agenity/chart/tests/seed-claude-creds-credential-wait.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+# bp-agenity — #6163: the seed-claude-creds init container must not be a
+# ONE-SHOT reader of the Anthropic credential.
+#
+# THE DEFECT this test locks down
+# ------------------------------------------------------------------------
+# The init container read the mounted Secret exactly once at pod start. On a
+# miss it printed
+#
+#     no credentials.json key in Secret — key-only mode
+#
+# and exited 0. Measured on hw293: a workspace held that line for EIGHT HOURS
+# after the Sovereign's openbao path was seeded. A one-shot reader has no way
+# to notice a credential that arrives later, so every workspace provisioned
+# before the seed was stranded until someone hand-deleted the Pod — and the
+# Pod reported Running the whole time, which is what let UAT row R19 ("the
+# init container validates the token and exits 0") read green over a workspace
+# that could not talk to Anthropic at all.
+#
+# "key-only mode" was also never a true description of that branch. This init
+# container renders ONLY under `if .Values.anthropic.credentialsKey` — i.e.
+# only when the install asked for OAuth mode. A genuinely key-only install
+# sets credentialsKey:"" and gets no init container. So the miss branch could
+# only ever mean "the credential you asked for did not arrive", and it named a
+# supported operating mode instead.
+#
+# WHAT THIS TEST DOES
+# ------------------------------------------------------------------------
+# It does not grep the template. It EXTRACTS the rendered init-container shell
+# script and RUNS it against a sandbox filesystem, so every assertion is about
+# behaviour: exit status and emitted lines.
+#
+#   Case 1  (red-before) credential NEVER arrives  -> non-zero exit + loud line
+#   Case 2  (red-before) credential arrives LATE   -> waits, then seeds
+#   Control A           credential present at t=0  -> seeds, exits 0, fast
+#   Control B           onTimeout=continue         -> exits 0 (escape hatch)
+#   Vacuity             a mutant that exits 0 must DEFEAT Case 1's assertion
+#
+# Controls A and B share the suspect property — the same rendered script, the
+# same mounted-Secret read path — and are green BOTH before and after the fix,
+# so a green run cannot be explained by "the script now always fails".
+
+set -euo pipefail
+
+chart_dir="${1:-$(cd "$(dirname "$0")/.." && pwd)}"
+helm="${HELM_BIN:-helm}"
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+# ── Extract the init container's shell script from the rendered StatefulSet ──
+# The script is the block scalar under `command: [sh, -c, |]` of the
+# seed-claude-creds container. Pulled out with awk rather than a YAML library
+# so the test has no dependency beyond helm + coreutils.
+render_script() {
+  "$helm" template agenity "$chart_dir" "$@" 2>/dev/null \
+    | awk '
+        /^        - name: seed-claude-creds$/ { inctr=1; next }
+        inctr && /^            - \|$/         { inblk=1; next }
+        inblk {
+          if ($0 == "") { print ""; next }
+          if (substr($0,1,14) == "              ") { print substr($0,15); next }
+          exit
+        }
+      '
+}
+
+script="$work/seed.sh"
+render_script --set "sovereignFqdn=agnstar.omani.homes" > "$script"
+
+# ── VACUITY GUARD 1: we must actually be running the init container ─────────
+# An empty / truncated extraction would make every "the script printed X"
+# assertion pass or fail for reasons that have nothing to do with the chart.
+[ -s "$script" ] || fail "extracted init-container script is EMPTY — the awk extractor no longer matches the rendered StatefulSet (indentation or container name changed). Every assertion below would be vacuous."
+[ "$(wc -c < "$script")" -gt 400 ] || fail "extracted init-container script is only $(wc -c < "$script") bytes — too short to be the real seed-claude-creds body."
+grep -q 'set -e' "$script" || fail "extracted script does not start with 'set -e' — the extraction is not the init-container body."
+echo "[6163] extracted seed-claude-creds script: $(wc -c < "$script") bytes"
+
+# ── Run one extraction in a sandbox ─────────────────────────────────────────
+# /creds and /claudehome are rewritten to a per-case temp tree so the script
+# runs unprivileged. Everything else — the wait loop, the branch, the exit
+# status — is exactly what the kubelet executes.
+#
+# $1 sandbox dir · $2 deadline · $3 poll · $4 onTimeout · $5 seconds to wait
+# before dropping the credential in ("never" = never drop it).
+run_case() {
+  local sb="$1" deadline="$2" poll="$3" ontimeout="$4" drop_after="$5"
+  mkdir -p "$sb/creds" "$sb/claudehome"
+  local s="$sb/run.sh"
+  render_script \
+    --set "sovereignFqdn=agnstar.omani.homes" \
+    --set "anthropic.credentialWait.deadlineSeconds=$deadline" \
+    --set "anthropic.credentialWait.pollSeconds=$poll" \
+    --set "anthropic.credentialWait.onTimeout=$ontimeout" \
+    | sed -e "s#/creds#$sb/creds#g" -e "s#/claudehome#$sb/claudehome#g" > "$s"
+  [ -s "$s" ] || fail "sandbox render produced an empty script"
+
+  if [ "$drop_after" != "never" ]; then
+    ( sleep "$drop_after"; printf '%s' '{"claudeAiOauth":{"accessToken":"NOT-A-REAL-TOKEN","refreshToken":"NOT-A-REAL-TOKEN","expiresAt":0,"scopes":["user:inference"]}}' > "$sb/creds/credentialsJson" ) &
+  fi
+
+  set +e
+  sh "$s" > "$sb/out.log" 2>&1
+  local rc=$?
+  set -e
+  wait 2>/dev/null || true
+  echo "$rc" > "$sb/rc"
+  return 0
+}
+
+rc_of()  { cat "$1/rc"; }
+log_of() { cat "$1/out.log"; }
+
+# ── Case 1 — the credential never arrives ───────────────────────────────────
+# BEFORE the fix this exits 0 announcing "key-only mode"; the pod reaches
+# Running and R19 reads green over a workspace that cannot authenticate.
+echo "[6163] Case 1: credential never arrives -> must FAIL LOUDLY, never announce key-only mode"
+c1="$work/c1"; run_case "$c1" 4 1 fail never
+[ "$(rc_of "$c1")" -ne 0 ] || fail "credential-less init container exited 0. A workspace that cannot authenticate must not report success — that is the announce-and-assume shape #6163 removes.
+--- rendered script output ---
+$(log_of "$c1")"
+grep -q 'AGENITY CREDENTIAL MISSING' "$c1/out.log" || fail "no loud missing-credential line. Got:
+$(log_of "$c1")"
+# The old line, verbatim. Matched exactly rather than on the substring
+# "key-only mode", because the replacement line legitimately mentions the
+# phrase while EXPLAINING that this is not it.
+if grep -q 'no credentials.json key in Secret' "$c1/out.log"; then
+  fail "the miss branch still announces 'no credentials.json key in Secret — key-only mode'. This init container only renders when anthropic.credentialsKey is SET, i.e. when OAuth mode was requested — key-only mode is credentialsKey:\"\", which renders no init container at all. Got:
+$(log_of "$c1")"
+fi
+
+# ── Case 2 — the credential arrives LATE (the hw293 case) ───────────────────
+# kubelet re-projects a mounted Secret on its own sync period, so a credential
+# seeded after the pod started lands in /creds with no restart. A one-shot
+# reader misses it forever; a waiting reader picks it up.
+echo "[6163] Case 2: credential arrives 2s late -> must wait for it and seed"
+c2="$work/c2"; run_case "$c2" 20 1 fail 2
+[ "$(rc_of "$c2")" -eq 0 ] || fail "init container did not succeed even though the credential arrived within the wait window (rc=$(rc_of "$c2")). Got:
+$(log_of "$c2")"
+grep -q 'seeded ~/.claude/.credentials.json' "$c2/out.log" || fail "a credential that arrived 2s after start was never seeded — the reader is still one-shot. Got:
+$(log_of "$c2")"
+grep -q 'Anthropic credential arrived after' "$c2/out.log" || fail "no line reporting that the credential arrived during the wait. Got:
+$(log_of "$c2")"
+[ -s "$c2/claudehome/.claude/.credentials.json" ] || fail "~/.claude/.credentials.json was not materialised from the late-arriving credential"
+
+# ── CONTROL A — credential present from t=0 ─────────────────────────────────
+# Shares the suspect property (identical script, identical mounted-Secret read)
+# and is GREEN BEFORE AND AFTER. If the fix had simply made the container fail,
+# this would go red.
+echo "[6163] CONTROL A: credential present at start -> seeds, exits 0, does not wait"
+ca="$work/ca"; mkdir -p "$ca/creds"
+printf '%s' '{"claudeAiOauth":{"accessToken":"NOT-A-REAL-TOKEN","refreshToken":"NOT-A-REAL-TOKEN","expiresAt":0,"scopes":["user:inference"]}}' > "$ca/creds/credentialsJson"
+run_case "$ca" 30 1 fail never
+[ "$(rc_of "$ca")" -eq 0 ] || fail "CONTROL A went red: a present credential must still seed and exit 0. Got:
+$(log_of "$ca")"
+grep -q 'seeded ~/.claude/.credentials.json' "$ca/out.log" || fail "CONTROL A: present credential was not seeded. Got:
+$(log_of "$ca")"
+grep -q 'AGENITY CREDENTIAL MISSING' "$ca/out.log" && fail "CONTROL A: a present credential was reported missing. Got:
+$(log_of "$ca")"
+grep -q 'waiting up to' "$ca/out.log" && fail "CONTROL A: the container waited even though the credential was already there — the wait must cost nothing in the healthy case. Got:
+$(log_of "$ca")"
+[ -s "$ca/claudehome/.claude.json" ] || fail "CONTROL A: the claude-code onboarding stub was not written"
+
+# ── CONTROL B — onTimeout=continue is a real escape hatch ───────────────────
+# Also green before and after: before the fix the value is simply unused and
+# the script exits 0 anyway.
+echo "[6163] CONTROL B: onTimeout=continue -> exits 0 with no credential"
+cb="$work/cb"; run_case "$cb" 3 1 continue never
+[ "$(rc_of "$cb")" -eq 0 ] || fail "CONTROL B went red: anthropic.credentialWait.onTimeout=continue must preserve the start-anyway behaviour. Got:
+$(log_of "$cb")"
+
+# ── VACUITY GUARD 2: Case 1's assertion must be defeatable ──────────────────
+# Mutate the rendered script so the missing-credential branch exits 0, and
+# check that Case 1's core assertion (non-zero exit) then does NOT hold. A
+# check that passes on the mutant as well is testing nothing.
+echo "[6163] VACUITY: a mutant that exits 0 on a missing credential must defeat Case 1"
+mv="$work/mut"; mkdir -p "$mv/creds" "$mv/claudehome"
+render_script \
+  --set "sovereignFqdn=agnstar.omani.homes" \
+  --set "anthropic.credentialWait.deadlineSeconds=2" \
+  --set "anthropic.credentialWait.pollSeconds=1" \
+  --set "anthropic.credentialWait.onTimeout=fail" \
+  | sed -e "s#/creds#$mv/creds#g" -e "s#/claudehome#$mv/claudehome#g" \
+  | sed -e 's/^\([[:space:]]*\)exit 1$/\1exit 0/' > "$mv/run.sh"
+grep -qE '^[[:space:]]*exit 0$' "$mv/run.sh" || fail "VACUITY: could not build the mutant — no 'exit 1' in the missing-credential branch to neutralise. Case 1's exit-status assertion may be passing for an unrelated reason."
+set +e
+sh "$mv/run.sh" > "$mv/out.log" 2>&1
+mrc=$?
+set -e
+[ "$mrc" -eq 0 ] || fail "VACUITY: the mutant still exited $mrc — Case 1's 'exit != 0' assertion is not actually observing the branch under test."
+echo "[6163] VACUITY ok: mutant exits 0, so Case 1 genuinely measures the exit status."
+
+echo "[6163] PASS — seed-claude-creds waits for a late credential, fails loudly when it never arrives, and stays quiet when it is already there."

--- a/products/agenity/chart/values.yaml
+++ b/products/agenity/chart/values.yaml
@@ -87,6 +87,34 @@ anthropic:
   # solo agent can call Claude. Empty = key-only mode (only works for a real
   # sk-ant-api03 API key, which the OAuth journey does not use).
   credentialsKey: credentialsJson
+  # ── late-arriving-credential wait (#6163) ───────────────────────────────
+  # The seed-claude-creds init container used to read the mounted Secret
+  # ONCE at pod start and, on a miss, print "key-only mode" and exit 0 —
+  # forever. Measured on hw293: a workspace held that line for EIGHT HOURS
+  # after the Sovereign's openbao path was seeded, because a one-shot reader
+  # has no way to notice a credential that arrives later.
+  #
+  # kubelet re-projects a mounted Secret on its own sync period, so simply
+  # POLLING the mount picks up an ExternalSecret that resolves after the pod
+  # started, with no restart and no operator action. deadlineSeconds bounds
+  # that wait; onTimeout decides what a still-missing credential means.
+  #
+  #   onTimeout: fail     (default) exit non-zero. The kubelet restarts the
+  #                       init container with backoff — so the wait RESUMES
+  #                       indefinitely and the pod starts by itself once the
+  #                       credential exists — and meanwhile the gap shows up
+  #                       in `kubectl get pod` instead of only in a log.
+  #   onTimeout: continue start the workspace credential-less (the old
+  #                       behaviour). The dashboard renders and every chat
+  #                       message fails 401. Opt in only if you would rather
+  #                       see a shell than an honest error.
+  #
+  # deadlineSeconds: 0 disables the wait (single read). Not recommended: it
+  # is exactly the one-shot shape this block exists to remove.
+  credentialWait:
+    deadlineSeconds: 180
+    pollSeconds: 5
+    onTimeout: fail
   externalSecret:
     enabled: true
     refreshInterval: 1h

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-11T01:17:31.392Z",
+  "generatedAt": "2026-08-11T07:16:24.237Z",
   "blueprints": [
     {
       "id": "bp-agenity",
@@ -11,7 +11,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "listed",
-      "version": "0.5.22",
+      "version": "0.5.24",
       "section": "pts-7-org-tenant",
       "depends": [
         "bp-external-secrets"

--- a/products/catalyst/bootstrap/api/internal/handler/anthropic_credential_rotation_6163_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/anthropic_credential_rotation_6163_test.go
@@ -1,0 +1,236 @@
+package handler
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/openbao"
+)
+
+// #6163 — the Anthropic credential the seed writes must come from the
+// operator-rotatable Secret, LIVE, not from the process env snapshot.
+//
+// THE DEFECT
+//
+//	CATALYST_ANTHROPIC_API_KEY / CATALYST_ANTHROPIC_CREDENTIALS_JSON are
+//	secretKeyRef env vars on the catalyst-api Deployment, and a container's
+//	environment is materialised ONCE at container start. seedAnthropicToken
+//	read them with os.Getenv on every pass, so the ten-minute self-heal loop
+//	re-wrote, forever, the credential this process booted with.
+//
+//	The seeded value is a claudeAiOauth pair whose accessToken lives for
+//	HOURS. When it expires the operator edits
+//	catalyst-system/sovereign-anthropic-credentials — and nothing changed,
+//	because the running process could not see the edit. Rotation only took
+//	effect on a catalyst-api roll, which nothing triggers. That is an outage
+//	on a timer, and it is what the "seed reconciler runs every 10 minutes"
+//	surface could never fix: a loop that re-applies a stale snapshot is not
+//	a self-heal, it is a self-repeat.
+//
+// CREDENTIAL HYGIENE (docs/PRINCIPLES.md #10): every fixture below is an
+// obviously-fake literal. No real key, token or OAuth blob appears in this
+// file, and no assertion prints credential material — only byte lengths and
+// outcome classes.
+
+// Deliberately non-credential-shaped fixtures. "ROTATED" vs "STALE" is the
+// whole experiment: the test asserts WHICH ONE reached OpenBao.
+const (
+	fake6163StaleCredsJSON   = `{"claudeAiOauth":{"accessToken":"FAKE-STALE-BOOT-SNAPSHOT","refreshToken":"FAKE","expiresAt":1,"scopes":["user:inference"]}}`
+	fake6163RotatedCredsJSON = `{"claudeAiOauth":{"accessToken":"FAKE-ROTATED-BY-OPERATOR","refreshToken":"FAKE","expiresAt":2,"scopes":["user:inference"]}}`
+	fake6163StaleAPIKey      = "FAKE-STALE-BOOT-SNAPSHOT-KEY"
+	fake6163RotatedAPIKey    = "FAKE-ROTATED-BY-OPERATOR-KEY"
+)
+
+// newSeedHandler6163 wires a Handler against the capture-KV fake OpenBao and,
+// optionally, a fake apiserver holding the operator Secret.
+func newSeedHandler6163(t *testing.T, secret *corev1.Secret) (*Handler, *captureKVServer) {
+	t.Helper()
+	srv := newCaptureKVServer(t)
+	h := &Handler{log: silentLogger()}
+	h.openbao = &openbao.Client{Addr: srv.srv.URL, Token: "test-token", HTTP: srv.srv.Client()}
+	var cs *k8sfake.Clientset
+	if secret != nil {
+		cs = k8sfake.NewSimpleClientset(secret)
+	} else {
+		cs = k8sfake.NewSimpleClientset()
+	}
+	h.SetSovereignDepsFactory(func() (*sovereignDeps, error) {
+		return &sovereignDeps{core: cs}, nil
+	})
+	// Pin the namespace so the test never depends on the CI runner having (or
+	// not having) a ServiceAccount namespace file.
+	t.Setenv(envAnthropicCredentialNamespace, "catalyst-system")
+	return h, srv
+}
+
+func operatorSecret6163(apiKey, credsJSON string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      sovereignAnthropicSecretName,
+			Namespace: "catalyst-system",
+		},
+		Data: map[string][]byte{
+			sovereignAnthropicSecretAPIKeyKey:    []byte(apiKey),
+			sovereignAnthropicSecretCredsJSONKey: []byte(credsJSON),
+		},
+	}
+}
+
+// Test_6163_RotatedSecretWinsOverBootTimeEnv is the red-before test.
+//
+// The process env holds what this Pod booted with; the operator has since
+// rotated the Secret. The seed must write the ROTATED credential.
+func Test_6163_RotatedSecretWinsOverBootTimeEnv(t *testing.T) {
+	h, srv := newSeedHandler6163(t, operatorSecret6163(fake6163RotatedAPIKey, fake6163RotatedCredsJSON))
+
+	// The boot-time snapshot — what the container's env still holds.
+	t.Setenv(anthropicSeedAPIKeyEnv, fake6163StaleAPIKey)
+	t.Setenv(anthropicSeedCredentialsJSONEnv, fake6163StaleCredsJSON)
+
+	// VACUITY: the two credentials must actually differ, or "the right one
+	// was written" is unfalsifiable.
+	if fake6163StaleCredsJSON == fake6163RotatedCredsJSON || fake6163StaleAPIKey == fake6163RotatedAPIKey {
+		t.Fatal("vacuity: the stale and rotated fixtures are identical — this test could not distinguish them")
+	}
+
+	if out := h.seedAnthropicToken(context.Background()); out != AnthropicSeedOutcomeSeeded {
+		t.Fatalf("outcome = %q, want %q", out, AnthropicSeedOutcomeSeeded)
+	}
+
+	// VACUITY: the fake must have actually received a write.
+	got, ok := srv.dataField("credentialsJson")
+	if !ok {
+		t.Fatal("vacuity: OpenBao fake recorded no credentialsJson field — the assertion below would pass on an empty write")
+	}
+
+	if got == fake6163StaleCredsJSON {
+		t.Fatalf("seed wrote the BOOT-TIME env snapshot, not the rotated operator Secret.\n"+
+			"secretKeyRef env is materialised once at container start, so re-reading os.Getenv every pass "+
+			"re-applies a credential the operator already replaced — rotation then needs a catalyst-api roll, "+
+			"and an expiring OAuth token re-creates the outage on a timer (#6163).\n"+
+			"wrote %d bytes matching the STALE fixture; wanted the %d-byte ROTATED one.",
+			len(got), len(fake6163RotatedCredsJSON))
+	}
+	if got != fake6163RotatedCredsJSON {
+		t.Fatalf("seed wrote neither fixture: %d bytes (stale=%d rotated=%d)",
+			len(got), len(fake6163StaleCredsJSON), len(fake6163RotatedCredsJSON))
+	}
+	if key, _ := srv.dataField("apiKey"); key != fake6163RotatedAPIKey {
+		t.Fatalf("apiKey came from the wrong seam: got %d bytes, want the %d-byte rotated value",
+			len(key), len(fake6163RotatedAPIKey))
+	}
+}
+
+// Test_6163_ResolvePrefersSecretReportsSource asserts the log-facing source
+// class, so an operator reading "credentialSource=process-env" on a Sovereign
+// that HAS the Secret knows the live read failed rather than guessing.
+func Test_6163_ResolvePrefersSecretReportsSource(t *testing.T) {
+	h, _ := newSeedHandler6163(t, operatorSecret6163(fake6163RotatedAPIKey, fake6163RotatedCredsJSON))
+	t.Setenv(anthropicSeedAPIKeyEnv, fake6163StaleAPIKey)
+	t.Setenv(anthropicSeedCredentialsJSONEnv, fake6163StaleCredsJSON)
+
+	_, creds, src := h.resolveAnthropicCredential(context.Background())
+	if src != anthropicCredentialFromSecret {
+		t.Fatalf("credential source = %q, want %q — the live operator Secret must win over the boot-time env",
+			src, anthropicCredentialFromSecret)
+	}
+	if creds != fake6163RotatedCredsJSON {
+		t.Fatalf("resolved credential is not the rotated one (%d bytes)", len(creds))
+	}
+}
+
+// ── CONTROL 1 ───────────────────────────────────────────────────────────────
+// Same function, same OpenBao fake, same env — the ONLY difference is that no
+// operator Secret exists. This is the pre-#6163 world and every Sovereign that
+// has not adopted the Secret seam, so it must behave EXACTLY as before: seed
+// from the env. Green before AND after the fix; if the change had simply
+// rewired everything to the Secret, this goes red.
+func Test_6163_CONTROL_NoOperatorSecretStillSeedsFromEnv(t *testing.T) {
+	h, srv := newSeedHandler6163(t, nil)
+	t.Setenv(anthropicSeedAPIKeyEnv, fake6163StaleAPIKey)
+	t.Setenv(anthropicSeedCredentialsJSONEnv, fake6163StaleCredsJSON)
+
+	if out := h.seedAnthropicToken(context.Background()); out != AnthropicSeedOutcomeSeeded {
+		t.Fatalf("CONTROL: outcome = %q, want %q — a Sovereign with no operator Secret must still seed from the env",
+			out, AnthropicSeedOutcomeSeeded)
+	}
+	got, ok := srv.dataField("credentialsJson")
+	if !ok || got != fake6163StaleCredsJSON {
+		t.Fatalf("CONTROL: env-sourced seed regressed — wrote %d bytes, want the %d-byte env value",
+			len(got), len(fake6163StaleCredsJSON))
+	}
+	if _, _, src := h.resolveAnthropicCredential(context.Background()); src != anthropicCredentialFromEnv {
+		t.Fatalf("CONTROL: source = %q, want %q", src, anthropicCredentialFromEnv)
+	}
+}
+
+// ── CONTROL 2 ───────────────────────────────────────────────────────────────
+// An operator Secret that EXISTS but is empty must not be read as a credential.
+// This is the empty-seed trap the agenity README warns about: an empty Secret
+// is presence without usability, and preferring it over a working env value
+// would break a Sovereign that was fine. Green before and after.
+func Test_6163_CONTROL_EmptyOperatorSecretFallsBackToEnv(t *testing.T) {
+	h, srv := newSeedHandler6163(t, operatorSecret6163("", "   "))
+	t.Setenv(anthropicSeedAPIKeyEnv, fake6163StaleAPIKey)
+	t.Setenv(anthropicSeedCredentialsJSONEnv, fake6163StaleCredsJSON)
+
+	if out := h.seedAnthropicToken(context.Background()); out != AnthropicSeedOutcomeSeeded {
+		t.Fatalf("CONTROL: outcome = %q, want %q", out, AnthropicSeedOutcomeSeeded)
+	}
+	got, _ := srv.dataField("credentialsJson")
+	if got != fake6163StaleCredsJSON {
+		t.Fatalf("CONTROL: a hollow operator Secret was preferred over a usable env credential — that is the empty-seed trap (%d bytes written)", len(got))
+	}
+}
+
+// ── CONTROL 3 ───────────────────────────────────────────────────────────────
+// No Secret, no env: the founder-supplied gap. Must still be the LOUD skip
+// (#4277), never a silent seed of empty bytes. Green before and after.
+func Test_6163_CONTROL_NoCredentialAnywhereStaysLoudSkip(t *testing.T) {
+	h, _ := newSeedHandler6163(t, nil)
+	lg, records := capturingLogger()
+	h.log = lg
+
+	t.Setenv(anthropicSeedAPIKeyEnv, "")
+	t.Setenv(anthropicSeedCredentialsJSONEnv, "")
+
+	if out := h.seedAnthropicToken(context.Background()); out != AnthropicSeedOutcomeSkippedNoEnv {
+		t.Fatalf("CONTROL: outcome = %q, want %q — no credential anywhere must be a loud skip, not a seed",
+			out, AnthropicSeedOutcomeSkippedNoEnv)
+	}
+	errs := recordsAtLevel(records(), "ERROR")
+	if !anyRecordContains(errs, "anthropic seed SKIPPED") {
+		t.Fatalf("CONTROL: the founder-supplied gap stopped being reported at ERROR. Records: %+v", records())
+	}
+	// The remediation must now name BOTH seams: an operator whose actual fix is
+	// "edit the Secret" was previously only ever told about the env var.
+	if !anyRecordContains(errs, sovereignAnthropicSecretName) {
+		t.Fatalf("CONTROL: the loud line does not name the operator-rotatable Secret %q, so it does not tell the operator where to act. Records: %+v",
+			sovereignAnthropicSecretName, errs)
+	}
+}
+
+// ── VACUITY GUARD ───────────────────────────────────────────────────────────
+// The whole suite rests on the fake apiserver actually serving the Secret. If
+// the fixture were unreadable, Test_6163_RotatedSecretWinsOverBootTimeEnv
+// would fail for a plumbing reason rather than the reason it claims, and the
+// CONTROLs would pass for the wrong reason. Prove the read works standalone.
+func Test_6163_VACUITY_FakeSecretIsActuallyReadable(t *testing.T) {
+	h, _ := newSeedHandler6163(t, operatorSecret6163(fake6163RotatedAPIKey, fake6163RotatedCredsJSON))
+	key, creds, err := h.readAnthropicCredentialSecret(context.Background())
+	if err != nil {
+		t.Fatalf("vacuity: the fake operator Secret is not readable (%v) — every assertion in this file would be measuring the env fallback instead", err)
+	}
+	if key != fake6163RotatedAPIKey || creds != fake6163RotatedCredsJSON {
+		t.Fatalf("vacuity: the fake Secret returned unexpected content (%d/%d bytes)", len(key), len(creds))
+	}
+	// And prove the negative case is distinguishable: no Secret must error.
+	hEmpty, _ := newSeedHandler6163(t, nil)
+	if _, _, err := hEmpty.readAnthropicCredentialSecret(context.Background()); err == nil {
+		t.Fatal("vacuity: reading a NON-EXISTENT operator Secret returned no error — the reader cannot distinguish present from absent, so CONTROL 1 proves nothing")
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/handler.go
+++ b/products/catalyst/bootstrap/api/internal/handler/handler.go
@@ -606,6 +606,15 @@ type Handler struct {
 	// it serves (mothership AND post-handover Sovereign).
 	sovereignDepsFactory SovereignDepsFactory
 
+	// anthropicCredentialReader (#6163) — test-only override of the LIVE read
+	// of the operator-rotatable Secret catalyst-system/sovereign-anthropic-
+	// credentials. Production leaves this nil and
+	// readAnthropicCredentialSecret runs against the in-cluster core client.
+	// See sovereign_anthropic_seed.go for why the seed must not read the
+	// process env alone: env is a snapshot taken at container start, so a
+	// rotated credential never reached OpenBao without a catalyst-api roll.
+	anthropicCredentialReader func(ctx context.Context) (apiKey, credsJSON string, err error)
+
 	// ── Compliance score aggregator (EPIC-1 #1096 slice S) ─────────
 	// compliance — joins PolicyReport + ClusterPolicyReport +
 	// compliance-evaluator events into per-resource +

--- a/products/catalyst/bootstrap/api/internal/handler/sovereign_anthropic_seed.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sovereign_anthropic_seed.go
@@ -75,8 +75,11 @@ package handler
 
 import (
 	"context"
+	"errors"
 	"os"
 	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // anthropicSeedMountPath / anthropicSeedSecretPath — the OpenBao KV-v2
@@ -100,6 +103,144 @@ const (
 	anthropicSeedAPIKeyEnv          = "CATALYST_ANTHROPIC_API_KEY"
 	anthropicSeedCredentialsJSONEnv = "CATALYST_ANTHROPIC_CREDENTIALS_JSON"
 )
+
+// ── The operator-rotatable credential Secret (#6163) ────────────────────────
+//
+// THE DEFECT this block closes. The env vars above are `secretKeyRef` entries
+// on the catalyst-api Deployment, and a container's environment is materialised
+// ONCE, at container start. So the seeding chain had a freeze in it:
+//
+//	catalyst-system/sovereign-anthropic-credentials   (operator rotates here)
+//	  -> helm lookup -> catalyst-openova-kc-credentials Secret
+//	  -> secretKeyRef -> catalyst-api PROCESS ENV        ← frozen at pod start
+//	  -> seedAnthropicToken -> openbao secret/catalyst/anthropic/token
+//	  -> ExternalSecret -> per-Org Secret -> the workspace agent
+//
+// The seeded value is a claudeAiOauth pair whose accessToken lives for HOURS.
+// When it expires or is revoked the operator rotates the source Secret — and
+// the running catalyst-api keeps re-seeding, every ten minutes, the credential
+// it read at boot. The self-heal loop cannot heal, because it is looking at a
+// snapshot of a credential that has since changed. Rotation only ever took
+// effect on the next catalyst-api roll, which nothing triggers, so an expiring
+// credential re-creates the outage on a timer.
+//
+// The fix is to read the operator's Secret LIVE on every seed and treat the
+// process env as the fallback. The Secret is the seam the chart already
+// documents as operator-rotatable (see
+// products/catalyst/chart/templates/catalyst-openova-kc-credentials-secret.yaml)
+// — this makes it actually rotatable without a pod restart.
+//
+// Namespace resolution mirrors the chart: the Secret is looked up in the
+// release namespace (`targetNamespace: catalyst-system` in bootstrap-kit slot
+// 13), which is also the Pod's own namespace, so the ServiceAccount's
+// namespace file is the truthful default. Overridable per Inviolable-Principle
+// #4.
+const (
+	sovereignAnthropicSecretName         = "sovereign-anthropic-credentials"
+	sovereignAnthropicSecretAPIKeyKey    = "apiKey"
+	sovereignAnthropicSecretCredsJSONKey = "credentialsJson"
+	envAnthropicCredentialNamespace      = "CATALYST_ANTHROPIC_CREDENTIAL_NAMESPACE"
+	defaultAnthropicCredentialNamespace  = "catalyst-system"
+	podNamespaceFile                     = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
+)
+
+// errNoSovereignCoreClient — the in-cluster core client is unwired (local dev,
+// CI, Catalyst-Zero). Not a failure: resolveAnthropicCredential falls back to
+// the process env, which is exactly the pre-#6163 behaviour.
+var errNoSovereignCoreClient = errors.New("anthropic seed: no in-cluster core client")
+
+// anthropicCredentialSource names where a resolved credential came from, so
+// the log line distinguishes "the operator's live Secret" from "the snapshot
+// this process booted with". Never carries credential material.
+type anthropicCredentialSource string
+
+const (
+	anthropicCredentialFromSecret anthropicCredentialSource = "sovereign-anthropic-credentials-secret"
+	anthropicCredentialFromEnv    anthropicCredentialSource = "process-env"
+	anthropicCredentialFromNone   anthropicCredentialSource = "none"
+)
+
+// anthropicCredentialNamespace — the namespace holding the operator-rotatable
+// Secret. Env override first, then the Pod's own namespace (which is the
+// release namespace the chart writes into), then the documented default.
+func anthropicCredentialNamespace() string {
+	if v := strings.TrimSpace(os.Getenv(envAnthropicCredentialNamespace)); v != "" {
+		return v
+	}
+	if b, err := os.ReadFile(podNamespaceFile); err == nil {
+		if ns := strings.TrimSpace(string(b)); ns != "" {
+			return ns
+		}
+	}
+	return defaultAnthropicCredentialNamespace
+}
+
+// SetAnthropicCredentialReader wires a test-only reader over the
+// operator-rotatable Secret. Production leaves this nil and
+// readAnthropicCredentialSecret runs against the in-cluster client.
+func (h *Handler) SetAnthropicCredentialReader(f func(ctx context.Context) (apiKey, credsJSON string, err error)) {
+	h.anthropicCredentialReader = f
+}
+
+// readAnthropicCredentialSecret fetches the operator-rotatable Secret from the
+// live apiserver. A missing Secret, an unwired client or any transport error
+// yields empty strings + the error; the caller falls back to the process env
+// rather than failing the seed, so an apiserver blip can never make a
+// Sovereign that was seeding fine stop seeding.
+func (h *Handler) readAnthropicCredentialSecret(ctx context.Context) (apiKey, credsJSON string, err error) {
+	if h.anthropicCredentialReader != nil {
+		return h.anthropicCredentialReader(ctx)
+	}
+	deps, derr := h.sovereignDepsFor()
+	if derr != nil || deps == nil || deps.core == nil {
+		if derr == nil {
+			derr = errNoSovereignCoreClient
+		}
+		return "", "", derr
+	}
+	sec, gerr := deps.core.CoreV1().
+		Secrets(anthropicCredentialNamespace()).
+		Get(ctx, sovereignAnthropicSecretName, metav1.GetOptions{})
+	if gerr != nil {
+		return "", "", gerr
+	}
+	return strings.TrimSpace(string(sec.Data[sovereignAnthropicSecretAPIKeyKey])),
+		strings.TrimSpace(string(sec.Data[sovereignAnthropicSecretCredsJSONKey])),
+		nil
+}
+
+// resolveAnthropicCredential picks the credential this seed pass will write.
+//
+// ORDER IS THE WHOLE POINT: the live Secret wins over the process env. The env
+// is a snapshot taken when this container started; the Secret is what the
+// operator edits when they rotate. Preferring the snapshot is what made
+// rotation require a pod roll (#6163).
+//
+// Falling back to env is what keeps this safe: a Sovereign that has never had
+// the operator Secret (values-only installs, Catalyst-Zero, every existing
+// deployment) behaves exactly as before, and so does one whose apiserver is
+// briefly unreachable.
+func (h *Handler) resolveAnthropicCredential(ctx context.Context) (apiKey, credsJSON string, src anthropicCredentialSource) {
+	secKey, secCreds, err := h.readAnthropicCredentialSecret(ctx)
+	if err == nil && (secKey != "" || secCreds != "") {
+		return secKey, secCreds, anthropicCredentialFromSecret
+	}
+	if err != nil && h.log != nil {
+		// Debug, not Warn: on a Sovereign that never adopted the Secret seam
+		// this fires on every pass and says nothing an operator must act on.
+		// The genuine gap — no credential ANYWHERE — is the loud ERROR in
+		// seedAnthropicToken.
+		h.log.Debug("anthropic seed: operator credential Secret unreadable; falling back to the process env snapshot",
+			"secret", anthropicCredentialNamespace()+"/"+sovereignAnthropicSecretName,
+			"err", err)
+	}
+	envKey := strings.TrimSpace(os.Getenv(anthropicSeedAPIKeyEnv))
+	envCreds := strings.TrimSpace(os.Getenv(anthropicSeedCredentialsJSONEnv))
+	if envKey != "" || envCreds != "" {
+		return envKey, envCreds, anthropicCredentialFromEnv
+	}
+	return "", "", anthropicCredentialFromNone
+}
 
 // AnthropicSeedOutcome — terminal classification of one seed attempt.
 type AnthropicSeedOutcome string
@@ -135,8 +276,11 @@ func (h *Handler) seedAnthropicToken(ctx context.Context) AnthropicSeedOutcome {
 		return AnthropicSeedOutcomeSkippedNoBao
 	}
 
-	apiKey := strings.TrimSpace(os.Getenv(anthropicSeedAPIKeyEnv))
-	credsJSON := strings.TrimSpace(os.Getenv(anthropicSeedCredentialsJSONEnv))
+	// #6163: the operator-rotatable Secret wins over the process env, so a
+	// credential rotated after this Pod started is the one that gets seeded.
+	// See the resolveAnthropicCredential doc comment for why the old
+	// env-only read made rotation require a catalyst-api roll.
+	apiKey, credsJSON, credSource := h.resolveAnthropicCredential(ctx)
 	if apiKey == "" && credsJSON == "" {
 		// 🛑 FOUNDER-SUPPLIED-SECRET GAP: the platform holds no Anthropic
 		// credential. Surface loud + skip rather than seed an empty path
@@ -158,6 +302,7 @@ func (h *Handler) seedAnthropicToken(ctx context.Context) AnthropicSeedOutcome {
 			h.log.Error("🛑 anthropic seed SKIPPED — the platform holds no Anthropic credential, so this Sovereign's OpenBao path is NOT written and EVERY Organization's agenity-anthropic-token ExternalSecret will stay SecretSyncedError (#4277)",
 				"apiKeyEnv", anthropicSeedAPIKeyEnv,
 				"credentialsJsonEnv", anthropicSeedCredentialsJSONEnv,
+				"operatorSecret", anthropicCredentialNamespace()+"/"+sovereignAnthropicSecretName,
 				"openbaoPath", anthropicSeedMountPath+"/"+anthropicSeedSecretPath,
 				"remediation", seedRemediation["anthropic"],
 			)
@@ -193,6 +338,10 @@ func (h *Handler) seedAnthropicToken(ctx context.Context) AnthropicSeedOutcome {
 			"openbaoPath", anthropicSeedMountPath+"/"+anthropicSeedSecretPath,
 			"apiKeyBytes", len(apiKey),
 			"credentialsJsonBytes", len(credsJSON),
+			// #6163: which seam supplied the bytes. "process-env" on a
+			// Sovereign that HAS the operator Secret means the live read
+			// failed and this pass re-seeded a boot-time snapshot.
+			"credentialSource", string(credSource),
 		)
 	}
 	return AnthropicSeedOutcomeSeeded

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -146,7 +146,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "listed",
-    "version": "0.5.22",
+    "version": "0.5.24",
     "section": "pts-7-org-tenant",
     "depends": [
       "bp-external-secrets"

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3874,7 +3874,19 @@ name: bp-catalyst-platform
 #   scripts/check-image-pin-writer-targets.sh plus the extended
 #   scripts/check-controller-image-tag-freshness.sh. Chart version bump is what
 #   actually delivers the three new tags, so it is the load-bearing half.
-version: 1.4.1395
+version: 1.4.1396
+# 1.4.1396 (#6163): catalog-seed bp-agenity 0.5.22 -> 0.5.24 — the
+#   seed-claude-creds init container stops being a ONE-SHOT reader of the
+#   Anthropic credential. It read the mounted Secret once at pod start and, on
+#   a miss, printed `no credentials.json key in Secret — key-only mode` and
+#   exited 0 forever; measured on hw293, a workspace held that line for eight
+#   hours after the Sovereign's openbao path was seeded, while the Pod reported
+#   Running. It now waits on the mount (kubelet re-projects a Secret on its own
+#   sync period), retries across kubelet init-container restarts, and fails
+#   loudly into `kubectl get pod`. Catalog-seed pin only; the catalyst-api half
+#   of the same fix (seedAnthropicToken reading
+#   catalyst-system/sovereign-anthropic-credentials LIVE instead of the
+#   boot-time env snapshot) rides the api image.
 # 1.4.1229 — #5389: catalog-seed bp-newapi declares its `ui` endpoint
 #   (newapi.<fqdn>, ssoEnabled, launchDefault, ssoInitPath "/") instead of
 #   `endpoints: []`. The empty list made userUIGatePasses fail closed, which
@@ -4029,7 +4041,7 @@ version: 1.4.1395
 # scripts/check-chart-version-forward.sh (#5743) fails unless the two match —
 # main was carrying a pre-existing 1.4.1330/1.4.1329 split, so this bump heals
 # it in the same commit, exactly as the documented self-heal contract does.
-appVersion: 1.4.1395
+appVersion: 1.4.1396
 # 1.4.239 — Wave 3 / Issue #2140 (2026-05-23): Huawei provider
 # implementation lands behind the Wave 2 CloudProvider interface.
 # Adds the OpenTofu module at infra/providers/huawei/ (VPC + Subnet +

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3874,8 +3874,8 @@ name: bp-catalyst-platform
 #   scripts/check-image-pin-writer-targets.sh plus the extended
 #   scripts/check-controller-image-tag-freshness.sh. Chart version bump is what
 #   actually delivers the three new tags, so it is the load-bearing half.
-version: 1.4.1396
-# 1.4.1396 (#6163): catalog-seed bp-agenity 0.5.22 -> 0.5.24 — the
+version: 1.4.1398
+# 1.4.1398 (#6163): catalog-seed bp-agenity 0.5.22 -> 0.5.24 — the
 #   seed-claude-creds init container stops being a ONE-SHOT reader of the
 #   Anthropic credential. It read the mounted Secret once at pod start and, on
 #   a miss, printed `no credentials.json key in Secret — key-only mode` and
@@ -4041,7 +4041,7 @@ version: 1.4.1396
 # scripts/check-chart-version-forward.sh (#5743) fails unless the two match —
 # main was carrying a pre-existing 1.4.1330/1.4.1329 split, so this bump heals
 # it in the same commit, exactly as the documented self-heal contract does.
-appVersion: 1.4.1396
+appVersion: 1.4.1398
 # 1.4.239 — Wave 3 / Issue #2140 (2026-05-23): Huawei provider
 # implementation lands behind the Wave 2 CloudProvider interface.
 # Adds the OpenTofu module at infra/providers/huawei/ (VPC + Subnet +

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -6021,7 +6021,7 @@ spec:
   # 0.5.22 (#5617): the oidc-gate companion gains its egress CNP — the per-Org
   # namespace is default-deny and the gate's ingress-only CNP left DNS + the
   # Keycloak token exchange dropped, 500ing every OAuth callback after login.
-  version: "0.5.22"
+  version: "0.5.24"
   visibility: listed
   card:
     title: "Agenity"
@@ -6051,7 +6051,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-agenity
-    version: 0.5.22
+    version: 0.5.24
   topology:
     supported:
       - singleton


### PR DESCRIPTION
## The defect

The Anthropic credential reaches an Agenity workspace agent through this chain, and it had **two one-shot reads** in it:

```
catalyst-system/sovereign-anthropic-credentials   (operator rotates here)
  -> helm lookup -> catalyst-openova-kc-credentials Secret
  -> secretKeyRef -> catalyst-api PROCESS ENV          <-- FREEZE 1
  -> seedAnthropicToken -> openbao secret/catalyst/anthropic/token
  -> ExternalSecret -> per-Org agenity-anthropic-token Secret
  -> seed-claude-creds init container                   <-- FREEZE 2
  -> ~/.claude/.credentials.json -> the workspace agent
```

Each freeze reads a credential once and then keeps asserting whatever it saw.

### FREEZE 2 — `seed-claude-creds` exits 0 into a degraded mode forever

The init container read the mounted Secret once at pod start and, on a miss, printed

```
no credentials.json key in Secret — key-only mode
```

and exited 0. Measured on hw293: a workspace held that line for **eight hours** after the Sovereign's OpenBao path was seeded. A one-shot reader cannot notice a credential that arrives later, and the Pod reported `Running` the whole time — which is what let UAT row R19, *"the init container validates the token and exits 0"*, read green over a workspace that could not talk to Anthropic at all.

"key-only mode" was never a true description of that branch either. This container renders **only** under `if .Values.anthropic.credentialsKey`, i.e. only when OAuth mode was requested; a genuinely key-only install sets `credentialsKey: ""` and gets no init container and an `ANTHROPIC_API_KEY` env instead. So the miss could only ever mean *"the OAuth credential you asked for did not arrive"*, and it announced a supported operating mode instead.

**The shape now: wait, retry, fail loudly** — all three, because they are the same mechanism:

- **WAIT.** kubelet re-projects a mounted Secret on its own sync period, so the file materialises in the container's filesystem the moment the ExternalSecret resolves. Polling the mount is what turns "stranded for the life of the pod" into "starts by itself", at zero cost in the healthy case.
- **RETRY.** On timeout the container exits non-zero; the kubelet restarts it with backoff, so the wait resumes indefinitely and the pod proceeds on its own once the credential exists.
- **FAIL LOUDLY.** `Init:Error` / `CrashLoopBackOff` puts the gap in `kubectl get pod` — the one place an operator already looks — instead of on line 3 of a log nobody reads.

Failing is right even though the dashboard then does not serve: a workspace whose entire purpose is chatting with Claude is not "serving" when it cannot authenticate. Rendering the shell is not the product. `anthropic.credentialWait.onTimeout: continue` restores the old start-anyway behaviour and is deliberately not the default.

### FREEZE 1 — the producer re-seeds a boot-time snapshot every ten minutes

`CATALYST_ANTHROPIC_API_KEY` / `CATALYST_ANTHROPIC_CREDENTIALS_JSON` are `secretKeyRef` env vars on the catalyst-api Deployment, and a container's environment is materialised **once, at container start**. `seedAnthropicToken` read them with `os.Getenv` on every pass, so the ten-minute self-heal loop re-wrote, forever, the credential the process booted with.

The seeded value is a `claudeAiOauth` pair whose `accessToken` lives for hours. When it expires the operator edits `catalyst-system/sovereign-anthropic-credentials` — and nothing changes, because the running process cannot see the edit. Rotation only ever took effect on a catalyst-api roll, which nothing triggers. An expiring credential therefore re-creates the outage on a timer, and the loop meant to heal it is re-applying a stale snapshot: a self-repeat, not a self-heal.

`seedAnthropicToken` now reads that Secret **live** on every pass and treats the process env as the fallback, so rotation takes effect without a pod roll and every Sovereign that never adopted the Secret seam behaves exactly as before. The seed log line now carries `credentialSource`, so `process-env` on a Sovereign that HAS the Secret is a readable signal rather than a guess.

## Red before, green after

Both tests were run against the pre-change tree and the post-change tree. Verbatim.

### `products/agenity/chart/tests/seed-claude-creds-credential-wait.sh`

It does not grep the template. It extracts the rendered init-container shell script and RUNS it against a sandbox filesystem, so every assertion is about behaviour — exit status and emitted lines.

RED, against the chart as on `origin/main`:

```
[6163] extracted seed-claude-creds script: 5295 bytes
[6163] Case 1: credential never arrives -> must FAIL LOUDLY, never announce key-only mode
FAIL: credential-less init container exited 0. A workspace that cannot authenticate must not report success — that is the announce-and-assume shape #6163 removes.
--- rendered script output ---
no credentials.json key in Secret — key-only mode
RED EXIT=1
```

GREEN, against this branch:

```
[6163] extracted seed-claude-creds script: 7539 bytes
[6163] Case 1: credential never arrives -> must FAIL LOUDLY, never announce key-only mode
[6163] Case 2: credential arrives 2s late -> must wait for it and seed
[6163] CONTROL A: credential present at start -> seeds, exits 0, does not wait
[6163] CONTROL B: onTimeout=continue -> exits 0 with no credential
[6163] VACUITY: a mutant that exits 0 on a missing credential must defeat Case 1
[6163] VACUITY ok: mutant exits 0, so Case 1 genuinely measures the exit status.
[6163] PASS — seed-claude-creds waits for a late credential, fails loudly when it never arrives, and stays quiet when it is already there.
GREEN EXIT=0
```

- **CONTROL A** (credential present at t=0) and **CONTROL B** (`onTimeout=continue`) share the suspect property — the same rendered script, the same mounted-Secret read path — and are green **before and after**. A green run therefore cannot be explained by "the script now always fails".
- **Vacuity guard 1**: the extracted script must be non-empty, >400 bytes and start with `set -e`, or the awk extractor has stopped matching and every assertion is vacuous.
- **Vacuity guard 2**: a mutant whose `exit 1` is neutralised must **defeat** Case 1's exit-status assertion. If the mutant cannot be built (no `exit 1` to neutralise) the test fails loudly rather than passing on nothing.

### `anthropic_credential_rotation_6163_test.go`

RED, with the pre-change env-only read restored:

```
--- FAIL: Test_6163_RotatedSecretWinsOverBootTimeEnv (0.00s)
    anthropic_credential_rotation_6163_test.go:111: seed wrote the BOOT-TIME env snapshot, not the rotated operator Secret.
        secretKeyRef env is materialised once at container start, so re-reading os.Getenv every pass re-applies a credential the operator already replaced — rotation then needs a catalyst-api roll, and an expiring OAuth token re-creates the outage on a timer (#6163).
        wrote 124 bytes matching the STALE fixture; wanted the 124-byte ROTATED one.
FAIL
FAIL	github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/handler	0.025s
```

GREEN, `go test ./internal/handler/ -run 'Test_6163' -count=1 -v`:

```
=== RUN   Test_6163_RotatedSecretWinsOverBootTimeEnv
--- PASS: Test_6163_RotatedSecretWinsOverBootTimeEnv (0.00s)
=== RUN   Test_6163_ResolvePrefersSecretReportsSource
--- PASS: Test_6163_ResolvePrefersSecretReportsSource (0.00s)
=== RUN   Test_6163_CONTROL_NoOperatorSecretStillSeedsFromEnv
--- PASS: Test_6163_CONTROL_NoOperatorSecretStillSeedsFromEnv (0.00s)
=== RUN   Test_6163_CONTROL_EmptyOperatorSecretFallsBackToEnv
--- PASS: Test_6163_CONTROL_EmptyOperatorSecretFallsBackToEnv (0.00s)
=== RUN   Test_6163_CONTROL_NoCredentialAnywhereStaysLoudSkip
--- PASS: Test_6163_CONTROL_NoCredentialAnywhereStaysLoudSkip (0.00s)
=== RUN   Test_6163_VACUITY_FakeSecretIsActuallyReadable
--- PASS: Test_6163_VACUITY_FakeSecretIsActuallyReadable (0.00s)
PASS
ok  	github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/handler	0.023s
```

Note the RED run reports exactly **one** failure — the three CONTROLs stayed green with the defect in place, which is what makes them controls:

- **CONTROL 1** — no operator Secret: must still seed from the env, i.e. every Sovereign that never adopted this seam is unchanged.
- **CONTROL 2** — an operator Secret that exists but is empty: must NOT be preferred over a usable env credential. That is the empty-seed trap the agenity README warns about; presence is not usability here either.
- **CONTROL 3** — no credential anywhere: must remain the LOUD `ERROR` skip (#4277), and the line must now also name the operator-rotatable Secret, so an operator whose real fix is "edit the Secret" is told so.
- **Vacuity guard** — proves the fake apiserver actually serves the Secret AND that a non-existent Secret is distinguishable (returns an error). Without that, CONTROL 1 would prove nothing and the headline test could be silently measuring the env fallback.

Full package suite green: `go test ./internal/handler/ -count=1` → `ok ... 322.047s`.

## Credential hygiene

Per `docs/PRINCIPLES.md` #10, nothing here logs, asserts on, or fixtures a real credential. Every test fixture is an obviously-fake literal (`FAKE-STALE-BOOT-SNAPSHOT`, `FAKE-ROTATED-BY-OPERATOR`), and every failure message reports byte lengths and outcome classes only.

## Not this PR — R19's "the subject is ABSENT" premise is retired

R19 was recorded from `kubectl get sts,deploy,hr -A` returning zero `agenity` objects. That premise does not hold, and it is not a missing producer. There are **two** producers:

- **automatic**, `products/catalyst/bootstrap/api/internal/handler/organization_gitops.go:1936` — the `orgTenantBPAgenity` overlay template (`chart: bp-agenity` at `:1979`), written at Org-create by `WriteTenantOverlay`. It self-disables under `TENANT_GITOPS_PER_ORG=true` (`:154`, `:170`);
- **install-on-demand**, the catalog door: `bp-agenity` is seeded `visibility: listed`, and the HelmRelease is built as an `unstructured.Unstructured` in `core/controllers/application/internal/render/fanout.go:180` — which is why `grep 'chart: bp-agenity'` over `core/` finds nothing and why a struct-name grep would call this absent.

`docs/DOD.md` Pillar 4 and `products/agenity/README.md` both state the design as **the customer installs it from the catalog**, and `docs/ledger/UAT.md` R19 already carries an `AUDIT 2026-08-11` note retiring the zero-HR reading. So R19's residual is the credential, which is what this PR addresses — the workspace half is not missing.

## Chart version

bp-agenity `0.5.22` -> `0.5.24` across `chart/Chart.yaml`, `blueprint.yaml`, the catalog-seed pin and both generated catalog artifacts. `0.5.23` is deliberately skipped: it is claimed by open PR #5968, which touches the same chart.

Refs #6163 #4277 #4111 #5956
