### PR TITLE
fix(catalyst-api): the DR panel printed an em-dash over a live replication lag it already had

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/continuum_dr_extras.go
+++ b/products/catalyst/bootstrap/api/internal/handler/continuum_dr_extras.go
@@ -320,6 +320,25 @@ func (h *Handler) HandleContinuumReplicationStatus(w http.ResponseWriter, r *htt
 			}
 			if lag > 0 {
 				resp.WALLagSeconds = lag
+				// #6114 — RE-DERIVE the gate from the reading we just adopted.
+				//
+				// The gate above came from enrichReplicationStatus ->
+				// walLagHealthGate, which reads the CONTINUUM CR. For
+				// dr-shared-pg that CR carries no lag key at all, so the gate
+				// is Warn/"not reported by the Continuum CR; unverified" —
+				// correct for the CR, and STALE the instant a real producer
+				// (this CNPGPair) hands us a measurement. Leaving it made the
+				// response ship a genuine numeric lag next to a Warn saying no
+				// measurement exists, and the console believes the gate: it
+				// renders an em-dash over the live number. That is what UAT
+				// rows R12/R13 and the topology block assert must never happen.
+				//
+				// Guarded by `lag > 0`, so this can only ever act on a POSITIVE
+				// reading a producer actually wrote. An absent lag never
+				// reaches here and keeps the "unverified" Warn, preserving the
+				// #4901/#4923 invariant that absence is unknown, not a healthy
+				// zero — never a verdict from absent evidence.
+				upsertHealthGate(&resp, walLagGateFromMeasurement(lag, cnpgPairName))
 			}
 			lagBytes := int64(readNumericNested(pair.Object, "status", "walLagBytes"))
 			if lagBytes > 0 {
@@ -1565,6 +1584,29 @@ func walLagHealthGate(obj map[string]interface{}, lag float64) continuumHealthGa
 			Message: fmt.Sprintf("replication lag %.0fs exceeds the 30s promotability threshold", lag)}
 	}
 	return continuumHealthGate{Name: "wal-lag-under-rpo", Status: "Pass", Severity: "info"}
+}
+
+// walLagGateFromMeasurement derives the wal-lag gate from a lag reading that a
+// real producer PUBLISHED, as opposed to walLagHealthGate which derives it from
+// whichever keys a given CR happens to carry.
+//
+// The distinction is the whole point (#6114). walLagHealthGate must treat an
+// absent key as unverified, because absence is not a healthy zero (#4901 kept
+// lag pinned at 0 straight through an outage). But once a producer has handed
+// us an actual positive measurement, continuing to report "no measurement" is
+// simply false — and the console, which trusts the gate over the number,
+// suppresses the live value behind an em-dash.
+//
+// Callers MUST only invoke this with a measurement they positively observed.
+// It has no absent-key branch by design: there is no input to this function
+// that means "unknown", so it can never manufacture a Pass out of nothing.
+func walLagGateFromMeasurement(lag float64, source string) continuumHealthGate {
+	if lag > 30 {
+		return continuumHealthGate{Name: "wal-lag-under-rpo", Status: "Warn", Severity: "warning",
+			Message: fmt.Sprintf("replication lag %.0fs exceeds the 30s promotability threshold (measured by CNPGPair %s)", lag, source)}
+	}
+	return continuumHealthGate{Name: "wal-lag-under-rpo", Status: "Pass", Severity: "info",
+		Message: fmt.Sprintf("replication lag %.1fs is under the 30s promotability threshold (measured by CNPGPair %s)", lag, source)}
 }
 
 // leaseWitnessHealthGate derives the witness-lease gate from the observed

