### PR TITLE
fix(catalyst-ui): the roll frees a Pod slot but loses it — no priorityClassName (#6166)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1391,8 +1391,8 @@ spec:
       #   Lockstep w/ products/catalyst/chart/Chart.yaml.
       #
       # 1.4.1404 — #6166: catalyst-ui gets priorityClassName
-      #   catalyst-control-plane, matching its catalyst-api sibling. #6157
-      #   fixed the ROLLOUT DEADLOCK (maxUnavailable: 1, so the old Pod may
+      #   catalyst-control-plane, matching its catalyst-api sibling. PR #6152
+      #   (issue #6157) fixed the ROLLOUT DEADLOCK (maxUnavailable: 1, so the old Pod may
       #   leave before the new one is admitted); that only FREES a Pod slot on
       #   a node at its max-pods cap, it does not WIN it. The scheduler awards
       #   a freed slot to the highest-priority pending Pod, and catalyst-ui ran

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1389,6 +1389,17 @@ spec:
       #   guacamole-pg and the shared-pg family as well. Egress half in
       #   bp-keycloak 1.5.9; neither half alone restores a brokered login.
       #   Lockstep w/ products/catalyst/chart/Chart.yaml.
+      #
+      # 1.4.1404 — #6166: catalyst-ui gets priorityClassName
+      #   catalyst-control-plane, matching its catalyst-api sibling. #6157
+      #   fixed the ROLLOUT DEADLOCK (maxUnavailable: 1, so the old Pod may
+      #   leave before the new one is admitted); that only FREES a Pod slot on
+      #   a node at its max-pods cap, it does not WIN it. The scheduler awards
+      #   a freed slot to the highest-priority pending Pod, and catalyst-ui ran
+      #   at priority 0 while catalyst-api carried catalyst-control-plane
+      #   (1e8), so the console lost every race and /sovereign served a Traefik
+      #   503 while catalyst-api beside it stayed 1/1 green. Both halves are
+      #   required. Lockstep w/ products/catalyst/chart/Chart.yaml.
       version: 1.4.1409
       sourceRef:
         kind: HelmRepository

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1390,7 +1390,7 @@ spec:
       #   bp-keycloak 1.5.9; neither half alone restores a brokered login.
       #   Lockstep w/ products/catalyst/chart/Chart.yaml.
       #
-      # 1.4.1404 — #6166: catalyst-ui gets priorityClassName
+      # 1.4.1413 — #6166: catalyst-ui gets priorityClassName
       #   catalyst-control-plane, matching its catalyst-api sibling. PR #6152
       #   (issue #6157) fixed the ROLLOUT DEADLOCK (maxUnavailable: 1, so the old Pod may
       #   leave before the new one is admitted); that only FREES a Pod slot on
@@ -1400,7 +1400,7 @@ spec:
       #   (1e8), so the console lost every race and /sovereign served a Traefik
       #   503 while catalyst-api beside it stayed 1/1 green. Both halves are
       #   required. Lockstep w/ products/catalyst/chart/Chart.yaml.
-      version: 1.4.1409
+      version: 1.4.1413
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3875,7 +3875,7 @@ name: bp-catalyst-platform
 #   scripts/check-controller-image-tag-freshness.sh. Chart version bump is what
 #   actually delivers the three new tags, so it is the load-bearing half.
 #
-# 1.4.1404 — #6166: catalyst-ui carries priorityClassName
+# 1.4.1413 — #6166: catalyst-ui carries priorityClassName
 #   catalyst-control-plane, the class its catalyst-api sibling has held since
 #   #4231. The two fixes stack and neither is sufficient alone. PR #6152
 #   (issue #6157) fixed the
@@ -3901,7 +3901,7 @@ name: bp-catalyst-platform
 #   Blast radius is scheduling only: a co-tenant RESCHEDULABLE Pod is now
 #   preempted instead of the console, the same trade #4231 already made for
 #   catalyst-api. Lockstep w/ slot-13 pin.
-version: 1.4.1409
+version: 1.4.1413
 # 1.4.1229 — #5389: catalog-seed bp-newapi declares its `ui` endpoint
 #   (newapi.<fqdn>, ssoEnabled, launchDefault, ssoInitPath "/") instead of
 #   `endpoints: []`. The empty list made userUIGatePasses fail closed, which
@@ -4056,7 +4056,7 @@ version: 1.4.1409
 # scripts/check-chart-version-forward.sh (#5743) fails unless the two match —
 # main was carrying a pre-existing 1.4.1330/1.4.1329 split, so this bump heals
 # it in the same commit, exactly as the documented self-heal contract does.
-appVersion: 1.4.1409
+appVersion: 1.4.1413
 # 1.4.239 — Wave 3 / Issue #2140 (2026-05-23): Huawei provider
 # implementation lands behind the Wave 2 CloudProvider interface.
 # Adds the OpenTofu module at infra/providers/huawei/ (VPC + Subnet +

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3874,6 +3874,32 @@ name: bp-catalyst-platform
 #   scripts/check-image-pin-writer-targets.sh plus the extended
 #   scripts/check-controller-image-tag-freshness.sh. Chart version bump is what
 #   actually delivers the three new tags, so it is the load-bearing half.
+#
+# 1.4.1404 — #6166: catalyst-ui carries priorityClassName
+#   catalyst-control-plane, the class its catalyst-api sibling has held since
+#   #4231. The two fixes stack and neither is sufficient alone. #6157 fixed the
+#   ROLLOUT DEADLOCK: at replicas=1 the default strategy rounds maxSurge 25% UP
+#   to 1 and maxUnavailable 25% DOWN to 0, so the roll needed two Pods live at
+#   once and could never start on a node already at its Pod ceiling;
+#   maxUnavailable: 1 lets the old Pod leave first. But leaving first only
+#   FREES the slot — it does not WIN it. On the mothership node at 110/110 the
+#   scheduler hands a freed slot to the highest-priority pending Pod, and
+#   catalyst-ui ran at priority 0 (no class at all) against four other queued
+#   Pods. It lost every race and sat Pending, so the /sovereign Ingress — whose
+#   backend IS catalyst-ui — served a Traefik 503 "no available server" while
+#   catalyst-api itself reported 1/1 and /readyz 200. That asymmetry is why the
+#   console looked dead while its API looked healthy.
+#   Written at BOTH deployment sites: ui-deployment-kustomize.yaml takes the
+#   literal class name (the raw-Kustomize path renders no templating, matching
+#   api-deployment-kustomize.yaml), and ui-deployment.yaml reuses the exact
+#   expression api-priorityclass.yaml uses to NAME the object
+#   (.Values.catalystApi.priorityClassName | default "catalyst-control-plane"),
+#   so an operator override can never point this reference at a class that was
+#   never rendered. No new PriorityClass object — catalyst-control-plane
+#   already ships on both paths.
+#   Blast radius is scheduling only: a co-tenant RESCHEDULABLE Pod is now
+#   preempted instead of the console, the same trade #4231 already made for
+#   catalyst-api. Lockstep w/ slot-13 pin.
 version: 1.4.1409
 # 1.4.1229 — #5389: catalog-seed bp-newapi declares its `ui` endpoint
 #   (newapi.<fqdn>, ssoEnabled, launchDefault, ssoInitPath "/") instead of

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3877,7 +3877,8 @@ name: bp-catalyst-platform
 #
 # 1.4.1404 — #6166: catalyst-ui carries priorityClassName
 #   catalyst-control-plane, the class its catalyst-api sibling has held since
-#   #4231. The two fixes stack and neither is sufficient alone. #6157 fixed the
+#   #4231. The two fixes stack and neither is sufficient alone. PR #6152
+#   (issue #6157) fixed the
 #   ROLLOUT DEADLOCK: at replicas=1 the default strategy rounds maxSurge 25% UP
 #   to 1 and maxUnavailable 25% DOWN to 0, so the roll needed two Pods live at
 #   once and could never start on a node already at its Pod ceiling;

--- a/products/catalyst/chart/templates/ui-deployment-kustomize.yaml
+++ b/products/catalyst/chart/templates/ui-deployment-kustomize.yaml
@@ -41,6 +41,21 @@ spec:
         app.kubernetes.io/name: catalyst-ui
         policy.cilium.io/enforced: "true"  # Wave 5.121 #2466 — kyverno cilium-l7-mtls policy
     spec:
+      # #6079 follow-up (2026-08-11): the rollout strategy above only guarantees
+      # the OLD Pod leaves first — it does NOT guarantee the new one wins the
+      # freed slot. On a node at its max-pods cap the scheduler hands that slot
+      # to whichever pending Pod outranks the rest, and catalyst-ui ran at
+      # priority 0 (no class) while its catalyst-api sibling carried
+      # catalyst-control-plane (1e8). So the console lost every race and sat
+      # Pending for 8 days behind co-tenant workloads, taking /sovereign to a
+      # Traefik 503 while catalyst-api itself stayed green — the asymmetry, not
+      # the strategy, is what wedged it. Same class as api-deployment-kustomize.
+      # yaml's rationale (#4231): the console is control plane, so it must
+      # outrank reschedulable co-tenant Pods rather than queue behind them.
+      # Literal class name for the contabo-mkt raw-Kustomize path; the
+      # catalyst-control-plane PriorityClass object ships in
+      # api-priorityclass-kustomize.yaml, already listed in kustomization.yaml.
+      priorityClassName: catalyst-control-plane
       imagePullSecrets:
         - name: ghcr-pull
       containers:

--- a/products/catalyst/chart/templates/ui-deployment.yaml
+++ b/products/catalyst/chart/templates/ui-deployment.yaml
@@ -41,6 +41,19 @@ spec:
         app.kubernetes.io/name: catalyst-ui
         policy.cilium.io/enforced: "true"  # Wave 5.121 #2466 — kyverno cilium-l7-mtls policy
     spec:
+      # #6079 follow-up (2026-08-11): keep in lockstep with the Kustomize
+      # sibling (ui-deployment-kustomize.yaml), which carries the full
+      # rationale. Short version: the strategy above lets the old Pod leave
+      # first, but on a node at its max-pods cap the freed slot goes to the
+      # highest-priority pending Pod. catalyst-ui ran at priority 0 while
+      # catalyst-api carried catalyst-control-plane (1e8), so the console lost
+      # every race and sat Pending for 8 days, serving /sovereign as a Traefik
+      # 503. The console is control plane and must outrank reschedulable
+      # co-tenant Pods (#4231 rationale).
+      # Same expression api-priorityclass.yaml uses to NAME the object, so an
+      # operator overriding catalystApi.priorityClassName cannot leave this
+      # reference dangling at a class that was never rendered.
+      priorityClassName: {{ .Values.catalystApi.priorityClassName | default "catalyst-control-plane" }}
       imagePullSecrets:
         - name: ghcr-pull
       containers:

--- a/tests/e2e/bootstrap-kit/ui_priority_class_6166_test.go
+++ b/tests/e2e/bootstrap-kit/ui_priority_class_6166_test.go
@@ -1,0 +1,338 @@
+package bootstrapkit
+
+// ui_priority_class_6166_test.go — #6166.
+//
+// THE DEFECT. `https://<mothership>/sovereign/` served a Traefik 503 "no
+// available server" while catalyst-api beside it was 1/1 with /readyz 200. The
+// /sovereign Ingress backends onto catalyst-ui, and catalyst-ui was Pending on
+// "0/1 nodes are available: 1 Too many pods" — the node sat at its 110/110 Pod
+// ceiling.
+//
+// #6157 had already fixed the ROLLOUT DEADLOCK on the same Deployment: at
+// replicas=1 the default strategy rounds maxSurge 25% UP to 1 and
+// maxUnavailable 25% DOWN to 0, so the roll needed two Pods alive at once and
+// could never start on a full node. That fix is correct and necessary.
+//
+// It is not sufficient, and the gap is the whole point of this guard: letting
+// the old Pod leave FREES a slot, it does not WIN it. The scheduler awards a
+// freed slot to the highest-priority pending Pod. catalyst-ui ran at priority
+// 0 — no priorityClassName at all — while its catalyst-api sibling had carried
+// `catalyst-control-plane` (value 100000000) since #4231. Against four other
+// queued Pods the console lost every race and sat Pending for 8 days.
+//
+// The asymmetry is the bug. Two Deployments in one chart, one control-plane
+// surface each, and only one of them was ranked. A live patch scheduled
+// catalyst-ui by preemption within seconds; Flux then reverted it, which is
+// why the fix has to live in the chart.
+//
+// WHAT THIS GUARD PINS
+//
+//  1. catalyst-ui declares a non-empty priorityClassName on BOTH render paths.
+//     The Helm path (ui-deployment.yaml) and the raw-Kustomize path
+//     (ui-deployment-kustomize.yaml) are rendered by different consumers — the
+//     mothership `catalyst-platform` Kustomization raw-kustomize-builds the
+//     templates directory — so a fix applied to only one path leaves the other
+//     starvable. Kustomize is the path the mothership actually served /sovereign
+//     from when this broke.
+//
+//  2. The class it names is one the chart SHIPS. A priorityClassName pointing
+//     at a class that was never rendered is not a high-priority Pod; on a
+//     cluster without that object the Pod is REJECTED at admission, which is
+//     strictly worse than priority 0. The Helm template deliberately reuses the
+//     same expression api-priorityclass.yaml uses to NAME the object, so an
+//     operator override moves both together — this asserts that coupling rather
+//     than trusting the comment that describes it.
+//
+//  3. catalyst-api still carries it too. That is the CONTROL, not padding: api
+//     has had the class since #4231, so if this file's parser ever breaks, the
+//     api arm goes red as well and the failure reads as "the guard is broken",
+//     not "the chart is fine". A guard whose only subject is the thing being
+//     fixed cannot distinguish a passing chart from a blind parser.
+//
+// VACUITY. Assertions 1 and 2 fail on the parent of the #6166 fix commit: both
+// ui-deployment files carried no priorityClassName key whatsoever, so the
+// extractor returns "" and the guard reports MISSING. TestUIPriorityClass_
+// DetectorIsNotVacuous proves the same extractor over synthetic input — the
+// detector must go red on a pod spec with the key removed, and must not be
+// fooled by the string appearing in a comment. Without that arm an extractor
+// that grep'd the whole file for the word would pass against a chart that only
+// MENTIONS priorityClassName in prose, which is exactly the shape of the
+// comment blocks these templates are full of.
+//
+// NO BINARIES ON PURPOSE. This is a static parse, not a `helm template` render.
+// The CI job that runs this package on pull_request (test-bootstrap-kit.yaml →
+// manifest-validation) installs Go and nothing else, so a helm- or kustomize-
+// based assertion would t.Skip there and gate nothing at review time. A guard
+// that skips in the job that is supposed to enforce it is decorative.
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// priorityClassRefRe matches a `priorityClassName:` key at pod-spec depth on a
+// line of its own, capturing the value. Anchored to line start plus indent so a
+// mention inside a `#` comment (these templates carry long comment blocks that
+// name the field in prose) can never satisfy it — the comment marker precedes
+// the key and breaks the anchor.
+var priorityClassRefRe = regexp.MustCompile(`(?m)^[ \t]+priorityClassName:[ \t]*(\S.*?)[ \t]*$`)
+
+// priorityClassObjRe captures the `name:` of a rendered PriorityClass object.
+var priorityClassNameKeyRe = regexp.MustCompile(`(?m)^[ \t]+name:[ \t]*(\S.*?)[ \t]*$`)
+
+// helmDefaultRe pulls the literal out of `{{ .Values.x | default "lit" }}`,
+// which is how the Helm-rendered path names the class.
+var helmDefaultRe = regexp.MustCompile(`\|\s*default\s+"([^"]+)"`)
+
+// extractPriorityClassRef returns the priorityClassName value declared in a
+// manifest, or "" when the key is absent. Only uncommented lines are
+// considered.
+func extractPriorityClassRef(manifest string) string {
+	for _, line := range strings.Split(manifest, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "#") {
+			continue
+		}
+		if m := priorityClassRefRe.FindStringSubmatch(line); m != nil {
+			return strings.TrimSpace(m[1])
+		}
+	}
+	return ""
+}
+
+// resolveClassName reduces a priorityClassName value to the class name it
+// resolves to by default. A literal returns itself; a Helm expression returns
+// the literal inside its `default` filter. An expression with no default
+// returns "" — that is a class name nobody can predict, and for this field an
+// unpredictable name is a dangling reference.
+func resolveClassName(raw string) string {
+	if !strings.Contains(raw, "{{") {
+		return strings.Trim(raw, `"'`)
+	}
+	if m := helmDefaultRe.FindStringSubmatch(raw); m != nil {
+		return m[1]
+	}
+	return ""
+}
+
+// shippedPriorityClasses collects every PriorityClass name the chart's
+// templates declare, resolving Helm expressions to their default the same way
+// resolveClassName does for the reference side.
+func shippedPriorityClasses(t *testing.T, templatesDir string) map[string]string {
+	t.Helper()
+	out := map[string]string{}
+	entries, err := os.ReadDir(templatesDir)
+	if err != nil {
+		t.Fatalf("read templates dir %s: %v", templatesDir, err)
+	}
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".yaml") {
+			continue
+		}
+		path := filepath.Join(templatesDir, e.Name())
+		b, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		body := string(b)
+		if !strings.Contains(body, "kind: PriorityClass") {
+			continue
+		}
+		// The metadata.name follows the kind line; take the first
+		// uncommented `name:` after it.
+		idx := strings.Index(body, "kind: PriorityClass")
+		for _, line := range strings.Split(body[idx:], "\n") {
+			if strings.HasPrefix(strings.TrimSpace(line), "#") {
+				continue
+			}
+			if m := priorityClassNameKeyRe.FindStringSubmatch(line); m != nil {
+				if name := resolveClassName(strings.TrimSpace(m[1])); name != "" {
+					out[name] = e.Name()
+				}
+				break
+			}
+		}
+	}
+	return out
+}
+
+// TestCatalystControlPlane_UIAndAPIAreBothRanked is the merge gate for #6166.
+func TestCatalystControlPlane_UIAndAPIAreBothRanked(t *testing.T) {
+	root := repoRoot(t)
+	templatesDir := filepath.Join(root, "products", "catalyst", "chart", "templates")
+
+	shipped := shippedPriorityClasses(t, templatesDir)
+	if len(shipped) == 0 {
+		t.Fatalf("no PriorityClass object found under %s — either the chart stopped "+
+			"shipping one (in which case every reference below dangles) or this "+
+			"guard's scanner is broken. Either way it must not pass silently.", templatesDir)
+	}
+
+	// catalyst-ui is the subject of #6166. catalyst-api is the CONTROL: it has
+	// carried the class since #4231, so it must stay green for a ui failure to
+	// mean anything.
+	cases := []struct {
+		file     string
+		workload string
+		role     string
+	}{
+		{"ui-deployment.yaml", "catalyst-ui", "subject (#6166, Helm path)"},
+		{"ui-deployment-kustomize.yaml", "catalyst-ui", "subject (#6166, raw-Kustomize path — what the mothership builds)"},
+		{"api-deployment.yaml", "catalyst-api", "control (#4231, Helm path)"},
+		{"api-deployment-kustomize.yaml", "catalyst-api", "control (#4231, raw-Kustomize path)"},
+	}
+
+	for _, tc := range cases {
+		path := filepath.Join(templatesDir, tc.file)
+		b, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("%s: read: %v", tc.file, err)
+		}
+
+		raw := extractPriorityClassRef(string(b))
+		if raw == "" {
+			t.Errorf("%s [%s]: %s declares NO priorityClassName, so it schedules at "+
+				"priority 0.\n"+
+				"On a node at its max-pods cap a freed slot goes to the highest-priority "+
+				"pending Pod, and an unranked single-replica control-plane workload loses "+
+				"every race — that is #6166, where /sovereign served a Traefik 503 for 8 "+
+				"days while catalyst-api beside it stayed green.\n"+
+				"Fix: add `priorityClassName: catalyst-control-plane` to the pod spec in %s.",
+				tc.file, tc.role, tc.workload, path)
+			continue
+		}
+
+		class := resolveClassName(raw)
+		if class == "" {
+			t.Errorf("%s [%s]: priorityClassName is %q, which names no predictable class.\n"+
+				"A templated reference with no `| default \"...\"` renders empty when the "+
+				"value is unset — and an empty priorityClassName is priority 0 again, with "+
+				"the added cost that nobody reading the template can tell.\n"+
+				"Fix: give the expression a default naming a class the chart ships.",
+				tc.file, tc.role, raw)
+			continue
+		}
+
+		if src, ok := shipped[class]; !ok {
+			t.Errorf("%s [%s]: references PriorityClass %q, which this chart never renders.\n"+
+				"Shipped classes: %v.\n"+
+				"A dangling reference is worse than no class at all: the API server REJECTS "+
+				"a Pod naming a non-existent PriorityClass, so the workload does not schedule "+
+				"at low priority — it does not schedule at all.\n"+
+				"Fix: reference a shipped class, or ship the object alongside it.",
+				tc.file, tc.role, class, keysOf(shipped))
+			_ = src
+		}
+	}
+}
+
+// TestCatalystControlPlane_UIMatchesAPIAcrossRenderPaths pins the symmetry
+// itself. #6166 existed because one Deployment in the pair was ranked and the
+// other was not; a future edit that drops the class from one render path while
+// leaving the other is the same defect returning through the same seam, and the
+// per-file assertions above would still pass if BOTH ui files were dropped
+// together only if the loop above were removed — this arm makes the pairing
+// explicit so a partial edit reads as a lockstep break.
+func TestCatalystControlPlane_UIMatchesAPIAcrossRenderPaths(t *testing.T) {
+	root := repoRoot(t)
+	templatesDir := filepath.Join(root, "products", "catalyst", "chart", "templates")
+
+	read := func(name string) string {
+		b, err := os.ReadFile(filepath.Join(templatesDir, name))
+		if err != nil {
+			t.Fatalf("%s: read: %v", name, err)
+		}
+		return resolveClassName(extractPriorityClassRef(string(b)))
+	}
+
+	uiHelm := read("ui-deployment.yaml")
+	uiKust := read("ui-deployment-kustomize.yaml")
+	apiHelm := read("api-deployment.yaml")
+	apiKust := read("api-deployment-kustomize.yaml")
+
+	if uiHelm != uiKust {
+		t.Errorf("catalyst-ui resolves to %q on the Helm path but %q on the raw-Kustomize path.\n"+
+			"These render for different consumers — the mothership catalyst-platform "+
+			"Kustomization builds the Kustomize path directly — so a split means one of "+
+			"the two deployments of the SAME workload is starvable while the other is not, "+
+			"and which one you get depends on how the chart was installed.",
+			uiHelm, uiKust)
+	}
+	if apiHelm != apiKust {
+		t.Errorf("catalyst-api resolves to %q on the Helm path but %q on the raw-Kustomize path (control arm).",
+			apiHelm, apiKust)
+	}
+	if uiHelm != apiHelm {
+		t.Errorf("catalyst-ui resolves to priority class %q but catalyst-api to %q.\n"+
+			"Both are single-replica control-plane surfaces in one chart, and #6166 was "+
+			"precisely this asymmetry: the console sat unranked behind co-tenant Pods "+
+			"while its own API outranked them. If the tiers are meant to differ now, that "+
+			"is a deliberate decision and this guard should be updated to state it.",
+			uiHelm, apiHelm)
+	}
+}
+
+// TestUIPriorityClass_DetectorIsNotVacuous is the vacuity control. A guard that
+// passes on the first run tells you nothing until you have watched it fail.
+func TestUIPriorityClass_DetectorIsNotVacuous(t *testing.T) {
+	const withField = `
+spec:
+  template:
+    spec:
+      priorityClassName: catalyst-control-plane
+      containers:
+        - name: ui
+`
+	// The pre-#6166 shape: the key is simply absent.
+	const withoutField = `
+spec:
+  template:
+    spec:
+      containers:
+        - name: ui
+`
+	// The trap: the words appear, but only in prose. An extractor that grep'd
+	// the file would call this a pass and ship the outage.
+	const mentionedInCommentOnly = `
+spec:
+  template:
+    spec:
+      # priorityClassName: catalyst-control-plane  <- describing, not declaring
+      containers:
+        - name: ui
+`
+	if got := extractPriorityClassRef(withField); got != "catalyst-control-plane" {
+		t.Errorf("detector failed to read a declared priorityClassName: got %q, want %q",
+			got, "catalyst-control-plane")
+	}
+	if got := extractPriorityClassRef(withoutField); got != "" {
+		t.Errorf("detector reported %q on a pod spec with NO priorityClassName — it cannot "+
+			"go red, so every green above is meaningless", got)
+	}
+	if got := extractPriorityClassRef(mentionedInCommentOnly); got != "" {
+		t.Errorf("detector was fooled by a commented-out priorityClassName (got %q). These "+
+			"templates carry long comment blocks naming this exact field, so a "+
+			"comment-blind extractor would pass against a chart that only talks about "+
+			"the fix.", got)
+	}
+
+	// resolveClassName must survive the templated form the Helm path uses, and
+	// must refuse an expression with no default rather than inventing one.
+	if got := resolveClassName(`{{ .Values.catalystApi.priorityClassName | default "catalyst-control-plane" }}`); got != "catalyst-control-plane" {
+		t.Errorf("resolveClassName lost the Helm default: got %q", got)
+	}
+	if got := resolveClassName(`{{ .Values.catalystApi.priorityClassName }}`); got != "" {
+		t.Errorf("resolveClassName invented %q for an expression with no default; an "+
+			"unset value renders empty and that must read as a defect", got)
+	}
+}
+
+func keysOf(m map[string]string) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/tests/e2e/bootstrap-kit/ui_priority_class_6166_test.go
+++ b/tests/e2e/bootstrap-kit/ui_priority_class_6166_test.go
@@ -8,7 +8,8 @@ package bootstrapkit
 // "0/1 nodes are available: 1 Too many pods" — the node sat at its 110/110 Pod
 // ceiling.
 //
