### PR TITLE
fix(guard,catalyst-api): a hostname no listener admits, a region that only half-serves, and a record reporting console health it never measured

### DIFF
--- a/.github/workflows/check-live-route-backends-selftest.yaml
+++ b/.github/workflows/check-live-route-backends-selftest.yaml
@@ -74,3 +74,74 @@ jobs:
           fi
           echo "OK: the mutated classifier is caught. Failing assertion:"
           grep -m1 'SELF-TEST FAIL' /tmp/mutant.out || cat /tmp/mutant.out
+
+      # Second vacuity check, for the listener pass (UAT rows 87/90/95, and the
+      # g7doora shape behind row 234). Regress `listener_admits` to the belief
+      # that a wildcard listener is a plain suffix match — the off-by-one that
+      # makes `*.walkone.omani.homes` appear to admit the bare apex — and
+      # require the suite to go RED. The two CONTROL fixtures that share the
+      # suspect property (a per-Org app hostname on the shared console Gateway,
+      # and a deeper sub-host under the same wildcard) must stay green in the
+      # mutant, which is what proves the failing fixtures fail on the hostname
+      # rule and not merely on being per-Org routes.
+      - name: listener pass must be able to fail
+        run: |
+          cp scripts/check-live-route-backends.sh /tmp/mutant-listener.sh
+          python3 - <<'PY'
+          p = "/tmp/mutant-listener.sh"
+          s = open(p).read()
+          old = '    if lh.startswith("*."):\n        suffix = lh[1:]'
+          new = '    if lh.startswith("*."):\n        return True\n        suffix = lh[1:]'
+          assert old in s, "mutation anchor not found — update this step"
+          open(p, "w").write(s.replace(old, new, 1))
+          PY
+          if bash /tmp/mutant-listener.sh --self-test >/tmp/mutant-listener.out 2>&1; then
+            echo "VACUITY FAIL: the self-test passed against a classifier whose"
+            echo "wildcard listener admits every hostname. A route nothing listens"
+            echo "for is a TLS reset, not a 503 — no status-code probe can see it."
+            cat /tmp/mutant-listener.out
+            exit 1
+          fi
+          for ctl in 'ok  per-Org app host admitted by the Org wildcard listener' \
+                     'ok  wildcard listener admits a deeper sub-host'; do
+            grep -qF "$ctl" /tmp/mutant-listener.out || {
+              echo "CONTROL FAIL: '$ctl' went red under the mutation, so the"
+              echo "failing fixtures cannot be attributed to the hostname rule."
+              cat /tmp/mutant-listener.out
+              exit 1
+            }
+          done
+          echo "OK: mutation caught, both controls stayed green. Failing assertion:"
+          grep -m1 'SELF-TEST FAIL' /tmp/mutant-listener.out
+
+      # Third vacuity check, for the region-symmetry pass. Rows 87/90/95 are a
+      # hostname that is FLAWLESS in the region under the microscope — healthy
+      # backend, admitting listener — and simply absent from the peer region
+      # that shares its round-robin pool. Disable the peer comparison and the
+      # suite must go red, or the guard is back to being unable to see the
+      # defect that produced those three rows.
+      - name: region-symmetry pass must be able to fail
+        run: |
+          cp scripts/check-live-route-backends.sh /tmp/mutant-peer.sh
+          python3 - <<'PY'
+          p = "/tmp/mutant-peer.sh"
+          s = open(p).read()
+          old = 'peer_known = "peerHosts" in b'
+          new = 'peer_known = False'
+          assert old in s, "mutation anchor not found — update this step"
+          open(p, "w").write(s.replace(old, new, 1))
+          PY
+          if bash /tmp/mutant-peer.sh --self-test >/tmp/mutant-peer.out 2>&1; then
+            echo "VACUITY FAIL: the self-test passed against a classifier that never"
+            echo "compares regions. A hostname only one region routes is a coin flip"
+            echo "for every customer behind the shared front door."
+            cat /tmp/mutant-peer.out
+            exit 1
+          fi
+          grep -qF 'ok  hostname served by both regions' /tmp/mutant-peer.out || {
+            echo "CONTROL FAIL: the both-regions fixture went red under the mutation."
+            cat /tmp/mutant-peer.out
+            exit 1
+          }
+          echo "OK: mutation caught, control stayed green. Failing assertion:"
+          grep -m1 'SELF-TEST FAIL' /tmp/mutant-peer.out