--- a/products/catalyst/bootstrap/api/internal/handler/continuum_dr_extras_6114_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/continuum_dr_extras_6114_test.go
@@ -1,0 +1,149 @@
+// continuum_dr_extras_6114_test.go — #6114 regression coverage.
+//
+// THE DEFECT: the DR panel prints an em-dash for replication lag while the
+// response carries a REAL measurement.
+//
+// HandleContinuumReplicationStatus builds its health gates from the Continuum
+// CR (enrichReplicationStatus -> walLagHealthGate). walLagHealthGate returns
+// Warn/"replication lag not reported by the Continuum CR; unverified" when the
+// CR carries neither status.walLagSeconds nor status.replicationLagSeconds —
+// correct and deliberate, because an absent lag is unknown, not a healthy zero
+// (#4901 kept lag pinned at 0 through an outage; #4923 made absence Warn).
+//
+// The handler THEN reads the linked CNPGPair and overwrites the number:
+//
+//	if lag > 0 { resp.WALLagSeconds = lag }        (continuum_dr_extras.go)
+//
+// ...and never re-derives the gate. So the response ships a genuine numeric
+// lag alongside a stale "unverified" Warn. The console treats that Warn as
+// proof the number is not a measurement and suppresses it:
+//
+//	AppDetail/TopologyTab.tsx  — lagUnverified => render '—'
+//
+// Which is exactly what UAT rows R12/R13 and the 51/52/55/56/62/64/65/66/67/
+// 69/70 topology block assert must never happen: "a live numeric
+// replication-lag, never a hardcoded —".
+//
+// The fix re-derives the gate ONLY from a positive measurement a real producer
+// wrote. It cannot manufacture a green from absence, and the tests below pin
+// both directions plus the absence case.
+package handler
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// linkedPairLagFixture — a Continuum CR that reports NO lag key of its own
+// (so the CR-derived gate is the "unverified" Warn) linked to a CNPGPair that
+// DOES carry a reading. This is the hw293/hw292 dr-shared-pg shape: the
+// Continuum controller publishes the pair link, the pair publishes the lag.
+func linkedPairLagFixture(t *testing.T, h *Handler, depID string, pairStatus map[string]interface{}) continuumReplicationStatus {
+	t.Helper()
+	cr := newContinuumUnstructured(
+		"dr-shared-pg", "shared-data", "shared-pg",
+		"me-east-215-a", []string{"me-east-215-b"})
+	_ = unstructured.SetNestedMap(cr.Object, map[string]interface{}{
+		"name":      "shared-pg-pair",
+		"namespace": "shared-data",
+	}, "spec", "cnpgPair")
+	pair := newCNPGPairCRUnstructured("shared-pg-pair", "shared-data", pairStatus)
+	factory, _ := fakeContinuumDynamicFactory(cr, pair)
+	h.dynamicFactory = factory
+	dep := installUserAccessDeployment(t, h, depID)
+	return fetchReplicationStatus(t, h, dep.ID, "dr-shared-pg", "shared-data")
+}
+
+// THE ROW. A real, under-threshold measurement from the linked pair must leave
+// the wal-lag gate PASSING, so the console renders the number instead of '—'.
+func TestReplicationStatus_6114_RealPairLagIsNotReportedUnverified(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	resp := linkedPairLagFixture(t, h, "dep-6114-real-lag", map[string]interface{}{
+		"phase":                 "Streaming",
+		"streaming":             true,
+		"replicationLagSeconds": int64(3),
+	})
+
+	if resp.WALLagSeconds != 3 {
+		t.Fatalf("walLagSeconds: got %v want 3 — fixture no longer exercises the overwrite, every assertion below is vacuous",
+			resp.WALLagSeconds)
+	}
+	g := gateByName(t, resp, "wal-lag-under-rpo")
+	if g.Status != "Pass" {
+		t.Errorf("wal-lag-under-rpo: got %q (msg=%q) want Pass.\n"+
+			"The response carries a REAL 3s measurement from the linked CNPGPair, but the gate "+
+			"was derived from the Continuum CR (which carries no lag key) and never re-derived. "+
+			"The console reads that Warn as 'not a measurement' and renders an em-dash over a "+
+			"live number — the exact thing UAT rows R12/R13 assert must never happen.",
+			g.Status, g.Message)
+	}
+}
+
+// CONTROL — same code path, opposite expectation. An OVER-threshold
+// measurement must still Warn, and the message must name the threshold. Without
+// this, the fix above could be "always Pass", which would be worse than the
+// defect: a 5-minute lag would render as a healthy green number.
+func TestReplicationStatus_6114_OverThresholdPairLagStillWarns(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	resp := linkedPairLagFixture(t, h, "dep-6114-over-threshold", map[string]interface{}{
+		"phase":                 "Streaming",
+		"streaming":             true,
+		"replicationLagSeconds": int64(45),
+	})
+
+	if resp.WALLagSeconds != 45 {
+		t.Fatalf("walLagSeconds: got %v want 45 (CONTROL fixture broken)", resp.WALLagSeconds)
+	}
+	g := gateByName(t, resp, "wal-lag-under-rpo")
+	if g.Status != "Warn" {
+		t.Errorf("wal-lag-under-rpo: got %q want Warn for a 45s lag — re-deriving the gate must not "+
+			"become a blanket Pass; an over-RPO lag has to stay visible", g.Status)
+	}
+	if g.Message == "" {
+		t.Errorf("wal-lag-under-rpo Warn carries no message naming the breach")
+	}
+}
+
+// CONTROL — the #4901/#4923 invariant the fix must NOT erode. When neither the
+// CR nor the pair reports any lag, the gate must REMAIN the "unverified" Warn.
+// Absent lag is unknown, not a healthy zero: #4901's outage kept lag pinned at
+// 0, and a gate that reads absence as Pass is a verdict from absent evidence.
+func TestReplicationStatus_6114_AbsentLagStaysUnverified(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	resp := linkedPairLagFixture(t, h, "dep-6114-absent-lag", map[string]interface{}{
+		"phase":     "Streaming",
+		"streaming": true,
+		// no lag key on either object
+	})
+
+	if resp.WALLagSeconds != 0 {
+		t.Fatalf("walLagSeconds: got %v want 0 (nothing reported one)", resp.WALLagSeconds)
+	}
+	g := gateByName(t, resp, "wal-lag-under-rpo")
+	if g.Status != "Warn" {
+		t.Errorf("wal-lag-under-rpo: got %q want Warn when NOTHING reports a lag. "+
+			"A zero that no producer wrote must never read as a healthy zero (#4901/#4923).",
+			g.Status)
+	}
+}
+
+// The CNPGPair CRD's own spelling must work identically to the controller's.
+// #5601 already proved the NUMBER is read from both keys; this proves the GATE
+// is too, so the fix is not wired to one spelling.
+func TestReplicationStatus_6114_WalLagSecondsSpellingAlsoPasses(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	resp := linkedPairLagFixture(t, h, "dep-6114-wallag-spelling", map[string]interface{}{
+		"phase":         "Streaming",
+		"streaming":     true,
+		"walLagSeconds": int64(2),
+	})
+
+	if resp.WALLagSeconds != 2 {
+		t.Fatalf("walLagSeconds: got %v want 2 (CNPGPair CRD spelling)", resp.WALLagSeconds)
+	}
+	if g := gateByName(t, resp, "wal-lag-under-rpo"); g.Status != "Pass" {
+		t.Errorf("wal-lag-under-rpo: got %q want Pass — the gate must follow BOTH lag spellings, "+
+			"not just the controller's (#5601 class)", g.Status)
+	}
+}


