### PR TITLE
fix(bp-postgres): repairing the spec did not repair the cluster — reap the stale initdb Job and stop the replica's silent absence (0.2.20)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1389,7 +1389,7 @@ spec:
       #   guacamole-pg and the shared-pg family as well. Egress half in
       #   bp-keycloak 1.5.9; neither half alone restores a brokered login.
       #   Lockstep w/ products/catalyst/chart/Chart.yaml.
-      version: 1.4.1401
+      version: 1.4.1402
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/clusters/_template/bootstrap-kit/16a-bp-postgres-shared.yaml
+++ b/clusters/_template/bootstrap-kit/16a-bp-postgres-shared.yaml
@@ -167,7 +167,19 @@ spec:
       # instance's region-B replica stayed read-only for the whole outage (keycloak
       # unrecoverable in region-B) because ONLY bp-cnpg-pair shipped a promoter. sync-
       # only fence; autoPromote.hr.name above targets THIS HR. Lockstep 16a/16c/16d.
-      version: 0.2.19
+      # 0.2.20 (#6114, Refs #6016 #5224): replica-side hub sentinel. #6016 repaired
+      # the dangling bootstrap.initdb.secret and region-B STILL did not heal — a Job
+      # pod template is IMMUTABLE and CNPG never recreates a stale bootstrap Job, so
+      # the generation-1 initdb Pod sat in CreateContainerConfigError for 12h against
+      # a correct generation-2 spec (hw293: keycloak-0 Init:0/1, harbor-jobservice
+      # 150 restarts, 8 HRs not Ready). The sentinel reaps that Job on POSITIVE
+      # evidence only (incomplete + names an absent Secret + older than the age
+      # guard; a COMPLETED initdb Job is never touched) and reports the cross-mesh
+      # hub-sync's absence as a Warning Event + status ConfigMap rather than leaving
+      # 14 Secrets silently missing. Readiness reports loop-liveness ONLY — it must
+      # never gate on the synced state, because this HR keeps Helm wait with
+      # install.remediation.retries: -1. Lockstep 16a/16c/16d.
+      version: 0.2.20
       sourceRef:
         kind: HelmRepository
         name: bp-postgres

--- a/clusters/_template/bootstrap-kit/16c-bp-postgres-shared-b.yaml
+++ b/clusters/_template/bootstrap-kit/16c-bp-postgres-shared-b.yaml
@@ -103,7 +103,7 @@ spec:
       # dr-promoter + failover-readiness + topology.promoted HR-value seam on the
       # active-hot-standby replica half (autoPromote.hr.name above targets THIS HR,
       # bp-postgres-shared-b). sync-only fence. Lockstep 16a/16c/16d.
-      version: 0.2.19
+      version: 0.2.20
       sourceRef:
         kind: HelmRepository
         name: bp-postgres

--- a/clusters/_template/bootstrap-kit/16d-bp-postgres-shared-c.yaml
+++ b/clusters/_template/bootstrap-kit/16d-bp-postgres-shared-c.yaml
@@ -91,7 +91,7 @@ spec:
       # dr-promoter + failover-readiness + topology.promoted HR-value seam on the
       # active-hot-standby replica half (autoPromote.hr.name above targets THIS HR,
       # bp-postgres-shared-c). sync-only fence. Lockstep 16a/16c/16d.
-      version: 0.2.19
+      version: 0.2.20
       sourceRef:
         kind: HelmRepository
         name: bp-postgres

--- a/platform/postgres/blueprint.yaml
+++ b/platform/postgres/blueprint.yaml
@@ -30,7 +30,14 @@ spec:
   # auto-promotes the survivor (keycloak et al. writable in region-B) instead of
   # leaving it pg_is_in_recovery()=t for the whole outage (hw292 G12). sync-only
   # data fence; default-OFF preserved for singleton/primary/async.
-  version: 0.2.19
+  # 0.2.20 (#6114): replica-side hub sentinel — reaps a stale CNPG initdb Job
+  # that CNPG never recreates (a Job pod template is immutable, so #6016's spec
+  # repair could not heal the generation-1 Pod: 12h in
+  # CreateContainerConfigError on hw293), and reports the cross-mesh
+  # consumer-hub sync's absence as a Warning Event + status ConfigMap instead
+  # of leaving 14 Secrets silently missing behind a green release. Readiness
+  # never gates on the synced state, so it cannot wedge Helm wait.
+  version: 0.2.20
   card:
     title: PostgreSQL
     summary: |

--- a/platform/postgres/chart/Chart.yaml
+++ b/platform/postgres/chart/Chart.yaml
@@ -291,8 +291,46 @@ name: bp-postgres
 #   the singleton render is byte-identical to 0.2.9 (the ipBlock only rendered
 #   under crossRegion, which singletons never set). Lockstep slot pins 16a/16c/
 #   16d → 0.2.10. tests/postgres-render.sh Case 4e/4f added.
-version: 0.2.19
-appVersion: 0.2.19
+# 0.2.20 (#6114, Refs #6016 #5224 #5157): replica-side HUB SENTINEL — a
+#   level-triggered actor for the two ways region-B fails SILENTLY.
+#   (1) THE REAP. #6016 (shipped 0.2.19) dropped cluster.yaml's dangling
+#   bootstrap.initdb.secret on the replica side and the cluster STILL did not
+#   heal: a Job's pod template is IMMUTABLE and CNPG only creates a bootstrap
+#   Job when one is ABSENT, never recreating a stale one. On hw293 the
+#   generation-1 shared-pg-1-initdb Pod therefore sat in
+#   CreateContainerConfigError for 12h against an already-repaired generation-2
+#   spec, taking keycloak-0 (Init:0/1), harbor-jobservice (CrashLoopBackOff,
+#   150 restarts) and 8 HelmReleases with it. Repairing a spec is not repairing
+#   a cluster. The sentinel deletes a bootstrap Job ONLY on positive evidence:
+#   incomplete (.status.succeeded == 0 — a COMPLETED initdb Job is never
+#   touched, since deleting one could invite a re-bootstrap over live data),
+#   older than minWedgeAgeSeconds, and naming a Secret that does not exist.
+#   No timeout heuristic anywhere in it.
+#   (2) THE LOUD HALF. role-secrets.yaml is gated `not isReplicaSide` BY DESIGN
+#   (#5224 — a replica that mints its own role passwords creates a permanently
+#   divergent credential set that resource-policy:keep freezes forever). The
+#   consequence was never handled: the replica mints NOTHING and depends
+#   entirely on catalyst-api's cross-mesh syncSharedPGConsumerHubSecrets, and
+#   when that has not run the namespace holds ZERO of the expected Secrets and
+#   says nothing. The sentinel watches for every role + hub Secret name the
+#   PRIMARY side would render and reports absence as a Warning Event + a
+#   `<instance>-replica-hub-sync-status` ConfigMap + a log line naming each one.
+#   Shape: a Deployment with a sleep loop, NOT a CronJob (#5157 — a CronJob's
+#   scheduler dies with the region's control plane) and NOT a Helm hook (a
+#   pre-upgrade hook runs BEFORE the repaired spec is applied so CNPG would
+#   recreate the Job from the broken one; a post-upgrade hook that fails blocks
+#   the release, and slot 16a runs install.remediation.retries: -1). Readiness
+#   reports only that the loop is alive, NEVER that the Secrets arrived —
+#   gating readiness on the synced state would turn the legitimate pre-sync
+#   window into an infinite install-remediation loop. Gated on isReplicaSide,
+#   NOT renderReplicaHalf: the wedge lives in the PRE-FLIP window (#4460
+#   placeholder singleton), which renderReplicaHalf does not cover. Opt-out via
+#   replicaHubSentinel.enabled=false (read with `dig`, so an explicit false is
+#   honoured — sprig's `default` swallows boolean false). Primary render is
+#   byte-identical. Lockstep slot pins 16a/16c/16d → 0.2.20.
+#   tests/postgres-render.sh Case 21 added.
+version: 0.2.20
+appVersion: 0.2.20
 description: |
   Catalyst-authored data-instance Blueprint for a shareable, reusable
   PostgreSQL engine. Each install of bp-postgres = ONE

--- a/platform/postgres/chart/templates/replica-hub-sentinel.yaml
+++ b/platform/postgres/chart/templates/replica-hub-sentinel.yaml
@@ -235,22 +235,28 @@ spec:
         catalyst.openova.io/role: replica-hub-sentinel
         catalyst.openova.io/data-instance: {{ $instance | quote }}
         # kyverno cilium-l7-mtls (Enforce) — required on the Pod template or the
-        # Deployment is DENIED at admission (#3238).
-        io.cilium.proxy-visibility: "<Egress/53/UDP/DNS>"
+        # Deployment is DENIED at admission (#3238). Same label dr-promoter and
+        # failover-readiness carry in this chart; verified against those
+        # templates rather than assumed.
+        policy.cilium.io/enforced: "true"
     spec:
       serviceAccountName: {{ $name | quote }}
       automountServiceAccountToken: true
       securityContext:
         runAsNonRoot: true
-        runAsUser: 1001
-        runAsGroup: 1001
         seccompProfile:
           type: RuntimeDefault
       containers:
         - name: sentinel
           image: {{ printf "%s:%s" $repo $tag | quote }}
           imagePullPolicy: {{ $pull | quote }}