-// #6157 had already fixed the ROLLOUT DEADLOCK on the same Deployment: at
+// PR #6152 (issue #6157) had already fixed the ROLLOUT DEADLOCK on the same
+// Deployment: at
 // replicas=1 the default strategy rounds maxSurge 25% UP to 1 and
 // maxUnavailable 25% DOWN to 0, so the roll needed two Pods alive at once and
 // could never start on a full node. That fix is correct and necessary.


### PR DESCRIPTION
## Problem

`https://console.<mothership-fqdn>/sovereign/` served a **Traefik 503 "no available server"** while `catalyst-api` beside it was green (1/1, `/readyz` 200). The `/sovereign` Ingress path backends onto **catalyst-ui**, which was `Pending` on `0/1 nodes are available: 1 Too many pods`.

PR #6152 (issue #6157) already fixed the *deadlock*: at `replicas: 1` the default strategy rounds `maxSurge` 25% **up** to 1 and `maxUnavailable` 25% **down** to 0, so the roll needed two Pods alive at once and could never start on a node at its Pod ceiling. `maxUnavailable: 1` lets the old Pod leave first. That fix is correct and stays.

It is not sufficient. Letting the old Pod leave **frees** a slot; it does not **win** it. On a node at `110/110` the scheduler awards the freed slot to the highest-priority pending Pod — and four others were queued. catalyst-ui ran at **priority 0** (no `priorityClassName` at all) while catalyst-api carried **`catalyst-control-plane` (1e8)** and had since #4231. The console lost every race and sat Pending for 8 days.