--- a/products/catalyst/bootstrap/api/internal/handler/phase1_console_gate_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/phase1_console_gate_test.go
@@ -20,9 +20,12 @@ import (
 //     the NON-FATAL ConsoleDegraded surface instead of latching the whole
 //     cross-region topology inert (the hw276 defect: failed+OutcomeReady
 //     matched no terminal block and no heal path, so region-b never meshed).
-//   - A genuinely-failed primary (outcome != OutcomeReady) stays "failed",
-//     fires NO handover, and never runs the console probe — the honest
-//     failure detection #4706/#3018 pinned is untouched.
+//   - A genuinely-failed primary (outcome != OutcomeReady) stays "failed"
+//     and fires NO handover — the honest failure detection #4706/#3018
+//     pinned is untouched. It DOES run the console probe (UAT row 241): the
+//     flag is a surface, so a failed record must still state whether the
+//     front door answers instead of being silent about a door nobody
+//     opened. Nothing in the failed arms reads the probe result.
 func TestMarkPhase1DoneConsoleGate(t *testing.T) {
 	twoRegions := []provisioner.RegionSpec{{Provider: "huawei"}, {Provider: "huawei"}}
 	mkDep := func() *Deployment {
@@ -100,11 +103,25 @@ func TestMarkPhase1DoneConsoleGate(t *testing.T) {
 		}
 	})
 
-	// The probe is skipped for non-Ready outcomes — a genuine hard failure
-	// upstream must stay failed regardless of console state, and must NOT
-	// fire the producer chain (the fire condition is OutcomeReady, i.e.
-	// every primary HR installed).
-	t.Run("genuinely-failed primary: stays failed, no fire, probe not run", func(t *testing.T) {
+	// The probe RUNS for non-Ready outcomes and changes NOTHING about the
+	// lifecycle — a genuine hard failure upstream stays failed regardless of
+	// console state and must NOT fire the producer chain (the fire condition
+	// is OutcomeReady, i.e. every primary HR installed).
+	//
+	// This subtest previously asserted the opposite ("console probe must not
+	// run for a non-Ready outcome"). That assertion is what made UAT row 241
+	// unsatisfiable in one of the two directions it names: a `failed`-latched
+	// record never ran the probe, so ConsoleDegraded stayed zero-valued and
+	// `omitempty` dropped it, and the record reported no console problem
+	// about a console nobody had looked at. Measured on hw293, dep
+	// a0077ba47e3720e5: `status: failed`, consoleDegraded absent, while
+	// https://console.<fqdn>/ answered 200 from the public internet.
+	//
+	// Skipping the probe was never what protected the lifecycle. The
+	// remaining assertions here are, and they are unchanged: Status, the
+	// handover fire, and the mesh gate are all decided without reading the
+	// probe result.
+	t.Run("genuinely-failed primary: stays failed, no fire, probe runs and surfaces", func(t *testing.T) {
 		h := NewWithPDM(silentLogger(), &fakePDM{})
 		h.suppressPostHandoverHooks = true
 		h.SetHandoverSigner(loadTestSigner(t))
@@ -112,8 +129,8 @@ func TestMarkPhase1DoneConsoleGate(t *testing.T) {
 		h.consoleProbe = func(fqdn string) error { called = true; return nil }
 		dep := mkDep()
 		h.markPhase1Done(dep, finalStates, helmwatch.OutcomeFluxNotReconciling)
-		if called {
-			t.Fatalf("console probe must not run for a non-Ready outcome")
+		if !called {
+			t.Fatalf("console probe must run on a non-Ready outcome — the flag is a surface, not a gate (#5253)")
 		}
 		if dep.Status != "failed" {
 			t.Fatalf("OutcomeFluxNotReconciling must stay failed, got %q", dep.Status)
@@ -122,8 +139,9 @@ func TestMarkPhase1DoneConsoleGate(t *testing.T) {
 			t.Fatalf("a genuinely-failed primary must NOT fire handover: firedAt=%v url=%q",
 				dep.Result.HandoverFiredAt, dep.Result.HandoverURL)
 		}
+		// The door answered, so the surface must say so — not stay silent.
 		if dep.Result.ConsoleDegraded {
-			t.Fatalf("ConsoleDegraded must not be set on a genuine failure")
+			t.Fatalf("ConsoleDegraded must be false when the probe succeeded")
 		}
 	})
 

--- a/products/catalyst/bootstrap/api/internal/handler/phase1_console_honesty_row241_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/phase1_console_honesty_row241_test.go
@@ -1,0 +1,173 @@
+package handler
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/helmwatch"
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/provisioner"
+)
+
+// UAT row 241 restated as a test.
+//
+// The clause: a deployment record's console health MATCHES the live front
+// door — `consoleDegraded` false/absent exactly while https://console.<fqdn>/
+// answers, `consoleDegraded: true` with a non-empty detail whenever it does
+// not — and it FAILS IN EITHER DIRECTION. The probe SURFACES, it never gates
+// (#5253).
+//
+// Before this test the second direction was structurally unreachable rather
+// than merely buggy. markPhase1Done ran the probe only under
+// `outcome == OutcomeReady`, so a record latched `failed` never probed at
+// all; ConsoleDegraded stayed zero-valued and `omitempty` dropped both fields
+// from the JSON. The record then read "no console problem" about a console
+// nobody had looked at. Measured on hw293, dep a0077ba47e3720e5: the record
+// sat `status: failed` with consoleDegraded absent while the door answered
+// 200 from the public internet — record and door disagreeing, which is
+// exactly what the clause forbids.
+//
+// The table drives EVERY terminal outcome constant against BOTH probe
+// results, which is the "either direction" clause made mechanical: 2N cells,
+// none of which may be silent.
+func TestConsoleHonesty_Row241_EveryOutcomeSurfacesTheDoor(t *testing.T) {
+	outcomes := []string{
+		helmwatch.OutcomeReady,
+		helmwatch.OutcomeFailed,
+		helmwatch.OutcomeTimeout,
+		helmwatch.OutcomeFluxNotReconciling,
+		helmwatch.OutcomeKubeconfigMissing,
+		helmwatch.OutcomeWatcherStartFailed,
+		helmwatch.OutcomeFluxCRDsAbsent,
+	}
+	doorShut := errors.New("console front door did not answer: dial tcp: connect: connection refused")
+
+	mkDep := func() *Deployment {
+		return &Deployment{
+			ID:        "row241",
+			Status:    "phase1-watching",
+			StartedAt: time.Now(),
+			eventsCh:  make(chan provisioner.Event, 256),
+			done:      make(chan struct{}),
+			Request: provisioner.Request{
+				SovereignFQDN: "hw999.omani.works",
+				OrgEmail:      "sovereign-admin@test.example.com",
+				Regions:       []provisioner.RegionSpec{{Provider: "huawei"}},
+			},
+			Result:     &provisioner.Result{},
+			OwnerEmail: "sovereign-admin@test.example.com",
+		}
+	}
+	finalStates := map[string]string{"cilium": helmwatch.StateInstalled}
+
+	for _, outcome := range outcomes {
+		for _, shut := range []bool{false, true} {
+			name := outcome + "/door-open"
+			if shut {
+				name = outcome + "/door-shut"
+			}
+			t.Run(name, func(t *testing.T) {
+				h := NewWithPDM(silentLogger(), &fakePDM{})
+				h.suppressPostHandoverHooks = true
+				h.SetHandoverSigner(loadTestSigner(t))
+				probed := false
+				h.consoleProbe = func(string) error {
+					probed = true
+					if shut {
+						return doorShut
+					}
+					return nil
+				}
+
+				dep := mkDep()
+				h.markPhase1Done(dep, finalStates, outcome)
+
+				if !probed {
+					t.Fatalf("outcome %q never probed the front door — the record cannot "+
+						"honestly report console health it did not measure", outcome)
+				}
+				if dep.Result.ConsoleDegraded != shut {
+					t.Fatalf("outcome %q: ConsoleDegraded = %v, want %v (door shut = %v)",
+						outcome, dep.Result.ConsoleDegraded, shut, shut)
+				}
+				if shut && dep.Result.ConsoleDegradedDetail == "" {
+					t.Fatalf("outcome %q: a degraded console must carry a non-empty detail; "+
+						"the clause names it explicitly", outcome)
+				}
+				if !shut && dep.Result.ConsoleDegradedDetail != "" {
+					t.Fatalf("outcome %q: an answering console must not carry a stale detail, got %q",
+						outcome, dep.Result.ConsoleDegradedDetail)
+				}
+			})
+		}
+	}
+}
+
+// CONTROL for the table above, sharing its suspect property.
+//
+// The table asserts the probe now runs everywhere. The obvious way to break
+// the platform while making that table pass is to let the probe result leak
+// into the lifecycle — which is the ORIGINAL #4706 defect inverted, and the
+// reason #5253 made the flag a surface. So: hold the outcome fixed and vary
+// ONLY the probe result. Status, the error text and the handover fire must be
+// byte-identical across the pair. A probe that gated anything would show up
+// here as a diff, and this control is what makes the table's "probe runs on
+// every outcome" safe rather than merely true.
+func TestConsoleHonesty_Row241_ProbeSurfacesButNeverGates(t *testing.T) {
+	mkDep := func() *Deployment {
+		return &Deployment{
+			ID:        "row241-control",
+			Status:    "phase1-watching",
+			StartedAt: time.Now(),
+			eventsCh:  make(chan provisioner.Event, 256),
+			done:      make(chan struct{}),
+			Request: provisioner.Request{
+				SovereignFQDN: "hw999.omani.works",
+				OrgEmail:      "sovereign-admin@test.example.com",
+				Regions:       []provisioner.RegionSpec{{Provider: "huawei"}},
+			},
+			Result:     &provisioner.Result{},
+			OwnerEmail: "sovereign-admin@test.example.com",
+		}
+	}
+	finalStates := map[string]string{"cilium": helmwatch.StateInstalled}
+
+	run := func(t *testing.T, outcome string, probeErr error) (status, errText string, fired bool) {
+		t.Helper()
+		h := NewWithPDM(silentLogger(), &fakePDM{})
+		h.suppressPostHandoverHooks = true
+		h.SetHandoverSigner(loadTestSigner(t))
+		h.consoleProbe = func(string) error { return probeErr }
+		dep := mkDep()
+		h.markPhase1Done(dep, finalStates, outcome)
+		return dep.Status, dep.Error, dep.Result.HandoverFiredAt != nil
+	}
+
+	for _, outcome := range []string{
+		helmwatch.OutcomeReady,
+		helmwatch.OutcomeFailed,
+		helmwatch.OutcomeTimeout,
+		helmwatch.OutcomeFluxNotReconciling,
+	} {
+		t.Run(outcome, func(t *testing.T) {
+			okStatus, okErr, okFired := run(t, outcome, nil)
+			shutStatus, shutErr, shutFired := run(t, outcome, errors.New("door shut"))
+
+			if okStatus != shutStatus {
+				t.Fatalf("outcome %q: the console probe changed Status (%q with the door open, "+
+					"%q with it shut) — the flag is a surface and must never gate (#5253)",
+					outcome, okStatus, shutStatus)
+			}
+			if okErr != shutErr {
+				t.Fatalf("outcome %q: the console probe changed dep.Error (%q vs %q); "+
+					"/deployments/{id} renders a non-empty Error as a hard failure card",
+					outcome, okErr, shutErr)
+			}
+			if okFired != shutFired {
+				t.Fatalf("outcome %q: the console probe changed whether the producer chain fired "+
+					"(%v vs %v) — that is the hw276 latch this contract exists to prevent",
+					outcome, okFired, shutFired)
+			}
+		})
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/phase1_converged_late.go
+++ b/products/catalyst/bootstrap/api/internal/handler/phase1_converged_late.go
@@ -145,6 +145,23 @@ func (h *Handler) runConvergedLateRescue(dep *Deployment) {
 		return
 	}
 
+	// UAT row 241 — probe the front door BEFORE the flip, outside the lock,
+	// for the same reason markPhase1Done does. #6082/#6083 taught this path
+	// to re-read the CLUSTER instead of the frozen classification; the
+	// console was left behind. The OutcomeFailed arm below flips a record to
+	// `ready` on a live census that says nothing whatsoever about whether the
+	// front door answers, so without this a rescued record reads `ready` with
+	// consoleDegraded absent — the first of the two directions UAT row 241
+	// forbids, reintroduced by the rescue itself. The OutcomeReady arm was no
+	// better: it re-homed a STALE termination-time dep.Error string onto the
+	// surface, so a console that had since recovered stayed flagged degraded
+	// forever.
+	var rescueConsoleErr error
+	rescueConsoleProbed := h.consoleProbe != nil
+	if rescueConsoleProbed {
+		rescueConsoleErr = h.consoleProbe(dep.Request.SovereignFQDN)
+	}
+
 	now := time.Now().UTC()
 	dep.mu.Lock()
 	// Re-check under lock — a concurrent resume/flip loses.
@@ -169,6 +186,21 @@ func (h *Handler) runConvergedLateRescue(dep *Deployment) {
 			dep.Result.ConsoleDegraded = true
 			dep.Result.ConsoleDegradedDetail = dep.Error
 			dep.Error = ""
+		}
+		// UAT row 241 — the FRESH probe wins over anything re-homed above.
+		// A rescue that flips a record to `ready` must state the console's
+		// condition as of the rescue, in both directions: set it when the
+		// door is shut, and CLEAR a re-homed stale text when the door has
+		// since opened. Applied to every rescued outcome, not only the two
+		// arms that carry an Error, because `ready` + silence is precisely
+		// the false-green this row exists to catch.
+		if rescueConsoleProbed {
+			dep.Result.ConsoleDegraded = rescueConsoleErr != nil
+			if rescueConsoleErr != nil {
+				dep.Result.ConsoleDegradedDetail = rescueConsoleErr.Error()
+			} else {
+				dep.Result.ConsoleDegradedDetail = ""
+			}
 		}
 		// #6082 — the FAILED arm's stale text ("Phase 1 finished with N failed
 		// component(s)…") is now provably obsolete: the census just confirmed

--- a/products/catalyst/bootstrap/api/internal/handler/phase1_watch.go
+++ b/products/catalyst/bootstrap/api/internal/handler/phase1_watch.go
@@ -1107,8 +1107,27 @@ func (h *Handler) markPhase1Done(dep *Deployment, finalStates map[string]string,
 	// production calls EnableConsoleReachabilityGate() at startup; unit
 	// tests leave it nil (so they never touch the network) and set a stub
 	// directly when they want to exercise it.
+	//
+	// UAT row 241 — the probe runs on EVERY terminal outcome, not only
+	// OutcomeReady. The clause is "a ready record's console health MATCHES
+	// the live front door, and FAILS IN EITHER DIRECTION", and gating the
+	// probe on OutcomeReady broke the second direction structurally: a
+	// record latched `failed` never ran the probe at all, so
+	// ConsoleDegraded stayed zero-valued and `omitempty` dropped it from
+	// the JSON entirely. The record then read "no console problem" about a
+	// console nobody had looked at — a verdict reported from absent
+	// evidence. Measured on hw293: dep a0077ba47e3720e5 sat `status:
+	// failed` with consoleDegraded absent while https://console.<fqdn>/
+	// answered 200 from the public internet.
+	//
+	// Running it everywhere is safe precisely because this flag is a
+	// SURFACE and never a gate (#5253): no Go consumer branches on
+	// ConsoleDegraded, and the switch below decides dep.Status without
+	// reading consoleReachErr on any non-Ready arm. Probing costs one HTTP
+	// request on a path that is already terminal.
 	var consoleReachErr error
-	if outcome == helmwatch.OutcomeReady && h.consoleProbe != nil {
+	consoleProbed := h.consoleProbe != nil
+	if consoleProbed {
 		consoleReachErr = h.consoleProbe(dep.Request.SovereignFQDN)
 	}
 
@@ -1283,6 +1302,24 @@ func (h *Handler) markPhase1Done(dep *Deployment, finalStates map[string]string,
 		// mechanism that let OutcomeTimeout flip ready on hw91.
 		dep.Status = "failed"
 		dep.Error = fmt.Sprintf("Phase 1 watch terminated with unhandled outcome %q — catalyst-api is missing a status mapping for it. The deployment is NOT marked ready; please file an issue with the deployment ID and the catalyst-api logs from this run.", outcome)
+	}
+
+	// UAT row 241 — publish the console surface for EVERY terminal outcome,
+	// after the switch so it can never influence dep.Status. The OutcomeReady
+	// arm above already set it (and logged the reasoning that belongs to that
+	// arm); this restates the same two fields for the failed arms, and — the
+	// half that only exists here — CLEARS a stale `true` when the probe now
+	// succeeds. Absence of the flag must mean "the console answered", never
+	// "nobody asked": the two were indistinguishable before this, and
+	// `omitempty` on both fields made the record silent in exactly the case
+	// the clause forbids.
+	if consoleProbed {
+		dep.Result.ConsoleDegraded = consoleReachErr != nil
+		if consoleReachErr != nil {
+			dep.Result.ConsoleDegradedDetail = consoleReachErr.Error()
+		} else {
+			dep.Result.ConsoleDegradedDetail = ""
+		}
 	}
 
 	// #3375 DoD-7 — DR INTEGRITY GATE, made SELF-FIRING for a converged

--- a/scripts/check-live-route-backends.sh
+++ b/scripts/check-live-route-backends.sh
@@ -36,7 +36,7 @@
 # every request stays in rotation forever. This script is the check that CAN
 # fail.
 #
-# THE INVARIANT
+# THE INVARIANT — PART 1, BACKENDS
 #
 # For every backendRef of every HTTPRoute, the backend Service must have a
 # path to at least one endpoint:
@@ -61,19 +61,58 @@
 #         counted. Region A carried exactly one of these (an Application
 #         installed 3 minutes before the sweep) and was clean once it settled.
 #
-# Exit 0 = every advertised backend can serve. 1 = at least one advertised
-# hostname is a 503 generator. 2 = setup error.
+# THE INVARIANT — PART 2, LISTENERS AND REGION SYMMETRY (UAT rows 87/90/95)
+#
+# Part 1 joins a route to its BACKEND. It is blind to the two ways a per-Org
+# application hostname fails on the SAME front door, both measured on hw293:
+#
+#   * The route exists and its backend is healthy, but the parent Gateway
+#     carries no listener whose hostname admits it. Gateway API then reports
+#     `Accepted=False  NoMatchingListenerHostname` and envoy resets the TLS
+#     handshake before any HTTP status exists — so a 503-hunting probe sees
+#     nothing at all. Namespace `g7doora` on hw293 held a healthy
+#     `bp-stalwart-tenant` and a `mail.g7doora.omani.rest` HTTPRoute while
+#     `kube-system/cilium-gateway-console` carried 14 listeners covering four
+#     OTHER Organizations and none for that one. Part 1 scores that route
+#     SERVING, because its backend genuinely serves — nothing can reach it.
+#
+#   * The route is absent from ONE region. Rows 87/90/95 are exactly this:
+#     `wordpress.<orgslug>.<pool-tld>` renders and is publicly trusted, and
+#     4-to-7 of every 12 fresh TCP connections are `Connection reset by peer`,
+#     because region B holds zero routes for that hostname while the ELB
+#     round-robins :443 across both regions' cilium-envoy. A single-cluster
+#     scan CANNOT see this: a region with no route for a hostname produces no
+#     row, no verdict, and a clean PASS. Absence is invisible by construction,
+#     so the peer region's route inventory has to be read too.
+#
+# Hence:
+#
+#   * every hostname on an HTTPRoute must be admitted by at least one listener
+#     of at least one of its parent Gateways, honouring Gateway API wildcard
+#     semantics (`*.a.b` admits `x.a.b` and `x.y.a.b`, never the bare `a.b`)
+#     and any `sectionName` / `port` pin on the parentRef -> else NO-LISTENER
+#   * a parentRef naming a Gateway that does not exist here    -> NO-GATEWAY
+#   * with --peer-kubeconfig / --peer-context, a hostname advertised in one
+#     region and not the other                                 -> REGION-ASYMMETRY
+#
+# Exit 0 = every advertised hostname is admitted by a listener, backed by a
+# reachable endpoint, and (when a peer is supplied) served by both regions.
+# 1 = at least one advertised hostname cannot serve. 2 = setup error.
 #
 # Usage:
 #   scripts/check-live-route-backends.sh                        # current context
 #   scripts/check-live-route-backends.sh --kubeconfig <path>
 #   scripts/check-live-route-backends.sh --context <ctx>
+#   scripts/check-live-route-backends.sh --kubeconfig <a> --peer-kubeconfig <b>
 #   scripts/check-live-route-backends.sh --self-test            # no cluster needed
 #
 # --self-test is a VACUITY CHECK, not decoration. A guard that has only ever
 # been observed passing is worthless, so the self-test drives the classifier
-# through four fixtures — two that MUST pass and two that MUST fail — and
-# fails the script if any must-fail fixture comes back clean.
+# through fixtures — some that MUST pass and some that MUST fail — and fails
+# the script if any must-fail fixture comes back clean. Every must-fail
+# fixture is paired with a CONTROL that shares its suspect property and must
+# stay green, so a verdict can never be read as "this classifier bans a
+# shape" when it should be reading one specific fact about that shape.
 #
 # 🛑 This repo is PUBLIC. The script prints object names, namespaces, hostnames
 #    and counts only. It never reads Secret data and never prints a value.
@@ -81,20 +120,26 @@
 set -euo pipefail
 
 KUBECTL_ARGS=()
+PEER_ARGS=()
+PEER_SUPPLIED=0
 SELF_TEST_ONLY=0
 GRACE_SECONDS="${GRACE_SECONDS:-300}"
 
 while [ $# -gt 0 ]; do
   case "$1" in
-    --kubeconfig)     KUBECTL_ARGS+=(--kubeconfig "$2"); shift 2 ;;
-    --context)        KUBECTL_ARGS+=(--context "$2");    shift 2 ;;
-    --grace-seconds)  GRACE_SECONDS="$2";                shift 2 ;;
-    --self-test)      SELF_TEST_ONLY=1;                  shift ;;
+    --kubeconfig)      KUBECTL_ARGS+=(--kubeconfig "$2"); shift 2 ;;
+    --context)         KUBECTL_ARGS+=(--context "$2");    shift 2 ;;
+    --peer-kubeconfig) PEER_ARGS+=(--kubeconfig "$2"); PEER_SUPPLIED=1; shift 2 ;;
+    --peer-context)    PEER_ARGS+=(--context "$2");    PEER_SUPPLIED=1; shift 2 ;;
+    --grace-seconds)   GRACE_SECONDS="$2";                shift 2 ;;
+    --self-test)       SELF_TEST_ONLY=1;                  shift ;;
     -h|--help)