+          # UID/GID + HOME copied from dr-promoter's `actor` container, which
+          # runs THIS SAME alpine/k8s image in THIS SAME chart. HOME=/tmp is
+          # load-bearing, not cosmetic: kubectl writes its discovery/HTTP cache
+          # under $HOME, and the root filesystem is read-only.
           securityContext:
+            runAsUser: 65534
+            runAsGroup: 65534
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
             capabilities:
@@ -274,6 +280,8 @@ spec:
               value: {{ $minAge | quote }}
             - name: EXPECTED_SECRETS
               value: {{ keys $expected | sortAlpha | join " " | quote }}
+            - name: HOME
+              value: /tmp
           # Readiness = "the loop is alive", never "the Secrets arrived". See
           # the header: gating readiness on the synced state would fail Helm
           # wait during the legitimate pre-sync window, and slot 16a's
@@ -290,10 +298,13 @@ spec:
             initialDelaySeconds: 30
             periodSeconds: 30
             failureThreshold: 4
-          command: ["/bin/bash", "-c"]
+          # /bin/sh, NOT /bin/bash — alpine/k8s is Alpine-based and dr-promoter
+          # (same image, same chart) invokes sh. The script below stays
+          # ash-compatible: no arrays, no [[ ]], no here-strings.
+          command: ["/bin/sh", "-c"]
           args:
             - |
-              set -uo pipefail
+              set -u
               # Touch BEFORE the first tick so Helm wait is satisfied immediately
               # and a slow API server can never look like a dead reconciler.
               touch /tmp/alive

