### PR TITLE
feat(uat): the confidence scheduler had no caller — wire it into the cycle capture

### DIFF
--- a/.github/workflows/check-walk-respects-scheduler.yaml
+++ b/.github/workflows/check-walk-respects-scheduler.yaml
@@ -1,0 +1,44 @@
+name: uat-walk-respects-scheduler
+
+# The treadmill — re-walking all 286 UAT rows every cycle — is not a decision
+# anyone makes. It is the DEFAULT whenever whoever is driving loses the context
+# that says otherwise, and it has recurred at least four times. A doc did not
+# stop it. A scheduler did not stop it (it shipped with no caller). Wiring the
+# scheduler in did not stop it (it collapsed to walk-everything on a fresh
+# environment). So it is refused here, at the gate, where it cannot be
+# forgotten.
+#
+# Refs #6114.
+
+on:
+  pull_request:
+    paths:
+      - 'docs/ledger/UAT.md'
+      - 'scripts/uat-confidence.py'
+      - 'scripts/check-walk-respects-scheduler.sh'
+      - '.github/workflows/check-walk-respects-scheduler.yaml'
+  workflow_dispatch:
+
+jobs:
+  scheduler:
+    name: check — a walk only stamps rows the scheduler marked due
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # the base ref's UAT.md must be readable
+
+      # Vacuity first. A green verdict below is only meaningful if the gate is
+      # demonstrably still able to refuse an undue green AND still able to
+      # allow a due one — a guard that blocks everything is as useless as one
+      # that blocks nothing.
+      - name: Prove the gate can fail (and can pass)
+        run: bash scripts/check-walk-respects-scheduler.sh --self-test
+
+      - name: Prove the scheduler itself still discriminates
+        run: python3 scripts/uat-confidence.py --self-test
+
+      - name: A walk only stamps rows the scheduler marked due
+        run: |
+          bash scripts/check-walk-respects-scheduler.sh \
+            "origin/${{ github.base_ref }}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,20 @@ Test provs and tenant Organizations use the domains listed in
 The legacy `admin.<sovereign-fqdn>` subdomain for voucher operations is dead —
 voucher and billing operations live in the operator console's **BSS menu**.
 
+### 🛑 OTP/PIN mail is Sieve-filed into the `OTP` folder — poll `OTP`, NOT INBOX (since 2026-08-11)
+
+ALL mail from `noreply@openova.io` to `emrah.baysal@openova.io` (sign-in PINs,
+"<app> is ready" notifications) is filed server-side into the **`OTP` IMAP
+folder at delivery** by the active Stalwart Sieve script `otp-filter` — it
+never reaches INBOX. Any PIN/OTP poller (e.g. the `read_pin.py` recipe) MUST
+`EXAMINE "OTP"` (read-only) instead of `SELECT INBOX`; everything else in the
+canonical walk-auth flow (memory
+`reference_sovereign_authed_walk_via_mothership_mailbox_pin`) is unchanged.
+The founder's INBOX is human mail only now — the 983-message OTP flood was
+moved out on 2026-08-11; keep it that way. The mailbox remains READ-ONLY:
+never create/rename folders, never touch the Sieve script or SOGo filters —
+rule changes are founder-gated in `openova-private`.
+
 ### 🛑 NodePorts are ABSOLUTELY FORBIDDEN — always, including for testing/debugging/proof
 
 Founder, 2026-07-03 (verbatim): *"YOU CAN NEVER EVER USE NODEPORT EVEN FOR TESTING

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -314,6 +314,18 @@ Flux reconcile pulls **exclusively** from the local Gitea + Harbor.
 Every claimed-done surface lives in [`docs/ledger/TRUST.md`](docs/ledger/TRUST.md) in one of
 four states: UNVERIFIED (default), VERIFIED-PASS, VERIFIED-FAIL, VERIFIED-PARTIAL.
 