-      sed -n '2,80p' "$0" | sed 's/^# \{0,1\}//'
+      sed -n '2,120p' "$0" | sed 's/^# \{0,1\}//'
       exit 0 ;;
     *) echo "Unknown arg: $1" >&2
-       echo "Usage: $0 [--kubeconfig <path>] [--context <ctx>] [--grace-seconds N] [--self-test]" >&2
+       echo "Usage: $0 [--kubeconfig <path>] [--context <ctx>]" >&2
+       echo "          [--peer-kubeconfig <path>] [--peer-context <ctx>]" >&2
+       echo "          [--grace-seconds N] [--self-test]" >&2
        exit 2 ;;
   esac
 done
@@ -109,8 +154,19 @@ done
 #   "graceSeconds":       <int>,
 #   "services":  [{"ns","name","global","ageSeconds"}],
 #   "endpoints": [{"ns","name","ready"}],
-#   "routes":    [{"ns","name","hosts":[..],"backends":[{"ns","name"}]}]
+#   "routes":    [{"ns","name","hosts":[..],
+#                  "backends":[{"ns","name"}],
+#                  "parents": [{"ns","name","sectionName","port"}]}],
+#   "gateways":  [{"ns","name","listeners":[{"name","hostname","port"}]}],
+#   "peerHosts": [<hostname>, ..]   # present only when a peer region was read
 # }