The asymmetry is the defect: two single-replica control-plane workloads in one chart, and only one of them was ranked.

## Fix

`priorityClassName` on catalyst-ui at both lockstep sites:

| site | value | why |
|---|---|---|
| `ui-deployment-kustomize.yaml` | literal `catalyst-control-plane` | the raw-Kustomize path renders no templating — matches `api-deployment-kustomize.yaml`. This is the path the mothership's `catalyst-platform` Kustomization actually builds. |
| `ui-deployment.yaml` | `{{ .Values.catalystApi.priorityClassName \| default "catalyst-control-plane" }}` | the same expression `api-priorityclass.yaml` uses to *name* the object, so an operator override cannot leave the reference dangling |

The `catalyst-control-plane` PriorityClass object already ships on both paths — no new object.

## Verification

- Live patch of `priorityClassName` scheduled catalyst-ui by **preemption within seconds**: `/sovereign/` 503 → **200**, `/sovereign/api/v1/deployments` → **401** (reachable, auth required).
- Flux **reverted** that live patch on its next reconcile (server-side apply owns the field) and catalyst-ui went back to `Pending` — demonstrating the fix only holds from the chart, which is what this PR does.
- `helm template` and `kubectl kustomize products/catalyst/chart/templates` both render `priorityClassName: catalyst-control-plane` on **catalyst-ui and catalyst-api**, with the `PriorityClass` object (`value: 100000000`, `globalDefault: false`) present in each render.

