### PR TITLE
fix(delivery): every per-Organization HelmRelease shipped version "*" — the seven chart pins had no writer [DO NOT MERGE]

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1389,7 +1389,7 @@ spec:
       #   guacamole-pg and the shared-pg family as well. Egress half in
       #   bp-keycloak 1.5.9; neither half alone restores a brokered login.
       #   Lockstep w/ products/catalyst/chart/Chart.yaml.
-      version: 1.4.1411
+      version: 1.4.1415
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/bootstrap/api/internal/handler/organization_chart_version_pins_6169_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/organization_chart_version_pins_6169_test.go
@@ -1,0 +1,353 @@
+package handler
+
+// organization_chart_version_pins_6169_test.go — Refs #6169.
+//
+// THE DEFECT. Every per-Organization application HelmRelease this overlay
+// writes shipped `version: "*"`.
+//
+// The seven chart pins are read from env by cmd/api/main.go:996-1002 into
+// OrganizationChartVersions. A repo-wide grep for CATALYST_ORG_BP_*_VER across
+// every .yaml/.yml/.tpl/.json matched ZERO times — no setter existed anywhere
+// in the repo — so withVersionDefaults (organization_gitops.go:919) resolved
+// six of the seven to the floating star, and Flux installed whatever the OCI
+// repo happened to serve newest at reconcile time. Same read-by-Go /
+// set-by-nothing shape as the console pin (#6139, 3.5 months) and
+// CATALYST_JANITOR_DESTRUCTIVE (UAT row 228).
+//
+// It is not a theoretical hazard. bp-agenity alone falls back to a BOUNDED
+// range instead of a star (agenityChartConstraint, organization_gitops.go:917)
+// because an unbounded star once resolved a stray 0.9.7 IMAGE manifest over
+// the real 0.5.x chart and bp-agenity never installed at all (#4922). Only
+// agenity was hardened, and only after it had already fired. The remaining six
+// carried the identical exposure.
+//
+// WHAT THIS GUARD PINS. Narrowly: a rendered per-Organization HelmRelease must
+// carry a CONCRETE chart version. It deliberately does NOT assert the general
+// "every env var Go reads must have a YAML setter" — 47 of the 108 CATALYST_*
+// vars are legitimately-optional override knobs with deliberate Go-side
+// defaults (recorded on #6169 so nobody writes that guard and then reverts it).
+// The subject here is a VERSION CONSTRAINT that silently degrades to a
+// wildcard, not an unset variable.
+//
+// CONTROL (TestChartVersionScanner_Table_6169). The scanner is exercised
+// against a HelmRelease that legitimately carries `version: "0.2.17"` — it
+// must return NO finding. A checker that flagged every HelmRelease would pass
+// the main assertion below for the wrong reason.
+//
+// VACUITY (TestOrgTenantHelmReleases_ScannerFailsOnThePreFixShape_6169). The
+// same scanner is pointed at the pre-fix render — the overlay built from an
+// EMPTY OrganizationChartVersions, which is exactly what the shipped chart
+// produced before this change — and is required to report findings. Without
+// that arm, a scanner that silently matched nothing would report green over
+// the very defect it exists to catch.
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// concreteVersionRE accepts an exact SemVer pin and nothing else. A range
+// (">=0.5.0 <0.6.0"), a caret/tilde constraint, an `x` wildcard and the bare
+// star are all rejected: every one of them lets the resolved artifact change
+// under a Sovereign that was never redeployed, which is the property that made
+// UAT rows 232/234 cite chart versions their deployment never pinned.
+var concreteVersionRE = regexp.MustCompile(`^\d+\.\d+\.\d+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$`)
+
+// chartVersionFinding is one rendered HelmRelease whose chart version is not a
+// concrete pin.
+type chartVersionFinding struct {
+	File    string
+	Release string
+	Chart   string
+	Version string
+}
+
+func (f chartVersionFinding) String() string {
+	return fmt.Sprintf("%s: HelmRelease %q chart %q version %q", f.File, f.Release, f.Chart, f.Version)
+}
+
+// scanHelmReleaseChartVersions decodes every YAML document in the rendered
+// overlay and returns the HelmReleases whose spec.chart.spec.version is not a
+// concrete SemVer, plus the number of HelmReleases actually inspected.
+//
+// The inspected count is returned so callers can prove the scan was not blind:
+// a parse that yielded zero HelmReleases would otherwise report "no wildcards"
+// with total confidence.
+func scanHelmReleaseChartVersions(files map[string]string) (findings []chartVersionFinding, inspected int, err error) {
+	names := make([]string, 0, len(files))
+	for name := range files {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		body := files[name]
+		dec := yaml.NewDecoder(strings.NewReader(body))
+		for {
+			var doc map[string]any
+			if derr := dec.Decode(&doc); derr != nil {
+				break
+			}
+			if doc == nil {
+				continue
+			}
+			if k, _ := doc["kind"].(string); k != "HelmRelease" {
+				continue
+			}
+			meta, _ := doc["metadata"].(map[string]any)
+			release, _ := meta["name"].(string)
+
+			spec, _ := doc["spec"].(map[string]any)
+			chartOuter, _ := spec["chart"].(map[string]any)
+			chartSpec, _ := chartOuter["spec"].(map[string]any)
+			if chartSpec == nil {
+				// A HelmRelease with no chart spec at all (chartRef-shaped, or
+				// malformed) is a different defect; report it rather than
+				// letting it pass as "no wildcard found".
+				return nil, inspected, fmt.Errorf("%s: HelmRelease %q has no spec.chart.spec — cannot assert a version pin on it", name, release)
+			}
+			chartName, _ := chartSpec["chart"].(string)
+			version := strings.TrimSpace(fmt.Sprintf("%v", chartSpec["version"]))
+			inspected++
+			if !concreteVersionRE.MatchString(version) {
+				findings = append(findings, chartVersionFinding{
+					File: name, Release: release, Chart: chartName, Version: version,
+				})
+			}
+		}
+	}
+	return findings, inspected, nil
+}
+
+// chartValuesOrgPins reads the SHIPPED per-Organization chart pins out of
+// products/catalyst/chart/values.yaml. Reading the real chart rather than
+// restating the numbers here is the point: a test carrying its own copy of the
+// versions would stay green against a values.yaml that lost the block entirely.
+func chartValuesOrgPins(t *testing.T) OrganizationChartVersions {
+	t.Helper()
+	path := filepath.Join(repoRootFromTest(t), "products", "catalyst", "chart", "values.yaml")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	// Navigated as a yaml.Node rather than unmarshalled into a struct on
+	// purpose: values.yaml carries two top-level `migrations:` keys (:2894 and
+	// :2908, a documented deliberate duplicate whose LAST occurrence wins under
+	// Helm), and yaml.v3's map decoder rejects the whole document for it. A
+	// node walk reads the block this test is about without taking a position on
+	// an unrelated key.
+	var root yaml.Node
+	if err := yaml.Unmarshal(raw, &root); err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+	cvNode := mappingChild(mappingChild(docRoot(&root), "orgTenants"), "chartVersions")
+	if cvNode == nil {
+		t.Fatalf("%s carries no orgTenants.chartVersions block — the per-Organization chart pins have no writer, so every per-Organization HelmRelease resolves `version: \"*\"` at reconcile time (#6169)", path)
+	}
+	get := func(key string) string {
+		n := mappingChild(cvNode, key)
+		if n == nil {
+			return ""
+		}
+		return strings.TrimSpace(n.Value)
+	}
+	return OrganizationChartVersions{
+		Keycloak:  get("keycloak"),
+		CNPG:      get("cnpg"),
+		WordPress: get("wordpress"),
+		OpenClaw:  get("openclaw"),
+		Stalwart:  get("stalwart"),
+		NewAPI:    get("newapi"),
+		Agenity:   get("agenity"),
+	}
+}
+
+// docRoot unwraps a decoded DocumentNode to its content mapping.
+func docRoot(n *yaml.Node) *yaml.Node {
+	if n != nil && n.Kind == yaml.DocumentNode && len(n.Content) > 0 {
+		return n.Content[0]
+	}
+	return n
+}
+
+// mappingChild returns the value node for key in a YAML mapping, or nil. When a
+// key appears more than once the LAST occurrence wins, matching Helm.
+func mappingChild(n *yaml.Node, key string) *yaml.Node {
+	if n == nil || n.Kind != yaml.MappingNode {
+		return nil
+	}
+	var found *yaml.Node
+	for i := 0; i+1 < len(n.Content); i += 2 {
+		if n.Content[i].Value == key {
+			found = n.Content[i+1]
+		}
+	}
+	return found
+}
+
+func repoRootFromTest(t *testing.T) string {
+	t.Helper()
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	dir := wd
+	for i := 0; i < 12; i++ {
+		if _, err := os.Stat(filepath.Join(dir, "docs", "PRINCIPLES.md")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	t.Fatalf("could not find repo root from %s", wd)
+	return ""
+}
+
+// THE ASSERTION. Rendered with the pins the shipped chart actually supplies,
+// no per-Organization HelmRelease may carry a floating version.
+func TestOrgTenantHelmReleases_CarryConcreteChartVersion_6169(t *testing.T) {
+	files, err := renderOrganizationOverlay(d31TestRec(), chartValuesOrgPins(t))
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	findings, inspected, err := scanHelmReleaseChartVersions(files)
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	// The scan must have SEEN the releases before its silence means anything.
+	// The overlay emits bp-keycloak, bp-newapi, bp-wordpress-tenant,
+	// bp-openclaw, bp-stalwart-tenant and bp-agenity (orgTenantTemplates).
+	if inspected < 6 {
+		t.Fatalf("only %d HelmReleases parsed out of the rendered overlay (want >= 6) — the render or the decode is broken, so any clean result below would be an artefact of this harness rather than a finding", inspected)
+	}
+	if len(findings) != 0 {
+		var b strings.Builder
+		for _, f := range findings {
+			b.WriteString("\n  " + f.String())
+		}
+		t.Fatalf("%d per-Organization HelmRelease(s) carry a non-concrete chart version even though the chart supplies pins:%s\n\nA floating version resolves to the HIGHEST semver tag on the OCI repo at reconcile time, so an Organization installs whatever was published most recently — which is how a stray bp-agenity IMAGE tag out-ranked the real chart and broke every install (#4922), and why UAT rows 232/234 cited chart versions their deployment never pinned. Fix the missing key in products/catalyst/chart/values.yaml orgTenants.chartVersions and its env entry in products/catalyst/chart/templates/api-deployment.yaml (#6169).", len(findings), b.String())
+	}
+}
+
+// Every pin the chart ships must itself be a concrete SemVer. Catches a
+// values.yaml that supplies a range or a star — which would satisfy "the env
+// is set" while leaving the resolution just as floating as before.
+func TestChartValuesOrgPins_AreConcrete_6169(t *testing.T) {
+	pins := chartValuesOrgPins(t)
+	for _, tc := range []struct{ key, val string }{
+		{"keycloak", pins.Keycloak},
+		{"cnpg", pins.CNPG},
+		{"wordpress", pins.WordPress},
+		{"openclaw", pins.OpenClaw},
+		{"stalwart", pins.Stalwart},
+		{"newapi", pins.NewAPI},
+		{"agenity", pins.Agenity},
+	} {
+		if !concreteVersionRE.MatchString(tc.val) {
+			t.Errorf("orgTenants.chartVersions.%s = %q — a per-Organization chart pin must be an exact SemVer; a range or a star leaves the installed artifact free to change under a Sovereign nobody redeployed (#6169)", tc.key, tc.val)
+		}
+	}
+}
+
+// The exact pin supplied for bp-agenity must stay inside the bounded range the
+// Go fallback declares. If they diverge, the chart and the never-fatal fallback
+// disagree about which minor line is correct and only one of them is right.
+func TestAgenityPin_StaysInsideTheBoundedFallback_6169(t *testing.T) {
+	pins := chartValuesOrgPins(t)
+	if !strings.HasPrefix(pins.Agenity, "0.5.") {
+		t.Fatalf("orgTenants.chartVersions.agenity = %q, which is outside agenityChartConstraint %q (organization_gitops.go:917) — bump the constant in lockstep or the chart pin and the fallback disagree about the bp-agenity minor line (#4922, #6169)", pins.Agenity, agenityChartConstraint)
+	}
+}
+
+// CONTROL — the scanner must not flag a HelmRelease that legitimately carries a
+// version. Without this arm, a scanner that flagged everything would satisfy
+// the vacuity check and the main assertion could never be trusted.
+func TestChartVersionScanner_Table_6169(t *testing.T) {
+	hr := func(version string) string {
+		return `apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bp-openclaw
+spec:
+  chart:
+    spec:
+      chart: bp-openclaw
+      version: ` + version + `
+`
+	}
+	cases := []struct {
+		name    string
+		version string
+		flagged bool
+	}{
+		// CONTROL: a real pin, the shape the fix ships.
+		{"exact semver is accepted", `"0.2.17"`, false},
+		{"exact semver, four-part patch line", `"1.4.153"`, false},
+		{"prerelease pin is accepted", `"0.2.17-rc.1"`, false},
+		// The defect, and its near neighbours — all must be flagged.
+		{"bare star is rejected", `"*"`, true},
+		{"empty is rejected", `""`, true},
+		{"caret range is rejected", `"^0.2.17"`, true},
+		{"tilde range is rejected", `"~0.2.17"`, true},
+		{"bounded range is rejected", `">=0.5.0 <0.6.0"`, true},
+		{"x-wildcard minor is rejected", `"0.2.x"`, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			findings, inspected, err := scanHelmReleaseChartVersions(map[string]string{"bp-openclaw.yaml": hr(tc.version)})
+			if err != nil {
+				t.Fatalf("scan: %v", err)
+			}
+			if inspected != 1 {
+				t.Fatalf("scanner inspected %d HelmReleases, want 1 — the fixture did not parse, so the verdict below means nothing", inspected)
+			}
+			if got := len(findings) > 0; got != tc.flagged {
+				t.Fatalf("version %s: flagged=%v, want %v", tc.version, got, tc.flagged)
+			}
+		})
+	}
+}
+
+// VACUITY — the same scanner, pointed at the PRE-FIX render (an empty
+// OrganizationChartVersions, which is precisely what the shipped chart produced
+// before this change), must report findings. This is the red half of
+// red-then-green kept permanently in the suite: if the scanner ever stops being
+// able to fail, this test goes red and says so.
+func TestOrgTenantHelmReleases_ScannerFailsOnThePreFixShape_6169(t *testing.T) {
+	files, err := renderOrganizationOverlay(d31TestRec(), OrganizationChartVersions{})
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	findings, inspected, err := scanHelmReleaseChartVersions(files)
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if inspected < 6 {
+		t.Fatalf("only %d HelmReleases parsed (want >= 6) — the harness, not the fixture, is what would be failing", inspected)
+	}
+	if len(findings) == 0 {
+		t.Fatalf("the scanner found NO floating version in an overlay rendered with zero configured pins — that is the exact pre-fix state (six of seven CATALYST_ORG_BP_*_VER resolving to `version: \"*\"`), so a scanner that reports it clean cannot detect the defect it exists to catch (#6169)")
+	}
+	// The star specifically, not merely "something non-concrete": the pre-fix
+	// shape is the bare wildcard for the five star-fallback charts, and
+	// agenity's bounded range for the sixth.
+	stars := 0
+	for _, f := range findings {
+		if f.Version == "*" {
+			stars++
+		}
+	}
+	if stars < 5 {
+		t.Fatalf("expected at least 5 bare `*` versions in the unconfigured render (keycloak, newapi, wordpress-tenant, openclaw, stalwart-tenant), got %d across findings %v — withVersionDefaults' star fallback has changed shape and this guard's premise needs re-reading (#6169)", stars, findings)
+	}
+}

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3922,7 +3922,7 @@ name: bp-catalyst-platform
 #   products/catalyst/bootstrap/api/internal/handler/
 #   organization_chart_version_pins_6169_test.go. Chart version bump is the
 #   load-bearing half — the env only reaches a Sovereign through this pin.
-version: 1.4.1411
+version: 1.4.1415
 # 1.4.1229 — #5389: catalog-seed bp-newapi declares its `ui` endpoint
 #   (newapi.<fqdn>, ssoEnabled, launchDefault, ssoInitPath "/") instead of
 #   `endpoints: []`. The empty list made userUIGatePasses fail closed, which
@@ -4077,7 +4077,7 @@ version: 1.4.1411
 # scripts/check-chart-version-forward.sh (#5743) fails unless the two match —
 # main was carrying a pre-existing 1.4.1330/1.4.1329 split, so this bump heals
 # it in the same commit, exactly as the documented self-heal contract does.
-appVersion: 1.4.1411
+appVersion: 1.4.1415
 # 1.4.239 — Wave 3 / Issue #2140 (2026-05-23): Huawei provider
 # implementation lands behind the Wave 2 CloudProvider interface.
 # Adds the OpenTofu module at infra/providers/huawei/ (VPC + Subnet +

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3889,6 +3889,39 @@ name: bp-catalyst-platform
 #   The seed pin is the delivery half: without this bump a pinned Sovereign
 #   resolves 1.5.9 and never sees the fix. This chart's own templates are
 #   unchanged.
+# 1.4.1403 — #6169: every per-Organization application HelmRelease shipped
+#   `version: "*"`. catalyst-api reads seven chart pins from env
+#   (CATALYST_ORG_BP_{KEYCLOAK,CNPG,WORDPRESS,OPENCLAW,STALWART,NEWAPI,
+#   AGENITY}_VER, cmd/api/main.go:996-1002) and a repo-wide grep for those
+#   names across every .yaml/.yml/.tpl/.json matched ZERO times — no shipped
+#   configuration could set any of them, so six of the seven fell through
+#   withVersionDefaults (organization_gitops.go:919) to the floating star and
+#   Flux resolved each release to whatever the OCI repo served newest at
+#   reconcile time. Same read-by-Go / set-by-nothing shape as the console pin
+#   above and as CATALYST_JANITOR_DESTRUCTIVE (UAT row 228). The second
+#   producer had the same hole: the provisioning service's
+#   CATALYST_HR_APP_CHART_VERSIONS also had no setter, so it ran on its
+#   compiled "openclaw=0.2.13,stalwart-mail=0.1.13" — stale against both
+#   shipped charts and missing `newapi` entirely, which therefore rendered a
+#   bare wildcard on every funnel Organization.
+#   Consequences, both live: a chart-side fix reached Organizations by luck
+#   rather than by delivery and inverted on the next publish; and UAT rows
+#   232/234, which cite bp-openclaw@0.2.17 and bp-stalwart-tenant@0.1.15 as
+#   evidence, named versions the deployment never pinned — two walks of the
+#   same row on the same Sovereign could legitimately disagree. bp-agenity is
+#   the proof it bites: it alone fell back to a BOUNDED range because an
+#   unbounded star once resolved a stray 0.9.7 IMAGE manifest over the real
+#   0.5.x chart and the release never installed (#4922).
+#   Fix per Inviolable Principle #4 (a chart version is configuration, not a Go
+#   literal): orgTenants.chartVersions in values.yaml, rendered into both
+#   Deployments, `required` so a blanked pin fails the render instead of
+#   degrading back to the star. Guarded by
+#   tests/e2e/bootstrap-kit/org_bp_chart_version_pins_6169_test.go (env
+#   present, concrete, equal to Chart.yaml AND to the catalog-seed pin, every
+#   HelmRelease-shaped slug covered) and by the render-side scanner in
+#   products/catalyst/bootstrap/api/internal/handler/
+#   organization_chart_version_pins_6169_test.go. Chart version bump is the
+#   load-bearing half — the env only reaches a Sovereign through this pin.
 version: 1.4.1411
 # 1.4.1229 — #5389: catalog-seed bp-newapi declares its `ui` endpoint
 #   (newapi.<fqdn>, ssoEnabled, launchDefault, ssoInitPath "/") instead of

--- a/products/catalyst/chart/templates/api-deployment.yaml
+++ b/products/catalyst/chart/templates/api-deployment.yaml
@@ -1891,6 +1891,47 @@ spec:
             # default). NEVER enable on customer Sovereigns.
             - name: CATALYST_TEST_SESSION_ENABLED
               value: "false"
+            # ─── Per-Organization application chart pins (#6169) ───────────
+            #
+            # These seven names are read by cmd/api/main.go:996-1002 into
+            # OrganizationChartVersions and stamped into every per-Organization
+            # HelmRelease the org-tenant overlay writes
+            # (internal/handler/organization_gitops.go, `version:` at :1108,
+            # :1368, :1619, :1863, :1980, :2121). Until #6169 they had NO
+            # setter anywhere in the repo, so six of the seven fell through
+            # withVersionDefaults() to `version: "*"` and each Organization
+            # installed whatever the OCI repo happened to serve newest at
+            # reconcile time. Same read-by-Go/set-by-nothing shape as the
+            # console pin (#6139) and CATALYST_JANITOR_DESTRUCTIVE (row 228).
+            #
+            # Emitted UNCONDITIONALLY and always with a concrete value. A
+            # conditionally-guarded pin (omit-when-unset, the shape most of the
+            # other optional knobs in this file use) would reintroduce exactly
+            # the failure being fixed: the wildcard is what an absent env MEANS
+            # here, so "absent" and "unpinned" must not be expressible in this
+            # chart at all. `required` makes
+            # a blanked value fail the render rather than degrade silently —
+            # an empty string here reads identically to the three-and-a-half
+            # months of empty that this block exists to end.
+            #
+            # Values come from .Values.orgTenants.chartVersions, which the
+            # bootstrap-kit guard holds equal to each chart's own Chart.yaml
+            # version and to the catalog-seed pin. Operators override per
+            # Sovereign through the usual values path.
+            - name: CATALYST_ORG_BP_KEYCLOAK_VER
+              value: {{ required "orgTenants.chartVersions.keycloak must be a concrete chart version — an empty per-Organization chart pin renders `version: \"*\"` (#6169)" .Values.orgTenants.chartVersions.keycloak | quote }}
+            - name: CATALYST_ORG_BP_CNPG_VER
+              value: {{ required "orgTenants.chartVersions.cnpg must be a concrete chart version — an empty per-Organization chart pin renders `version: \"*\"` (#6169)" .Values.orgTenants.chartVersions.cnpg | quote }}
+            - name: CATALYST_ORG_BP_WORDPRESS_VER
+              value: {{ required "orgTenants.chartVersions.wordpress must be a concrete chart version — an empty per-Organization chart pin renders `version: \"*\"` (#6169)" .Values.orgTenants.chartVersions.wordpress | quote }}
+            - name: CATALYST_ORG_BP_OPENCLAW_VER
+              value: {{ required "orgTenants.chartVersions.openclaw must be a concrete chart version — an empty per-Organization chart pin renders `version: \"*\"` (#6169)" .Values.orgTenants.chartVersions.openclaw | quote }}
+            - name: CATALYST_ORG_BP_STALWART_VER
+              value: {{ required "orgTenants.chartVersions.stalwart must be a concrete chart version — an empty per-Organization chart pin renders `version: \"*\"` (#6169)" .Values.orgTenants.chartVersions.stalwart | quote }}
+            - name: CATALYST_ORG_BP_NEWAPI_VER
+              value: {{ required "orgTenants.chartVersions.newapi must be a concrete chart version — an empty per-Organization chart pin renders `version: \"*\"` (#6169)" .Values.orgTenants.chartVersions.newapi | quote }}
+            - name: CATALYST_ORG_BP_AGENITY_VER
+              value: {{ required "orgTenants.chartVersions.agenity must be a concrete chart version — an empty per-Organization chart pin falls back to the bounded agenityChartConstraint, not to an exact pin (#6169)" .Values.orgTenants.chartVersions.agenity | quote }}
           resources:
             requests:
               cpu: 100m

--- a/products/catalyst/chart/templates/org-services/provisioning.yaml
+++ b/products/catalyst/chart/templates/org-services/provisioning.yaml
@@ -543,6 +543,34 @@ spec:
             # per-Org Flux GitRepository watches `main` of <slug>/catalyst-tenant.
             - name: TENANT_GITOPS_BRANCH
               value: {{ .Values.orgServices.provisioning.perOrgBranch | default "main" | quote }}
+            # ── Per-Organization application chart pins, funnel leg (#6169) ──
+            #
+            # The SECOND producer of per-Organization HelmReleases. The BSS door
+            # writes the org-tenant overlay (catalyst-api, CATALYST_ORG_BP_*_VER
+            # in templates/api-deployment.yaml); this service writes the funnel
+            # cart's per-Org GitOps tree, and its HR templates carry the same
+            # literal `version: "*"`
+            # (core/services/provisioning/gitops/helmrelease_apps.go:315, :451,
+            # :622). pinHRChartVersion(:211) replaces that wildcard ONLY when a
+            # pin is configured, and an empty pin keeps the floating value.
+            #
+            # This name also had zero setters in the repo, so the service ran on
+            # its Go-side default (main.go:192,
+            # "openclaw=0.2.13,stalwart-mail=0.1.13"). That default was wrong in
+            # two ways at once: both pins were four and two patches STALE
+            # against the shipped charts, and `newapi` — the third
+            # HelmRelease-shaped slug (helmrelease_apps.go:58-62, added in
+            # #4739) — was absent from it entirely, so bp-newapi rendered a bare
+            # wildcard on every funnel Organization.
+            #
+            # Wire format is "slug=version,slug=version" (ParseHRAppVersions,
+            # helmrelease_apps.go:672), keyed by CATALOG APP SLUG — not the bp-*
+            # chart name. All three HelmRelease-shaped slugs are listed; adding a
+            # fourth to helmReleaseAppSlugs without adding it here re-opens the
+            # wildcard for that app, which is what the bootstrap-kit guard
+            # asserts against by enumerating that map.
+            - name: CATALYST_HR_APP_CHART_VERSIONS
+              value: "openclaw={{ required "orgTenants.chartVersions.openclaw must be a concrete chart version (#6169)" .Values.orgTenants.chartVersions.openclaw }},stalwart-mail={{ required "orgTenants.chartVersions.stalwart must be a concrete chart version (#6169)" .Values.orgTenants.chartVersions.stalwart }},newapi={{ required "orgTenants.chartVersions.newapi must be a concrete chart version (#6169)" .Values.orgTenants.chartVersions.newapi }}"
           resources:
             requests:
               cpu: 25m

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -1785,6 +1785,71 @@ orgTenants:
     org: openova
     repo: openova
     branch: org-tenants
+  # ─── Per-Organization application chart pins (#6169) ─────────────────
+  #
+  # THE DEFECT THIS BLOCK EXISTS TO CLOSE. catalyst-api reads seven chart
+  # versions from env — CATALYST_ORG_BP_{KEYCLOAK,CNPG,WORDPRESS,OPENCLAW,
+  # STALWART,NEWAPI,AGENITY}_VER (cmd/api/main.go:996-1002) — and a repo-wide
+  # grep for those names across every .yaml/.yml/.tpl/.json matched them ZERO
+  # times. Six of the seven therefore fell through withVersionDefaults()
+  # (internal/handler/organization_gitops.go:919) to the floating `version: "*"`
+  # every per-Organization HelmRelease shipped with. Same shape as the console
+  # pin that had no writer for 3.5 months (#6139) and as
+  # CATALYST_JANITOR_DESTRUCTIVE (UAT row 228): read by Go, set by nothing.
+  #
+  # `*` resolves to the HIGHEST semver tag on the OCI repo at reconcile time,
+  # so an Organization installed whatever happened to be newest that minute.
+  # Two consequences, both live:
+  #   - A chart-side fix reached Organizations by luck, not by delivery, and
+  #     inverted on the next publish.
+  #   - UAT rows 232/234 cite exact chart versions as evidence. Under `*` those
+  #     numbers were not reproducible — two walks of the same row on the same
+  #     Sovereign could legitimately disagree.
+  # bp-agenity is the proof this bites: it alone falls back to a BOUNDED range
+  # rather than `*`, because an unbounded `*` once resolved a stray IMAGE tag
+  # (0.9.7) over the real 0.5.x chart and bp-agenity never installed (#4922).
+  # Only agenity was hardened, and only after it had already fired.
+  #
+  # Per Inviolable Principle #4 (docs/PRINCIPLES.md §4, "Helm chart version
+  # literal in install function → read from values") the version is
+  # CONFIGURATION, so it lives here and is operator-overridable — it is not a
+  # Go constant. Every value below equals that chart's own
+  # `platform/<x>/chart/Chart.yaml` `version:` AND the pin the Sovereign's own
+  # catalog advertises (templates/catalog-seed/blueprints.yaml). All three are
+  # asserted equal by tests/e2e/bootstrap-kit/org_bp_chart_version_pins_6169_test.go,
+  # so this block cannot silently drift behind a chart bump the way a
+  # catalog-seed pin can drift behind check-bootstrap-kit-pin-sync.sh.
+  #
+  # BUMPING ONE OF THESE: bump platform/<x>/chart/Chart.yaml (via
+  # scripts/bump-chart-version.sh), the matching blueprint.yaml spec.version,
+  # the catalog-seed entry, and this key — in the same commit. The guard names
+  # whichever one you missed.
+  chartVersions:
+    # bp-keycloak — the per-Organization Keycloak realm host.
+    keycloak: "1.5.9"
+    # bp-cnpg — currently has NO consumer: the per-Org bp-cnpg operator
+    # HelmRelease was removed in #4920 (organization_gitops.go:1259) because the
+    # per-Org operator hijacked the shared CNPG webhook. main.go still reads
+    # CATALYST_ORG_BP_CNPG_VER into OrganizationChartVersions.CNPG, so the pin
+    # is wired here to be correct-by-construction the moment a template
+    # references it again rather than reintroducing a wildcard at that point.
+    cnpg: "1.0.14"
+    # bp-wordpress-tenant — the SSO-pre-wired per-Organization WordPress.
+    wordpress: "0.4.23"
+    # bp-openclaw — the per-Organization OpenClaw controller. Row 232 cites
+    # this exact version as evidence; under `*` that citation was unreproducible.
+    openclaw: "0.2.17"
+    # bp-stalwart-tenant — per-Organization mail. Rows 232/234 cite this exact
+    # version as evidence.
+    stalwart: "0.1.15"
+    # bp-newapi — openclaw's LLM gateway (#4739).
+    newapi: "1.4.153"
+    # bp-agenity — the per-Organization Agenity workspace (DoD Pillar 4). An
+    # EXACT pin here supersedes agenityChartConstraint (">=0.5.0 <0.6.0"),
+    # which stays in Go as the never-fatal last resort for a catalyst-api
+    # deployed outside this chart. Keep this inside that range, or bump the
+    # constant in lockstep (organization_gitops.go:917 records the same rule).
+    agenity: "0.5.22"
 
 # ─── catalog-sovereign Flux source (#3668 / #4285 leg C) ──────────────
 # The `openova-catalog-sovereign` GitRepository

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -1826,7 +1826,7 @@ orgTenants:
   # whichever one you missed.
   chartVersions:
     # bp-keycloak — the per-Organization Keycloak realm host.
-    keycloak: "1.5.9"
+    keycloak: "1.5.10"
     # bp-cnpg — currently has NO consumer: the per-Org bp-cnpg operator
     # HelmRelease was removed in #4920 (organization_gitops.go:1259) because the
     # per-Org operator hijacked the shared CNPG webhook. main.go still reads

--- a/tests/e2e/bootstrap-kit/org_bp_chart_version_pins_6169_test.go
+++ b/tests/e2e/bootstrap-kit/org_bp_chart_version_pins_6169_test.go
@@ -1,0 +1,357 @@
+package bootstrapkit
+
+// org_bp_chart_version_pins_6169_test.go — Refs #6169.
+//
+// THE DEFECT. catalyst-api reads seven per-Organization chart versions from env
+// — CATALYST_ORG_BP_{KEYCLOAK,CNPG,WORDPRESS,OPENCLAW,STALWART,NEWAPI,AGENITY}_VER,
+// at products/catalyst/bootstrap/api/cmd/api/main.go:996-1002 — and a repo-wide
+// grep for those names across every .yaml/.yml/.tpl/.json matched them ZERO
+// times. No configuration the platform shipped could set any of them, so six of
+// the seven fell through withVersionDefaults (internal/handler/
+// organization_gitops.go:919) to `version: "*"` and every per-Organization
+// HelmRelease resolved to whatever the OCI repo served newest at reconcile time.
+//
+// The provisioning service — the SECOND producer, writing the funnel cart's
+// per-Org tree — had the same hole under a different name:
+// CATALYST_HR_APP_CHART_VERSIONS (core/services/provisioning/main.go:191) also
+// had zero setters, so it ran on its compiled default
+// "openclaw=0.2.13,stalwart-mail=0.1.13" — both pins stale against the shipped
+// charts, and `newapi` (the third HelmRelease-shaped slug) absent entirely, so
+// bp-newapi rendered a bare wildcard on every funnel Organization.
+//
+// WHY THIS GUARD IS NARROW. It does NOT assert the general "every CATALYST_*
+// var Go reads must have a YAML setter". 47 of the 108 such vars are
+// legitimately-optional override knobs with deliberate Go-side defaults
+// (CATALYST_PIN_ECHO, CATALYST_PREFLIGHT_DISABLE, …); a blunt guard would fire
+// on all 47 and be reverted, which is recorded on #6169 precisely so nobody
+// writes it. The subject here is one narrow property with a live failure mode:
+// a chart VERSION CONSTRAINT that silently degrades to a wildcard.
+//
+// WHAT IT PINS
+//
+//  1. All seven names reach the rendered catalyst-api Pod — the literal absence.
+//  2. Each carries a CONCRETE SemVer. "Set" is not the property that matters;
+//     an env set to "*" would satisfy assertion 1 and change nothing.
+//  3. Each equals BOTH that chart's own platform|products/<x>/chart/Chart.yaml
+//     `version:` AND the pin the Sovereign's catalog advertises
+//     (templates/catalog-seed/blueprints.yaml). Asserting against Chart.yaml is
+//     what stops this from passing green over a stale seed — the trap
+//     check-bootstrap-kit-pin-sync.sh leaves open, since it compares the
+//     bootstrap-kit slot to Chart.yaml and never looks at the seed.
+//  4. CATALYST_HR_APP_CHART_VERSIONS reaches the provisioning Pod and covers
+//     EVERY slug in helmReleaseAppSlugs — enumerated out of the Go source, so
+//     adding a fourth HelmRelease-shaped app without a pin fails here rather
+//     than shipping a wildcard.
+//
+// CONTROL. Every assertion runs against a render that also carries 150+ other
+// CATALYST_* entries; the count is asserted first, so an absence below is a
+// finding and not an empty parse. The version predicate is unit-tested
+// separately in the producer's own package
+// (products/catalyst/bootstrap/api/internal/handler/
+// organization_chart_version_pins_6169_test.go) against a HelmRelease that
+// legitimately carries a version — it must NOT be flagged.
+//
+// VACUITY. TestOrgBPChartVersionPins_CannotBeBlanked_6169 blanks one pin and
+// requires the render to FAIL. That proves both that the guard's subject can
+// fail and that the chart refuses to express "unpinned" at all — an empty
+// value here reads identically to the state this change ends.
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// orgBPChartPin ties one env var to the chart it pins and to that chart's
+// source-tree location, so a failure names the file to edit rather than the
+// symptom.
+type orgBPChartPin struct {
+	Env       string // env var read by catalyst-api
+	Chart     string // bp-* chart name, as it appears in the catalog seed
+	ChartYAML string // repo-relative path to the chart's own Chart.yaml
+}
+
+var orgBPChartPins = []orgBPChartPin{
+	{"CATALYST_ORG_BP_KEYCLOAK_VER", "bp-keycloak", "platform/keycloak/chart/Chart.yaml"},
+	{"CATALYST_ORG_BP_CNPG_VER", "bp-cnpg", "platform/cnpg/chart/Chart.yaml"},
+	{"CATALYST_ORG_BP_WORDPRESS_VER", "bp-wordpress-tenant", "platform/wordpress-tenant/chart/Chart.yaml"},
+	{"CATALYST_ORG_BP_OPENCLAW_VER", "bp-openclaw", "platform/openclaw/chart/Chart.yaml"},
+	{"CATALYST_ORG_BP_STALWART_VER", "bp-stalwart-tenant", "platform/stalwart-tenant/chart/Chart.yaml"},
+	{"CATALYST_ORG_BP_NEWAPI_VER", "bp-newapi", "platform/newapi/chart/Chart.yaml"},
+	{"CATALYST_ORG_BP_AGENITY_VER", "bp-agenity", "products/agenity/chart/Chart.yaml"},
+}
+
+// hrAppSlugChart maps each HelmRelease-shaped CATALOG APP SLUG (the key format
+// CATALYST_HR_APP_CHART_VERSIONS uses) to its bp-* chart. The slug set itself is
+// read from the Go source at test time — this map only supplies the slug→chart
+// correspondence, which has no machine-readable declaration.
+var hrAppSlugChart = map[string]string{
+	"openclaw":      "bp-openclaw",
+	"stalwart-mail": "bp-stalwart-tenant",
+	"newapi":        "bp-newapi",
+}
+
+var concreteChartVersionRE = regexp.MustCompile(`^\d+\.\d+\.\d+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$`)
+
+// chartYAMLVersion reads the `version:` field of a chart's own Chart.yaml.
+func chartYAMLVersion(t *testing.T, root, rel string) string {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join(root, rel))
+	if err != nil {
+		t.Fatalf("read %s: %v", rel, err)
+	}
+	re := regexp.MustCompile(`(?m)^version:\s*"?([^"\s#]+)"?`)
+	m := re.FindSubmatch(raw)
+	if m == nil {
+		t.Fatalf("%s has no top-level `version:` field — this guard's premise (Chart.yaml is the authoritative chart version) no longer holds", rel)
+	}
+	return string(m[1])
+}
+
+// catalogSeedPinsByChart reuses main_test.go's catalog-seed parser and keys it
+// by chart name — the version the Sovereign's own catalog advertises for each
+// bp-*. Reusing that parser rather than adding a second one keeps this guard
+// and TestCatalogSeed_DeliveryPinsNotBehindComponentCharts reading the seed the
+// same way; two parsers that disagree about what a pin IS would let a drift slip
+// between them.
+func catalogSeedPinsByChart(t *testing.T, root string) map[string]string {
+	t.Helper()
+	pins := catalogSeedPins(t, root)
+	if len(pins) < 40 {
+		t.Fatalf("parsed only %d catalog-seed source blocks — the parser is broken, so any comparison below would be an artefact of this harness rather than a finding", len(pins))
+	}
+	out := map[string]string{}
+	for _, p := range pins {
+		out[p.chart] = p.version
+	}
+	return out
+}
+
+// renderChartTemplate renders one template of products/catalyst/chart and
+// returns its YAML. Extra --set args may be appended.
+func renderChartTemplate(t *testing.T, root, tmpl string, sets ...string) string {
+	t.Helper()
+	helmBin := os.Getenv("HELM_BIN")
+	if helmBin == "" {
+		helmBin = "helm"
+	}
+	if _, err := exec.LookPath(helmBin); err != nil {
+		t.Skipf("helm not on PATH (%v)", err)
+	}
+	args := []string{"template", "catalyst", "."}
+	for _, s := range sets {
+		args = append(args, "--set", s)
+	}
+	args = append(args, "-s", tmpl)
+	cmd := exec.Command(helmBin, args...)
+	cmd.Dir = filepath.Join(root, "products", "catalyst", "chart")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("helm template %s failed: %v\n%s", tmpl, err, out)
+	}
+	return string(out)
+}
+
+// helmReleaseAppSlugsFromSource reads the HelmRelease-shaped app slugs straight
+// out of core/services/provisioning/gitops/helmrelease_apps.go. Reading the
+// producer rather than restating its contents is what makes a FOURTH such app
+// fail this guard instead of quietly shipping a wildcard.
+func helmReleaseAppSlugsFromSource(t *testing.T, root string) []string {
+	t.Helper()
+	path := filepath.Join(root, "core", "services", "provisioning", "gitops", "helmrelease_apps.go")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	block := regexp.MustCompile(`(?s)var helmReleaseAppSlugs = map\[string\]bool\{(.*?)\n\}`).FindSubmatch(raw)
+	if block == nil {
+		t.Fatalf("could not locate `var helmReleaseAppSlugs = map[string]bool{` in %s — the enumeration this guard reads has been renamed or reshaped, so it can no longer see a newly added HelmRelease-shaped app", path)
+	}
+	entries := regexp.MustCompile(`"([^"]+)":\s*true`).FindAllSubmatch(block[1], -1)
+	if len(entries) == 0 {
+		t.Fatalf("helmReleaseAppSlugs parsed to zero slugs — the scan is blind, not the map empty")
+	}
+	out := make([]string, 0, len(entries))
+	for _, e := range entries {
+		out = append(out, string(e[1]))
+	}
+	sort.Strings(out)
+	return out
+}
+
+// ── 1-3: the catalyst-api leg ────────────────────────────────────────────────
+
+func TestOrgBPChartVersionPins_ReachThePod_AndAreConcrete_6169(t *testing.T) {
+	root := repoRoot(t)
+
+	env, err := renderCatalystAPI(t, root)
+	if err != nil {
+		t.Fatalf("default render failed: %v", err)
+	}
+
+	// CONTROL FIRST — the env block is large and full of CATALYST_ names. If the
+	// lookups below find nothing it must be because THESE names are absent, not
+	// because the render or the parse came up empty.
+	catalystCount := 0
+	for name := range env {
+		if strings.HasPrefix(name, "CATALYST_") {
+			catalystCount++
+		}
+	}
+	if catalystCount < 50 {
+		t.Fatalf("only %d CATALYST_* env entries parsed out of the rendered Pod — the render/parse is broken, so any absence below would be an artefact of this harness rather than a finding", catalystCount)
+	}
+
+	seed := catalogSeedPinsByChart(t, root)
+
+	for _, pin := range orgBPChartPins {
+		got, ok := env[pin.Env]
+		if !ok {
+			t.Errorf("%s is absent from the rendered catalyst-api Pod (%d CATALYST_* entries present, so the scan is not blind) — main.go reads it into OrganizationChartVersions and no shipped configuration can set it, so every per-Organization %s HelmRelease resolves `version: \"*\"` and installs whatever the OCI repo serves newest at reconcile time (#6169)", pin.Env, catalystCount, pin.Chart)
+			continue
+		}
+		if !concreteChartVersionRE.MatchString(got) {
+			t.Errorf("%s renders %q — a per-Organization chart pin must be an exact SemVer. A star, a range or an empty value leaves the installed artifact free to change under a Sovereign nobody redeployed, which is the property that made UAT rows 232/234 cite chart versions their deployment never pinned (#6169)", pin.Env, got)
+			continue
+		}
+		if want := chartYAMLVersion(t, root, pin.ChartYAML); got != want {
+			t.Errorf("%s renders %q but %s declares version %s — the per-Organization pin has drifted behind the chart it pins. Bump orgTenants.chartVersions in products/catalyst/chart/values.yaml in the same commit as the chart (#6169)", pin.Env, got, pin.ChartYAML, want)
+		}
+		// The catalog advertises a version to the customer; the deployment
+		// installs one. When those differ, a walk's evidence cites a version the
+		// Organization never received — the measurement half of #6169.
+		if want, ok := seed[pin.Chart]; ok && got != want {
+			t.Errorf("%s renders %q but the Sovereign's own catalog seed advertises %s@%s — the version a customer is shown and the version their Organization installs must be the same one, or UAT evidence naming a chart version is unreproducible (#6169)", pin.Env, got, pin.Chart, want)
+		} else if !ok {
+			t.Errorf("catalog seed carries no source.version for %s, yet %s pins it — one of the two enumerations is wrong (#6169)", pin.Chart, pin.Env)
+		}
+	}
+}
+
+// ── 4: the provisioning (funnel) leg ─────────────────────────────────────────
+
+func TestHelmReleaseAppChartVersions_ReachProvisioning_AndCoverEverySlug_6169(t *testing.T) {
+	root := repoRoot(t)
+
+	// The provisioning Deployment renders only when the marketplace ingress is
+	// on — that is the Sovereign shape where funnel Organizations exist at all.
+	out := renderChartTemplate(t, root, "templates/org-services/provisioning.yaml", "ingress.marketplace.enabled=true")
+
+	re := regexp.MustCompile(`(?m)^\s*-\s*name:\s*CATALYST_HR_APP_CHART_VERSIONS\s*\n\s*value:\s*"?([^"\n]*)"?`)
+	m := re.FindStringSubmatch(out)
+	if m == nil {
+		t.Fatalf("CATALYST_HR_APP_CHART_VERSIONS is absent from the rendered provisioning Pod — core/services/provisioning/main.go:191 reads it, nothing sets it, and the compiled fallback (\"openclaw=0.2.13,stalwart-mail=0.1.13\") is both stale and missing newapi, so bp-newapi ships `version: \"*\"` on every funnel Organization (#6169)")
+	}
+
+	// CONTROL that the render is not empty: the provisioning Pod carries the
+	// TENANT_GITOPS_* block alongside this one.
+	if !strings.Contains(out, "TENANT_GITOPS_PER_ORG") {
+		t.Fatalf("the rendered provisioning template carries no TENANT_GITOPS_PER_ORG — the render is not the provisioning Deployment, so the finding above is about the wrong object")
+	}
+
+	pins := map[string]string{}
+	for _, kv := range strings.Split(strings.TrimSpace(m[1]), ",") {
+		k, v, ok := strings.Cut(strings.TrimSpace(kv), "=")
+		if ok {
+			pins[strings.TrimSpace(k)] = strings.TrimSpace(v)
+		}
+	}
+
+	for _, slug := range helmReleaseAppSlugsFromSource(t, root) {
+		got, ok := pins[slug]
+		if !ok {
+			t.Errorf("CATALYST_HR_APP_CHART_VERSIONS has no entry for HelmRelease-shaped app %q (rendered value: %q) — an unpinned slug renders the template's literal `version: \"*\"` because pinHRChartVersion only substitutes when a pin is configured (helmrelease_apps.go:211). Add it to the env in products/catalyst/chart/templates/org-services/provisioning.yaml (#6169)", slug, m[1])
+			continue
+		}
+		if !concreteChartVersionRE.MatchString(got) {
+			t.Errorf("CATALYST_HR_APP_CHART_VERSIONS pins %s=%q — must be an exact SemVer (#6169)", slug, got)
+			continue
+		}
+		chart, known := hrAppSlugChart[slug]
+		if !known {
+			t.Errorf("HelmRelease-shaped app %q has no chart mapping in this guard — add it to hrAppSlugChart so its pin can be compared against the chart it installs (#6169)", slug)
+			continue
+		}
+		for _, pin := range orgBPChartPins {
+			if pin.Chart != chart {
+				continue
+			}
+			if want := chartYAMLVersion(t, root, pin.ChartYAML); got != want {
+				t.Errorf("CATALYST_HR_APP_CHART_VERSIONS pins %s=%s but %s declares version %s — the funnel leg installs a different chart version than the one the repo ships (#6169)", slug, got, pin.ChartYAML, want)
+			}
+		}
+	}
+}
+
+// The two producers must agree. A funnel Organization and a BSS-door
+// Organization on the SAME Sovereign receiving different versions of the same
+// chart is the shape that makes one walk's evidence contradict another's.
+func TestBothProducers_PinTheSameVersions_6169(t *testing.T) {
+	root := repoRoot(t)
+
+	env, err := renderCatalystAPI(t, root)
+	if err != nil {
+		t.Fatalf("default render failed: %v", err)
+	}
+	out := renderChartTemplate(t, root, "templates/org-services/provisioning.yaml", "ingress.marketplace.enabled=true")
+	re := regexp.MustCompile(`(?m)^\s*-\s*name:\s*CATALYST_HR_APP_CHART_VERSIONS\s*\n\s*value:\s*"?([^"\n]*)"?`)
+	m := re.FindStringSubmatch(out)
+	if m == nil {
+		t.Fatalf("CATALYST_HR_APP_CHART_VERSIONS absent — see TestHelmReleaseAppChartVersions_ReachProvisioning_AndCoverEverySlug_6169")
+	}
+	funnel := map[string]string{}
+	for _, kv := range strings.Split(strings.TrimSpace(m[1]), ",") {
+		k, v, ok := strings.Cut(strings.TrimSpace(kv), "=")
+		if ok {
+			funnel[strings.TrimSpace(k)] = strings.TrimSpace(v)
+		}
+	}
+
+	for slug, chart := range hrAppSlugChart {
+		for _, pin := range orgBPChartPins {
+			if pin.Chart != chart {
+				continue
+			}
+			door, ok := env[pin.Env]
+			if !ok {
+				continue // reported by the first test
+			}
+			if funnel[slug] != door {
+				t.Errorf("%s: the funnel leg pins %q and the BSS-door leg pins %q — two Organizations on the same Sovereign would receive different versions of the same chart (#6169)", chart, funnel[slug], door)
+			}
+		}
+	}
+}
+
+// VACUITY — blanking a pin must FAIL the render. Two things are proven at once:
+// this guard's subject can fail, and the chart cannot express "unpinned", which
+// is the state that produced `version: "*"` for the entire life of the feature.
+func TestOrgBPChartVersionPins_CannotBeBlanked_6169(t *testing.T) {
+	root := repoRoot(t)
+	helmBin := os.Getenv("HELM_BIN")
+	if helmBin == "" {
+		helmBin = "helm"
+	}
+	if _, err := exec.LookPath(helmBin); err != nil {
+		t.Skipf("helm not on PATH (%v)", err)
+	}
+	for _, key := range []string{"keycloak", "cnpg", "wordpress", "openclaw", "stalwart", "newapi", "agenity"} {
+		t.Run(key, func(t *testing.T) {
+			cmd := exec.Command(helmBin, "template", "catalyst", ".",
+				"--set", "orgTenants.chartVersions."+key+"=",
+				"-s", "templates/api-deployment.yaml")
+			cmd.Dir = filepath.Join(root, "products", "catalyst", "chart")
+			out, err := cmd.CombinedOutput()
+			if err == nil {
+				t.Fatalf("blanking orgTenants.chartVersions.%s rendered successfully — an empty per-Organization chart pin must fail the render, not degrade to the floating `version: \"*\"` that #6169 exists to end. Rendered output:\n%s", key, out)
+			}
+			if !strings.Contains(string(out), "concrete chart version") {
+				t.Fatalf("blanking orgTenants.chartVersions.%s failed the render, but not with the `required` message this guard is asserting — the failure may be unrelated:\n%s", key, out)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## The defect

Every per-Organization application HelmRelease shipped `version: "*"`.

catalyst-api reads seven per-Organization chart versions from env —
`CATALYST_ORG_BP_{KEYCLOAK,CNPG,WORDPRESS,OPENCLAW,STALWART,NEWAPI,AGENITY}_VER`,
at `products/catalyst/bootstrap/api/cmd/api/main.go:996-1002` — and a repo-wide grep for
those names across every `.yaml/.yml/.tpl/.json` matched **zero** times. No configuration the
platform ships could set any of them, so six of the seven fell through `withVersionDefaults`
(`internal/handler/organization_gitops.go:919`) to the floating star, and `pinHRChartVersion`
(`core/services/provisioning/gitops/helmrelease_apps.go:216`) substitutes only when a pin is
configured. Same read-by-Go / set-by-nothing shape as the console pin (#6139) and as
`CATALYST_JANITOR_DESTRUCTIVE` (UAT row 228).

**The second producer had the same hole under a different name.** The provisioning service's
`CATALYST_HR_APP_CHART_VERSIONS` (`core/services/provisioning/main.go:191`) also had no
setter, so the funnel leg ran on its compiled default `"openclaw=0.2.13,stalwart-mail=0.1.13"` —
both pins stale against the shipped charts (0.2.17 / 0.1.15), and `newapi`, the third
HelmRelease-shaped slug (`helmrelease_apps.go:58-62`, added in #4739), absent entirely, so
`bp-newapi` rendered a bare wildcard on every funnel Organization.

### Verified state of the seven, on `origin/main`

| env var | chart | resolved before | resolved now |
|---|---|---|---|
| `CATALYST_ORG_BP_KEYCLOAK_VER` | `bp-keycloak` | `*` | `1.5.9` |
| `CATALYST_ORG_BP_CNPG_VER` | `bp-cnpg` | `*` (field is read but no template consumes it — the per-Org bp-cnpg HelmRelease was removed in #4920) | `1.0.14` |
| `CATALYST_ORG_BP_WORDPRESS_VER` | `bp-wordpress-tenant` | `*` | `0.4.23` |
| `CATALYST_ORG_BP_OPENCLAW_VER` | `bp-openclaw` | `*` | `0.2.17` |
| `CATALYST_ORG_BP_STALWART_VER` | `bp-stalwart-tenant` | `*` | `0.1.15` |
| `CATALYST_ORG_BP_NEWAPI_VER` | `bp-newapi` | `*` | `1.4.153` |
| `CATALYST_ORG_BP_AGENITY_VER` | `bp-agenity` | `>=0.5.0 <0.6.0` (bounded, not a star) | `0.5.22` |

### Why it matters

A star resolves to the **highest semver tag** on the OCI repo at reconcile time.

- A chart-side fix reached Organizations because the wildcard floated to it, not because
  anything pinned it. That inverts on the next publish.
- **Rows 232 and 234 cite `bp-openclaw@0.2.17` and `bp-stalwart-tenant@0.1.15` as evidence.**
  Under a floating star the deployment never pinned those numbers, so two walks of the same
  row on the same Sovereign could legitimately disagree.
- `bp-agenity` is the proof this bites. It alone fell back to a bounded range rather than a
  star, because an unbounded star once resolved a stray `0.9.7` **image** manifest over the
  real `0.5.x` chart and the release never installed at all (#4922,
  `organization_gitops.go:81-88`). Only agenity was hardened, and only after it had already
  fired. The other six carried the identical exposure.

## Every path a version could arrive by — all checked

| path | verdict |
|---|---|
| `products/catalyst/chart/values.yaml` | no key existed |
| `products/catalyst/chart/templates/api-deployment.yaml` (166 `CATALYST_*` entries) | none of the seven |
| `products/catalyst/chart/templates/org-services/provisioning.yaml` | no `CATALYST_HR_APP_CHART_VERSIONS` |
| bootstrap-kit slot 13 (`clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml`) | only touches `orgTenants.gitRepository.secretRef.reflectNamespaces` |
| catalog seed (`templates/catalog-seed/blueprints.yaml`) | carries correct pins for all seven, but **nothing reads them into the generator** |
| Blueprint CR `spec.source.version` | same data as the seed; the overlay generator never consults it |
| the provisioner's env / substitute map | `CATALYST_HR_APP_CHART_VERSIONS` — also unset, Go default stale |
| any `.tf` / `.tftpl` / `.sh` / `.env` | zero hits |

## The decision, and why

**The chart becomes the writer** — not a Go constant, and not a render-time abort.

- **Inviolable Principle #4** (`docs/PRINCIPLES.md:68-78`) names this exact case in its table:
  *"Helm chart version `1.16.5` literal in install function → read from `chart/values.yaml`"*.
  A compiled-in Go default map would have been the smallest diff and is what
  `core/services/provisioning/main.go:192` already does — and it is precisely the pattern the
  principle forbids. It is also how that default went four patch versions stale unnoticed.
- **Fail-loud-at-render was considered and rejected on evidence.** It converts a wrong-version
  risk into a certain, customer-facing Organization-create failure during any chart/image skew
  window — the window in which a fresh prov is most fragile. The repo's own design intent is
  recorded at `helmrelease_apps.go:206-208` (*"the pin is a hardening, not a new hard
  dependency"*), and `organization_provisioning_test.go:873` pins the star fallback as an
  intentional contract. What actually failed in #6139 and row 228 was the **absence of a
  guard**, not the presence of a soft default, so the durable fix is the guard.
- **Deriving from the Blueprint CR** would make the overlay generator depend on a live cluster
  read for a value that is static per release. The catalog seed is the same data, already in
  this chart, and is now asserted equal to the pins.
- **No wildcard is genuinely intended anywhere.** The two tests that assert `version: "*"`
  (`organization_provisioning_test.go:873`, `helmrelease_apps_test.go:357`) pin the *fallback
  contract* for a catalyst-api deployed outside this chart — not an intent to ship a star.
  That fallback is left untouched and both tests stay green; the star simply no longer occurs
  in any configuration the platform ships.

So: `orgTenants.chartVersions` in `values.yaml`, rendered into **both** Deployments, with
`required` on every pin so a blanked value **fails the render** instead of degrading back to
the star. Absent and unpinned must not be expressible in this chart.

### Deliberately NOT the generic guard

A blunt *"every env var read by Go must have a YAML setter"* check would be wrong: **47 of the
108 `CATALYST_*` vars are legitimately-optional override knobs** with deliberate Go-side
defaults (`CATALYST_PIN_ECHO`, `CATALYST_PREFLIGHT_DISABLE`, …). That measurement is recorded
on #6169 specifically so nobody writes that guard and then reverts it. The guard here targets
one narrow property with a live failure mode: **a version constraint that silently degrades to
a wildcard.**

## The guards

`tests/e2e/bootstrap-kit/org_bp_chart_version_pins_6169_test.go` — the delivery side:

1. all seven names reach the rendered catalyst-api Pod;
2. each carries a **concrete** SemVer (set-to-`*` would satisfy "present" and change nothing);
3. each equals **both** its own `platform|products/<x>/chart/Chart.yaml` `version:` **and** the
   pin the Sovereign's catalog seed advertises. Asserting against `Chart.yaml` is what stops
   this passing green over a stale seed — `check-bootstrap-kit-pin-sync.sh` compares the slot
   to `Chart.yaml` and never looks at the seed;
4. `CATALYST_HR_APP_CHART_VERSIONS` reaches the provisioning Pod and covers **every** slug in
   `helmReleaseAppSlugs`, enumerated out of the Go source so a fourth HelmRelease-shaped app
   fails here rather than shipping a wildcard;
5. the two producers pin the same versions — a funnel Org and a BSS-door Org on one Sovereign
   receiving different versions of the same chart is how one walk's evidence contradicts
   another's.

`products/catalyst/bootstrap/api/internal/handler/organization_chart_version_pins_6169_test.go`
— the render side: no per-Organization HelmRelease may carry a non-concrete chart version when
the chart's own pins are supplied.

### RED before, GREEN after — verbatim

**Before** (`origin/main` chart files restored over this branch's tests):

```
--- FAIL: TestOrgBPChartVersionPins_ReachThePod_AndAreConcrete_6169 (0.14s)
    org_bp_chart_version_pins_6169_test.go:214: CATALYST_ORG_BP_KEYCLOAK_VER is absent from the rendered catalyst-api Pod (76 CATALYST_* entries present, so the scan is not blind) — main.go reads it into OrganizationChartVersions and no shipped configuration can set it, so every per-Organization bp-keycloak HelmRelease resolves `version: "*"` and installs whatever the OCI repo serves newest at reconcile time (#6169)
    ... identical findings for CNPG, WORDPRESS, OPENCLAW, STALWART, NEWAPI, AGENITY
--- FAIL: TestHelmReleaseAppChartVersions_ReachProvisioning_AndCoverEverySlug_6169 (0.16s)
    org_bp_chart_version_pins_6169_test.go:247: CATALYST_HR_APP_CHART_VERSIONS is absent from the rendered provisioning Pod — core/services/provisioning/main.go:191 reads it, nothing sets it, and the compiled fallback ("openclaw=0.2.13,stalwart-mail=0.1.13") is both stale and missing newapi, so bp-newapi ships `version: "*"` on every funnel Organization (#6169)
--- FAIL: TestBothProducers_PinTheSameVersions_6169 (0.31s)
--- FAIL: TestOrgBPChartVersionPins_CannotBeBlanked_6169 (0.98s)
    --- FAIL: TestOrgBPChartVersionPins_CannotBeBlanked_6169/keycloak (0.13s)
        org_bp_chart_version_pins_6169_test.go:350: blanking orgTenants.chartVersions.keycloak rendered successfully — an empty per-Organization chart pin must fail the render, not degrade to the floating `version: "*"` that #6169 exists to end.
```

```
--- FAIL: TestOrgTenantHelmReleases_CarryConcreteChartVersion_6169 (0.00s)
    organization_chart_version_pins_6169_test.go:219: products/catalyst/chart/values.yaml carries no orgTenants.chartVersions block — the per-Organization chart pins have no writer, so every per-Organization HelmRelease resolves `version: "*"` at reconcile time (#6169)
--- FAIL: TestChartValuesOrgPins_AreConcrete_6169 (0.00s)
--- FAIL: TestAgenityPin_StaysInsideTheBoundedFallback_6169 (0.00s)
```

**After** (`-count=1`):

```
--- PASS: TestOrgBPChartVersionPins_ReachThePod_AndAreConcrete_6169 (0.14s)
--- PASS: TestHelmReleaseAppChartVersions_ReachProvisioning_AndCoverEverySlug_6169 (0.16s)
--- PASS: TestBothProducers_PinTheSameVersions_6169 (0.32s)
--- PASS: TestOrgBPChartVersionPins_CannotBeBlanked_6169 (0.41s)
    --- PASS: .../keycloak .../cnpg .../wordpress .../openclaw .../stalwart .../newapi .../agenity
ok  	github.com/openova-io/openova/tests/e2e/bootstrap-kit	1.030s
```

```
--- PASS: TestOrgTenantHelmReleases_CarryConcreteChartVersion_6169 (0.01s)
--- PASS: TestChartValuesOrgPins_AreConcrete_6169 (0.00s)
--- PASS: TestAgenityPin_StaysInsideTheBoundedFallback_6169 (0.00s)
--- PASS: TestChartVersionScanner_Table_6169 (0.00s)
--- PASS: TestOrgTenantHelmReleases_ScannerFailsOnThePreFixShape_6169 (0.01s)
ok  	github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/handler	0.045s
```

### CONTROL

`TestChartVersionScanner_Table_6169` runs the version predicate against a HelmRelease that
**legitimately carries a version** — `"0.2.17"`, `"1.4.153"`, `"0.2.17-rc.1"` — and requires
**no** finding, alongside the shapes that must be flagged (`"*"`, `""`, `"^0.2.17"`,
`"~0.2.17"`, `">=0.5.0 <0.6.0"`, `"0.2.x"`). Without this arm a scanner that flagged every
HelmRelease would satisfy the vacuity check and the main assertion would be worthless. This
control **passed in the RED run too** — it is independent of the fix, which is the point.

`TestOrgBPChartVersionPins_ReachThePod_AndAreConcrete_6169` also asserts ≥50 `CATALYST_*`
entries parsed before looking for the seven, so an absence is a finding and not an empty
render — the same control the row-228 guard uses. The provisioning arm asserts
`TENANT_GITOPS_PER_ORG` is present in the render it inspects, so it cannot report against the
wrong object.

### VACUITY

Two independent arms, both permanent:

- `TestOrgTenantHelmReleases_ScannerFailsOnThePreFixShape_6169` points the same scanner at an
  overlay rendered with an **empty** `OrganizationChartVersions` — exactly what the chart
  produced before this change — and **requires** at least five bare `*` findings. If the
  scanner ever stops being able to fail, this goes red and says so. It **passed in the RED
  run**, proving the scanner detects the defect independently of the chart edit.
- `TestOrgBPChartVersionPins_CannotBeBlanked_6169` blanks each of the seven values keys in turn
  and requires the helm render to **fail** with the `required` message. On `origin/main` the
  same blanking rendered successfully — which is the defect stated as a test.

## Rows 232 and 234

Yes — both become reproducible. `bp-openclaw` and `bp-stalwart-tenant`, the two charts those
rows cite, now render `0.2.17` and `0.1.15` as exact pins on **both** producers, and the guard
holds those equal to the charts' own `Chart.yaml` and to what the Sovereign's catalog
advertises. A walker reading a chart version off a live HelmRelease is now reading a number the
deployment actually pinned, so two walks of the same row on the same Sovereign cannot disagree.

The rest of each row is unchanged by this PR: row 232's plan-"s" arithmetic (the app set still
exceeds `CPU: "2"` at `core/controllers/organization/internal/gitops/manifests.go:121`) and row
234's storefront-bundle gap remain separate checklist items on #6169.

## Delivery

Chart re-serialized to `1.4.1403` via `scripts/bump-chart-version.sh` (main baseline `1.4.1401`,
ceiling `1.4.1402` held by open PR #6167) with the slot-13 bootstrap-kit pin in lockstep. The
env only reaches a Sovereign through that pin, so the chart bump is the load-bearing half.

Gates run locally: `helm lint` clean, `scripts/check-bootstrap-kit-pin-sync.sh` PASS (67 pairs),
`scripts/check-no-banned-words.sh` OK, full `products/catalyst/bootstrap/api` module suite green,
`tests/e2e/bootstrap-kit` green, `core/services/provisioning/gitops` green.

## Incidental finding, not touched here

`products/catalyst/chart/values.yaml` carries **two** top-level `migrations:` keys (`:2894` and
`:2908`) with identical content — a deliberate, comment-documented duplicate where the last
wins under Helm. It makes the file unparseable by a strict YAML map decoder; this PR's test
navigates the document as nodes rather than taking a position on an unrelated key.

## 🛑 DO NOT MERGE

hw294 is mid-provision and wedged on #6172. This PR is opened for review and CI only.

Refs #6169
Refs #6114

🤖 Generated with [Claude Code](https://claude.com/claude-code)