+#
+# `gateways` and `peerHosts` are OPTIONAL keys and each gates its own pass.
+# That is not a fail-open: the LIVE path always supplies `gateways` and exits
+# 2 if the cluster will not serve them, and it prints a loud NOTICE when no
+# peer was supplied. The keys are optional so that the four original backend
+# fixtures keep exercising the backend classifier alone — they are the
+# controls proving this change did not disturb it.
 # ─────────────────────────────────────────────────────────────────────────────
 read -r -d '' CLASSIFY_PY <<'PY' || true
 import json, sys
@@ -120,6 +176,31 @@ mesh = int(b.get("meshRemoteClusters", 0))
 grace = int(b.get("graceSeconds", 300))
 svc = {(s["ns"], s["name"]): s for s in b.get("services", [])}
 ready = {(e["ns"], e["name"]): int(e.get("ready", 0)) for e in b.get("endpoints", [])}
+
+
+def listener_admits(lh, h):
+    """Gateway API hostname intersection: does listener hostname `lh` admit
+    route hostname `h`?
+
+    Spec (gateway-api Listener.hostname / HTTPRoute.hostnames): a listener
+    with NO hostname admits every host; a wildcard is a SUFFIX match one or
+    more labels deep, so `*.a.b` admits `x.a.b` AND `x.y.a.b` but never the
+    bare `a.b`. Getting that last clause wrong in either direction is the
+    whole bug class — `endswith("a.b")` would wrongly admit the apex and
+    wrongly admit `nota.b`, and a single-label rule would wrongly reject a
+    legitimate deep host."""
+    if not lh:
+        return True
+    if not h:
+        return True          # a route with no hostnames inherits the listener's
+    if lh.startswith("*."):
+        suffix = lh[1:]      # "*.a.b" -> ".a.b"
+        if h.startswith("*."):
+            return h[1:] == suffix or h[1:].endswith(suffix)
+        return h.endswith(suffix)
+    if h.startswith("*."):
+        return False         # a concrete listener cannot admit a wildcard route
+    return lh == h
 
 rows, seen = [], set()
 for r in b.get("routes", []):