### PR DESCRIPTION
## The number was already there. The console was told not to trust it.

UAT rows **R12 / R13** and the **51 52 55 56 62 64 65 66 67 69 70** topology block assert a **live numeric replication lag, never a hardcoded `—`**. This is the half of that assertion which is not a convergence problem: even with a perfectly healthy pair, the panel prints an em-dash over a real measurement it is already holding.

## Mechanism

`HandleContinuumReplicationStatus` builds its health gates from the **Continuum CR**, via `walLagHealthGate`. For `dr-shared-pg` that CR carries neither `status.walLagSeconds` nor `status.replicationLagSeconds`, so the gate is:

```
wal-lag-under-rpo  Warn  "replication lag not reported by the Continuum CR; unverified"
```

That is **correct for the CR, and deliberate**: an absent lag is unknown, not a healthy zero. #4901's outage kept lag pinned at `0` throughout, and #4923 made absence `Warn` rather than `Pass` precisely so a zero nobody measured could never read as green.

The handler then reads the linked **CNPGPair** and overwrites the number:

```go
if lag > 0 { resp.WALLagSeconds = lag }      // continuum_dr_extras.go
```

…and never re-derives the gate. So the response ships a **genuine measurement next to a Warn asserting no measurement exists**. The console believes the gate over the number — `AppDetail/TopologyTab.tsx`, `lagUnverified => '—'` — and a real 3s lag renders as an em-dash captioned *"unverified — the health gates below report no live measurement"*.