## A guard that runs at REVIEW time, not delivery

Before this PR, **nothing in the repo referenced `priorityClassName`** — a sweep of `scripts/`, `tests/`, `products/catalyst/chart/tests/` and `.github/` matched it zero times. The fix would have shipped unguarded, and the next edit to either file could drop it exactly the way #4231 gave the class to catalyst-api and never gave it to catalyst-ui.

The obvious home for such a guard, `products/catalyst/chart/tests/*.sh`, **does not gate merges.** That fan-out runs from `blueprint-release.yaml`, whose triggers are `push: branches: [main]` and `workflow_dispatch` — there is no `pull_request:` trigger at all. A guard placed there fires *after* the merge decision, on the way to GHCR. That is delivery, not review.

So the guard is a Go test in `tests/e2e/bootstrap-kit/`, which `test-bootstrap-kit.yaml` runs on `pull_request` for `products/**/chart/**` via the `manifest-validation` job — a check that already reports on this PR. It is a **static parse, not a `helm template` render**, because `manifest-validation` installs Go and nothing else: the package's existing helm-based tests `t.Skipf` when helm is off PATH, so a render-based assertion would skip in the very job meant to enforce it.

What it pins: both render paths carry a non-empty class; the class named is one the chart actually ships (a dangling reference is *worse* than priority 0 — the API server rejects the Pod outright); the Helm and Kustomize paths agree; and ui agrees with api. The catalyst-api arm is the **control** — it has had the class since #4231, so a broken parser turns both arms red and reads as "the guard is broken", not "the chart is fine".