@@ -153,27 +234,115 @@ rows.sort(key=lambda r: (order[r[0]], r[1], r[2]))
 bad = [r for r in rows if r[0] == "DEAD-BACKEND"]
 pending = [r for r in rows if r[0] == "PENDING"]
 
+# ── Pass 2: listener coverage. A hostname nothing listens for is not a 503,
+# it is a TLS reset — which is why the backend pass above cannot see it.
+gws = {(g["ns"], g["name"]): g for g in b.get("gateways", [])}
+hostrows, local_hosts = [], set()
+listener_pass = "gateways" in b
+for r in b.get("routes", []):
+    parents = r.get("parents") or []
+    for h in (r.get("hosts") or []):
+        local_hosts.add(h)
+    if not listener_pass or not parents:
+        continue
+    for h in (r.get("hosts") or [""]):
+        admitted, absent_gws, seen_listeners = False, [], 0
+        for p in parents:
+            key = (p.get("ns") or r["ns"], p["name"])
+            g = gws.get(key)
+            if g is None:
+                absent_gws.append(f"{key[0]}/{key[1]}")
+                continue
+            for ls in (g.get("listeners") or []):
+                if p.get("sectionName") and ls.get("name") != p["sectionName"]:
+                    continue
+                if p.get("port") and int(ls.get("port") or 0) != int(p["port"]):
+                    continue
+                seen_listeners += 1
+                if listener_admits(ls.get("hostname"), h):
+                    admitted = True
+                    break
+            if admitted:
+                break
+        who = f"{r['ns']}/{r['name']}"
+        if admitted:
+            hostrows.append(("SERVING", h or "(inherits listener)", who, "admitted by a parent listener"))
+        elif absent_gws and seen_listeners == 0:
+            hostrows.append(("NO-GATEWAY", h or "(inherits listener)", who,
+                             "parent Gateway absent here: " + ",".join(sorted(set(absent_gws)))))
+        else:
+            hostrows.append(("NO-LISTENER", h or "(inherits listener)", who,
+                             f"no parent listener admits it ({seen_listeners} listener(s) considered)"))
+
+# ── Pass 3: region symmetry. Both regions' nodes sit in ONE round-robin pool,
+# so a hostname either region cannot route is a coin-flip failure for the
+# customer — the shape behind UAT rows 87/90/95.
+peer_known = "peerHosts" in b
+peer_hosts = set(b.get("peerHosts") or [])
+asym = []
+if peer_known:
+    for h in sorted(local_hosts - peer_hosts):
+        asym.append(("REGION-ASYMMETRY", h, "(this region only)",
+                     "advertised here, absent from the peer region"))
+    for h in sorted(peer_hosts - local_hosts):
+        asym.append(("REGION-ASYMMETRY", h, "(peer region only)",
+                     "advertised by the peer region, absent here"))
+
+hostbad = [r for r in hostrows if r[0] != "SERVING"] + asym
+horder = {"NO-GATEWAY": 0, "NO-LISTENER": 1, "REGION-ASYMMETRY": 2, "SERVING": 3}
+hostrows.sort(key=lambda r: (horder[r[0]], r[1], r[2]))
+
 print(f"ClusterMesh remote clusters ready: {mesh}")
 print(f"HTTPRoute backendRefs examined:    {len(rows)}")
 print(f"  SERVING       {sum(1 for r in rows if r[0] == 'SERVING')}")
 print(f"  PENDING       {len(pending)}  (younger than {grace}s — reported, not counted)")
 print(f"  DEAD-BACKEND  {len(bad)}")
+if listener_pass:
+    print(f"HTTPRoute hostnames examined:      {len(hostrows)}  "
+          f"(against {len(gws)} Gateway(s))")
+    print(f"  SERVING       {sum(1 for r in hostrows if r[0] == 'SERVING')}")
+    print(f"  NO-LISTENER   {sum(1 for r in hostrows if r[0] == 'NO-LISTENER')}")
+    print(f"  NO-GATEWAY    {sum(1 for r in hostrows if r[0] == 'NO-GATEWAY')}")
+else:
+    print("HTTPRoute hostnames examined:      skipped (no `gateways` in bundle)")
+if peer_known:
+    print(f"Region symmetry:                   {len(peer_hosts)} peer hostname(s), "
+          f"{len(asym)} asymmetric")
+else:
+    print("Region symmetry:                   NOT CHECKED — no peer region supplied.")
+    print("    A region that holds ZERO routes for a hostname produces no row and no")
+    print("    verdict here, so THIS RUN CANNOT SEE rows 87/90/95's defect. Pass")
+    print("    --peer-kubeconfig / --peer-context to close that hole.")
 print()
 for v, h, be, why in rows:
     if v == "SERVING":
         continue
-    print(f"  {v:<13} host={h:<40} backend={be:<44} {why}")
+    print(f"  {v:<17} host={h:<40} backend={be:<44} {why}")
+for v, h, who, why in hostrows + asym:
+    if v == "SERVING":
+        continue
+    print(f"  {v:<17} host={h:<40} route={who:<44} {why}")
 
-if bad:
+if bad or hostbad:
     print()
-    print(f"FAIL: {len(bad)} advertised backendRef(s) cannot serve. Every request this")
-    print("      Gateway round-robins onto this region for those hostnames returns")
-    print("      envoy 503 `no healthy upstream`. Any UAT verdict recorded against")
-    print("      these hostnames from this region is measurement noise, not a result.")
+    if bad:
+        print(f"FAIL: {len(bad)} advertised backendRef(s) cannot serve. Every request this")
+        print("      Gateway round-robins onto this region for those hostnames returns")
+        print("      envoy 503 `no healthy upstream`.")
+    if hostbad:
+        print(f"FAIL: {len(hostbad)} advertised hostname(s) have no way to be served here.")
+        print("      A hostname no listener admits is not a 503 — envoy resets the TLS")
+        print("      handshake before any HTTP status exists, so a status-code probe")
+        print("      sees nothing wrong. A hostname only one region routes is a")
+        print("      coin flip for every customer behind the shared front door.")
+    print("      Any UAT verdict recorded against these hostnames from this region")
+    print("      is measurement noise, not a result.")
     sys.exit(1)
 
 print()