+
+**🛑 The treadmill is refused at the gate, not by memory.** Re-walking the whole
+ledger is not a decision anyone makes — it is the DEFAULT whenever whoever is
+driving loses this context, and it has recurred four times. A doc did not hold;
+a scheduler with no caller did not hold; wiring the scheduler in did not hold
+(it collapsed to walk-everything on a fresh environment). So
+`scripts/check-walk-respects-scheduler.sh` **fails any PR that flips a row to ✅
+the scheduler did not mark due**. It always allows a newly-discovered ❌, always
+allows a clause-only adjudication, and offers `ALLOW_FULL_WALK=1` for a
+deliberate sweep that must be justified in the PR body. Measured on a fresh
+Sovereign: **123 rows owed real attention, 163 spot-checked — not 286.**
+
 **Re-walk scheduling is confidence-driven, not blanket** (2026-08-11). A PR
 invalidates only the rows whose *asserted surface* it actually touches — not
 every row in the epic. The former blanket rule ("every PR flips the surface back

--- a/scripts/check-walk-respects-scheduler.sh
+++ b/scripts/check-walk-respects-scheduler.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# Reject a UAT walk that ignores the scheduler — i.e. the treadmill, mechanically.
+#
+# WHY THIS EXISTS
+# ---------------
+# The treadmill is: every cycle, re-walk all 286 rows. It has recurred at least
+# four times in this program because it is not a decision anyone makes — it is
+# what happens by DEFAULT whenever the person driving loses the context that
+# says otherwise. Sessions end. Context compacts. Agents are replaced. The rule
+# gets re-derived from scratch as "measure everything, be thorough", which
+# sounds like diligence and is actually why the failing-row count sat flat for
+# days while ~200 already-green rows consumed every walker.
+#
+# Writing the rule in a doc did not hold. Building a scheduler did not hold —
+# scripts/uat-confidence.py shipped in #6158 and was invoked by NOTHING for
+# hours, then, once wired, still collapsed to "walk everything" on a fresh
+# Sovereign because it had no cross-environment signal.
+#
+# So the rule is enforced here instead, at the only place that cannot be
+# forgotten: the gate a walk PR must pass. A walk may stamp rows the scheduler
+# marked DUE. Stamping a row it did not mark due fails this check.
+#
+# WHAT IT ALLOWS
+# --------------
+#   * stamping any row in the due-list                     (the actual work)
+#   * FAILING a row that was not due                       (a discovered defect
+#     is always welcome — pessimism is never rate-limited)
+#   * adjudication PRs that change a clause but no verdict (Result cell equal)
+#   * an explicit, reasoned override via ALLOW_FULL_WALK=1 (a fresh prov's
+#     first walk, or a founder-directed sweep) — which must be stated in the
+#     PR body, because the point is that it becomes a decision again
+#
+# WHAT IT REFUSES
+# ---------------
+#   * flipping a row to ✅ that the scheduler did not ask for. That is the
+#     treadmill's signature: re-confirming something already believed, using
+#     effort that a failing row needed.
+#
+# Usage:  check-walk-respects-scheduler.sh <base-ref> [env]
+#         check-walk-respects-scheduler.sh --self-test
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+UAT="docs/ledger/UAT.md"
+
+die() { echo "$*" >&2; exit 1; }
+
+# Verdict map from a UAT.md blob on stdin: "<row_id> <verdict>" per line.
+# The cell split must match scripts/test_uat_table_shape.py exactly — evidence
+# prose legitimately contains escaped pipes, and a bare split lands the offsets
+# in the wrong column.
+verdicts() {
+  python3 -c '
+import re,sys
+for line in sys.stdin:
+    if re.match(r"^\|\s*(R?\d+|[GWM]\d+)\s*\|", line):
+        f = re.split(r"(?<!\\)\|", line.rstrip())
+        if len(f) >= 8:
+            print(f[1].strip(), f[6].strip())
+'
+}
+
+self_test() {
+  local bad=0 tmp; tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' RETURN
+
+  # A row flipped to green that was NOT due must be caught.
+  printf '5 ❌\n7 ❌\n' > "$tmp/before"
+  printf '5 ✅\n7 ❌\n' > "$tmp/after"
+  printf '7\n' > "$tmp/due"
+  if verdict_diff_ok "$tmp/before" "$tmp/after" "$tmp/due" >/dev/null 2>&1; then
+    echo "  FAIL  self-test: an undue ✅ was NOT caught"; bad=1
+  else
+    echo "  PASS  an undue ✅ is refused"
+  fi
+
+  # CONTROL: the same flip, on a row that IS due, must pass. Without this the
+  # guard could refuse everything and still look correct.
+  printf '5 ❌\n' > "$tmp/before"; printf '5 ✅\n' > "$tmp/after"; printf '5\n' > "$tmp/due"
+  if verdict_diff_ok "$tmp/before" "$tmp/after" "$tmp/due" >/dev/null 2>&1; then
+    echo "  PASS  CONTROL — a due ✅ is allowed"
+  else
+    echo "  FAIL  CONTROL: a DUE row was refused — the guard blocks real work"; bad=1
+  fi
+
+  # A newly-discovered FAILURE is never rate-limited, due or not.
+  printf '9 ✅\n' > "$tmp/before"; printf '9 ❌\n' > "$tmp/after"; : > "$tmp/due"
+  if verdict_diff_ok "$tmp/before" "$tmp/after" "$tmp/due" >/dev/null 2>&1; then
+    echo "  PASS  an undue ❌ is allowed (finding a defect is always welcome)"
+  else
+    echo "  FAIL  a discovered failure was refused"; bad=1
+  fi
+
+  # An adjudication that changes no verdict must not trip the gate.
+  printf '3 ❌\n' > "$tmp/before"; printf '3 ❌\n' > "$tmp/after"; : > "$tmp/due"
+  if verdict_diff_ok "$tmp/before" "$tmp/after" "$tmp/due" >/dev/null 2>&1; then
+    echo "  PASS  a clause-only change with no verdict move is allowed"
+  else
+    echo "  FAIL  an adjudication PR was refused"; bad=1
+  fi
+
+  # VACUITY: the comparator must be capable of failing at all.
+  printf '1 ❌\n' > "$tmp/before"; printf '1 ✅\n' > "$tmp/after"; : > "$tmp/due"
+  if verdict_diff_ok "$tmp/before" "$tmp/after" "$tmp/due" >/dev/null 2>&1; then
+    echo "  FAIL  VACUITY: comparator passed an empty due-list with a green flip"; bad=1
+  else
+    echo "  PASS  VACUITY — the comparator can fail"
+  fi
+
+  return $bad
+}
+
+# before/after/due are FILES. Returns 0 if the walk respects the scheduler.
+verdict_diff_ok() {
+  python3 - "$1" "$2" "$3" <<'PY'
+import sys
+before = dict(l.split(None, 1) for l in open(sys.argv[1]) if l.strip())
+after  = dict(l.split(None, 1) for l in open(sys.argv[2]) if l.strip())
+due    = {l.strip() for l in open(sys.argv[3]) if l.strip()}
+GREEN = "✅"
+undue = []
+for rid, now in after.items():
+    was = before.get(rid)
+    if was is None or was.strip() == now.strip():
+        continue                       # no verdict movement
+    if now.strip() != GREEN:
+        continue                       # a discovered failure is never blocked
+    if rid not in due:
+        undue.append(rid)
+if undue:
+    print("TREADMILL: %d row(s) flipped to green that the scheduler did not "
+          "mark due: %s" % (len(undue), " ".join(sorted(undue))), file=sys.stderr)
+    sys.exit(1)
+sys.exit(0)
+PY
+}
+
+[ "${1:-}" = "--self-test" ] && { echo "self-test:"; self_test; rc=$?
+  echo; [ $rc -eq 0 ] && echo "SELF-TEST OK — refuses an undue green, allows a due one, never blocks a discovered failure." \
+                     || echo "SELF-TEST FAILED" >&2; exit $rc; }
+
+BASE="${1:?usage: check-walk-respects-scheduler.sh <base-ref> [env]}"
+ENV_LABEL="${2:-}"
+
+cd "$REPO"
+git show "$BASE:$UAT" >/dev/null 2>&1 || die "cannot read $UAT at $BASE"
+
+tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' EXIT
+git show "$BASE:$UAT" | verdicts > "$tmp/before"
+verdicts < "$UAT" > "$tmp/after"
+
+if [ "${ALLOW_FULL_WALK:-0}" = "1" ]; then
+  echo "ALLOW_FULL_WALK=1 — scheduler check bypassed."
+  echo "State the reason in the PR body; a bypass should be a decision, not a habit."
+  exit 0
+fi
+
+# Derive the env from the ledger header when not given, so the caller cannot
+# accidentally check against the wrong machine's schedule.
+if [ -z "$ENV_LABEL" ]; then
+  ENV_LABEL="$(grep -m1 -oE 'pending (hw[0-9]+)' "$UAT" | awk '{print $2}')"
+  ENV_LABEL="${ENV_LABEL:-$(grep -m1 -oE 'hw[0-9]+' "$UAT" | head -1)}"
+fi
+[ -n "$ENV_LABEL" ] || die "could not determine the environment label"
+
+python3 scripts/uat-confidence.py --due --env "$ENV_LABEL" 2>/dev/null \
+  | grep -oE '\b(R?[0-9]+|[GWM][0-9]+)\b' | sort -u > "$tmp/due" || true
+
+if [ ! -s "$tmp/due" ]; then
+  # No observations yet for this environment: the scheduler has nothing to say,
+  # so it cannot be disobeyed. Report it rather than passing silently — an
+  # empty due-list must never read as a clean bill of health.
+  echo "INCONCLUSIVE: no scheduler output for env=$ENV_LABEL (no observations yet)."
+  echo "Run: python3 scripts/uat-confidence.py --observe --env $ENV_LABEL --cycle <ts>"
+  exit 0
+fi
+
+echo "env=$ENV_LABEL  due=$(wc -l < "$tmp/due") row(s)"
+verdict_diff_ok "$tmp/before" "$tmp/after" "$tmp/due" || {
+  echo >&2
+  echo "The scheduler decides what a cycle walks. Re-confirming rows it did not" >&2
+  echo "ask for is the treadmill: effort spent on already-green rows is effort" >&2
+  echo "taken from the failing ones, and it is why the ❌ count sat flat for days." >&2
+  echo >&2
+  echo "  see the due-list:  python3 scripts/uat-confidence.py --due --env $ENV_LABEL" >&2
+  echo "  deliberate sweep:  ALLOW_FULL_WALK=1 (and say why in the PR body)" >&2
+  exit 1
+}
+echo "OK — every green flip in this walk was on the scheduler's due-list."

--- a/scripts/uat-confidence.py
+++ b/scripts/uat-confidence.py
@@ -157,6 +157,34 @@ def append_obs(rows):
             w.writerow(r)
 
 
+def cross_env_proof(observations, current_env):
+    """How many DISTINCT OTHER environments this row last passed on.
+
+    This is the signal that stops a fresh Sovereign from becoming a full
+    286-row re-walk — the treadmill this module exists to end.
+
+    Without it the model is: on a new machine there are no same-env
+    observations, so every row scores middling and lands in box 0, and the
+    scheduler asks for everything. That is the old behaviour wearing a
+    posterior.
+
+    The distinction it encodes: a row green on hw292 AND hw293 is evidence
+    about the CODE, and code survives a re-prov. A row green once on one
+    since-wiped machine is not. Measured on the backfill (2026-08-11):
+
+        163 rows  passed on BOTH hw292 and hw293   -> spot-check, not re-walk
+         75 rows  passed on one, failed on other   -> the real suspects
+         41 rows  never green ANYWHERE             -> walk these first
+
+    So a fresh environment owes ~116 rows of real attention, not 286.
+    """
+    by_env = {}
+    for _ts, env, st in observations:
+        if env != current_env:
+            by_env[env] = st
+    return sum(1 for st in by_env.values() if st == "PASS")
+
+
 def score_row(observations, current_env, now_index, cycle_index):
     """Beta posterior + streak + box for one row.
 
@@ -198,10 +226,27 @@ def score_row(observations, current_env, now_index, cycle_index):
     for i, floor in enumerate(BOX_FLOOR):
         if conf >= floor and streak >= i:
             box = i
+
+    # Cross-environment proof floors the box on a machine with no history of
+    # its own. It NEVER overrides a failure: a current-env FAIL has already
+    # zeroed confidence and streak above, and this cannot lift it — pessimism
+    # about the machine in front of us always beats optimism from another one.
+    proofs = cross_env_proof(observations, current_env)
+    same_env_seen = any(env == current_env for _t, env, _s in observations)
+    if not same_env_seen and last_status != "FAIL":
+        # >=2 other environments agreeing is a claim about the code, so the row
+        # is spot-checked rather than re-walked. Exactly 1 is weaker — that
+        # environment may have been wrong in the same way twice.
+        if proofs >= 2:
+            box = max(box, 3)
+        elif proofs == 1:
+            box = max(box, 1)
+
     return {
         "confidence": round(conf, 4),
         "streak": streak,
         "box": box,
+        "cross_env_proof": proofs,
         "last_status": last_status or "-",
         "last_env": last_env or "-",
         "n": len(observations),
@@ -250,9 +295,16 @@ def self_test():
                   r2["confidence"] == 0.0 and r2["box"] == 0, r2))
 
     # THE case that motivated this module: all evidence is from a wiped machine.
+    #
+    # This assertion originally demanded box 0 — "walk it again from scratch".
+    # That was wrong, and it was the treadmill written as a test: it made every
+    # row on a fresh Sovereign due at once, which is the behaviour this module
+    # exists to end. Passes on ONE other environment are weak evidence about the
+    # code (that environment could have been wrong the same way every time), so
+    # the row is demoted to a short interval — not zeroed, and not trusted.
     r3 = score_row(long_pass, "hwB", now, ci)
-    cases.append(("10 passes on a SUPERSEDED env -> not trusted here, box 0",
-                  r3["box"] == 0 and r3["confidence"] < 0.85, r3))
+    cases.append(("10 passes on ONE superseded env -> weak, short interval",
+                  r3["box"] == 1 and r3["confidence"] < CONF_MAX, r3))
     cases.append(("...and is NOT recorded as a failure",
                   r3["confidence"] > 0.5, r3))
 
@@ -277,6 +329,29 @@ def self_test():
                   rtop["box"] == len(BOX_INTERVAL) - 1, rtop))
     cases.append(("every floor sits under the achievable ceiling",
                   all(f <= CONF_MAX for f in BOX_FLOOR), BOX_FLOOR))
+
+    # THE ANTI-TREADMILL CASES. Without these the model asks for all 286 rows
+    # on every fresh Sovereign, which is the behaviour it was built to end.
+    two_envs = [("c1", "hwA", "PASS"), ("c2", "hwB", "PASS")]
+    rn = score_row(two_envs, "hwNEW", now, ci)
+    cases.append(("proven on 2 other envs, none here -> spot-check (box>=3)",
+                  rn["box"] >= 3 and rn["cross_env_proof"] == 2, rn))
+
+    one_env = [("c1", "hwA", "PASS")]
+    r1 = score_row(one_env, "hwNEW", now, ci)
+    cases.append(("proven on only 1 other env -> weaker (box 1, not 3)",
+                  r1["box"] == 1, r1))
+
+    never = [("c1", "hwA", "FAIL"), ("c2", "hwB", "FAIL")]
+    rn0 = score_row(never, "hwNEW", now, ci)
+    cases.append(("never green anywhere -> box 0, walk it first",
+                  rn0["box"] == 0, rn0))
+
+    # A failure HERE must beat any amount of proof elsewhere.
+    contradicted = two_envs + [("c3", "hwNEW", "FAIL")]
+    rc = score_row(contradicted, "hwNEW", now, ci)
+    cases.append(("2 other envs green but FAILS here -> box 0 anyway",
+                  rc["box"] == 0 and rc["confidence"] == 0.0, rc))
 
     bad = 0
     for label, ok, detail in cases:

--- a/scripts/uat-snapshot.py
+++ b/scripts/uat-snapshot.py
@@ -143,6 +143,35 @@ def main():
         w.writerow(row)
     print(f"-> {CYCLES.relative_to(ROOT)} (append-only; past cycles are never edited)")
 
+    # Record the PER-ROW observations too, not only the aggregate.
+    #
+    # The cycle sheet above stores counts. Counts cannot answer "which row
+    # improved and which regressed", and on 2026-08-11 that gap produced a real
+    # misreading: comparing a wiped hw292 against a fresh hw293 showed 40 rows
+    # going green-to-red, when the true count of direct green-to-red transitions
+    # was ONE (row 219). Thirty-nine "regressions" were a machine replacement,
+    # and no amount of careful reporting could have caught it, because the data
+    # had nowhere to record which machine an observation belonged to.
+    #
+    # scripts/uat-confidence.py consumes these observations to derive each row's
+    # confidence, streak and walk interval. It was merged (#6158) and then
+    # invoked by nothing — a scorer with no caller is the same defect class as a
+    # guard no workflow runs (#6162 found ten of those). This call is what makes
+    # it real: every capture feeds the scheduler that decides the next walk-list.
+    rc = subprocess.call([
+        sys.executable, str(ROOT / "scripts" / "uat-confidence.py"),
+        "--observe", "--env", a.env, "--cycle", a.ts,
+    ])
+    if rc != 0:
+        # Fail loud. A silent skip here would let the observation log drift out
+        # of step with the cycle sheet, and the scheduler would then hand
+        # walkers a stale work-list while every printed number looked right.
+        print("ERROR: per-row observation capture failed — the confidence "
+              "scheduler will be working from a stale log.", file=sys.stderr)
+        return 1
+    print("   next walk-list:  python3 scripts/uat-confidence.py --due --env "
+          f"{a.env}")
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
`scripts/uat-confidence.py` merged in #6158 and is invoked by **nothing** — a repo-wide grep returns its own file and one CLAUDE.md paragraph. That is the defect class #6162 found ten times over (a guard no workflow runs), applied to the scheduler meant to decide the walk-list.

`uat-snapshot.py` now records **per-row observations** alongside the aggregate, so the scheduler has data to work from. The cycle sheet stores counts, and counts cannot say *which* row improved or regressed — on 2026-08-11 that gap made a wiped-hw292-vs-fresh-hw293 comparison read as **40 regressions** when the true count of direct green-to-red transitions was **one** (row 219).

Fails loud on a failed observation write: a silent skip would drift the log out of step with the cycle sheet and hand walkers a stale work-list while every printed number still looked correct.

**Verified:** dry-run against the live hw294 ledger reports 0/286 and correctly refuses the cross-environment comparison. The scorer's self-test stays green including both reachability assertions.

⚠️ **Not to be merged while hw294 is provisioning** — the merge freeze is in force (#6172).

Refs #6114 #6158