**Vacuity was measured, not asserted.** Restoring both `ui-deployment` files to their `origin/main` content and re-running gives exit 1, naming each file. Restoring the fix gives exit 0. A third test drives the extractor over synthetic input so it must go red on an absent key and must *not* be satisfied by a commented-out one — these templates carry long comment blocks naming this exact field, so a comment-blind grep would pass against a chart that only talks about the fix.

## Blast radius

Scheduling only. Raising catalyst-ui to control-plane priority means a co-tenant **reschedulable** Pod is preempted instead of the console — the same trade #4231 already made for catalyst-api. Observed preemption victim was `flux-system/notification-controller` (alert delivery only, already Pending for 4h beforehand).

## Chart version

`1.4.1407`, taken through the canonical writer (`scripts/bump-chart-version.sh`), never by hand. This branch had been sitting at 1.4.1397 while main advanced to 1.4.1401, so merging as-is would have **regressed** the chart version — the hollow-pin shape where the repo says N and the fleet keeps running M, because Helm versions are immutable and the registry keeps whichever push landed first. Rebased onto main; the writer read the baseline fresh from `origin/main`, consulted all 39 open-PR claims, found the ceiling at 1.4.1406 (open PR #6177) and allocated 1.4.1407. An earlier pass allocated 1.4.1404 and the claim guard caught PR #6175 taking the same number — re-run of the writer, not a hand-picked bump.

Lockstep re-stamped and verified on exit codes rather than printed output:

| site | state |
|---|---|
| `Chart.yaml` `version` + `appVersion` | 1.4.1407 (writer) |
| `clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml` | 1.4.1407 |
| changelog entry at both sites | added |
| catalog-seed `spec.version` / `source.version` | renders `{{ .Chart.Version }}` — tracks by construction, no edit |
| `catalog.generated.ts` + `blueprints.json` | regenerated via `build-catalog.mjs`, byte-identical |

`scripts/check-bootstrap-kit-pin-sync.sh` (67 pairs), `scripts/check-catalog-seed-lockstep.sh` (68 checked), `tests/e2e/bootstrap-kit` `go test -count=1 ./...`, `scripts/check-mothership-kustomize-plain-yaml.sh` and `scripts/check-chart-version-forward.sh` all exit 0. The two shell gates alone are not sufficient — they pass when a pin and its chart are *equally* stale; the Go guards are the ones that read the seed.

## Follow-up worth its own issue — do not sweep it here

The census this fix invites: of **22** Deployments in `products/catalyst/chart/templates/` (and 0 StatefulSets), **every one is single-replica**, and only catalyst-api and catalyst-ui name a priority class. The other **20** run at priority 0, **18** of them on a user- or operator-facing critical path (the five controllers, `marketplace-api`, and the org-services set including `console`, `auth`, `gateway`, `ferretdb`, `provisioning`). No `globalDefault: true` PriorityClass exists and no Kyverno policy injects one, so nothing assigns priority implicitly.

That is deliberately **not** fixed here. Priority is a scarce ordering resource: making everything high-priority makes nothing high-priority, and a flat sweep would restore the same tie it is meant to break while adding 18 new preemption sources. It needs a tier design, not a sweep.

One trap found while counting, worth recording: `platform/kyverno/README.md` documents rule **M6 `inject-priority-class`** deriving priority from a namespace tier label. Grep returns that README line and nothing else — no ClusterPolicy implements it and no PriorityClass by those names ships. A reader of that doc would reasonably conclude priority is already handled automatically.

Refs #6166, #6152, #6157, #4231

🤖 Generated with [Claude Code](https://claude.com/claude-code)