-print("PASS: every advertised backendRef has a path to at least one endpoint.")
+print("PASS: every advertised backendRef has a path to at least one endpoint,")
+if listener_pass:
+    print("      and every advertised hostname is admitted by a parent listener.")
 PY
 
 # Run the classifier with the bundle on STDIN. `python3 -c` (not `python3 -`)
@@ -219,7 +388,7 @@ if [ "$SELF_TEST_ONLY" = "1" ]; then
     echo "  ok  $name (want=$want, exit=$rc, verdict=${token%:})"
   }
 
-  echo "self-test: driving the classifier through 4 fixtures (2 must pass, 2 must fail)"
+  echo "self-test: driving the classifier through 11 fixtures (6 must pass, 5 must fail)"
 
   # 1. Healthy backend — must PASS.
   run_fixture "healthy backend" pass '{
@@ -258,6 +427,117 @@ if [ "$SELF_TEST_ONLY" = "1" ]; then
     "endpoints": [{"ns":"catalyst-system","name":"catalyst-ui","ready":0}],
     "routes":    [{"ns":"catalyst-system","name":"catalyst-ui","hosts":["console.example.test"],
                    "backends":[{"ns":"catalyst-system","name":"catalyst-ui"}]}]}'
+
+  # ───────────────────────────────────────────────────────────────────────────
+  # Listener coverage (UAT rows 87/90/95, and the g7doora shape behind 234).
+  #
+  # Every fixture below carries a HEALTHY backend, so a verdict can only come
+  # from the listener pass. Org hostnames use the per-Org pool TLDs and TWO
+  # DIFFERENT ones, because a Sovereign assigns pool TLDs per Org — a fixture
+  # set that shared one TLD would pass a classifier that hardcoded it.
+  # ───────────────────────────────────────────────────────────────────────────
+
+  # 5. CONTROL for 6/7/8 — a per-Org app hostname on the shared console
+  #    Gateway, admitted by that Org's wildcard listener. Shares every suspect
+  #    property of the failing fixtures (same Gateway, same route shape, same
+  #    per-Org hostname depth) and MUST stay green. Without it, a classifier
+  #    that simply rejected per-Org hostnames would score 6/7/8 "caught".
+  run_fixture "per-Org app host admitted by the Org wildcard listener" pass '{
+    "meshRemoteClusters": 0, "graceSeconds": 300,
+    "services":  [{"ns":"walkone","name":"wordpress","global":null,"ageSeconds":50000}],
+    "endpoints": [{"ns":"walkone","name":"wordpress","ready":1}],
+    "gateways":  [{"ns":"kube-system","name":"cilium-gateway-console","listeners":[
+                    {"name":"apex-https","hostname":"*.sov.example.test","port":443},
+                    {"name":"walkone-https","hostname":"*.walkone.omani.homes","port":443}]}],
+    "routes":    [{"ns":"walkone","name":"app-wordpress-hostroute",
+                   "hosts":["wordpress.walkone.omani.homes"],
+                   "backends":[{"ns":"walkone","name":"wordpress"}],
+                   "parents":[{"ns":"kube-system","name":"cilium-gateway-console"}]}]}'
+
+  # 6. The g7doora shape — the Gateway carries OTHER Organizations wildcards
+  #    and none for this one. Backend is healthy; the customer still cannot
+  #    reach it, and envoy resets TLS rather than answering 503.
+  run_fixture "per-Org app host with no listener on the shared Gateway" fail '{
+    "meshRemoteClusters": 0, "graceSeconds": 300,
+    "services":  [{"ns":"g7doora","name":"bp-stalwart-tenant","global":null,"ageSeconds":50000}],
+    "endpoints": [{"ns":"g7doora","name":"bp-stalwart-tenant","ready":1}],
+    "gateways":  [{"ns":"kube-system","name":"cilium-gateway-console","listeners":[
+                    {"name":"apex-https","hostname":"*.sov.example.test","port":443},
+                    {"name":"walkone-https","hostname":"*.walkone.omani.homes","port":443},
+                    {"name":"walktwo-https","hostname":"*.walktwo.omani.trade","port":443}]}],
+    "routes":    [{"ns":"g7doora","name":"app-mail-hostroute",
+                   "hosts":["mail.g7doora.omani.rest"],
+                   "backends":[{"ns":"g7doora","name":"bp-stalwart-tenant"}],
+                   "parents":[{"ns":"kube-system","name":"cilium-gateway-console"}]}]}'
+
+  # 7. parentRef naming a Gateway that does not exist in this region.
+  run_fixture "route parented to an absent Gateway" fail '{
+    "meshRemoteClusters": 0, "graceSeconds": 300,
+    "services":  [{"ns":"walktwo","name":"wordpress","global":null,"ageSeconds":50000}],
+    "endpoints": [{"ns":"walktwo","name":"wordpress","ready":1}],
+    "gateways":  [],
+    "routes":    [{"ns":"walktwo","name":"app-wordpress-hostroute",
+                   "hosts":["wordpress.walktwo.omani.trade"],
+                   "backends":[{"ns":"walktwo","name":"wordpress"}],
+                   "parents":[{"ns":"kube-system","name":"cilium-gateway-console"}]}]}'
+
+  # 8. The off-by-one that a naive `endswith` gets wrong in BOTH directions:
+  #    `*.walkone.omani.homes` must NOT admit the bare apex it wildcards.
+  run_fixture "wildcard listener must not admit its own apex" fail '{
+    "meshRemoteClusters": 0, "graceSeconds": 300,
+    "services":  [{"ns":"walkone","name":"wordpress","global":null,"ageSeconds":50000}],
+    "endpoints": [{"ns":"walkone","name":"wordpress","ready":1}],
+    "gateways":  [{"ns":"kube-system","name":"cilium-gateway-console","listeners":[
+                    {"name":"walkone-https","hostname":"*.walkone.omani.homes","port":443}]}],
+    "routes":    [{"ns":"walkone","name":"apex","hosts":["walkone.omani.homes"],
+                   "backends":[{"ns":"walkone","name":"wordpress"}],
+                   "parents":[{"ns":"kube-system","name":"cilium-gateway-console"}]}]}'
+
+  # 9. CONTROL for 8 — the SAME wildcard must admit a deeper host, because
+  #    Gateway API wildcards are suffix matches, not single-label matches.
+  #    Paired with 8 this pins the rule from both sides; a classifier that
+  #    passed one and failed the other would be caught here.
+  run_fixture "wildcard listener admits a deeper sub-host" pass '{
+    "meshRemoteClusters": 0, "graceSeconds": 300,
+    "services":  [{"ns":"walkone","name":"wordpress","global":null,"ageSeconds":50000}],
+    "endpoints": [{"ns":"walkone","name":"wordpress","ready":1}],
+    "gateways":  [{"ns":"kube-system","name":"cilium-gateway-console","listeners":[
+                    {"name":"walkone-https","hostname":"*.walkone.omani.homes","port":443}]}],
+    "routes":    [{"ns":"walkone","name":"deep","hosts":["a.b.walkone.omani.homes"],
+                   "backends":[{"ns":"walkone","name":"wordpress"}],
+                   "parents":[{"ns":"kube-system","name":"cilium-gateway-console"}]}]}'
+
+  # 10. Rows 87/90/95 exactly — both regions sit in ONE round-robin pool and
+  #     the peer holds no route for the purchased app hostname, so a fraction
+  #     of every customer visit is reset. The local region is FLAWLESS here:
+  #     healthy backend, admitting listener, nothing a single-cluster scan
+  #     could object to. Only the peer inventory makes it visible.
+  run_fixture "hostname served here, absent from the peer region" fail '{
+    "meshRemoteClusters": 1, "graceSeconds": 300,
+    "services":  [{"ns":"walkone","name":"wordpress","global":null,"ageSeconds":50000}],
+    "endpoints": [{"ns":"walkone","name":"wordpress","ready":1}],
+    "gateways":  [{"ns":"kube-system","name":"cilium-gateway-console","listeners":[
+                    {"name":"walkone-https","hostname":"*.walkone.omani.homes","port":443}]}],
+    "peerHosts": ["console.sov.example.test"],
+    "routes":    [{"ns":"walkone","name":"app-wordpress-hostroute",
+                   "hosts":["wordpress.walkone.omani.homes"],
+                   "backends":[{"ns":"walkone","name":"wordpress"}],
+                   "parents":[{"ns":"kube-system","name":"cilium-gateway-console"}]}]}'
+
+  # 11. CONTROL for 10 — the same two regions once BOTH advertise the host.
+  #     Proves fixture 10 fails on the asymmetry and not merely on the
+  #     presence of a peerHosts key.
+  run_fixture "hostname served by both regions" pass '{
+    "meshRemoteClusters": 1, "graceSeconds": 300,
+    "services":  [{"ns":"walkone","name":"wordpress","global":null,"ageSeconds":50000}],
+    "endpoints": [{"ns":"walkone","name":"wordpress","ready":1}],
+    "gateways":  [{"ns":"kube-system","name":"cilium-gateway-console","listeners":[
+                    {"name":"walkone-https","hostname":"*.walkone.omani.homes","port":443}]}],
+    "peerHosts": ["wordpress.walkone.omani.homes"],
+    "routes":    [{"ns":"walkone","name":"app-wordpress-hostroute",
+                   "hosts":["wordpress.walkone.omani.homes"],
+                   "backends":[{"ns":"walkone","name":"wordpress"}],
+                   "parents":[{"ns":"kube-system","name":"cilium-gateway-console"}]}]}'
 
   echo
   if [ "$fail_count" -ne 0 ]; then