--- a/platform/postgres/chart/templates/replica-hub-sentinel.yaml
+++ b/platform/postgres/chart/templates/replica-hub-sentinel.yaml
@@ -313,9 +313,8 @@ spec:
               KC="kubectl --request-timeout=20s"
 
               reap_wedged_initdb_jobs() {
-                local jobs_json j name succeeded age created now refs s missing
+                local jobs_json j name succeeded age refs s missing
                 jobs_json="$($KC -n "${NS}" get jobs -o json 2>/dev/null)" || return 0
-                now="$(date -u +%s)"
                 for name in $(printf '%s' "$jobs_json" \
                     | jq -r --arg i "${INSTANCE}" \
                       '.items[] | select(.metadata.name | endswith("-initdb"))
@@ -329,8 +328,19 @@ spec:
                   if [ "${succeeded}" != "0" ]; then continue; fi
 
                   # (d) age guard — never race a Secret that is about to sync.
-                  created="$(printf '%s' "$j" | jq -r '.metadata.creationTimestamp')"
-                  age=$(( now - $(date -u -d "${created}" +%s 2>/dev/null || echo "${now}") ))
+                  #
+                  # Computed with jq's fromdateiso8601, NOT `date -u -d "<ts>"`.
+                  # busybox date (this is an Alpine image) does not parse an
+                  # RFC3339 string with -d, and the natural fallback for that
+                  # is age=0 — which silently makes the reap NEVER fire. A
+                  # repair that quietly does nothing is worse than no repair,
+                  # because it looks present. jq is already a hard dependency
+                  # two lines up, so this removes a dependency rather than
+                  # adding one.
+                  age="$(printf '%s' "$j" | jq -r '(now - (.metadata.creationTimestamp | fromdateiso8601)) | floor' 2>/dev/null)"
+                  case "${age}" in
+                    ''|*[!0-9-]*) echo "[sentinel] WARN: could not compute age for ${name} (creationTimestamp unparseable) — NOT reaping" >&2; continue ;;
+                  esac
                   if [ "${age}" -lt "${MIN_WEDGE_AGE}" ]; then continue; fi
 
                   # (c) POSITIVE evidence: the Job names a Secret that is absent.

--- a/platform/postgres/chart/templates/replica-hub-sentinel.yaml
+++ b/platform/postgres/chart/templates/replica-hub-sentinel.yaml
@@ -1,0 +1,415 @@
+{{- /*
+Replica-side hub sentinel (0.2.20, #6114) — the region-B half of shared-pg has
+TWO failure modes that both end in silence. This one workload closes both.
+
+────────────────────────────────────────────────────────────────────────────
+WHY THIS EXISTS — the hw293 chain, in order
+────────────────────────────────────────────────────────────────────────────
+
+role-secrets.yaml is gated `not isReplicaSide` — DELIBERATELY (#5224, the hw273
+harbor 28P01 lockout: a replica region that mints its own role passwords creates
+a permanently DIVERGENT credential set that `helm.sh/resource-policy: keep`
+then preserves forever, and any DR promote actor asserting those local values
+clobbers the primary's canonical password). That gate is correct and this file
+does not touch it.
+
+Its CONSEQUENCE is what was never handled: the replica region mints NOTHING and
+depends ENTIRELY on catalyst-api's cross-mesh `syncSharedPGConsumerHubSecrets`
+to deliver every role + hub Secret. When that sync does not run, region-B's
+shared-data holds ZERO of region-A's consumer hub Secrets — and nothing anywhere
+says so. On hw293 that was 14 absent Secrets behind a green bp-postgres release.
+
+  1. Chart 0.2.18 named a role Secret in `bootstrap.initdb.secret` on the
+     replica side — an object role-secrets.yaml deliberately never renders
+     there. CNPG projects it into the initdb Job as
+     `APP_USERNAME <- secretKeyRef{shared-pg-harbor, optional: false}`, which is
+     POD-FATAL: the container cannot be configured at all.
+  2. #6016 (shipped 0.2.19) dropped that reference. The Cluster spec was
+     repaired at generation 2 and the chart ran in BOTH regions.
+  3. IT STILL DID NOT HEAL. A Job's pod template is IMMUTABLE, and CNPG only
+     creates a bootstrap Job when one is ABSENT — it never recreates a Job whose
+     spec has gone stale. The generation-1 `shared-pg-1-initdb` Pod therefore sat
+     in CreateContainerConfigError for TWELVE HOURS against a repaired spec,
+     taking keycloak-0 (Init:0/1), harbor-jobservice (CrashLoopBackOff, 150
+     restarts) and 8 HelmReleases down with it.
+
+A chart fix that repairs the spec but leaves the wedged Pod has not fixed the
+cluster. The repair needs an ACTOR.
+
+────────────────────────────────────────────────────────────────────────────
+WHY A LEVEL-TRIGGERED Deployment, and NOT a Helm hook
+────────────────────────────────────────────────────────────────────────────
+
+  * A `pre-upgrade` hook is WRONG BY ORDERING. It runs BEFORE the repaired
+    Cluster spec is applied, so CNPG would immediately recreate the initdb Job
+    from the still-broken generation-1 spec. The reap is only meaningful AFTER
+    the new spec is live.
+
+  * A `post-upgrade` hook is right by ordering and wrong by blast radius. Slot
+    16a runs `install.remediation.retries: -1` with Helm wait KEPT and a 15m
+    timeout. A failing hook fails the release, and an infinitely-remediated
+    release re-enters install on a Cluster CR that is mid-bootstrap. That trades
+    a silent wedge for a self-inflicted outage — and a hook fires only on a
+    Helm operation, so a wedge that appears BETWEEN upgrades waits for the next
+    one. hw293's wedge existed for 12h without a Helm operation to catch it.
+
+  * A Deployment running an idempotent loop reaps whenever the wedge appears,
+    retries forever, self-heals, and CANNOT block delivery. It is also the
+    repo's canon for a region-local reconciler: the openbao unseal-reconciler
+    shipped as a CronJob (#5148) and did not survive the very region-kill it
+    guarded, because a CronJob's scheduler dies with the region's control plane
+    and did not resume for 40+ min (#5157 converted it to a Deployment).
+
+The readiness probe deliberately reports only "the loop is alive", NEVER "the
+Secrets arrived". Gating readiness on the synced state would convert the
+LEGITIMATE pre-sync window into a failed Helm wait on every fresh 2-region prov,
+and with `retries: -1` that is an infinite install-remediation loop. Loudness is
+delivered as a Warning Event + a status ConfigMap + a failed-state log line —
+all of which are visible without any of them being able to wedge the release.
+
+────────────────────────────────────────────────────────────────────────────
+THE REAP CRITERION IS POSITIVE EVIDENCE, NOT A TIMEOUT
+────────────────────────────────────────────────────────────────────────────
+
+A Job is reaped ONLY when ALL of these hold:
+    (a) it belongs to THIS instance and its name ends in `-initdb`;
+    (b) `.status.succeeded` is 0 — a COMPLETED initdb Job is never touched,
+        because deleting one could invite a re-bootstrap over live data. This
+        is the single most important guard in the file;
+    (c) it references a Secret that DOES NOT EXIST in this namespace — the
+        pod-fatal condition itself, read from the Job's own pod template
+        rather than guessed from a status string;
+    (d) it is older than `minWedgeAgeSeconds`, so a Secret that is merely
+        seconds away from being synced is never raced.
+
+(b)+(c) together mean the reap can only ever delete a Job that is incapable of
+ever starting. There is no timeout heuristic anywhere in it.
+
+Side gate: `isReplicaSide`, NOT `renderReplicaHalf`. The wedge is reachable in
+the PRE-FLIP window — `side` is stamped from SOVEREIGN_REGION_ROLE at cloud-init
+and is present from the very first render, while `activeHotStandby` flips LATE
+(#4460). The hw293 initdb Pods wedged on the pre-flip placeholder singleton
+Cluster, which is exactly the render `renderReplicaHalf` does NOT cover.
+*/ -}}
+{{- $sentinel := .Values.replicaHubSentinel | default dict }}
+{{- /* `dig`, NEVER `$sentinel.enabled | default true`: sprig's `default` treats
+       boolean false as EMPTY and hands back the default, so an explicit
+       `enabled: false` would silently render the sentinel anyway. `dig` returns
+       a present key's real value and only falls back when the key is absent. */ -}}
+{{- if and (ne (toString .Values.enabled) "false") (include "bp-postgres.isReplicaSide" .) (ne (toString (dig "enabled" true $sentinel)) "false") }}
+{{- $ns := include "bp-postgres.namespace" . }}
+{{- $instance := include "bp-postgres.instanceName" . }}
+{{- $name := printf "%s-replica-hub-sentinel" $instance | trunc 63 | trimSuffix "-" }}
+{{- $statusCM := printf "%s-replica-hub-sync-status" $instance | trunc 63 | trimSuffix "-" }}
+{{- $img := $sentinel.image | default dict }}
+{{- $repo := $img.repository | default "harbor.openova.io/proxy-dockerhub/alpine/k8s" }}
+{{- $tag := $img.tag | default "1.30.0" }}
+{{- $pull := $img.pullPolicy | default "IfNotPresent" }}
+{{- $interval := $sentinel.intervalSeconds | default 30 }}
+{{- $minAge := $sentinel.minWedgeAgeSeconds | default 180 }}
+{{- /* Expected Secret names: every role Secret + every consumer hub Secret this
+       chart would have rendered on the PRIMARY side. On the replica these can
+       only arrive via the cross-mesh sync, so their absence is the signal. */ -}}
+{{- $ctx := . }}
+{{- $expected := dict }}
+{{- range .Values.databases }}
+{{- $db := . }}
+{{- $_ := set $expected (include "bp-postgres.roleSecretName" (dict "ctx" $ctx "db" $db)) true }}
+{{- if and $db.reflect $db.reflect.secretName }}
+{{- $_ := set $expected $db.reflect.secretName true }}
+{{- end }}
+{{- end }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $name | quote }}
+  namespace: {{ $ns | quote }}
+  labels:
+    {{- include "bp-postgres.labels" . | nindent 4 }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $name | quote }}
+  namespace: {{ $ns | quote }}
+  labels:
+    {{- include "bp-postgres.labels" . | nindent 4 }}
+rules:
+  # Read the Jobs to classify them, delete ONLY the ones proven unstartable.
+  - apiGroups: [batch]
+    resources: [jobs]
+    verbs: [get, list, delete]
+  # Read the wedged Pod's status message so the log names the real cause.
+  - apiGroups: [""]
+    resources: [pods]
+    verbs: [get, list]
+  # Existence checks only — the sentinel never reads a Secret's DATA.
+  - apiGroups: [""]
+    resources: [secrets]
+    verbs: [get, list]
+  - apiGroups: [""]
+    resources: [events]
+    verbs: [create, patch]
+  # `create` cannot carry resourceNames (the object does not exist yet); the
+  # mutating verbs are pinned to this instance's own status object.
+  - apiGroups: [""]
+    resources: [configmaps]
+    verbs: [create]
+  - apiGroups: [""]
+    resources: [configmaps]
+    verbs: [get, update, patch]
+    resourceNames: [{{ $statusCM | quote }}]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $name | quote }}
+  namespace: {{ $ns | quote }}
+  labels:
+    {{- include "bp-postgres.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ $name | quote }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ $name | quote }}
+    namespace: {{ $ns | quote }}
+---
+{{- /* shared-data is covered by the platform default-deny CCNP
+       (bp-network-policies), and the kube-apiserver is a reserved Cilium entity
+       a vanilla NetworkPolicy cannot express (#4428 idiom) — so the sentinel's
+       whole egress allow-list lives in ONE CiliumNetworkPolicy, exactly as
+       dr-promoter's does. Without this the Pod cannot reach the API server and
+       the reconciler is inert (a silent failure of the thing that exists to end
+       silent failures). */ -}}
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: {{ printf "%s-egress" $name | trunc 63 | trimSuffix "-" | quote }}
+  namespace: {{ $ns | quote }}
+  labels:
+    {{- include "bp-postgres.labels" . | nindent 4 }}
+spec:
+  endpointSelector:
+    matchLabels:
+      catalyst.openova.io/role: replica-hub-sentinel
+      catalyst.openova.io/data-instance: {{ $instance | quote }}
+  egress:
+    - toEntities:
+        - kube-apiserver
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+            k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $name | quote }}
+  namespace: {{ $ns | quote }}
+  labels:
+    {{- include "bp-postgres.labels" . | nindent 4 }}
+    catalyst.openova.io/role: replica-hub-sentinel
+  annotations:
+    catalyst.openova.io/blueprint: bp-postgres
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: bp-postgres
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      catalyst.openova.io/role: replica-hub-sentinel
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: bp-postgres
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        catalyst.openova.io/role: replica-hub-sentinel
+        catalyst.openova.io/data-instance: {{ $instance | quote }}
+        # kyverno cilium-l7-mtls (Enforce) — required on the Pod template or the
+        # Deployment is DENIED at admission (#3238).
+        io.cilium.proxy-visibility: "<Egress/53/UDP/DNS>"
+    spec:
+      serviceAccountName: {{ $name | quote }}
+      automountServiceAccountToken: true
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1001
+        runAsGroup: 1001
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: sentinel
+          image: {{ printf "%s:%s" $repo $tag | quote }}
+          imagePullPolicy: {{ $pull | quote }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: [ALL]
+          resources:
+            requests: { cpu: 10m, memory: 48Mi }
+            limits: { memory: 128Mi }
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+          env:
+            - name: NS
+              value: {{ $ns | quote }}
+            - name: INSTANCE
+              value: {{ $instance | quote }}
+            - name: STATUS_CM
+              value: {{ $statusCM | quote }}
+            - name: INTERVAL
+              value: {{ $interval | quote }}
+            - name: MIN_WEDGE_AGE
+              value: {{ $minAge | quote }}
+            - name: EXPECTED_SECRETS
+              value: {{ keys $expected | sortAlpha | join " " | quote }}
+          # Readiness = "the loop is alive", never "the Secrets arrived". See
+          # the header: gating readiness on the synced state would fail Helm
+          # wait during the legitimate pre-sync window, and slot 16a's
+          # `install.remediation.retries: -1` would make that an infinite loop.
+          readinessProbe:
+            exec:
+              command: ["/bin/sh", "-c", "test -f /tmp/alive"]
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            failureThreshold: 6
+          livenessProbe:
+            exec:
+              command: ["/bin/sh", "-c", "test -f /tmp/alive"]
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            failureThreshold: 4
+          command: ["/bin/bash", "-c"]
+          args:
+            - |
+              set -uo pipefail
+              # Touch BEFORE the first tick so Helm wait is satisfied immediately
+              # and a slow API server can never look like a dead reconciler.
+              touch /tmp/alive
+              echo "[sentinel] bp-postgres replica hub sentinel — ns=${NS} instance=${INSTANCE} interval=${INTERVAL}s"
+              echo "[sentinel] expected (cross-mesh-synced) Secrets: ${EXPECTED_SECRETS}"
+              KC="kubectl --request-timeout=20s"
+
+              reap_wedged_initdb_jobs() {
+                local jobs_json j name succeeded age created now refs s missing
+                jobs_json="$($KC -n "${NS}" get jobs -o json 2>/dev/null)" || return 0
+                now="$(date -u +%s)"
+                for name in $(printf '%s' "$jobs_json" \
+                    | jq -r --arg i "${INSTANCE}" \
+                      '.items[] | select(.metadata.name | endswith("-initdb"))
+                                | select(.metadata.name | startswith($i))
+                                | .metadata.name'); do
+                  j="$(printf '%s' "$jobs_json" | jq --arg n "$name" '.items[] | select(.metadata.name==$n)')"
+
+                  # (b) NEVER touch a completed initdb Job — deleting one could
+                  #     invite a re-bootstrap over live data.
+                  succeeded="$(printf '%s' "$j" | jq -r '.status.succeeded // 0')"
+                  if [ "${succeeded}" != "0" ]; then continue; fi
+
+                  # (d) age guard — never race a Secret that is about to sync.
+                  created="$(printf '%s' "$j" | jq -r '.metadata.creationTimestamp')"
+                  age=$(( now - $(date -u -d "${created}" +%s 2>/dev/null || echo "${now}") ))
+                  if [ "${age}" -lt "${MIN_WEDGE_AGE}" ]; then continue; fi
+
+                  # (c) POSITIVE evidence: the Job names a Secret that is absent.
+                  refs="$(printf '%s' "$j" | jq -r '
+                    [ .spec.template.spec.containers[]?, .spec.template.spec.initContainers[]? ]
+                    | map( (.env[]?.valueFrom.secretKeyRef.name // empty),
+                           (.envFrom[]?.secretRef.name // empty) )
+                    | flatten | unique | .[]' 2>/dev/null)"
+                  missing=""
+                  for s in ${refs}; do
+                    if ! $KC -n "${NS}" get secret "${s}" >/dev/null 2>&1; then
+                      missing="${missing} ${s}"
+                    fi
+                  done
+                  if [ -z "${missing}" ]; then continue; fi
+
+                  echo "[sentinel] REAPING stale bootstrap Job ${name}: incomplete, ${age}s old, references absent Secret(s):${missing}"
+                  echo "[sentinel]   a Job pod template is IMMUTABLE and CNPG never recreates a stale one — the repaired Cluster spec cannot heal this Pod on its own."
+                  if $KC -n "${NS}" delete job "${name}" --cascade=foreground --wait=false >/dev/null 2>&1; then
+                    echo "[sentinel]   deleted ${name}; CNPG will recreate it from the CURRENT Cluster spec"
+                  else
+                    echo "[sentinel]   ERROR: delete of ${name} FAILED — the wedge persists and needs an operator" >&2
+                  fi
+                done
+              }
+
+              report_missing_hub_secrets() {
+                local missing="" present=0 total=0 s state last
+                for s in ${EXPECTED_SECRETS}; do
+                  total=$(( total + 1 ))
+                  if $KC -n "${NS}" get secret "${s}" >/dev/null 2>&1; then
+                    present=$(( present + 1 ))
+                  else
+                    missing="${missing}${s} "
+                  fi
+                done
+
+                if [ -z "${missing}" ]; then
+                  state="synced"
+                  echo "[sentinel] hub sync OK — ${present}/${total} expected Secret(s) present"
+                else
+                  state="MISSING"
+                  echo "[sentinel] HUB SYNC INCOMPLETE — ${present}/${total} present; ABSENT: ${missing}" >&2
+                  if [ "${present}" -eq 0 ] && [ "${total}" -gt 0 ]; then
+                    echo "[sentinel]   ZERO of ${total} expected Secrets are present. role-secrets.yaml is gated 'not isReplicaSide' BY DESIGN (#5224), so this region mints none of its own and depends entirely on catalyst-api's cross-mesh syncSharedPGConsumerHubSecrets. Zero present means that sync has not run for this namespace." >&2
+                  fi
+                fi
+
+                # Status object — machine-readable, and the de-dupe source for
+                # the Warning Event so a steady failure does not spam the stream.
+                last="$($KC -n "${NS}" get configmap "${STATUS_CM}" -o jsonpath='{.data.missing}' 2>/dev/null || true)"
+                $KC -n "${NS}" create configmap "${STATUS_CM}" \
+                    --from-literal=state="${state}" \
+                    --from-literal=present="${present}/${total}" \
+                    --from-literal=missing="${missing}" \
+                    --dry-run=client -o yaml 2>/dev/null | $KC -n "${NS}" apply -f - >/dev/null 2>&1 || true
+
+                # Emitted via printf, NOT a heredoc: this whole script is the
+                # indented body of a YAML `args:` block, and an unindented `EOF`
+                # terminator cannot survive that (`<<-` strips only TABS).
+                if [ -n "${missing}" ] && [ "${missing}" != "${last}" ]; then
+                  printf '%s\n' \
+                    'apiVersion: v1' \
+                    'kind: Event' \
+                    'metadata:' \
+                    "  generateName: ${INSTANCE}-hub-sync-" \
+                    "  namespace: ${NS}" \
+                    'involvedObject:' \
+                    '  apiVersion: v1' \
+                    '  kind: ConfigMap' \
+                    "  name: ${STATUS_CM}" \
+                    "  namespace: ${NS}" \
+                    'type: Warning' \
+                    'reason: ReplicaHubSecretsMissing' \
+                    "message: \"${present}/${total} cross-mesh-synced Secret(s) present in ${NS}; absent: ${missing}\"" \
+                    'source:' \
+                    '  component: bp-postgres-replica-hub-sentinel' \
+                  | $KC -n "${NS}" create -f - >/dev/null 2>&1 || true
+                fi
+              }
+
+              while true; do
+                # Each tick in a subshell so one fault retries instead of
+                # crashing the loop (#5157 pattern).
+                ( reap_wedged_initdb_jobs ) || echo "[sentinel] reap tick failed; retrying next interval" >&2
+                ( report_missing_hub_secrets ) || echo "[sentinel] report tick failed; retrying next interval" >&2
+                touch /tmp/alive
+                sleep "${INTERVAL}"
+              done
+      volumes:
+        - name: tmp
+          emptyDir: {}
+{{- end }}

--- a/platform/postgres/chart/templates/replica-hub-sentinel.yaml
+++ b/platform/postgres/chart/templates/replica-hub-sentinel.yaml
@@ -222,6 +222,14 @@ metadata:
     catalyst.openova.io/blueprint: bp-postgres
 spec:
   replicas: 1
+  # Recreate, matching dr-promoter (#6079). A single-replica Deployment with the
+  # DEFAULT RollingUpdate can never roll on a full node: maxSurge 25% ceils to 1
+  # so the new Pod is created, but maxUnavailable 25% floors to 0 so the old Pod
+  # may never be evicted to make room for it. A reconciler that cannot be rolled
+  # out is a reconciler stuck on whatever image it first got — which for THIS
+  # workload would mean the repair silently never updates.
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app.kubernetes.io/name: bp-postgres

--- a/platform/postgres/chart/tests/postgres-render.sh
+++ b/platform/postgres/chart/tests/postgres-render.sh
@@ -1490,4 +1490,39 @@ helm template shared-pg . -f "$TMP/sentinel.values.yaml" --set replicaHubSentine
 if grep -q 'replica-hub-sentinel' "$TMP/sentinel-off.yaml"; then
   fail "#6114 replicaHubSentinel.enabled=false still rendered the sentinel (sprig 'default' swallowing boolean false?)"
 fi
-echo "  PASS (sentinel on replica + pre-flip; reap guards completed/age/positive-evidence; watch-list names hub AND role Secrets; readiness cannot wedge Helm wait; absent on primary CONTROL; opt-out clean)"
+# 21h — RUNTIME-SHAPE assertions, each copied from dr-promoter's `actor`
+# container, which runs the SAME alpine/k8s image in THIS chart. Every one of
+# these was initially written wrong from memory and corrected only by reading
+# the proven template, so they are pinned rather than trusted:
+#   * kyverno cilium-l7-mtls (Enforce) DENIES a Pod template without the
+#     policy.cilium.io/enforced label (#3238) — the Deployment would never
+#     be admitted at all.
+#   * alpine/k8s is Alpine: /bin/bash is not the interpreter to assume.
+#   * HOME=/tmp is load-bearing under readOnlyRootFilesystem — kubectl writes
+#     its discovery cache under $HOME.
+grep -q 'policy.cilium.io/enforced: "true"' "$TMP/sentinel-replica.yaml" \
+  || fail "#6114 sentinel Pod template lacks policy.cilium.io/enforced — kyverno cilium-l7-mtls (Enforce) DENIES it at admission (#3238)"
+grep -q 'runAsUser: 65534' "$TMP/sentinel-replica.yaml" \
+  || fail "#6114 sentinel must run as 65534, the UID dr-promoter's actor uses for this same image"
+awk '/name: HOME/{getline; print; exit}' "$TMP/sentinel-replica.yaml" | grep -q '/tmp' \
+  || fail "#6114 sentinel needs HOME=/tmp — kubectl writes its cache under \$HOME and the rootfs is read-only"
+grep -q '"/bin/bash"' "$TMP/sentinel-replica.yaml" \
+  && fail "#6114 sentinel invokes /bin/bash, but alpine/k8s is Alpine — dr-promoter uses /bin/sh"
+
+# 21i — the rendered loop must actually PARSE as POSIX sh. A bashism here is
+# invisible to every assertion above (they all match text) and would surface
+# only as a CrashLoopBackOff on the replica, which is the failure mode this
+# whole file exists to end. `sh` is dash on Debian/Ubuntu runners.
+python3 - "$TMP/sentinel-replica.yaml" > "$TMP/sentinel-script.sh" <<'PY'
+import sys, yaml
+for d in yaml.safe_load_all(open(sys.argv[1])):
+    if isinstance(d, dict) and d.get("kind") == "Deployment" \
+       and "replica-hub-sentinel" in (d.get("metadata") or {}).get("name", ""):
+        print(d["spec"]["template"]["spec"]["containers"][0]["args"][0])
+PY
+[ -s "$TMP/sentinel-script.sh" ] \
+  || fail "#6114 VACUOUS: extracted an EMPTY sentinel script — the shape check below would pass on nothing"
+sh -n "$TMP/sentinel-script.sh" \
+  || fail "#6114 the sentinel loop is not valid POSIX sh — it would CrashLoopBackOff on the Alpine-based image"
+
+echo "  PASS (sentinel on replica + pre-flip; reap guards completed/age/positive-evidence; watch-list names hub AND role Secrets; readiness cannot wedge Helm wait; absent on primary CONTROL; opt-out clean; admission label + UID + HOME + POSIX-sh parse pinned)"

--- a/platform/postgres/chart/tests/postgres-render.sh
+++ b/platform/postgres/chart/tests/postgres-render.sh
@@ -1030,13 +1030,13 @@ repl_sel=$(helm template shared-pg . \
   --api-versions postgresql.cnpg.io/v1 2>/dev/null)
 # Every `additional` service in the managed block must be selectorType rw:
 # the replication source (this fix) and the write alias (#3629) alike.
-if printf '%s' "${repl_sel}" | grep -qE 'selectorType:[[:space:]]*r[[:space:]]*$'; then
+if grep -qE 'selectorType:[[:space:]]*r[[:space:]]*$' <<<"${repl_sel}"; then
   echo "FAIL (#5473): a managed additional Service still declares 'selectorType: r'." >&2
   echo "  The cross-region replication SOURCE must be the primary ('rw'); 'r' selects every" >&2
   echo "  instance and lets a region-b replica cascade off a standby (live: hw291 2026-07-29)." >&2
   exit 1
 fi
-if ! printf '%s' "${repl_sel}" | grep -q 'catalyst.openova.io/role: replication-source'; then
+if ! grep -q 'catalyst.openova.io/role: replication-source' <<<"${repl_sel}"; then
   echo "FAIL (#5473): the replication-source Service did not render — the assertion is vacuous." >&2
   exit 1
 fi
@@ -1061,11 +1061,11 @@ seed_out=$(helm template shared-pg . \
   --api-versions postgresql.cnpg.io/v1 2>/dev/null)
 
 # VACUITY FIRST: a grep for a missing key "passes" trivially on an empty render.
-if ! printf '%s' "${seed_out}" | grep -q '^kind: Cluster'; then
+if ! grep -q '^kind: Cluster' <<<"${seed_out}"; then
   echo "FAIL (#5504): no Cluster CR rendered — every assertion below is vacuous." >&2
   exit 2
 fi
-if ! printf '%s' "${seed_out}" | grep -qE '^      owner: "harbor"'; then
+if ! grep -qE '^      owner: "harbor"' <<<"${seed_out}"; then
   echo "FAIL (#5504): initdb owner did not render — assertion vacuous." >&2
   exit 2
 fi
@@ -1147,13 +1147,13 @@ pos_out=$(helm template shared-pg . -f "${pos_vals}" --namespace shared-data \
   || { echo "FAIL (#5639): the region-BEARING render errored — the guard must not reject a valid install:" >&2
        printf '%s\n' "${pos_out}" >&2; exit 1; }
 
-printf '%s' "${pos_out}" | grep -qE '^kind: Cluster$' \
+grep -qE '^kind: Cluster$' <<<"${pos_out}" \
   || { echo "FAIL (#5639): no Cluster rendered — every assertion below is vacuous." >&2; exit 2; }
-printf '%s' "${pos_out}" | grep -qE '^    openova\.io/region: "hz-fsn-rtz-prod"$' \
+grep -qE '^    openova\.io/region: "hz-fsn-rtz-prod"$' <<<"${pos_out}" \
   || { echo "FAIL (#5639): primary Cluster LABEL is not the real region (empty label = the defect)." >&2; exit 1; }
-printf '%s' "${pos_out}" | grep -qE '^                values: \["hz-fsn-rtz-prod"\]$' \
+grep -qE '^                values: \["hz-fsn-rtz-prod"\]$' <<<"${pos_out}" \
   || { echo "FAIL (#5639): primary nodeAffinity values[] is not [hz-fsn-rtz-prod]." >&2; exit 1; }
-if printf '%s' "${pos_out}" | grep -qE 'values: \[""\]'; then
+if grep -qE 'values: \[""\]' <<<"${pos_out}"; then
   echo "FAIL (#5639): the render still emits an EMPTY nodeAffinity selector." >&2; exit 1
 fi
 echo "  PASS (+ primary: label + nodeAffinity both carry hz-fsn-rtz-prod)"
@@ -1163,9 +1163,9 @@ pos_replica=$(helm template shared-pg . -f "${pos_vals}" --namespace shared-data
   --set topology.side=secondary --api-versions postgresql.cnpg.io/v1 2>&1) \
   || { echo "FAIL (#5639): the region-bearing REPLICA render errored:" >&2
        printf '%s\n' "${pos_replica}" >&2; exit 1; }
-printf '%s' "${pos_replica}" | grep -qE '^    openova\.io/region: "hz-hel-rtz-prod"$' \
+grep -qE '^    openova\.io/region: "hz-hel-rtz-prod"$' <<<"${pos_replica}" \
   || { echo "FAIL (#5639): replica Cluster LABEL is not the real replica region." >&2; exit 1; }
-printf '%s' "${pos_replica}" | grep -qE '^                values: \["hz-hel-rtz-prod"\]$' \
+grep -qE '^                values: \["hz-hel-rtz-prod"\]$' <<<"${pos_replica}" \
   || { echo "FAIL (#5639): replica nodeAffinity values[] is not [hz-hel-rtz-prod]." >&2; exit 1; }
 echo "  PASS (+ replica: label + nodeAffinity both carry hz-hel-rtz-prod)"
 
@@ -1187,7 +1187,7 @@ if neg_out=$(helm template postgres . -f "${neg_vals}" --namespace hw292-omani-w
   printf '%s\n' "${neg_out}" | grep -E 'openova\.io/region|values: \[' >&2
   rm -f "${neg_vals}"; exit 1
 fi
-printf '%s' "${neg_out}" | grep -q 'topology.primary.region' \
+grep -q 'topology.primary.region' <<<"${neg_out}" \
   || { echo "FAIL (#5639): the render failed but the error does NOT name topology.primary.region:" >&2
        printf '%s\n' "${neg_out}" >&2; rm -f "${neg_vals}"; exit 1; }
 echo "  PASS (- primary: render REFUSED, error names topology.primary.region)"
@@ -1207,7 +1207,7 @@ if neg_replica_out=$(helm template postgres . -f "${neg_replica_vals}" --namespa
   printf '%s\n' "${neg_replica_out}" | grep -E 'openova\.io/region|values: \[' >&2
   rm -f "${neg_vals}" "${neg_replica_vals}"; exit 1
 fi
-printf '%s' "${neg_replica_out}" | grep -q 'topology.replica.region' \
+grep -q 'topology.replica.region' <<<"${neg_replica_out}" \
   || { echo "FAIL (#5639): the replica render failed but the error does NOT name topology.replica.region:" >&2
        printf '%s\n' "${neg_replica_out}" >&2; rm -f "${neg_vals}" "${neg_replica_vals}"; exit 1; }
 echo "  PASS (- replica: render REFUSED, error names topology.replica.region)"
@@ -1221,10 +1221,10 @@ sing_out=$(helm template postgres . -f "${singleton_vals}" --namespace org-acme 
   --api-versions postgresql.cnpg.io/v1 2>&1) \
   || { echo "FAIL (#5639): the SINGLETON render was broken by the region guard:" >&2
        printf '%s\n' "${sing_out}" >&2; rm -f "${neg_vals}" "${neg_replica_vals}" "${singleton_vals}"; exit 1; }
-printf '%s' "${sing_out}" | grep -qE '^kind: Cluster$' \
+grep -qE '^kind: Cluster$' <<<"${sing_out}" \
   || { echo "FAIL (#5639): singleton render emitted no Cluster." >&2
        rm -f "${neg_vals}" "${neg_replica_vals}" "${singleton_vals}"; exit 1; }
-if printf '%s' "${sing_out}" | grep -q 'openova.io/region'; then
+if grep -q 'openova.io/region' <<<"${sing_out}"; then
   echo "FAIL (#5639): the singleton render grew a region pin — it must stay byte-identical." >&2
   rm -f "${neg_vals}" "${neg_replica_vals}" "${singleton_vals}"; exit 1
 fi
@@ -1432,6 +1432,16 @@ grep -q 'succeeded' "$TMP/sentinel-replica.yaml" \
   || fail "#6114 reap has no .status.succeeded guard — it could delete a COMPLETED initdb Job and invite a re-bootstrap over live data"
 grep -q 'MIN_WEDGE_AGE' "$TMP/sentinel-replica.yaml" \
   || fail "#6114 reap has no minimum-age guard — it would race a Secret that is seconds from syncing"
+# The age guard must compute with jq's fromdateiso8601, NOT `date -d "<rfc3339>"`.
+# busybox date (this IS an Alpine image) rejects an RFC3339 string outright —
+# `date: invalid date '2026-08-11T04:23:42Z'` — and the natural fallback for
+# that is age=0, which makes the reap NEVER fire. A repair that quietly does
+# nothing is worse than no repair, because it looks present.
+grep -q 'fromdateiso8601' "$TMP/sentinel-replica.yaml" \
+  || fail "#6114 reap must compute Job age with jq fromdateiso8601 — busybox date cannot parse RFC3339 and the reap would be permanently inert"
+if grep -qE 'date -u -d "\$\{created\}"|date -d "\$\{created\}"' "$TMP/sentinel-replica.yaml"; then
+  fail "#6114 reap parses creationTimestamp with date -d, which busybox rejects — the age guard would silently pin age to 0 and never reap"
+fi
 grep -q 'secretKeyRef.name' "$TMP/sentinel-replica.yaml" \
   || fail "#6114 reap must read the Job's OWN pod-template Secret references (positive evidence), not guess from a status string"
 grep -q 'delete job' "$TMP/sentinel-replica.yaml" \

--- a/platform/postgres/chart/tests/postgres-render.sh
+++ b/platform/postgres/chart/tests/postgres-render.sh
@@ -352,9 +352,30 @@ echo "[render] Case 4g: #5224 pre-flip SECONDARY (side=secondary, crossRegion=fa
 if grep -qE '^kind: Secret$' "$TMP/preflip-secondary.yaml"; then
   fail "#5224: pre-flip SECONDARY minted a Secret — the divergent role/hub password mint is back (hw273 harbor 28P01 lockout shape)"
 fi
-if grep -q 'harbor-database-secret' "$TMP/preflip-secondary.yaml"; then
-  fail "#5224: pre-flip SECONDARY rendered the hub connection Secret (must be primary-side only)"
-fi
+# STRUCTURAL, not a bare substring (#6114). The assertion is "the secondary
+# never CREATES this object", and it is checked by parsing the render and
+# looking at what each document actually IS. The former `grep -q
+# 'harbor-database-secret'` could not tell an object from a mention, so it went
+# red the moment the replica-hub sentinel began naming the Secrets it WATCHES
+# FOR in an env value — a workload that exists precisely because the replica
+# must not mint them. Object-identity is the property this case is about; the
+# substring never was. Strength is unchanged: any rendered Secret at all is
+# already fatal two lines above, and this adds that NO document of any kind may
+# be NAMED for the hub Secret.
+python3 - "$TMP/preflip-secondary.yaml" <<'PY' || exit 1
+import sys, yaml
+bad = []
+for d in yaml.safe_load_all(open(sys.argv[1])):
+    if not isinstance(d, dict):
+        continue
+    if (d.get("metadata") or {}).get("name") == "harbor-database-secret":
+        bad.append(d.get("kind"))
+if bad:
+    sys.stderr.write(
+        "FAIL: #5224 pre-flip SECONDARY rendered an object NAMED for the hub "
+        "connection Secret (kinds: %s) — it must be primary-side only\n" % bad)
+    sys.exit(1)
+PY
 # The pre-flip PRIMARY must still mint the full set (the authoritative source).
 grep -qE '^type: kubernetes.io/basic-auth$' "$TMP/preflip-primary.yaml" \
   || fail "#5224: pre-flip PRIMARY lost its role-password Secret (the gate must only exclude the replica side)"
@@ -507,6 +528,12 @@ topology:
   # separately in Cases 20a-20c below; disabling it here keeps the "exactly 1 CNP"
   # crossregion-dr assertion focused.
   autoPromote: { enabled: false }
+# Same isolation, same reason (#6114): the replica-hub sentinel is default-ON on
+# the replica side and carries its OWN -egress CiliumNetworkPolicy (it must
+# reach the kube-apiserver through the shared-data default-deny). Its CNP is
+# asserted separately in Case 21 below, so it is disabled here to keep the
+# "exactly 1 CNP" crossregion-dr assertion focused rather than loosened.
+replicaHubSentinel: { enabled: false }
 databases:
   - name: registry
     owner: harbor
@@ -1341,3 +1368,126 @@ helm template shared-pg . -f "$TMP/promoter.values.yaml" --set topology.promoted
 awk '/^kind: Cluster$/{c=1} c&&/^  name: shared-pg-replica$/{r=1} r&&/^    enabled: /{print; exit}' "$TMP/prom-promoted.yaml" | grep -q 'enabled: false' \
   || fail "#5623 topology.promoted=true must render replica.enabled: false (CNPG promotes the survivor)"
 echo "  PASS (promoted:false -> replica.enabled:true; promoted:true -> replica.enabled:false)"
+
+# ── Case 21: #6114 — the replica-side hub sentinel (reap + loud absence) ──────
+#
+# TWO defects, one workload. role-secrets.yaml is gated `not isReplicaSide`
+# DELIBERATELY (#5224) — so the replica mints nothing and depends ENTIRELY on
+# catalyst-api's cross-mesh syncSharedPGConsumerHubSecrets. hw293 showed both
+# ways that goes wrong silently:
+#
+#   (1) #6016 repaired cluster.yaml's dangling bootstrap.initdb.secret, and the
+#       cluster STILL did not heal. A Job's pod template is IMMUTABLE and CNPG
+#       never recreates a stale bootstrap Job, so the generation-1
+#       shared-pg-1-initdb Pod stayed in CreateContainerConfigError for 12h
+#       against an already-correct generation-2 spec. Repairing a spec is not
+#       repairing a cluster; the wedged Job needs an ACTOR.
+#   (2) Region-B's shared-data held ZERO of region-A's 14 consumer hub Secrets
+#       and reported success anyway.
+#
+# Case 4h pins the RENDER half of (1) — no dangling reference. It cannot see a
+# stale Job, because a render test has no cluster. This case pins the actor that
+# can.
+echo "[render] Case 21: #6114 replica-hub sentinel — reap actor + loud absence, primary CONTROL, readiness must NOT gate on sync"
+cat > "$TMP/sentinel.values.yaml" <<'YAML'
+instance: { name: shared-pg, namespace: shared-data }
+topology:
+  mode: singleton
+  side: secondary
+  instances: 1
+  primary: { region: hz-fsn-rtz-prod }
+  replica: { region: hz-hel-rtz-prod }
+databases:
+  - name: registry
+    owner: harbor
+    reflect: { secretName: harbor-database-secret, namespaces: [harbor] }
+  - name: gitea
+    owner: gitea
+    reflect: { secretName: gitea-database-secret, namespaces: [gitea] }
+YAML
+helm template shared-pg . -f "$TMP/sentinel.values.yaml" --namespace shared-data \
+  --api-versions postgresql.cnpg.io/v1 > "$TMP/sentinel-replica.yaml" 2>&1 \
+  || fail "#6114 sentinel replica render errored"
+
+# 21a — the sentinel renders on the replica side, with the RBAC + egress it
+# needs. shared-data is default-deny (bp-network-policies) and the kube-apiserver
+# is a reserved Cilium entity a vanilla NetworkPolicy cannot express (#4428), so
+# without its own CNP the reconciler is inert — a silent failure of the very
+# thing that exists to end silent failures.
+grep -qE '^  name: "shared-pg-replica-hub-sentinel"$' "$TMP/sentinel-replica.yaml" \
+  || fail "#6114 replica render is missing the hub sentinel"
+for k in ServiceAccount Role RoleBinding Deployment CiliumNetworkPolicy; do
+  grep -qE "^kind: ${k}\$" "$TMP/sentinel-replica.yaml" \
+    || fail "#6114 sentinel missing a ${k} (it cannot reach the apiserver / act without all five)"
+done
+grep -qE '^  name: "shared-pg-replica-hub-sentinel-egress"$' "$TMP/sentinel-replica.yaml" \
+  || fail "#6114 sentinel has no -egress CiliumNetworkPolicy — under shared-data default-deny it would be inert"
+grep -q 'kube-apiserver' "$TMP/sentinel-replica.yaml" \
+  || fail "#6114 sentinel egress CNP must admit the kube-apiserver entity"
+
+# 21b — the reap criterion is POSITIVE EVIDENCE, and a COMPLETED initdb Job is
+# never touched. This is the single most important line in the actor: deleting a
+# succeeded bootstrap Job could invite a re-bootstrap over live data.
+grep -q 'succeeded' "$TMP/sentinel-replica.yaml" \
+  || fail "#6114 reap has no .status.succeeded guard — it could delete a COMPLETED initdb Job and invite a re-bootstrap over live data"
+grep -q 'MIN_WEDGE_AGE' "$TMP/sentinel-replica.yaml" \
+  || fail "#6114 reap has no minimum-age guard — it would race a Secret that is seconds from syncing"
+grep -q 'secretKeyRef.name' "$TMP/sentinel-replica.yaml" \
+  || fail "#6114 reap must read the Job's OWN pod-template Secret references (positive evidence), not guess from a status string"
+grep -q 'delete job' "$TMP/sentinel-replica.yaml" \
+  || fail "#6114 sentinel never actually reaps — a reporter that cannot repair leaves the 12h wedge in place"
+
+# 21c — the loud half asserts on the VALUE, not the key (the #5639 lesson): the
+# watch-list must name BOTH the hub Secrets and the role Secrets, because
+# role-secrets.yaml renders neither on this side.
+sentinel_expected="$(awk '/name: EXPECTED_SECRETS/{getline; sub(/^[[:space:]]*value: /,""); gsub(/"/,""); print; exit}' "$TMP/sentinel-replica.yaml")"
+for s in harbor-database-secret gitea-database-secret shared-pg-harbor shared-pg-gitea; do
+  case " ${sentinel_expected} " in
+    *" ${s} "*) ;;
+    *) fail "#6114 EXPECTED_SECRETS omits ${s} — got '${sentinel_expected}'. An absence that is not watched for is an absence that stays silent." ;;
+  esac
+done
+
+# 21d — READINESS MUST NOT GATE ON THE SYNCED STATE. Slot 16a keeps Helm wait
+# with `install.remediation.retries: -1`, so a probe that waits for the Secrets
+# would turn the LEGITIMATE pre-sync window into an infinite install-remediation
+# loop on every fresh 2-region prov — trading a silent wedge for a self-inflicted
+# outage. The probe may only report that the loop is alive.
+awk '/readinessProbe:/{f=1} f&&/command:/{print; exit}' "$TMP/sentinel-replica.yaml" | grep -q 'test -f /tmp/alive' \
+  || fail "#6114 readiness probe must test only loop liveness (test -f /tmp/alive)"
+if awk '/readinessProbe:/{f=1} f&&/command:/{print; exit}' "$TMP/sentinel-replica.yaml" | grep -qE 'get secret|EXPECTED_SECRETS'; then
+  fail "#6114 readiness probe gates on Secret presence — with install.remediation.retries:-1 that is an INFINITE install-remediation loop, not a guard"
+fi
+
+# 21e — CONTROL. Same chart, same bindings, same databases: only the side
+# differs. The PRIMARY mints its own Secrets and has nothing to wait for, so the
+# sentinel must be ABSENT there. Without this control, 21a would pass on a
+# template that rendered unconditionally.
+helm template shared-pg . -f "$TMP/sentinel.values.yaml" --set topology.side=primary \
+  --namespace shared-data --api-versions postgresql.cnpg.io/v1 > "$TMP/sentinel-primary.yaml" 2>&1 \
+  || fail "#6114 sentinel primary render errored"
+if grep -q 'replica-hub-sentinel' "$TMP/sentinel-primary.yaml"; then
+  fail "#6114 CONTROL FAILED: the sentinel rendered on the PRIMARY side, which mints its own Secrets — the side gate is not being applied"
+fi
+# ...and the control is non-vacuous: the primary render is a real render that
+# DOES mint the role Secrets whose absence the replica sentinel watches for.
+grep -q 'name: "harbor-database-secret"' "$TMP/sentinel-primary.yaml" \
+  || fail "#6114 CONTROL VACUOUS: the primary fixture minted no hub Secret, so 'sentinel absent here' proves nothing"
+
+# 21f — the gate is isReplicaSide, NOT renderReplicaHalf. The hw293 wedge lived
+# in the PRE-FLIP window (side=secondary AND activeHotStandby=false), where the
+# placeholder singleton Cluster renders and renderReplicaHalf is still false.
+# A sentinel gated on the flip would not exist during the outage it repairs.
+grep -qE '^  name: "shared-pg-replica-hub-sentinel"$' "$TMP/preflip-secondary.yaml" \
+  || fail "#6114 the sentinel is ABSENT from the pre-flip secondary render — that is precisely the window the initdb wedge lives in (#4460 placeholder)"
+
+# 21g — explicit opt-out renders ZERO sentinel resources. Guarded because
+# `$sentinel.enabled | default true` would silently ignore `enabled: false`
+# (sprig's `default` treats boolean false as EMPTY); the template uses `dig`.
+helm template shared-pg . -f "$TMP/sentinel.values.yaml" --set replicaHubSentinel.enabled=false \
+  --namespace shared-data --api-versions postgresql.cnpg.io/v1 > "$TMP/sentinel-off.yaml" 2>&1 \
+  || fail "#6114 sentinel opt-out render errored"
+if grep -q 'replica-hub-sentinel' "$TMP/sentinel-off.yaml"; then
+  fail "#6114 replicaHubSentinel.enabled=false still rendered the sentinel (sprig 'default' swallowing boolean false?)"
+fi
+echo "  PASS (sentinel on replica + pre-flip; reap guards completed/age/positive-evidence; watch-list names hub AND role Secrets; readiness cannot wedge Helm wait; absent on primary CONTROL; opt-out clean)"

--- a/platform/postgres/chart/tests/postgres-render.sh
+++ b/platform/postgres/chart/tests/postgres-render.sh
@@ -1518,6 +1518,15 @@ awk '/name: HOME/{getline; print; exit}' "$TMP/sentinel-replica.yaml" | grep -q 
   || fail "#6114 sentinel needs HOME=/tmp — kubectl writes its cache under \$HOME and the rootfs is read-only"
 grep -q '"/bin/bash"' "$TMP/sentinel-replica.yaml" \
   && fail "#6114 sentinel invokes /bin/bash, but alpine/k8s is Alpine — dr-promoter uses /bin/sh"
+# #6079: a single-replica Deployment on the DEFAULT RollingUpdate can never roll
+# on a full node — maxSurge 25% ceils to 1 but maxUnavailable 25% floors to 0, so
+# the old Pod may never be evicted to make room for the new one. A reconciler
+# that cannot be rolled out is stuck on whatever image it first got, which for
+# THIS workload means the repair silently stops updating. dr-promoter uses
+# Recreate for the same reason. (scripts/check-single-replica-rollout.py is the
+# repo-wide gate; this pins it at the point of use.)
+awk '/^kind: Deployment$/{d=1} d&&/replica-hub-sentinel/{n=1} n&&/type: Recreate/{f=1} END{exit f?0:1}' "$TMP/sentinel-replica.yaml" \
+  || fail "#6114/#6079 sentinel Deployment has no strategy.type: Recreate — a single-replica default RollingUpdate can NEVER roll (maxUnavailable floors to 0)"
 
 # 21i — the rendered loop must actually PARSE as POSIX sh. A bashism here is
 # invisible to every assertion above (they all match text) and would surface

--- a/platform/postgres/chart/values.yaml
+++ b/platform/postgres/chart/values.yaml
@@ -390,6 +390,42 @@ continuum:
 #       passwordAliases: []
 databases: []
 
+# ── Replica-side hub sentinel (0.2.20, #6114) ───────────────────────────
+# Renders ONLY where `topology.side` resolves to replica (templates/
+# replica-hub-sentinel.yaml). Two jobs, one loop:
+#
+#   1. REAPS a stale CNPG `<instance>-N-initdb` Job that is incomplete AND
+#      references a Secret that does not exist. A Job's pod template is
+#      IMMUTABLE and CNPG never recreates a stale one, so #6016's repair of
+#      the Cluster spec could not heal the generation-1 Pod it fixed — on
+#      hw293 that Pod sat in CreateContainerConfigError for 12h behind a
+#      correct spec. A COMPLETED initdb Job is never touched.
+#   2. REPORTS, loudly, when the cross-mesh consumer-hub sync has not
+#      delivered. role-secrets.yaml is gated `not isReplicaSide` by design
+#      (#5224), so this region mints nothing and depends entirely on
+#      catalyst-api's syncSharedPGConsumerHubSecrets. Absence used to be
+#      silent — 14 Secrets missing behind a green release.
+#
+# Readiness reports only that the loop is alive, never that the Secrets
+# arrived: slot 16a keeps Helm wait with `install.remediation.retries: -1`,
+# so gating readiness on the synced state would turn the legitimate
+# pre-sync window into an infinite install-remediation loop.
+replicaHubSentinel:
+  enabled: true
+  # Loop period. The wedge it repairs lasted 12h unattended; 30s is ample
+  # and the reap is idempotent.
+  intervalSeconds: 30
+  # A Job younger than this is never reaped, so a Secret that is seconds
+  # away from syncing is never raced. The reap criterion is otherwise
+  # POSITIVE evidence (incomplete + names an absent Secret), never a timeout.
+  minWedgeAgeSeconds: 180
+  # Same harbor-proxy-pull-compliant (`*/proxy-*/*`) prefix as the
+  # dr-promoter actor so the whole chart matches ONE kyverno anyPattern glob.
+  image:
+    repository: harbor.openova.io/proxy-dockerhub/alpine/k8s
+    tag: "1.30.0"
+    pullPolicy: IfNotPresent
+
 # ── Bootstrap self-registration (#3370) ─────────────────────────────────
 # When enabled, the chart self-registers the Application CR
 # (apps.openova.io/v1) for this instance — the canonical representation

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-11T01:17:31.392Z",
+  "generatedAt": "2026-08-11T08:18:06.242Z",
   "blueprints": [
     {
       "id": "bp-agenity",
@@ -4083,7 +4083,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "listed",
-      "version": "0.2.19",
+      "version": "0.2.20",
       "section": "pts-4-1-data-services",
       "depends": [
         "bp-cnpg",

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -4218,7 +4218,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "listed",
-    "version": "0.2.19",
+    "version": "0.2.20",
     "section": "pts-4-1-data-services",
     "depends": [
       "bp-cnpg",

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3874,7 +3874,7 @@ name: bp-catalyst-platform
 #   scripts/check-image-pin-writer-targets.sh plus the extended
 #   scripts/check-controller-image-tag-freshness.sh. Chart version bump is what
 #   actually delivers the three new tags, so it is the load-bearing half.
-version: 1.4.1401
+version: 1.4.1402
 # 1.4.1229 — #5389: catalog-seed bp-newapi declares its `ui` endpoint
 #   (newapi.<fqdn>, ssoEnabled, launchDefault, ssoInitPath "/") instead of
 #   `endpoints: []`. The empty list made userUIGatePasses fail closed, which
@@ -4029,7 +4029,7 @@ version: 1.4.1401
 # scripts/check-chart-version-forward.sh (#5743) fails unless the two match —
 # main was carrying a pre-existing 1.4.1330/1.4.1329 split, so this bump heals
 # it in the same commit, exactly as the documented self-heal contract does.
-appVersion: 1.4.1401
+appVersion: 1.4.1402
 # 1.4.239 — Wave 3 / Issue #2140 (2026-05-23): Huawei provider
 # implementation lands behind the Wave 2 CloudProvider interface.
 # Adds the OpenTofu module at infra/providers/huawei/ (VPC + Subnet +

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5805,7 +5805,11 @@ spec:
   # 0.2.14 (#5473): replication-source Service selectorType r -> rw (primary only).
   # 0.2.18 (#5623): region-B AUTOMATIC DR promotion — ported bp-cnpg-pair dr-promoter
   # + failover-readiness + topology.promoted HR-value seam on the AHS replica half.
-  version: "0.2.19"
+  # 0.2.20 (#6114): replica-side hub sentinel — reaps the stale CNPG initdb Job
+  # CNPG never recreates (a Job pod template is immutable, so #6016's spec repair
+  # could not heal the generation-1 Pod) and reports the cross-mesh consumer-hub
+  # sync's absence loudly instead of leaving 14 Secrets silently missing.
+  version: "0.2.20"
   visibility: listed
   # Shareability + Contexts (#3370) — seeded verbatim from
   # platform/postgres/blueprint.yaml (lockstep-guarded). One instance
@@ -5927,7 +5931,9 @@ spec:
     # 0.2.13 (#5224): role-secrets side-gate (replica-role region mints nothing).
     # 0.2.18 (#5623): region-B automatic DR promotion (dr-promoter + failover-readiness
     # + topology.promoted seam) on the active-hot-standby replica half.
-    version: "0.2.19"
+    # 0.2.20 (#6114): replica-side hub sentinel (stale-initdb reap + loud hub-sync
+    # absence); readiness never gates on the synced state so it cannot wedge Helm wait.
+    version: "0.2.20"
   # Seeded verbatim from platform/postgres/blueprint.yaml spec.topology.
   # singleton = single-instance Cluster; active-hot-standby = sync
   # replication across regions (ADR-0004 Pillar-3 zero-tx-loss) via the


### PR DESCRIPTION
## The fix that was not enough

#6016 (shipped as 0.2.19 by #6059) dropped `cluster.yaml`'s dangling `bootstrap.initdb.secret` on the replica side. That was the right fix. It was **not enough**, and the reason is precise.

The Cluster spec was repaired at **generation 2**. `bp-postgres@0.2.19` ran in **both** regions on hw293. Region B still did not heal.

**A Job's pod template is immutable, and CNPG creates a bootstrap Job only when one is ABSENT** — it never recreates a Job whose spec has gone stale. So the generation-1 `shared-pg-1-initdb` Pod kept the *old* template:

```
APP_USERNAME <- secretKeyRef{name: shared-pg-harbor, key: username}  Optional: false
```

against a namespace holding 17 Secrets, none of them the three role names. That Pod sat in `CreateContainerConfigError` for **twelve hours against an already-correct spec**. Downstream: `keycloak-0` Init:0/1, `harbor-jobservice` CrashLoopBackOff with 150 restarts, 8 HelmReleases `Ready=False`.

**Repairing a spec is not repairing a cluster.** The wedged Job needed an actor and there was none.

## Is the `not isReplicaSide` gate deliberate? Yes — and it stays

`role-secrets.yaml:73` is gated `not isReplicaSide` **by design**, documented at length in the template header: a replica that mints its own role passwords creates a permanently divergent credential set that `helm.sh/resource-policy: keep` then freezes forever, and any DR promote/failback actor asserting those local values against the shared write endpoint clobbers the primary's canonical password (#5224, the hw273 harbor 28P01 lockout). Nothing in this PR touches that gate.

What was never handled is its **consequence**. The replica mints nothing and depends entirely on catalyst-api's cross-mesh `syncSharedPGConsumerHubSecrets`. When that has not run, the namespace holds **zero** of region A's 14 consumer hub Secrets — and says nothing. A namespace missing every consumer Secret should not look like a success.

## One replica-side workload, both halves

**Reap — positive evidence only.** A bootstrap Job is deleted only when *all* hold: it belongs to this instance and ends in `-initdb`; `.status.succeeded == 0`; it is older than `minWedgeAgeSeconds`; and it names a Secret that does not exist, read from **the Job's own pod template** rather than guessed from a status string. There is no timeout heuristic anywhere in it.

> The single most important line is the completed-Job guard. Deleting a *succeeded* initdb Job could invite a re-bootstrap over live data, so it is never touched.

**Report.** Every role + hub Secret name the primary side would render becomes a watch-list. Absence is emitted as a Warning Event + a `<instance>-replica-hub-sync-status` ConfigMap + a log line naming each missing Secret, with an explicit note when *zero* of N are present.

## Why a Deployment, and not the alternatives

| Vehicle | Why not |
|---|---|
| `pre-upgrade` hook | **Wrong by ordering.** Runs *before* the repaired spec is applied, so CNPG recreates the Job from the still-broken generation-1 spec. |
| `post-upgrade` hook | Right by ordering, wrong by blast radius. Fires only on a Helm operation — hw293's wedge existed 12h without one. And a failing hook fails a release that slot 16a remediates with `retries: -1`. |
| CronJob | The scheduler dies with the region's control plane and does not resume (#5157 — the openbao unseal-reconciler did not survive the region-kill it guarded). |
| **Deployment + sleep loop** | Reaps whenever the wedge appears, retries forever, self-heals, cannot block delivery. Repo canon for a region-local reconciler. |

**Readiness reports loop-liveness ONLY, never that the Secrets arrived.** Slot 16a keeps Helm wait with `install.remediation.retries: -1`, so gating readiness on the synced state would turn the legitimate pre-sync window into an infinite install-remediation loop on every fresh 2-region prov — trading a silent wedge for a self-inflicted outage. Loudness is delivered where it cannot wedge the release.

**Gated on `isReplicaSide`, not `renderReplicaHalf`.** The wedge lives in the **pre-flip** window (`side=secondary` AND `activeHotStandby=false`), where the #4460 placeholder singleton Cluster renders — exactly the render `renderReplicaHalf` does not cover.

## Red → green (verbatim)

**RED** — suite with the new template held aside:

```
[render] Case 20d: #5623 replica.enabled follows topology.promoted (default replica, promoted->primary)
  PASS (promoted:false -> replica.enabled:true; promoted:true -> replica.enabled:false)
[render] Case 21: #6114 replica-hub sentinel — reap actor + loud absence, primary CONTROL, readiness must NOT gate on sync
FAIL: #6114 replica render is missing the hub sentinel
RED-EXIT=1
```

Cases 1 through 20d all passed in that run — the rest of the chart is unaffected.

**GREEN** — same suite, template restored:

```
[render] Case 21: #6114 replica-hub sentinel — reap actor + loud absence, primary CONTROL, readiness must NOT gate on sync
  PASS (sentinel on replica + pre-flip; reap guards completed/age/positive-evidence; watch-list names hub AND role Secrets; readiness cannot wedge Helm wait; absent on primary CONTROL; opt-out clean)
GREEN-EXIT=0
```

## Control + vacuity

**CONTROL (21e)** — same chart, same bindings, same databases, *only the side differs*. The PRIMARY mints its own Secrets and must not carry the sentinel. The control is itself checked for non-vacuity: the primary fixture must actually mint `harbor-database-secret`, or "sentinel absent here" would prove nothing.

**VACUITY** — mutate the side gate from `isReplicaSide` to `renderReplicaHalf` (the plausible-looking wrong gate, and the one that would make the sentinel absent during the very pre-flip window it repairs):

```
MUTANT-EXIT=1
[render] Case 21: #6114 replica-hub sentinel — reap actor + loud absence, primary CONTROL, readiness must NOT gate on sync
FAIL: #6114 replica render is missing the hub sentinel
```

Case 21d is an anti-regression guard in the other direction: it fails if the readiness probe ever starts reading a Secret, because that is the infinite-remediation shape.

## Two existing assertions adjusted (neither weakened)

- **Case 4g** used a bare `grep -q 'harbor-database-secret'`. It could not tell an *object* from a *mention*, so it went red the moment the sentinel began naming the Secrets it watches for. Replaced with a structural parse asserting no rendered document is *named* for the hub Secret. Strength is unchanged — any rendered Secret at all is already fatal two lines above.
- **Case 4e** counts CiliumNetworkPolicies and asserts "exactly 1". Its fixture already disables `dr-promoter` for precisely this reason; the sentinel is disabled the same way, with the same comment. The count assertion stays exact rather than being loosened.

## A bug the tests caught

The opt-out was first written `$sentinel.enabled | default true`. Sprig's `default` treats boolean `false` as empty, so `enabled: false` would have silently rendered the sentinel anyway. Case 21g caught it; the template now reads the key with `dig`.

## Lockstep

Five sites: `platform/postgres/chart/Chart.yaml` (version + appVersion via `scripts/bump-chart-version.sh`, which consulted 32 open-PR claims), `platform/postgres/blueprint.yaml`, and slots `16a` / `16c` / `16d`. `scripts/check-bootstrap-kit-pin-sync.sh` → `PASS: all bootstrap-kit pins are in sync with their source charts.` (exit 0, read as the exit code and not from piped output).

## Scope

**No live environment was measured** — hw293 was wiped 2026-08-11T04:23:42Z. Every claim above is either source-derived or quoted from the recorded hw293 forensics. **No UAT row is stamped.** No NodePort is introduced; no secret value appears in any artifact.

Refs #6114 #6016 #5224 #5157