## The fix, and why it does not erode #4901/#4923

The gate is re-derived from the reading actually adopted. `walLagGateFromMeasurement` has **no absent-key branch by design** — there is no input to it that means "unknown", so it cannot manufacture a `Pass` out of nothing. The existing `lag > 0` guard means an absent lag never reaches it and keeps the unverified `Warn`.

The invariant is preserved rather than weakened: *absence stays unverified; only a positive reading a real producer wrote can move the gate.*

## Red → green (`-count=1`)

**RED**, before the fix:

```
--- FAIL: TestReplicationStatus_6114_RealPairLagIsNotReportedUnverified
    wal-lag-under-rpo: got "Warn" (msg="replication lag not reported by the Continuum CR; unverified") want Pass.
--- PASS: TestReplicationStatus_6114_OverThresholdPairLagStillWarns
--- PASS: TestReplicationStatus_6114_AbsentLagStaysUnverified
--- FAIL: TestReplicationStatus_6114_WalLagSecondsSpellingAlsoPasses
    wal-lag-under-rpo: got "Warn" want Pass — the gate must follow BOTH lag spellings
FAIL
```

**GREEN**, after:

```
--- PASS: TestReplicationStatus_6114_RealPairLagIsNotReportedUnverified
--- PASS: TestReplicationStatus_6114_OverThresholdPairLagStillWarns
--- PASS: TestReplicationStatus_6114_AbsentLagStaysUnverified
--- PASS: TestReplicationStatus_6114_WalLagSecondsSpellingAlsoPasses
ok  github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/handler  0.023s
```

## Controls

**Both controls passed BEFORE the fix** — they are not mirroring it:

- `OverThresholdPairLagStillWarns` — a 45s reading must still `Warn`. Without it the fix could be a blanket `Pass`, which is *worse* than the defect: a five-minute lag would render as a healthy green number.
- `AbsentLagStaysUnverified` — nothing reports a lag anywhere, so the gate must **stay** `Warn`. This is the #4901 guard.

The fourth test covers both lag spellings, so the fix is not wired to one key (the #5601 class).

## Vacuity

Delete the over-threshold branch, making the new gate a blanket `Pass`:

```
--- FAIL: TestReplicationStatus_6114_OverThresholdPairLagStillWarns
```

Caught. The suite can go red on the plausible wrong fix.

Full `internal/handler` package green: `ok ... 296.687s`.

## Related, NOT fixed here

Two sibling defects found while tracing this, recorded so they are not lost. Neither is touched by this PR:

- `liveReplicationStatusFromCNPGPair` hardcodes `gatePass(lag <= 30)` rather than calling the gate deriver, and its `cnpgClusterLag()` **returns 0 when the key is absent** (CloudNativePG does not publish `status.lag`). So on that path an unmeasured 0 renders as a green `0.0 s` — the mirror image of this bug, and a verdict from absent evidence.
- `infrastructure.go` hardcodes `TargetHealth: "—"` on the synthesized load-balancer item, and assigns one deployment-level status to every cluster and node rather than measuring per object.

## Scope

**No live environment was measured** — hw293 was wiped 2026-08-11T04:23:42Z. This is source and test work. **No UAT row is stamped.** No NodePort; no secret in any artifact.

Refs #6114 #4923 #4901 #5601