@@ -312,13 +592,41 @@ k get endpoints -A -o json > "$WORKDIR/eps.json"
 k get httproutes.gateway.networking.k8s.io -A -o json > "$WORKDIR/rt.json" 2>/dev/null \
   || echo '{"items":[]}' > "$WORKDIR/rt.json"
 
-if ! MESH_REMOTE="$mesh_remote" GRACE="$GRACE_SECONDS" python3 - \
-      "$WORKDIR/svc.json" "$WORKDIR/eps.json" "$WORKDIR/rt.json" \
+# Gateways are NOT allowed the empty-on-error fallback that HTTPRoutes get. An
+# empty Gateway list makes every route NO-GATEWAY, so a silent fallback would
+# turn an unreadable cluster into a wall of false reds; and the opposite
+# fallback (skip the pass) would be the fail-open that let #6040 hide for 12
+# hours. Unreadable Gateways alongside readable HTTPRoutes is a setup error,
+# and it says so.
+if ! k get gateways.gateway.networking.k8s.io -A -o json > "$WORKDIR/gw.json" 2>/dev/null; then
+  if grep -q '"items": *\[ *\]' "$WORKDIR/rt.json" || ! grep -q '"kind"' "$WORKDIR/rt.json"; then
+    echo '{"items":[]}' > "$WORKDIR/gw.json"
+  else
+    echo "HTTPRoutes are readable but Gateways are not — cannot verify listener" >&2
+    echo "coverage, and passing without it would be a fail-open guard." >&2
+    exit 2
+  fi
+fi
+
+# Peer region, when supplied: only the hostname inventory is needed, so this
+# is one read and it never touches the peer's Services.
+PEER_JSON=""
+if [ "$PEER_SUPPLIED" = "1" ]; then
+  if ! kubectl "${PEER_ARGS[@]}" get httproutes.gateway.networking.k8s.io -A -o json \
+        > "$WORKDIR/peer-rt.json" 2>/dev/null; then
+    echo "cannot read HTTPRoutes from the peer region with the supplied kubeconfig/context" >&2
+    exit 2
+  fi
+  PEER_JSON="$WORKDIR/peer-rt.json"
+fi
+
+if ! MESH_REMOTE="$mesh_remote" GRACE="$GRACE_SECONDS" PEER_JSON="$PEER_JSON" python3 - \
+      "$WORKDIR/svc.json" "$WORKDIR/eps.json" "$WORKDIR/rt.json" "$WORKDIR/gw.json" \
       > "$WORKDIR/bundle.json" <<'PY'
 import json, os, sys
 from datetime import datetime, timezone
 
-svc, eps, rt = (json.load(open(a)) for a in sys.argv[1:4])
+svc, eps, rt, gw = (json.load(open(a)) for a in sys.argv[1:5])
 now = datetime.now(timezone.utc)
 
 
@@ -350,8 +658,30 @@ bundle = {
         "backends": [{"ns": b.get("namespace", r["metadata"]["namespace"]), "name": b["name"]}
                      for rule in (r["spec"].get("rules") or [])
                      for b in (rule.get("backendRefs") or [])],
+        # parentRef.namespace defaults to the ROUTE's namespace per Gateway API,
+        # which is why `cilium-gateway-console` must be written with its
+        # kube-system namespace by every per-Org producer.
+        "parents": [{"ns": p.get("namespace", r["metadata"]["namespace"]),
+                     "name": p["name"],
+                     "sectionName": p.get("sectionName"),
+                     "port": p.get("port")}
+                    for p in (r["spec"].get("parentRefs") or [])],
     } for r in rt["items"]],
+    "gateways": [{
+        "ns": g["metadata"]["namespace"],
+        "name": g["metadata"]["name"],
+        "listeners": [{"name": l.get("name"),
+                       "hostname": l.get("hostname"),
+                       "port": l.get("port")}
+                      for l in (g["spec"].get("listeners") or [])],
+    } for g in gw["items"]],
 }
+
+peer = os.environ.get("PEER_JSON") or ""
+if peer:
+    bundle["peerHosts"] = sorted({h
+                                  for r in json.load(open(peer))["items"]
+                                  for h in (r["spec"].get("hostnames") or [])})
 json.dump(bundle, sys.stdout)
 PY
 then

--- a/scripts/check-live-route-backends.sh
+++ b/scripts/check-live-route-backends.sh
@@ -134,7 +134,7 @@ while [ $# -gt 0 ]; do
     --grace-seconds)   GRACE_SECONDS="$2";                shift 2 ;;
     --self-test)       SELF_TEST_ONLY=1;                  shift ;;
     -h|--help)
-      sed -n '2,120p' "$0" | sed 's/^# \{0,1\}//'
+      sed -n '2,118p' "$0" | sed 's/^# \{0,1\}//'
       exit 0 ;;
     *) echo "Unknown arg: $1" >&2
        echo "Usage: $0 [--kubeconfig <path>] [--context <ctx>]" >&2


### PR DESCRIPTION
Two source-and-test changes for the funnel-serving cluster of the #6114 residue. **No live environment exists** — hw293 was wiped 2026-08-11T04:23:42Z. Nothing here claims a runtime outcome and `docs/ledger/UAT.md` is untouched.

## 1. Rows 87 / 90 / 95 — the guard named after this defect could not see it

The evidence on these three rows is unusually good news. The redirect passes. TLS is genuinely publicly trusted (`ssl_verify_result 0`, no `-k`). The purchased WordPress renders its real installer at its own FQDN. Two Organizations on two different pool TLDs run the identical mechanism. All three fail on **serving reliability only**: fresh-TCP sampling returned 8/12, 5/12 and 6/12 successes, the rest `Connection reset by peer`, because region B held zero routes for those hostnames while the load balancer round-robins :443 across both regions' cilium-envoy.

`scripts/check-live-route-backends.sh` (merged as #6119, tracking #6040) exists for exactly that sentence — *a region must not advertise a hostname it cannot serve*. It could not see any of it, for two structural reasons that are properties of the script rather than of the environment:

- **It never reads a Gateway.** `listener` appears zero times in the file; `parentRefs` and route `status` are never read. It joins a route to its **backend** only. A healthy backend behind a hostname no listener admits therefore scores `SERVING`. That is the `g7doora` shape from row 234: a 1/1 Running `bp-stalwart-tenant` behind `mail.g7doora.omani.rest` while `kube-system/cilium-gateway-console` carried 14 listeners for four **other** Organizations and none for that one. It is not a 503 — envoy resets the TLS handshake before any HTTP status exists, so a status-code probe sees nothing wrong.
- **It scans one cluster.** A region holding zero routes for a hostname produces no row, no verdict, and a clean `PASS`. Absence is invisible by construction, which is precisely how rows 87/90/95 survived a guard named after them.

Both passes are added.

**Listener coverage.** Every hostname on an HTTPRoute must be admitted by a listener of one of its parent Gateways, honouring Gateway API semantics: a listener with no hostname admits everything; a wildcard is a **suffix** match, so `*.a.b` admits `x.a.b` and `x.y.a.b` and never the bare `a.b`; a parentRef's `sectionName` / `port` narrows the candidates. `NO-GATEWAY` is kept distinct from `NO-LISTENER` because the two have different owners — the per-Org app route is written by the provisioning service into the per-Org GitOps tree (`core/services/provisioning/gitops/gitops.go:2169`), while the `*.<slug>.<parent>` listener is appended by the Organization reconciler (`core/controllers/organization/internal/controller/tenant_console_tls.go:474`). Two producers, two triggers, no shared transaction — which is why a namespace can hold a route with no listener at all.

**Region symmetry.** With `--peer-kubeconfig` / `--peer-context` the peer region's hostname inventory is read, and any hostname advertised by exactly one region is `REGION-ASYMMETRY`, in **both** directions, because both regions' nodes sit in one round-robin pool. When no peer is supplied the run says so in its own summary rather than staying quiet, so a single-region run can never be mistaken for coverage of this clause.

**Fail-open avoided at the one place it would have been easy.** An unreadable Gateway list exits 2 — not a skipped pass, not an empty list. Skipping is the fail-open that hid #6040 for twelve hours; an empty list would turn an unreachable cluster into a wall of false `NO-GATEWAY` reds.

### Red-then-green, three mutations, each with a control

| Mutation | Goes red | Control that stays green |
|---|---|---|
| wildcard listener admits everything | `per-Org app host with no listener`, `wildcard must not admit its own apex` | `per-Org app host admitted by the Org wildcard listener`, `wildcard admits a deeper sub-host` |
| listener pass disabled | 3 fixtures | region-symmetry fixtures unaffected |
| peer comparison disabled | `hostname served here, absent from the peer region` — alone | `hostname served by both regions` |

Each control shares the suspect property of the fixture it guards, so a failure is attributable to the specific rule and not to the shape. All three mutations are wired into `check-live-route-backends-selftest.yaml`, which asserts the control lines survive. The pre-existing `mesh > 0` mutation still fires unchanged.

Fixture hostnames deliberately use three different per-Org pool TLDs (`.omani.homes`, `.omani.trade`, `.omani.rest`) because a Sovereign assigns pool TLDs **per Organization** — a fixture set sharing one TLD would pass a classifier that hardcoded it.

## 2. Row 241 — a record cannot report console health it never measured

The row says the record and the front door must agree and that it fails in **either** direction. One of those directions was not a bug; it was unreachable code.

`markPhase1Done` ran the #4706 probe only under `outcome == OutcomeReady`. A record latched `failed` never probed at all, `ConsoleDegraded` stayed zero-valued, and `omitempty` dropped both fields from the JSON — so the record read "no console problem" about a door nobody had opened. On hw293, dep `a0077ba47e3720e5` sat `status: failed` with `consoleDegraded` **absent** while `https://console.<fqdn>/` answered 200 from the public internet.

The row was parked against #4706. That producer had been in the running image for three weeks. The flag was missing because the probe never fired.

Two producers are fixed, because #6082 / #6083 had just introduced a second way to produce the same silence:

- `phase1_watch.go` — the probe runs on every terminal outcome, and the surface is published **after** the switch so it cannot influence `dep.Status`. That is also the only place that clears a stale `true` once the door reopens.
- `phase1_converged_late.go` — the converged-late rescue probes fresh before the flip. #6083 taught this path to re-read the **cluster** instead of the frozen classification; the console was left behind, so its `OutcomeFailed` arm flipped a record to `ready` on a census that says nothing about the front door — a new false-green of exactly the shape this row catches. Its `OutcomeReady` arm re-homed a stale termination-time `dep.Error`, so a recovered console stayed flagged degraded forever.

Running the probe everywhere is safe because the flag is a surface and never a gate (#5253): no Go consumer branches on `ConsoleDegraded`, and every non-Ready arm decides `dep.Status` without reading the probe result.

### Red-then-green with a control

The new table drives all 7 terminal outcome constants against both probe results — 14 cells, *"fails in either direction"* made mechanical. Reverting the one-line gate turns **12 of 14 red** with `outcome "failed" never probed the front door`, while both `ready/*` cells stay green, so the table is not simply failing on everything.

The control shares the suspect property: the obvious way to satisfy that table while breaking the platform is to let the probe result leak into the lifecycle — the original #4706 defect inverted. `TestConsoleHonesty_Row241_ProbeSurfacesButNeverGates` holds the outcome fixed, varies only the probe result, and requires `Status`, `dep.Error` and the handover fire to be byte-identical. It stays **green** under the same mutation that reddens the table.

One pre-existing assertion is inverted rather than worked around: `phase1_console_gate_test.go` asserted *"console probe must not run for a non-Ready outcome"*. That assertion **was** the defect, written down. Its neighbours — stays failed, fires no handover, still a mesh candidate — are untouched and still pass, which is the evidence that skipping the probe was never what protected the lifecycle.

## Verification

```
bash -n scripts/check-live-route-backends.sh                      # clean
bash scripts/check-live-route-backends.sh --self-test             # 11/11, 6 pass 5 fail as designed
go build ./...                                                    # clean
go test -count=1 ./internal/handler/                              # ok, 330s, whole package
```

Refs #6114
