### PR TITLE
fix(catalyst-api): showback billed an Organization the control plane does not hold — and dropped ones it does

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/fleet_treemap.go
+++ b/products/catalyst/bootstrap/api/internal/handler/fleet_treemap.go
@@ -443,7 +443,8 @@ func (h *Handler) collectFleetOrgItems(ctx context.Context) []fleetTreemapItem {
 		if parentOrg == "" {
 			parentOrg = "sovereign"
 		}
-		items = append(items, fleetOrgItemsForSovereign(rows, parentOrg, infraNamespaces)...)
+		items = append(items, fleetOrgItemsForSovereign(rows, parentOrg, infraNamespaces,
+			h.knownOrganizationSlugs(clusterID))...)
 	}
 	return items
 }
@@ -459,7 +460,13 @@ func (h *Handler) collectFleetOrgItems(ctx context.Context) []fleetTreemapItem {
 // size_value) instead of the showback wire shape. SizeValue reuses the
 // showback cost-unit weights (CPU+memory+storage requests) so cell area
 // reflects live resource footprint, never a billing $ figure.
-func fleetOrgItemsForSovereign(rows []podRow, parentOrg string, infraNamespaces map[string]struct{}) []fleetTreemapItem {
+// knownOrgs is threaded through for the same reason the resolver is
+// shared: #6114 made orgForRow check the label against the Organization CR
+// set, and a treemap that kept the old two-argument call would render an
+// Organization cell for a slug showback has stopped attributing — the two
+// surfaces drifting is precisely what sharing the resolver exists to
+// prevent, and it is one of the four disagreements UAT row 25 names.
+func fleetOrgItemsForSovereign(rows []podRow, parentOrg string, infraNamespaces map[string]struct{}, knownOrgs map[string]struct{}) []fleetTreemapItem {
 	type orgTally struct {
 		count int
 		cost  float64
@@ -481,7 +488,7 @@ func fleetOrgItemsForSovereign(rows []podRow, parentOrg string, infraNamespaces 
 
 	var total float64
 	for _, row := range rows {
-		org := orgForRow(row, infraNamespaces)
+		org := orgForRow(row, infraNamespaces, knownOrgs, parentOrg)
 		t := ensure(org)
 		t.count++
 		cost := row.cpuReq*weightCPUPerMilli +
@@ -501,6 +508,12 @@ func fleetOrgItemsForSovereign(rows []podRow, parentOrg string, infraNamespaces 
 			name = parentOrg
 		case platformOrg:
 			name = "Platform overhead"
+		case unownedOrg:
+			// #6114: the raw `__unowned__` sentinel would render as a cell
+			// label. Give it the same human name the showback line uses so
+			// the orphan is legible on the treemap rather than looking like
+			// a malformed slug.
+			name = "Unowned namespaces"
 		}
 		var pct *float64
 		if total > 0 {

--- a/products/catalyst/bootstrap/api/internal/handler/fleet_treemap.go
+++ b/products/catalyst/bootstrap/api/internal/handler/fleet_treemap.go
@@ -439,10 +439,15 @@ func (h *Handler) collectFleetOrgItems(ctx context.Context) []fleetTreemapItem {
 		replicaSets, _, _ := h.k8sCache.List(clusterID, "replicaset", labels.Everything())
 		rows := buildPodRows(pods, pvcs, podMetrics, namespaces, nodes, replicaSets, clusterID, "")
 
-		parentOrg := sov.FQDN
-		if parentOrg == "" {
-			parentOrg = "sovereign"
-		}
+		// The SHARED parent derivation (org_consumption.go) — not a local
+		// orgNamespace() call. This used to be the raw `sov.FQDN`, which
+		// matches no `openova.io/organization` label value, and under
+		// #6114 that would have denied orgForRow's owned-escape to the
+		// estate's own namespaces and rendered the operator's workloads as
+		// "Unowned namespaces". Deriving the identifier a second way in a
+		// second place is exactly how #5819's fix failed to reach this
+		// surface, so both callers now go through one function.
+		parentOrg := showbackParentSlug(sov.FQDN)
 		items = append(items, fleetOrgItemsForSovereign(rows, parentOrg, infraNamespaces,
 			h.knownOrganizationSlugs(clusterID))...)
 	}

--- a/products/catalyst/bootstrap/api/internal/handler/fleet_treemap_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/fleet_treemap_test.go
@@ -322,7 +322,7 @@ func TestFleetOrgItemsForSovereign_SeparatesCustomerFromPlatform(t *testing.T) {
 		{namespace: "kube-system", application: "coredns", org: "", cpuReq: 50, memReq: 64 << 20},
 	}
 	infra := infraNamespaceSet("")
-	items := fleetOrgItemsForSovereign(rows, "hw292.omani.works", infra)
+	items := fleetOrgItemsForSovereign(rows, "hw292.omani.works", infra, nil)
 
 	if len(items) < 2 {
 		t.Fatalf("expected >=2 items (customer Org + Platform overhead), got %d: %+v", len(items), items)

--- a/products/catalyst/bootstrap/api/internal/handler/org_consumption.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_consumption.go
@@ -60,7 +60,7 @@ type orgConsumption struct {
 	IsPlatform bool `json:"isPlatform"`
 	// IsUnowned flags the synthetic "Unowned namespaces" rollup — real
 	// consumption carrying an `openova.io/organization` label whose slug
-	// has NO Organization CR. It is neither a tenant nor platform
+	// has NO Organization CR. It is neither an Organization nor platform
 	// overhead: nothing is billed to an Organization, but the units are
 	// still counted into TotalCostUnits and the orphaned slugs are named
 	// in UnownedOrgs so the estate total stays honest and the orphan is
@@ -359,7 +359,7 @@ func (h *Handler) knownOrganizationSlugs(clusterID string) map[string]struct{} {
 // It closes UAT row 25's set-agreement conjunct in BOTH directions:
 // a labelled namespace with no CR lands in unownedOrg instead of minting a
 // phantom billable Organization, and every CR gets a row even with nothing
-// running. The tenant rows the console bills — those with
+// running. The Organization rows the console bills — those with
 // !IsParent && !IsPlatform && !IsUnowned — are then exactly the
 // Organization set, which is the invariant the row asserts.
 //

--- a/products/catalyst/bootstrap/api/internal/handler/org_consumption.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_consumption.go
@@ -632,6 +632,38 @@ func (h *Handler) consumptionParentOrg(depID string) string {
 	return "sovereign"
 }
 
+// showbackParentSlug derives the parent-estate identifier for the FLEET
+// TREEMAP from a Sovereign FQDN, producing the same value
+// consumptionParentOrg produces for the same FQDN. The two are pinned
+// together by value in TestShowbackParentSlug_IsOneDerivationForBothSurfaces;
+// they are separate functions only because consumptionParentOrg resolves
+// its FQDN from the deployment store while the treemap already holds one.
+//
+// It exists because #6114 turned this from a cosmetic detail into a
+// correctness one. orgForRow treats `org == parentOrg` as the "always
+// owned" escape, and parentOrg is compared against
+// `openova.io/organization` label values, which are CR slugs — DNS-1123,
+// no dots. The treemap derived its parent as the RAW Sovereign FQDN, so an
+// FQDN-shaped parent matched no label, denied the escape to the estate's
+// own namespaces, and on an estate whose self-org CR is absent would have
+// rendered the operator's own workloads as "Unowned namespaces" while
+// showback correctly placed them on the parent row. #5819 fixed exactly
+// this on the showback side; it survived on the treemap because the
+// identifier was derived a second time in a second place.
+//
+// The empty check is on the INPUT, not on orgNamespace's output:
+// orgNamespace("") returns "org", not "" (namespace_ensure.go), so an
+// output-emptiness guard would hand an unidentifiable estate the
+// real-looking slug "org". The "sovereign" fallback is deliberately
+// synthetic — a plausible-looking slug for an Org we cannot identify would
+// read as a genuine Organization on the panel.
+func showbackParentSlug(fqdn string) string {
+	if strings.TrimSpace(fqdn) == "" {
+		return "sovereign"
+	}
+	return orgNamespace(fqdn)
+}
+
 func roundPct(v float64) float64 { return round2(v) }
 
 func round2(v float64) float64 {

--- a/products/catalyst/bootstrap/api/internal/handler/org_consumption.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_consumption.go
@@ -39,6 +39,7 @@ import (
 	"sort"
 	"strings"
 
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 )
 
@@ -57,6 +58,14 @@ type orgConsumption struct {
 	// tenant. The console renders this as one distinct line, never
 	// itemized inside a tenant's app list.
 	IsPlatform bool `json:"isPlatform"`
+	// IsUnowned flags the synthetic "Unowned namespaces" rollup — real
+	// consumption carrying an `openova.io/organization` label whose slug
+	// has NO Organization CR. It is neither a tenant nor platform
+	// overhead: nothing is billed to an Organization, but the units are
+	// still counted into TotalCostUnits and the orphaned slugs are named
+	// in UnownedOrgs so the estate total stays honest and the orphan is
+	// visible rather than silent (UAT row 25(c), #6114).
+	IsUnowned bool `json:"isUnowned"`
 	// CostUnits — the showback cost in abstract attribution units (the
 	// weighted CPU+memory+storage sum). Showback attributes consumption;
 	// it is not a billed currency amount.
@@ -87,6 +96,14 @@ type SovereignConsumptionResponse struct {
 	// Orgs — one rollup per org, parent first. Empty estate ⇒ a single
 	// parent row with zeros (never null — the page renders its chrome).
 	Orgs []orgConsumption `json:"orgs"`
+	// UnownedOrgs — the `openova.io/organization` label values that drew
+	// consumption but have no Organization CR, sorted. Empty (never null)
+	// when the object model contains everything the estate bills, which
+	// is the state UAT row 25 asserts. Naming them here is the whole
+	// point: the alternative to billing a phantom Organization is NOT
+	// dropping its consumption silently, it is saying which slug is
+	// orphaned so the sovereign-admin can reconcile or reap it.
+	UnownedOrgs []string `json:"unownedOrgs"`
 	// Pending — true when the metrics cache wasn't available so the page
 	// can flag "metering warming up" instead of asserting a false zero.
 	Pending bool `json:"pending"`
@@ -111,6 +128,43 @@ const (
 // guards against collision with a real slug (slugs match
 // [a-z][a-z0-9-]{2,30}).
 const platformOrg = "__platform__"
+
+// unownedOrg is the synthetic bucket for consumption whose namespace
+// carries an `openova.io/organization` label that NO Organization CR
+// claims. It exists because the label alone used to be the whole join:
+// orgForRow returned any non-empty label value verbatim, so a namespace
+// that outlived (or never had) its CR produced a full customer
+// Organization row and accrued showback against an entity the control
+// plane does not model. Measured on hw293: `g7doora` had no Organization
+// CR — `kubectl get organizations` listed hw293vch, hw293walkone,
+// hw293walktwo, uat107org, uat107vc and not g7doora — yet it drew the
+// LARGEST customer slice on the Sovereign, 4272.25 units across
+// bp-keycloak, bp-agenity, bp-stalwart-tenant, bp-newapi, bp-openclaw and
+// bp-wordpress, because its namespace kept converging after the Org
+// create failed. That is UAT row 25's set-agreement conjunct failing:
+// the billable set and the Organization set disagreed.
+//
+// Why a distinct bucket and not one of the three obvious alternatives:
+//
+//   - NOT folded into platformOrg. "Platform overhead" is a claim that
+//     the consumption is the control plane's own, and a half-torn-down
+//     customer namespace is not that. Folding it there re-hides the
+//     orphan behind a line the sovereign-admin is trained to ignore —
+//     silent again, just in a different column.
+//   - NOT dropped. Dropping the rows would make TotalCostUnits understate
+//     the estate by whatever the orphan actually runs (4272 units on
+//     hw293) and leave no surface on which the orphan is visible. The
+//     units are real; only their attribution was wrong.
+//   - NOT reaped. Reaping the namespace is destructive and belongs to the
+//     organization-controller's finalizer cascade, not to a read-only
+//     showback aggregation. A namespace legitimately outlives its CR for
+//     the duration of a teardown, so no predicate this handler can
+//     evaluate from a cache read distinguishes "orphan" from "mid-delete"
+//     safely enough to justify deletion.
+//
+// The double-underscore guards against collision with a real slug
+// (slugs match [a-z][a-z0-9-]{2,30}), same convention as platformOrg.
+const unownedOrg = "__unowned__"
 
 // ephemeralApp is the single app row every one-shot Job pod folds into
 // inside the platform-overhead org. Before #5485 each Job pod produced
@@ -201,8 +255,9 @@ func (h *Handler) HandleSovereignConsumption(w http.ResponseWriter, r *http.Requ
 	// §5 "never blank" rule applied to the metering feed.
 	if clusterID == "" || h.k8sCache == nil || !h.k8sCacheHasCluster(clusterID) {
 		writeJSON(w, http.StatusOK, SovereignConsumptionResponse{
-			Orgs:    []orgConsumption{{Org: parentOrg, IsParent: true, Apps: []appConsumption{}}},
-			Pending: true,
+			Orgs:        []orgConsumption{{Org: parentOrg, IsParent: true, Apps: []appConsumption{}}},
+			UnownedOrgs: []string{},
+			Pending:     true,
 		})
 		return
 	}
@@ -219,8 +274,73 @@ func (h *Handler) HandleSovereignConsumption(w http.ResponseWriter, r *http.Requ
 
 	rows := buildPodRows(pods, pvcs, podMetrics, namespaces, nodes, replicaSets, clusterID, "")
 
-	resp := aggregateConsumption(rows, parentOrg, infraNamespaceSet(os.Getenv("SHOWBACK_INFRA_NAMESPACES")))
+	resp := aggregateConsumption(rows, parentOrg,
+		infraNamespaceSet(os.Getenv("SHOWBACK_INFRA_NAMESPACES")),
+		h.knownOrganizationSlugs(clusterID))
 	writeJSON(w, http.StatusOK, resp)
+}
+
+// knownOrganizationSlugs reads the Organization CR set for a cluster —
+// the object model showback's billable set must be a function of (#6114,
+// UAT row 25(c)).
+//
+// `organization` is already a registered k8scache kind
+// (k8scache/kinds.go: orgs.openova.io/v1 organizations, cluster-scoped)
+// and the catalyst-api-cutover-driver ClusterRole already grants read on
+// it, so this join adds no informer, no apiserver round-trip and no RBAC
+// rule — it reads the same warm indexer the /organizations page does.
+//
+// Returns nil — meaning "the Organization set is UNKNOWN", never "the
+// Organization set is empty" — when the cache cannot vouch for it:
+//
+//   - no cache / no cluster id (CI, pre-handover mothership),
+//   - List error (cluster unregistered, or the Organization CRD is not
+//     served on this cluster),
+//   - zero Organizations returned.
+//
+// The zero case is folded into "unknown" on purpose. A cold or
+// not-yet-synced informer returns an empty list with no error, and it is
+// indistinguishable at this seam from a genuinely Org-less Sovereign — but
+// the two states are NOT equally costly to get wrong. Treating an unsynced
+// read as authoritative would move every labelled namespace on the estate
+// into the unowned rollup at once and bill nobody, which is the
+// over-correction this fix must not make. Treating a genuinely Org-less
+// Sovereign as unknown costs nothing, because a Sovereign with no
+// Organization CRs also has no organization-controller-stamped namespaces
+// to mis-attribute: the label and the CR come from the same producer
+// (core/controllers/organization/internal/gitops/manifests.go stamps
+// `openova.io/organization: {{ .Slug }}`).
+func (h *Handler) knownOrganizationSlugs(clusterID string) map[string]struct{} {
+	if h == nil || h.k8sCache == nil || clusterID == "" {
+		return nil
+	}
+	orgs, _, err := h.k8sCache.List(clusterID, "organization", labels.Everything())
+	if err != nil || len(orgs) == 0 {
+		return nil
+	}
+	set := make(map[string]struct{}, len(orgs))
+	for _, o := range orgs {
+		if o == nil {
+			continue
+		}
+		// spec.slug is the value the org-controller stamps as the
+		// namespace label; metadata.name is set to the same slug by every
+		// producer (org_tenant_org_cr.go ensureOrganizationCR, the
+		// provisioning-service's createOrganizationCR). Accept both so a
+		// CR authored by a future producer that diverges on one of the two
+		// still counts as owning its namespaces — the failure mode this
+		// guards against is a REAL Organization being called unowned.
+		if slug, _, _ := unstructured.NestedString(o.Object, "spec", "slug"); strings.TrimSpace(slug) != "" {
+			set[strings.TrimSpace(slug)] = struct{}{}
+		}
+		if name := strings.TrimSpace(o.GetName()); name != "" {
+			set[name] = struct{}{}
+		}
+	}
+	if len(set) == 0 {
+		return nil
+	}
+	return set
 }
 
 // aggregateConsumption rolls podRows up into the per-org / per-app
@@ -235,12 +355,20 @@ func (h *Handler) HandleSovereignConsumption(w http.ResponseWriter, r *http.Requ
 // their own org row immediately, with no per-name special-casing — adding
 // a third org needs zero code change (the generality proof §7c).
 //
+// knownOrgs is the Organization CR set (nil = not read; see orgForRow).
+// It closes UAT row 25's set-agreement conjunct in BOTH directions:
+// a labelled namespace with no CR lands in unownedOrg instead of minting a
+// phantom billable Organization, and every CR gets a row even with nothing
+// running. The tenant rows the console bills — those with
+// !IsParent && !IsPlatform && !IsUnowned — are then exactly the
+// Organization set, which is the invariant the row asserts.
+//
 // Inside the platform bucket the one-shot Job pods further collapse into
 // a SINGLE `(one-shot jobs)` app row (#5485 defect A) instead of one row
 // per Job pod. Their cost still counts toward the platform row's totals
 // and the Sovereign-wide total — only the per-app itemization folds, so
 // the table shows durable platform workloads plus one activity line.
-func aggregateConsumption(rows []podRow, parentOrg string, infraNamespaces map[string]struct{}) SovereignConsumptionResponse {
+func aggregateConsumption(rows []podRow, parentOrg string, infraNamespaces map[string]struct{}, knownOrgs map[string]struct{}) SovereignConsumptionResponse {
 	// org → namespace+app key → app rollup.
 	type appKey struct{ org, ns, app string }
 	appAgg := map[appKey]*appConsumption{}
@@ -253,6 +381,7 @@ func aggregateConsumption(rows []podRow, parentOrg string, infraNamespaces map[s
 				Org:        org,
 				IsParent:   org == parentOrg,
 				IsPlatform: org == platformOrg,
+				IsUnowned:  org == unownedOrg,
 				Apps:       []appConsumption{},
 			}
 			orgAgg[org] = oc
@@ -261,10 +390,37 @@ func aggregateConsumption(rows []podRow, parentOrg string, infraNamespaces map[s
 	}
 	// Always seed the parent so the estate is never blank (§5).
 	ensureOrg(parentOrg)
+	// #6114, the INVERSE of the phantom-org defect and the other half of
+	// row 25's set-agreement conjunct: seed a row for every Organization
+	// the CR set holds, so an Org that exists but currently runs nothing
+	// renders a zero slice instead of vanishing from the feed entirely.
+	//
+	// Rows only ever materialised from pod rows before this, so an
+	// Organization's presence in showback tracked whether it happened to
+	// have a running pod, not whether it existed. hw293 measured exactly
+	// that asymmetry: uat107org and its twin uat107vc were created and
+	// deleted the same way on the same day, both reading state deleted,
+	// and uat107vc carried a 525.5-unit slice purely because its pods had
+	// not finished terminating while uat107org drew no slice at all.
+	// Same disposition, different treatment — a join defect cutting the
+	// opposite way from g7doora's.
+	for slug := range knownOrgs {
+		ensureOrg(slug)
+	}
 
 	var total float64
+	unowned := []string{}
 	for _, row := range rows {
-		org := orgForRow(row, infraNamespaces)
+		org := orgForRow(row, infraNamespaces, knownOrgs, parentOrg)
+		if org == unownedOrg {
+			// Record the label value that had no CR behind it. This is the
+			// slug the sovereign-admin needs in order to act; the bucket
+			// name alone would say "something is orphaned" without saying
+			// what, which is the silence this fix exists to break.
+			if slug := strings.TrimSpace(row.org); slug != "" && !containsString(unowned, slug) {
+				unowned = append(unowned, slug)
+			}
+		}
 		cpuMilli := row.cpuReq
 		memGiB := row.memReq / bytesPerGiB
 		storageGiB := row.storageLim / bytesPerGiB
@@ -323,6 +479,7 @@ func aggregateConsumption(rows []podRow, parentOrg string, infraNamespaces map[s
 	// Stable ordering: parent first, then orgs by descending cost; apps
 	// within an org by descending cost.
 	orgs := make([]orgConsumption, 0, len(orgAgg))
+	sort.Strings(unowned)
 	for _, oc := range orgAgg {
 		sort.Slice(oc.Apps, func(i, j int) bool {
 			return oc.Apps[i].CostUnits > oc.Apps[j].CostUnits
@@ -334,14 +491,13 @@ func aggregateConsumption(rows []podRow, parentOrg string, infraNamespaces map[s
 		orgs = append(orgs, *oc)
 	}
 	// Ordering: parent estate first, then customer Organizations by
-	// descending cost, then the synthetic platform-overhead row last so
-	// the console renders it as a trailing distinct line (#3687 §6).
+	// descending cost, then the unowned rollup, then the synthetic
+	// platform-overhead row last so the console renders it as a trailing
+	// distinct line (#3687 §6, extended by #6114).
 	sort.Slice(orgs, func(i, j int) bool {
-		if orgs[i].IsParent != orgs[j].IsParent {
-			return orgs[i].IsParent // parent first
-		}
-		if orgs[i].IsPlatform != orgs[j].IsPlatform {
-			return orgs[j].IsPlatform // platform overhead last
+		ri, rj := orgSortRank(orgs[i]), orgSortRank(orgs[j])
+		if ri != rj {
+			return ri < rj
 		}
 		return orgs[i].CostUnits > orgs[j].CostUnits
 	})
@@ -349,7 +505,21 @@ func aggregateConsumption(rows []podRow, parentOrg string, infraNamespaces map[s
 	return SovereignConsumptionResponse{
 		TotalCostUnits: round2(total),
 		Orgs:           orgs,
+		UnownedOrgs:    unowned,
 	}
+}
+
+// containsString — small linear membership helper. The unowned slug list
+// is bounded by the number of orphaned namespaces on a Sovereign (zero on
+// a healthy estate, single digits on a broken one), so a linear scan is
+// cheaper than building a map.
+func containsString(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+	return false
 }
 
 // orgForRow resolves the owning org for a pod row's showback attribution
@@ -361,17 +531,64 @@ func aggregateConsumption(rows []podRow, parentOrg string, infraNamespaces map[s
 // as a single "Platform overhead" line, never inside a tenant's app list.
 // No per-org-name or per-namespace-name special-casing: the resolver keys
 // purely on the label + the config-driven exclusion set.
-func orgForRow(row podRow, infraNamespaces map[string]struct{}) string {
+//
+// #6114 (UAT row 25(c)): the label is now checked AGAINST the Organization
+// CR set rather than trusted on its own. A label value with no CR resolves
+// to unownedOrg, so the set of billable Organization rows is a strict
+// function of the Organization set — which is exactly the conjunct row 25
+// asserts and the one hw293 refuted.
+//
+// knownOrgs is deliberately NILABLE and nil means "not read", not "empty":
+//
+//   - nil          → the Organization CR set could not be established
+//     (no cache, cluster unregistered, CRD not served, informer not yet
+//     synced). Every labelled row keeps its pre-#6114 attribution. To move
+//     a row into unownedOrg we require POSITIVE evidence that the
+//     Organization set was actually read; absence of evidence must never
+//     become evidence of orphanhood, or a cold cache would relabel the
+//     entire estate as unowned and bill nobody.
+//   - non-nil      → authoritative. A slug outside it has no CR.
+//
+// parentOrg is always owned regardless of knownOrgs: it is the Sovereign
+// estate itself (§2.2), seeded unconditionally by aggregateConsumption,
+// and not a customer Organization whose CR must exist for it to be real.
+func orgForRow(row podRow, infraNamespaces map[string]struct{}, knownOrgs map[string]struct{}, parentOrg string) string {
 	if _, infra := infraNamespaces[row.namespace]; infra {
 		return platformOrg
 	}
 	if strings.EqualFold(row.ownerKind, "Job") {
 		return platformOrg
 	}
-	if org := strings.TrimSpace(row.org); org != "" {
+	org := strings.TrimSpace(row.org)
+	if org == "" {
+		return platformOrg
+	}
+	if org == parentOrg || knownOrgs == nil {
 		return org
 	}
-	return platformOrg
+	if _, owned := knownOrgs[org]; owned {
+		return org
+	}
+	return unownedOrg
+}
+
+// orgSortRank orders the response: the parent estate first, then customer
+// Organizations (by descending cost), then the unowned rollup, then
+// platform overhead last. Expressed as a rank rather than a chain of
+// pairwise boolean flips because the pairwise form silently mis-orders
+// once a third synthetic bucket exists — comparing an unowned row against
+// a platform row would consult the wrong flag and put platform first.
+func orgSortRank(oc orgConsumption) int {
+	switch {
+	case oc.IsParent:
+		return 0
+	case oc.IsPlatform:
+		return 3
+	case oc.IsUnowned:
+		return 2
+	default:
+		return 1
+	}
 }
 
 // consumptionParentOrg resolves the parent Organization's SLUG — the same

--- a/products/catalyst/bootstrap/api/internal/handler/org_consumption_billable_set_6114_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_consumption_billable_set_6114_test.go
@@ -1,0 +1,414 @@
+// org_consumption_billable_set_6114_test.go — UAT row 25's set-agreement
+// conjunct: "/organizations shows the Orgs that /apps, the dashboard and
+// showback all agree on".
+//
+// The measurement this locks (hw293, dep a0077ba47e3720e5, 2026-08-11):
+//
+//	(c) g7doora has NO Organization CR — `kubectl get organizations` listed
+//	    hw293vch, hw293walkone, hw293walktwo, uat107org, uat107vc and not
+//	    g7doora — yet it drew the LARGEST customer showback slice on the
+//	    Sovereign, 4272.25 units. Showback billed an entity the control
+//	    plane does not model.
+//
+//	(b) p474del1 and uat107org appear in the directory and draw no showback
+//	    slice at all, while uat107org's twin uat107vc — created and deleted
+//	    the same way on the same day, both reading state deleted — does
+//	    carry one (525.5 units). Same disposition, different treatment.
+//
+// Those are the two halves of ONE join defect, and it cuts both ways. The
+// forward half billed a slug with no CR because the join trusted the
+// `openova.io/organization` namespace label on its own. The inverse half
+// dropped an Org that HAS a CR because rows only ever materialised from
+// pod rows, so an Organization's presence in the feed tracked whether it
+// happened to be running a pod rather than whether it exists. Checking one
+// direction is how the other survived, so both are asserted here.
+//
+// Every assertion below is on a VALUE — the unit count, the joined set,
+// the ordering rank — never on key presence. The over-correction guard is
+// explicit: TestBillableSet_GenuineOrganizationsAreStillBilledInFull is
+// the CONTROL, and it shares the suspect property (its Orgs are resolved
+// through the very same label join key that mis-billed g7doora); it must
+// stay green and its numbers must not move.
+package handler
+
+import (
+	"testing"
+)
+
+// hw293OrgCRSet is the Organization CR set exactly as hw293 reported it:
+// five Organizations, and g7doora is NOT among them.
+func hw293OrgCRSet() map[string]struct{} {
+	return map[string]struct{}{
+		"hw293vch":     {},
+		"hw293walkone": {},
+		"hw293walktwo": {},
+		"uat107org":    {},
+		"uat107vc":     {},
+	}
+}
+
+// billedOrgs returns the slugs the response bills as customer
+// Organizations — every row that is not the parent estate and not one of
+// the two synthetic rollups. This is the "billable set" row 25 compares
+// against the Organization set.
+func billedOrgs(resp SovereignConsumptionResponse) map[string]float64 {
+	out := map[string]float64{}
+	for _, oc := range resp.Orgs {
+		if oc.IsParent || oc.IsPlatform || oc.IsUnowned {
+			continue
+		}
+		out[oc.Org] = oc.CostUnits
+	}
+	return out
+}
+
+// TestBillableSet_ANamespaceWithNoOrganizationCRIsNeverBilled is the
+// forward half: the g7doora shape. A namespace carrying the join-key label
+// whose slug has no Organization CR must not appear as a billable
+// Organization — and its consumption must not be dropped either, because
+// the units are real cluster resource and dropping them understates the
+// estate.
+func TestBillableSet_ANamespaceWithNoOrganizationCRIsNeverBilled(t *testing.T) {
+	const parent = "hw293-omantel-biz"
+	rows := []podRow{
+		// g7doora: the namespace kept converging after the Org create
+		// failed. Six real Applications, no Organization CR.
+		{namespace: "g7doora", application: "bp-keycloak", org: "g7doora", ownerKind: "StatefulSet", cpuReq: 1000, memReq: 2 << 30},
+		{namespace: "g7doora", application: "bp-agenity", org: "g7doora", ownerKind: "Deployment", cpuReq: 500, memReq: 1 << 30},
+		{namespace: "g7doora", application: "bp-wordpress", org: "g7doora", ownerKind: "Deployment", cpuReq: 250, memReq: 512 << 20},
+		// hw293vch: a genuine Organization, CR present.
+		{namespace: "hw293vch", application: "bp-newapi", org: "hw293vch", ownerKind: "Deployment", cpuReq: 400, memReq: 1 << 30},
+	}
+
+	resp := aggregateConsumption(rows, parent, testInfraSet(), hw293OrgCRSet())
+
+	// 1. g7doora draws NO billable Organization slice.
+	billed := billedOrgs(resp)
+	if cost, present := billed["g7doora"]; present {
+		t.Errorf("g7doora is billed %v units as a customer Organization, but it has no Organization CR "+
+			"(the CR set is %v) — this is the hw293 4272.25-unit phantom", cost, sortedSlugs6114(hw293OrgCRSet()))
+	}
+
+	// 2. The consumption is NOT dropped: it lands in the unowned rollup
+	//    with its exact cost. 1750 millicores + 3.5 GiB =
+	//    1750*1.0 + 3.5*4.0 = 1764.
+	var unownedRow *orgConsumption
+	for i := range resp.Orgs {
+		if resp.Orgs[i].IsUnowned {
+			unownedRow = &resp.Orgs[i]
+		}
+	}
+	if unownedRow == nil {
+		t.Fatalf("no unowned rollup row: g7doora's consumption vanished entirely from the feed, "+
+			"which understates the estate by its whole footprint. Orgs=%#v", resp.Orgs)
+	}
+	if unownedRow.CostUnits != 1764 {
+		t.Errorf("unowned CostUnits = %v, want 1764 (1750 milli * 1.0 + 3.5 GiB * 4.0)", unownedRow.CostUnits)
+	}
+	if unownedRow.CPUMilli != 1750 {
+		t.Errorf("unowned CPUMilli = %v, want 1750", unownedRow.CPUMilli)
+	}
+
+	// 3. The orphan is NAMED, not merely bucketed. Silence is the failure
+	//    mode this row exists to catch; an unlabelled rollup would hide
+	//    g7doora just as effectively as billing it did.
+	if got, want := resp.UnownedOrgs, []string{"g7doora"}; !equalStringSlices6114(got, want) {
+		t.Errorf("UnownedOrgs = %v, want %v", got, want)
+	}
+
+	// 4. It is NOT folded into platform overhead — that line asserts the
+	//    consumption is the control plane's own, which is a false claim
+	//    about a half-torn-down customer namespace.
+	for _, oc := range resp.Orgs {
+		if !oc.IsPlatform {
+			continue
+		}
+		if oc.CostUnits != 0 {
+			t.Errorf("platform overhead absorbed %v units — the orphan must not hide inside it", oc.CostUnits)
+		}
+	}
+
+	// 5. The estate total still counts every unit: 1764 unowned + 400 milli
+	//    + 1 GiB = 404 for hw293vch.
+	if resp.TotalCostUnits != 2168 {
+		t.Errorf("TotalCostUnits = %v, want 2168 (1764 unowned + 404 hw293vch) — "+
+			"the Sovereign-wide total must not shrink when attribution is corrected", resp.TotalCostUnits)
+	}
+}
+
+// TestBillableSet_AnOrganizationWithACRIsBilledEvenWithNothingRunning is
+// the INVERSE half: the uat107org shape. An Organization the CR set holds
+// must draw a slice whether or not it currently runs a pod, otherwise its
+// presence in showback tracks pod liveness rather than existence — which
+// is what made uat107vc (525.5 units) and uat107org (absent) diverge
+// despite identical disposition.
+func TestBillableSet_AnOrganizationWithACRIsBilledEvenWithNothingRunning(t *testing.T) {
+	const parent = "hw293-omantel-biz"
+	rows := []podRow{
+		// uat107vc still has a terminating pod.
+		{namespace: "uat107vc", application: "bp-wordpress", org: "uat107vc", ownerKind: "Deployment", cpuReq: 500, memReq: 64 << 20},
+		// uat107org's pods are already gone. It has a CR all the same.
+	}
+
+	resp := aggregateConsumption(rows, parent, testInfraSet(), hw293OrgCRSet())
+	billed := billedOrgs(resp)
+
+	// Every Organization in the CR set is present in the billable set.
+	for slug := range hw293OrgCRSet() {
+		if _, present := billed[slug]; !present {
+			t.Errorf("Organization %q has a CR but draws no showback slice at all — "+
+				"the billable set %v is missing it", slug, sortedSlugs6114(slugSetOf6114(billed)))
+		}
+	}
+
+	// And the values are right: uat107vc carries its real cost, uat107org
+	// renders at exactly zero rather than vanishing.
+	if got := billed["uat107vc"]; got != 500.25 {
+		t.Errorf("uat107vc CostUnits = %v, want 500.25 (500 milli * 1.0 + 0.0625 GiB * 4.0)", got)
+	}
+	if got := billed["uat107org"]; got != 0 {
+		t.Errorf("uat107org CostUnits = %v, want 0 — an Org with a CR and no workload is a zero slice, not an absence", got)
+	}
+
+	// The two surfaces now agree as SETS, which is the row-25 conjunct.
+	if len(billed) != len(hw293OrgCRSet()) {
+		t.Errorf("billable set has %d Orgs, Organization CR set has %d — the sets must be equal. billed=%v crs=%v",
+			len(billed), len(hw293OrgCRSet()), sortedSlugs6114(slugSetOf6114(billed)), sortedSlugs6114(hw293OrgCRSet()))
+	}
+}
+
+// TestBillableSet_GenuineOrganizationsAreStillBilledInFull is the CONTROL.
+//
+// It shares the suspect property with the defect: acme and beta are
+// attributed through the exact same `openova.io/organization` label join
+// key that mis-billed g7doora, and they sit alongside an orphan in the
+// same aggregation. The whole risk of this fix is over-correcting into
+// "nothing is billed", so the control asserts the full billed values, the
+// per-app breakdown and the percent share — not merely that a row exists.
+func TestBillableSet_GenuineOrganizationsAreStillBilledInFull(t *testing.T) {
+	const parent = "hw293-omantel-biz"
+	knownOrgs := map[string]struct{}{"acme": {}, "beta": {}}
+	rows := []podRow{
+		{namespace: "acme", application: "blog", org: "acme", ownerKind: "StatefulSet", cpuReq: 200, memReq: 256 << 20},
+		{namespace: "acme", application: "shop", org: "acme", ownerKind: "Deployment", cpuReq: 600, memReq: 256 << 20},
+		{namespace: "beta", application: "api", org: "beta", ownerKind: "Deployment", cpuReq: 300, memReq: 512 << 20},
+		// An orphan in the same estate — the control must survive its presence.
+		{namespace: "ghost", application: "bp-wordpress", org: "ghost", ownerKind: "Deployment", cpuReq: 100},
+	}
+
+	resp := aggregateConsumption(rows, parent, testInfraSet(), knownOrgs)
+	billed := billedOrgs(resp)
+
+	// acme: (200+600) milli + 0.5 GiB = 800 + 2 = 802.
+	if got := billed["acme"]; got != 802 {
+		t.Errorf("acme CostUnits = %v, want 802 — a genuine Organization must still be billed in full", got)
+	}
+	// beta: 300 milli + 0.5 GiB = 300 + 2 = 302.
+	if got := billed["beta"]; got != 302 {
+		t.Errorf("beta CostUnits = %v, want 302 — a genuine Organization must still be billed in full", got)
+	}
+	if len(billed) != 2 {
+		t.Errorf("billable set = %v, want exactly {acme, beta}", sortedSlugs6114(slugSetOf6114(billed)))
+	}
+
+	// The per-app breakdown inside a genuine Org is untouched: acme keeps
+	// both Applications, ordered by descending cost, summing to 100%.
+	var acme *orgConsumption
+	for i := range resp.Orgs {
+		if resp.Orgs[i].Org == "acme" {
+			acme = &resp.Orgs[i]
+		}
+	}
+	if acme == nil || len(acme.Apps) != 2 {
+		t.Fatalf("acme lost its per-app breakdown: %#v", acme)
+	}
+	if acme.Apps[0].Application != "shop" || acme.Apps[1].Application != "blog" {
+		t.Errorf("acme apps = %q/%q, want shop/blog (descending cost)", acme.Apps[0].Application, acme.Apps[1].Application)
+	}
+	if sum := acme.Apps[0].Percent + acme.Apps[1].Percent; sum < 99.9 || sum > 100.1 {
+		t.Errorf("acme per-app percent sums to %v, want 100", sum)
+	}
+
+	// Nothing is silently zeroed estate-wide: 802 + 302 + 100 (ghost) = 1204.
+	if resp.TotalCostUnits != 1204 {
+		t.Errorf("TotalCostUnits = %v, want 1204 — the fix must not zero the estate", resp.TotalCostUnits)
+	}
+}
+
+// TestBillableSet_AnUnreadOrganizationSetChangesNothing guards the other
+// over-correction. nil means "the Organization CR set could not be read",
+// NOT "there are no Organizations". A cold or unsynced informer must never
+// relabel a whole estate as unowned and bill nobody: to call a namespace
+// an orphan we require positive evidence that the CR set was read.
+func TestBillableSet_AnUnreadOrganizationSetChangesNothing(t *testing.T) {
+	const parent = "hw293-omantel-biz"
+	rows := []podRow{
+		{namespace: "acme", application: "blog", org: "acme", ownerKind: "StatefulSet", cpuReq: 200, memReq: 256 << 20},
+		{namespace: "g7doora", application: "bp-keycloak", org: "g7doora", ownerKind: "StatefulSet", cpuReq: 1000, memReq: 2 << 30},
+	}
+
+	resp := aggregateConsumption(rows, parent, testInfraSet(), nil)
+	billed := billedOrgs(resp)
+
+	if got := billed["acme"]; got != 201 {
+		t.Errorf("acme CostUnits = %v, want 201 with an unread Organization set", got)
+	}
+	if got := billed["g7doora"]; got != 1008 {
+		t.Errorf("g7doora CostUnits = %v, want 1008 with an unread Organization set — "+
+			"an unread set must not be treated as an empty one", got)
+	}
+	if len(resp.UnownedOrgs) != 0 {
+		t.Errorf("UnownedOrgs = %v, want empty when the Organization set was never read", resp.UnownedOrgs)
+	}
+}
+
+// TestBillableSet_ParentEstateIsOwnedWithoutACR — the parent row is the
+// Sovereign itself (§2.2), not a customer Organization, and it is seeded
+// unconditionally. It must never be demoted into the unowned rollup just
+// because its self-org CR is absent from the set, or the estate row would
+// disappear from its own showback page.
+func TestBillableSet_ParentEstateIsOwnedWithoutACR(t *testing.T) {
+	const parent = "hw293-omantel-biz"
+	rows := []podRow{
+		{namespace: "spine", application: "catalyst-ui", org: parent, ownerKind: "Deployment", cpuReq: 100},
+	}
+
+	// A CR set that does NOT contain the parent slug.
+	resp := aggregateConsumption(rows, parent, testInfraSet(), map[string]struct{}{"acme": {}})
+
+	if len(resp.Orgs) == 0 || !resp.Orgs[0].IsParent {
+		t.Fatalf("parent estate row must be present and first, got %#v", resp.Orgs)
+	}
+	if got := resp.Orgs[0].CostUnits; got != 100 {
+		t.Errorf("parent CostUnits = %v, want 100 — the estate's own consumption must stay on the parent row", got)
+	}
+	if len(resp.UnownedOrgs) != 0 {
+		t.Errorf("UnownedOrgs = %v, want empty — the parent estate is not an orphan", resp.UnownedOrgs)
+	}
+}
+
+// TestBillableSet_UnownedRollupOrdersBeforePlatformOverhead — the console
+// renders the trailing synthetic lines in a fixed order. Asserted because
+// the pre-#6114 pairwise-boolean sort mis-orders as soon as a third
+// synthetic bucket exists: comparing an unowned row against a platform row
+// consults the wrong flag.
+func TestBillableSet_UnownedRollupOrdersBeforePlatformOverhead(t *testing.T) {
+	const parent = "hw293-omantel-biz"
+	rows := []podRow{
+		{namespace: "acme", application: "blog", org: "acme", ownerKind: "Deployment", cpuReq: 100},
+		{namespace: "ghost", application: "bp-wordpress", org: "ghost", ownerKind: "Deployment", cpuReq: 50},
+		{namespace: "kube-system", application: "cilium", ownerKind: "DaemonSet", cpuReq: 25},
+	}
+
+	resp := aggregateConsumption(rows, parent, testInfraSet(), map[string]struct{}{"acme": {}})
+
+	got := make([]string, 0, len(resp.Orgs))
+	for _, oc := range resp.Orgs {
+		got = append(got, oc.Org)
+	}
+	want := []string{parent, "acme", unownedOrg, platformOrg}
+	if !equalStringSlices6114(got, want) {
+		t.Errorf("row order = %v, want %v", got, want)
+	}
+}
+
+// ── vacuity check ────────────────────────────────────────────────────
+//
+// A guard that cannot fail is decorative. This proves the new assertions
+// DO fail on the pre-fix behaviour by reconstructing it exactly: the old
+// orgForRow returned any non-empty label value verbatim, and the old
+// aggregateConsumption seeded only the parent. Feeding the hw293 rows
+// through that reconstruction must reproduce BOTH halves of the measured
+// defect — g7doora billed, uat107org absent — which is precisely what the
+// two tests above reject. If this test ever goes green with the assertions
+// inverted, the new tests are asserting on nothing.
+func TestBillableSet_VacuityCheck_PreFixBehaviourFailsBothAssertions(t *testing.T) {
+	const parent = "hw293-omantel-biz"
+	rows := []podRow{
+		{namespace: "g7doora", application: "bp-keycloak", org: "g7doora", ownerKind: "StatefulSet", cpuReq: 1000, memReq: 2 << 30},
+		{namespace: "uat107vc", application: "bp-wordpress", org: "uat107vc", ownerKind: "Deployment", cpuReq: 500, memReq: 64 << 20},
+	}
+
+	// The pre-#6114 resolver, verbatim: label wins, no CR cross-check.
+	preFixOrgForRow := func(row podRow, infra map[string]struct{}) string {
+		if _, isInfra := infra[row.namespace]; isInfra {
+			return platformOrg
+		}
+		if row.ownerKind == "Job" {
+			return platformOrg
+		}
+		if row.org != "" {
+			return row.org
+		}
+		return platformOrg
+	}
+	// The pre-#6114 aggregation's org set: parent + whatever the rows
+	// produced. No CR seeding.
+	preFixBilled := map[string]struct{}{}
+	for _, row := range rows {
+		if org := preFixOrgForRow(row, testInfraSet()); org != platformOrg && org != parent {
+			preFixBilled[org] = struct{}{}
+		}
+	}
+
+	// Forward half: the old join DID bill g7doora. The new assertion
+	// "g7doora is absent from the billable set" therefore fails here.
+	if _, billed := preFixBilled["g7doora"]; !billed {
+		t.Fatalf("vacuity check is broken: the reconstructed pre-fix join did not bill g7doora, "+
+			"so TestBillableSet_ANamespaceWithNoOrganizationCRIsNeverBilled would have passed before the fix. got=%v",
+			sortedSlugs6114(preFixBilled))
+	}
+
+	// Inverse half: the old aggregation produced NO row for uat107org,
+	// which has a CR but no pod. The new assertion "every CR draws a
+	// slice" therefore fails here too.
+	if _, billed := preFixBilled["uat107org"]; billed {
+		t.Fatalf("vacuity check is broken: the reconstructed pre-fix aggregation produced a uat107org row " +
+			"without a pod, so the inverse assertion would have passed before the fix")
+	}
+
+	// And the same rows through the SHIPPED aggregation must invert both.
+	resp := aggregateConsumption(rows, parent, testInfraSet(), hw293OrgCRSet())
+	billed := billedOrgs(resp)
+	if _, present := billed["g7doora"]; present {
+		t.Errorf("shipped aggregation still bills g7doora — the fix is inert")
+	}
+	if _, present := billed["uat107org"]; !present {
+		t.Errorf("shipped aggregation still drops uat107org — the inverse half is inert")
+	}
+}
+
+// ── tiny test helpers ────────────────────────────────────────────────
+
+func equalStringSlices6114(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func slugSetOf6114(m map[string]float64) map[string]struct{} {
+	out := make(map[string]struct{}, len(m))
+	for k := range m {
+		out[k] = struct{}{}
+	}
+	return out
+}
+
+func sortedSlugs6114(m map[string]struct{}) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	for i := 1; i < len(out); i++ {
+		for j := i; j > 0 && out[j] < out[j-1]; j-- {
+			out[j], out[j-1] = out[j-1], out[j]
+		}
+	}
+	return out
+}

--- a/products/catalyst/bootstrap/api/internal/handler/org_consumption_billable_set_6114_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_consumption_billable_set_6114_test.go
@@ -32,6 +32,7 @@
 package handler
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -375,6 +376,117 @@ func TestBillableSet_VacuityCheck_PreFixBehaviourFailsBothAssertions(t *testing.
 	}
 	if _, present := billed["uat107org"]; !present {
 		t.Errorf("shipped aggregation still drops uat107org — the inverse half is inert")
+	}
+}
+
+// TestBillableSet_TreemapAgreesWithShowbackOnTheSameEstate — the treemap
+// shares orgForRow with showback precisely so the two cannot drift, and
+// row 25 lists the dashboard as one of the four surfaces that must agree.
+//
+// The specific regression this guards: orgForRow's "always owned" escape
+// keys on `org == parentOrg`, and the treemap used to derive parentOrg as
+// the raw Sovereign FQDN while showback derives it as the CR slug. An
+// FQDN never equals a label value, so the escape would have been denied to
+// the estate's own namespaces and — with no self-org CR in the set — the
+// treemap would have labelled the operator's own workloads "Unowned
+// namespaces" while showback put them on the parent row. Same rows, same
+// resolver, two answers.
+func TestBillableSet_TreemapAgreesWithShowbackOnTheSameEstate(t *testing.T) {
+	const parentSlug = "hw293-omantel-biz"
+	rows := []podRow{
+		// The Sovereign's own spine workload, labelled with the slug.
+		{namespace: "spine", application: "catalyst-ui", org: parentSlug, ownerKind: "Deployment", cpuReq: 100},
+		// A genuine Organization.
+		{namespace: "acme", application: "blog", org: "acme", ownerKind: "Deployment", cpuReq: 200},
+		// An orphan.
+		{namespace: "ghost", application: "bp-wordpress", org: "ghost", ownerKind: "Deployment", cpuReq: 50},
+	}
+	// A CR set holding the customer Org but NOT the Sovereign self-org —
+	// the state that exposes the escape.
+	knownOrgs := map[string]struct{}{"acme": {}}
+
+	showback := aggregateConsumption(rows, parentSlug, testInfraSet(), knownOrgs)
+	treemap := fleetOrgItemsForSovereign(rows, parentSlug, testInfraSet(), knownOrgs)
+
+	// Showback: the estate's own 100 units sit on the parent row.
+	if !showback.Orgs[0].IsParent || showback.Orgs[0].CostUnits != 100 {
+		t.Fatalf("showback parent row = %+v, want the parent carrying 100 units", showback.Orgs[0])
+	}
+	// Showback names exactly one orphan.
+	if !equalStringSlices6114(showback.UnownedOrgs, []string{"ghost"}) {
+		t.Errorf("showback UnownedOrgs = %v, want [ghost]", showback.UnownedOrgs)
+	}
+
+	// Treemap: the same three buckets with the same size values.
+	byName := map[string]float64{}
+	for _, it := range treemap {
+		byName[it.Name] = it.SizeValue
+	}
+	if got := byName[parentSlug]; got != 100 {
+		t.Errorf("treemap parent cell = %v units, want 100 — the estate's own workload must not "+
+			"be reclassified; cells were %v", got, byName)
+	}
+	if got := byName["acme"]; got != 200 {
+		t.Errorf("treemap acme cell = %v units, want 200", got)
+	}
+	if got := byName["Unowned namespaces"]; got != 50 {
+		t.Errorf("treemap unowned cell = %v units, want 50 (only the orphan)", got)
+	}
+	// And the raw sentinel never reaches a cell label.
+	if _, wrong := byName["__unowned__"]; wrong {
+		t.Errorf("treemap rendered the raw sentinel instead of a human label: %v", byName)
+	}
+
+	// THE STAKE. Feed the same rows an FQDN-shaped parent — what the
+	// treemap caller used to derive — and the estate's own workload is
+	// reclassified as an orphan. This is what showbackParentSlug prevents,
+	// asserted rather than described so the guard above is not merely
+	// passing on a value the test itself chose correctly.
+	wrong := fleetOrgItemsForSovereign(rows, "hw293.omantel.biz", testInfraSet(), knownOrgs)
+	wrongByName := map[string]float64{}
+	for _, it := range wrong {
+		wrongByName[it.Name] = it.SizeValue
+	}
+	if wrongByName["Unowned namespaces"] != 150 {
+		t.Errorf("expected an FQDN-shaped parent to sweep the estate's own 100 units into the "+
+			"unowned bucket alongside the orphan's 50 (=150), got %v — if this no longer holds, "+
+			"the parent-slug derivation has stopped mattering and this guard is decorative", wrongByName)
+	}
+}
+
+// TestShowbackParentSlug_IsOneDerivationForBothSurfaces pins the shared
+// seam itself. #5819 fixed the FQDN-vs-slug mismatch on the showback side;
+// it came back on the treemap because the identifier was derived a second
+// time in a second place. Both callers now route through this function, so
+// the value is asserted once, here.
+func TestShowbackParentSlug_IsOneDerivationForBothSurfaces(t *testing.T) {
+	cases := []struct{ fqdn, want string }{
+		{"hw293.omantel.biz", "hw293-omantel-biz"},
+		{"t99.omani.works", "t99-omani-works"},
+		// Unresolvable Sovereign → the visibly synthetic placeholder, never
+		// an invented plausible-looking slug.
+		{"", "sovereign"},
+		{"   ", "sovereign"},
+	}
+	for _, tc := range cases {
+		if got := showbackParentSlug(tc.fqdn); got != tc.want {
+			t.Errorf("showbackParentSlug(%q) = %q, want %q", tc.fqdn, got, tc.want)
+		}
+	}
+
+	// The value must be label-shaped: a dot can never match an
+	// `openova.io/organization` value, which is the defect that keeps
+	// recurring.
+	if got := showbackParentSlug("hw293.omantel.biz"); strings.Contains(got, ".") {
+		t.Errorf("showbackParentSlug returned %q — a dotted value matches no CR slug label", got)
+	}
+
+	// And the showback handler's own resolver agrees with it, so the two
+	// surfaces cannot report two spellings of one estate.
+	h := &Handler{}
+	h.deployments.Store("dep-6114", newDepWithFQDN("dep-6114", "hw293.omantel.biz"))
+	if got, want := h.consumptionParentOrg("dep-6114"), showbackParentSlug("hw293.omantel.biz"); got != want {
+		t.Errorf("consumptionParentOrg = %q but showbackParentSlug = %q — the surfaces have drifted again", got, want)
 	}
 }
 

--- a/products/catalyst/bootstrap/api/internal/handler/org_consumption_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_consumption_test.go
@@ -35,7 +35,7 @@ func TestAggregateConsumption_PlatformOverheadRollup(t *testing.T) {
 		{namespace: "acme", application: "scan-vulnerabilityreport-xyz", org: "acme", ownerKind: "Job", cpuReq: 50, memReq: 64 << 20},
 	}
 
-	resp := aggregateConsumption(rows, parent, testInfraSet())
+	resp := aggregateConsumption(rows, parent, testInfraSet(), nil)
 
 	// The parent estate row is always present and first.
 	if len(resp.Orgs) == 0 || !resp.Orgs[0].IsParent {
@@ -82,7 +82,7 @@ func TestAggregateConsumption_RealSecondOrgViaLabelJoinKey(t *testing.T) {
 		{namespace: "kube-system", application: "cilium", ownerKind: "DaemonSet", cpuReq: 100, memReq: 128 << 20},
 	}
 
-	resp := aggregateConsumption(rows, parent, testInfraSet())
+	resp := aggregateConsumption(rows, parent, testInfraSet(), nil)
 
 	var acme, beta *orgConsumption
 	for i := range resp.Orgs {
@@ -125,7 +125,7 @@ func TestAggregateConsumption_PerAppPercentSumsTo100WithinOrg(t *testing.T) {
 		{namespace: "acme", application: "blog", org: "acme", ownerKind: "StatefulSet", cpuReq: 200, memReq: 256 << 20},
 	}
 
-	resp := aggregateConsumption(rows, parent, testInfraSet())
+	resp := aggregateConsumption(rows, parent, testInfraSet(), nil)
 
 	var acme *orgConsumption
 	for i := range resp.Orgs {
@@ -162,7 +162,7 @@ func TestAggregateConsumption_PerAppPercentSumsTo100WithinOrg(t *testing.T) {
 
 func TestAggregateConsumption_EmptyEstateNeverBlank(t *testing.T) {
 	// Zero rows ⇒ still exactly one parent row (the §5 never-blank rule).
-	resp := aggregateConsumption(nil, "sovereign", testInfraSet())
+	resp := aggregateConsumption(nil, "sovereign", testInfraSet(), nil)
 	if len(resp.Orgs) != 1 {
 		t.Fatalf("empty estate must still render the parent row, got %d orgs", len(resp.Orgs))
 	}
@@ -188,7 +188,7 @@ func TestOrgForRow_KeysOnLabelNotName(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := orgForRow(tc.row, infra); got != tc.want {
+			if got := orgForRow(tc.row, infra, nil, "hw291-omani-works"); got != tc.want {
 				t.Errorf("orgForRow(%s) = %q, want %q", tc.name, got, tc.want)
 			}
 		})
@@ -233,7 +233,7 @@ func TestAggregateConsumption_OneShotJobsCollapseToASingleRow(t *testing.T) {
 		{namespace: "cert-manager", application: "cert-nextkey-guard", ownerKind: "Job", cpuReq: 10, memReq: 32 << 20},
 	}
 
-	resp := aggregateConsumption(rows, parent, testInfraSet())
+	resp := aggregateConsumption(rows, parent, testInfraSet(), nil)
 
 	platform := resp.Orgs[len(resp.Orgs)-1]
 	if !platform.IsPlatform {
@@ -331,7 +331,7 @@ func TestAggregateConsumption_SingleNamespaceCollapseKeepsRealNamespace(t *testi
 	resp := aggregateConsumption([]podRow{
 		{namespace: "catalyst-system", application: "cutover-harbor-prewarm-1785340840", ownerKind: "Job", cpuReq: 10},
 		{namespace: "catalyst-system", application: "cutover-gitea-mirror-1785340111", ownerKind: "Job", cpuReq: 20},
-	}, "hw291.omani.works", testInfraSet())
+	}, "hw291.omani.works", testInfraSet(), nil)
 
 	platform := resp.Orgs[len(resp.Orgs)-1]
 	if !platform.IsPlatform || len(platform.Apps) != 1 {
@@ -350,7 +350,7 @@ func TestAggregateConsumption_TenantAppsNeverCollapse(t *testing.T) {
 		{namespace: "acme", application: "blog", org: "acme", ownerKind: "StatefulSet", cpuReq: 200},
 		{namespace: "acme", application: "api", org: "acme", ownerKind: "Deployment", cpuReq: 300},
 		{namespace: "acme", application: "shop", org: "acme", ownerKind: "Deployment", cpuReq: 100},
-	}, "hw291.omani.works", testInfraSet())
+	}, "hw291.omani.works", testInfraSet(), nil)
 
 	var acme *orgConsumption
 	for i := range resp.Orgs {

--- a/products/catalyst/bootstrap/ui/src/lib/organizations.api.consumption-unowned-6114.test.ts
+++ b/products/catalyst/bootstrap/ui/src/lib/organizations.api.consumption-unowned-6114.test.ts
@@ -1,0 +1,74 @@
+/**
+ * organizations.api.consumption-unowned-6114.test.ts — the getConsumption
+ * mapper must carry the #6114 orphan fields through to the panel.
+ *
+ * Why this file exists as a separate guard: getConsumption rebuilds the
+ * response object field by field rather than passing the body through, so
+ * any field it does not explicitly name is silently dropped. Every
+ * ShowbackPanel test seeds its feed via the `initialOverride` prop and
+ * therefore never traverses this function — a mapper that dropped
+ * `unownedOrgs` would leave the orphan warning permanently unrenderable in
+ * the browser while the whole panel suite stayed green. That is the
+ * "the guard tested a surface that cannot fail" shape, so the mapping is
+ * asserted here, on the function the live page actually calls.
+ */
+
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+
+let responseBody: unknown = {}
+let responseOk = true
+
+vi.mock('@/shared/lib/authedFetch', () => ({
+  authedFetch: async () => ({
+    ok: responseOk,
+    json: async () => responseBody,
+  }),
+}))
+
+const { getConsumption } = await import('./organizations.api')
+
+beforeEach(() => {
+  responseOk = true
+  responseBody = {}
+})
+
+describe('getConsumption — #6114 orphan fields survive the mapper', () => {
+  it('carries unownedOrgs through with its exact values', async () => {
+    responseBody = {
+      totalCostUnits: 2168,
+      pending: false,
+      unownedOrgs: ['g7doora'],
+      orgs: [
+        { org: 'hw293vch', isParent: false, isPlatform: false, costUnits: 404, cpuMilli: 400, memoryGiB: 1, storageGiB: 0, apps: [] },
+        { org: '__unowned__', isParent: false, isPlatform: false, isUnowned: true, costUnits: 1764, cpuMilli: 1750, memoryGiB: 3.5, storageGiB: 0, apps: [] },
+      ],
+    }
+
+    const feed = await getConsumption()
+
+    expect(feed.unownedOrgs).toEqual(['g7doora'])
+    // The isUnowned flag rides along on the org rows the mapper passes
+    // through wholesale — asserted so a future mapper that starts
+    // reshaping org rows cannot drop it unnoticed.
+    expect(feed.orgs.find((o) => o.org === '__unowned__')?.isUnowned).toBe(true)
+    // CONTROL: the genuine Organization's numbers are untouched.
+    expect(feed.orgs.find((o) => o.org === 'hw293vch')?.costUnits).toBe(404)
+    expect(feed.totalCostUnits).toBe(2168)
+  })
+
+  it('yields an empty list, not undefined, when the estate has no orphans', async () => {
+    responseBody = { totalCostUnits: 900, pending: false, orgs: [] }
+
+    const feed = await getConsumption()
+
+    expect(feed.unownedOrgs).toEqual([])
+  })
+
+  it('tolerates a malformed unownedOrgs without crashing the panel', async () => {
+    responseBody = { totalCostUnits: 0, pending: false, orgs: [], unownedOrgs: 'g7doora' }
+
+    const feed = await getConsumption()
+
+    expect(feed.unownedOrgs).toEqual([])
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/lib/organizations.api.ts
+++ b/products/catalyst/bootstrap/ui/src/lib/organizations.api.ts
@@ -381,6 +381,12 @@ export async function getConsumption(): Promise<SovereignConsumption> {
     return {
       totalCostUnits: Number(body.totalCostUnits ?? 0),
       orgs: Array.isArray(body.orgs) ? (body.orgs as OrgConsumption[]) : [],
+      // #6114: this mapper rebuilds the object field by field, so a field
+      // it does not name is dropped no matter what the API sends. Omitting
+      // unownedOrgs here would leave the orphan warning permanently
+      // unrenderable while every panel-level test still passed — they seed
+      // the feed through initialOverride and never traverse this function.
+      unownedOrgs: Array.isArray(body.unownedOrgs) ? (body.unownedOrgs as string[]) : [],
       pending: Boolean(body.pending),
     }
   } catch {

--- a/products/catalyst/bootstrap/ui/src/lib/organizations.api.ts
+++ b/products/catalyst/bootstrap/ui/src/lib/organizations.api.ts
@@ -324,6 +324,14 @@ export interface OrgConsumption {
   /** True on the single synthetic "Platform overhead" row the API folds
    *  infra/Job usage into (org_consumption.go `json:"isPlatform"`). */
   isPlatform?: boolean
+  /** True on the single synthetic "Unowned namespaces" row (#6114,
+   *  org_consumption.go `json:"isUnowned"`): real consumption whose
+   *  namespace carries an `openova.io/organization` label that no
+   *  Organization CR claims. It is NOT an Organization and must never be
+   *  labelled as one — the panel says so explicitly, because the whole
+   *  reason this row exists is that the alternative to billing a phantom
+   *  Org is showing the orphan, not hiding it. */
+  isUnowned?: boolean
   costUnits: number
   cpuMilli: number
   memoryGiB: number
@@ -335,6 +343,9 @@ export interface OrgConsumption {
 export interface SovereignConsumption {
   totalCostUnits: number
   orgs: OrgConsumption[]
+  /** The `openova.io/organization` label values drawing consumption with
+   *  no Organization CR behind them (#6114). Empty on a healthy estate. */
+  unownedOrgs?: string[]
   /** True when the metrics cache wasn't ready — the panel flags "metering
    *  warming up" instead of asserting a false zero. */
   pending: boolean
@@ -343,6 +354,7 @@ export interface SovereignConsumption {
 const EMPTY_CONSUMPTION: SovereignConsumption = {
   totalCostUnits: 0,
   orgs: [],
+  unownedOrgs: [],
   pending: true,
 }
 

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/organizations/ShowbackPanel.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/organizations/ShowbackPanel.test.tsx
@@ -96,4 +96,43 @@ describe('ShowbackPanel — parent self-showback (DoD 3)', () => {
     renderPanel({ totalCostUnits: 0, pending: true, orgs: [] })
     expect(screen.getByTestId('showback-empty')).toBeTruthy()
   })
+
+  // #6114 / UAT row 25(c) — hw293 billed `g7doora` 4272.25 units as a
+  // customer Organization while `kubectl get organizations` did not list
+  // it. The API now routes that consumption to the synthetic unowned
+  // rollup; the panel must say what it is rather than calling it an
+  // Organization or printing the raw `__unowned__` sentinel.
+  it('names the unowned rollup instead of claiming it is an Organization', () => {
+    const orphaned: SovereignConsumption = {
+      totalCostUnits: 2168,
+      pending: false,
+      unownedOrgs: ['g7doora'],
+      orgs: [
+        { org: 'sovereign', isParent: true, isPlatform: false, costUnits: 0, cpuMilli: 0, memoryGiB: 0, storageGiB: 0, apps: [] },
+        { org: 'hw293vch', isParent: false, isPlatform: false, costUnits: 404, cpuMilli: 400, memoryGiB: 1, storageGiB: 0,
+          apps: [{ application: 'bp-newapi', namespace: 'hw293vch', costUnits: 404, cpuMilli: 400, memoryGiB: 1, storageGiB: 0, percent: 100 }] },
+        { org: '__unowned__', isParent: false, isPlatform: false, isUnowned: true, costUnits: 1764, cpuMilli: 1750, memoryGiB: 3.5, storageGiB: 0,
+          apps: [{ application: 'bp-keycloak', namespace: 'g7doora', costUnits: 1008, cpuMilli: 1000, memoryGiB: 2, storageGiB: 0, percent: 57.14 }] },
+      ],
+    }
+    renderPanel(orphaned)
+
+    // The row is labelled honestly — not "(Organization)", not the sentinel.
+    const labels = screen.getAllByTestId('showback-org').map((n) => n.textContent)
+    expect(labels).toContain('Unowned namespaces')
+    expect(labels).not.toContain('__unowned__')
+
+    // The orphaned slug is named explicitly, which is the whole point of
+    // not billing it silently.
+    expect(screen.getByTestId('showback-unowned-slugs').textContent).toBe('g7doora')
+
+    // CONTROL: the genuine Organization alongside it still renders in full.
+    expect(screen.getByTestId('showback-org-slice-hw293vch')).toBeTruthy()
+    expect(screen.getAllByTestId('showback-total').some((n) => n.textContent === '404')).toBe(true)
+  })
+
+  it('shows no unowned warning on a healthy estate', () => {
+    renderPanel(FEED)
+    expect(screen.queryByTestId('showback-unowned-warning')).toBeNull()
+  })
 })

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/organizations/ShowbackPanel.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/organizations/ShowbackPanel.tsx
@@ -33,15 +33,25 @@ export interface ShowbackPanelProps {
 /** OrgShowbackSlice — one org's per-app consumption block. Rendered once
  *  in the org-detail view and once per org in the directory view. */
 function OrgShowbackSlice({ target }: { target: OrgConsumption }) {
+  // #6114: the unowned rollup must never read "(Organization)". Its whole
+  // reason for existing is that the consumption belongs to no Organization
+  // — labelling it as one restates the defect on the surface that is
+  // supposed to expose it, and the raw `__unowned__` sentinel would render
+  // as a malformed slug.
+  const label = target.isUnowned
+    ? 'Unowned namespaces'
+    : target.org
   return (
     <div data-testid={`showback-org-slice-${target.org}`} className="mb-4 last:mb-0">
       <p className="mb-2 text-xs text-[var(--color-text-dim)]">
-        <span data-testid="showback-org" className="font-medium text-[var(--color-text)]">{target.org}</span>
+        <span data-testid="showback-org" className="font-medium text-[var(--color-text)]">{label}</span>
         {target.isParent
           ? ' (parent — your own estate)'
           : target.isPlatform
             ? ' (platform overhead)'
-            : ' (Organization)'}{' '}
+            : target.isUnowned
+              ? ' (no Organization CR — not billed to any Organization)'
+              : ' (Organization)'}{' '}
         ·{' '}
         <span data-testid="showback-total" className="font-mono">{target.costUnits}</span> units ·{' '}
         {target.cpuMilli}m CPU · {target.memoryGiB} GiB mem · {target.storageGiB} GiB storage
@@ -119,6 +129,27 @@ export function ShowbackPanel({ org, initialOverride }: ShowbackPanelProps) {
           </span>
         ) : null}
       </div>
+
+      {/* #6114 (UAT row 25): name the orphans. The directory view is where
+          the sets are compared, so this is where a slug that draws
+          consumption with no Organization CR behind it has to be said out
+          loud — an estate can otherwise run a whole namespace's worth of
+          workloads under an identity the control plane does not model, and
+          nothing on any surface says so. */}
+      {!org && feed && (feed.unownedOrgs?.length ?? 0) > 0 ? (
+        <div
+          data-testid="showback-unowned-warning"
+          className="mb-3 rounded-lg border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-amber-200"
+        >
+          <span className="font-semibold">No Organization CR:</span>{' '}
+          <span data-testid="showback-unowned-slugs" className="font-mono">
+            {feed.unownedOrgs?.join(', ')}
+          </span>{' '}
+          — these namespaces draw consumption but the control plane holds no
+          Organization for them, so nothing is billed to an Organization.
+          Reconcile or remove them.
+        </div>
+      ) : null}
 
       {loading ? (
         <div data-testid="showback-loading" className="text-sm text-[var(--color-text-dim)]">Loading…</div>


### PR DESCRIPTION
## Hold lifted — #6172 landed

The hold cited on this PR was "hw294 is mid-provision and wedged on #6172". That wedge is fixed and merged: bp-keycloak 1.5.10 (#6177, merge c290d0a1) gives the catalyst-pin backchannel a ClusterIP anchor the chart owns, so the sovereign realm import no longer 400s at bootstrap-kit slot 09. This PR touches only catalyst-api handlers and console sources - no chart, no pin, no bootstrap-kit slot - and its full check set is green.

## The join site

`products/catalyst/bootstrap/api/internal/handler/org_consumption.go:364` — `orgForRow`, before this change:

```go
if org := strings.TrimSpace(row.org); org != "" {
    return org
}
```

The `openova.io/organization` namespace label was the entire join. Nothing cross-checked it against the object model, so any namespace carrying the label became a billable Organization by virtue of carrying the label.

## The mechanism, and the read that proves it

`buildPodRows` (`dashboard.go:604`) lifts the label onto `podRow.org`. `aggregateConsumption` calls `orgForRow` per row and `ensureOrg(org)` mints a customer Organization row for whatever comes back. Two consequences, both measured on hw293 (`hw293.omantel.biz`, dep `a0077ba47e3720e5`), both recorded on UAT row 25:

**Forward — billed without a CR.** `g7doora` has no Organization CR. `kubectl get organizations` listed `hw293vch`, `hw293walkone`, `hw293walktwo`, `uat107org`, `uat107vc` — not `g7doora`. It nonetheless drew the largest customer showback slice on the Sovereign, **4272.25 units** across bp-keycloak, bp-agenity, bp-stalwart-tenant, bp-newapi, bp-openclaw and bp-wordpress, up from 2574 the previous walk, because the namespace kept converging after the Org create failed. The producer explains why the state exists at all: `org_tenant_org_cr.go:84` `createOrgOrganizationCR` is deliberately best-effort — it returns early on an invalid slug and logs-and-returns on a create failure, without failing the Organization pipeline. So a failed create leaves the provisioning record (the directory) and the labelled namespace, and no CR.

**Inverse — a CR that is not billed. It does occur.** Org rows only ever materialised from pod rows, so an Organization's presence in showback tracked whether it happened to be running a pod rather than whether it exists. Row 25(b) measured exactly that: `uat107org` has a CR, appears in the directory, and drew **no slice at all**, while its twin `uat107vc` — created and deleted the same way on the same day, both reading state `deleted` — carried **525.5 units** purely because its pods had not finished terminating. Same disposition, different treatment. A join defect usually cuts both ways, and this one does.

## The decision

**(c), with (a)'s set-discipline.** The billable set becomes a strict function of the Organization CR set, and the orphan is surfaced explicitly rather than silently dropped.

- **Not (b), reap the namespace.** Deletion belongs to the organization-controller's finalizer cascade, not to a read-only showback aggregation. A namespace legitimately outlives its CR for the duration of a teardown, and no predicate this handler can evaluate from a cache read separates "orphan" from "mid-delete" safely enough to justify destroying data.
- **Not (a) alone.** Excluding the rows would make `TotalCostUnits` understate the estate by the orphan's whole footprint and leave no surface on which the orphan is visible. Silently billing an entity that does not exist is definitely wrong; silently un-billing it is the same failure with the sign flipped.
- **Not folded into `__platform__`.** "Platform overhead" asserts the consumption is the control plane's own. That is false of a half-torn-down customer namespace, and it re-hides the orphan behind the one line a sovereign-admin is trained to skip.

So: a labelled namespace with no CR routes to a distinct `__unowned__` rollup, its slugs are named in a new `unownedOrgs` response field and an amber console banner, and its units still count toward the estate total. Every Organization CR gets a row whether or not it runs a pod, which closes the inverse.

The Organization CR set comes from the k8scache kind already registered at `k8scache/kinds.go:271` — no new informer, no apiserver round-trip, no RBAC rule. `nil` means **"not read"**, never "empty": a cold or unsynced informer must not relabel a whole estate as unowned and bill nobody, so moving a row into unowned requires positive evidence the CR set was actually read.

The treemap shares `orgForRow` by design (`fleet_treemap.go:455` says so), so the Organization set is threaded through it too — the two surfaces drifting is precisely what sharing the resolver exists to prevent, and it is one of the four disagreements row 25 names.

## Red → green, verbatim

RED — the two behavioural lines neutered, signatures unchanged, so the test compiles against the pre-fix semantics:

```
$ go test ./internal/handler/ -run 'TestBillableSet' -count=1
--- FAIL: TestBillableSet_ANamespaceWithNoOrganizationCRIsNeverBilled (0.00s)
    org_consumption_billable_set_6114_test.go:88: g7doora is billed 1764 units as a customer Organization, but it has no Organization CR (the CR set is [hw293vch hw293walkone hw293walktwo uat107org uat107vc]) — this is the hw293 4272.25-unit phantom
    org_consumption_billable_set_6114_test.go:102: no unowned rollup row: g7doora's consumption vanished entirely from the feed, which understates the estate by its whole footprint.
--- FAIL: TestBillableSet_AnOrganizationWithACRIsBilledEvenWithNothingRunning (0.00s)
    org_consumption_billable_set_6114_test.go:159: Organization "hw293vch" has a CR but draws no showback slice at all — the billable set [uat107vc] is missing it
    org_consumption_billable_set_6114_test.go:159: Organization "hw293walkone" has a CR but draws no showback slice at all — the billable set [uat107vc] is missing it
    org_consumption_billable_set_6114_test.go:159: Organization "hw293walktwo" has a CR but draws no showback slice at all — the billable set [uat107vc] is missing it
    org_consumption_billable_set_6114_test.go:159: Organization "uat107org" has a CR but draws no showback slice at all — the billable set [uat107vc] is missing it
    org_consumption_billable_set_6114_test.go:175: billable set has 1 Orgs, Organization CR set has 5 — the sets must be equal. billed=[uat107vc] crs=[hw293vch hw293walkone hw293walktwo uat107org uat107vc]
--- FAIL: TestBillableSet_GenuineOrganizationsAreStillBilledInFull (0.00s)
    org_consumption_billable_set_6114_test.go:211: billable set = [acme beta ghost], want exactly {acme, beta}
--- FAIL: TestBillableSet_UnownedRollupOrdersBeforePlatformOverhead (0.00s)
    org_consumption_billable_set_6114_test.go:311: row order = [hw293-omantel-biz acme ghost __platform__], want [hw293-omantel-biz acme __unowned__ __platform__]
--- FAIL: TestBillableSet_VacuityCheck_PreFixBehaviourFailsBothAssertions (0.00s)
    org_consumption_billable_set_6114_test.go:374: shipped aggregation still bills g7doora — the fix is inert
    org_consumption_billable_set_6114_test.go:377: shipped aggregation still drops uat107org — the inverse half is inert
FAIL
FAIL	github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/handler	0.019s
```

The red reproduces the measurement: `g7doora` billed as a customer Organization with no CR, four CR-holding Organizations absent from the billable set.

GREEN — fix restored, nothing else changed:

```
$ go test ./internal/handler/ -run 'TestBillableSet' -count=1 -v
=== RUN   TestBillableSet_ANamespaceWithNoOrganizationCRIsNeverBilled
--- PASS: TestBillableSet_ANamespaceWithNoOrganizationCRIsNeverBilled (0.00s)
=== RUN   TestBillableSet_AnOrganizationWithACRIsBilledEvenWithNothingRunning
--- PASS: TestBillableSet_AnOrganizationWithACRIsBilledEvenWithNothingRunning (0.00s)
=== RUN   TestBillableSet_GenuineOrganizationsAreStillBilledInFull
--- PASS: TestBillableSet_GenuineOrganizationsAreStillBilledInFull (0.00s)
=== RUN   TestBillableSet_AnUnreadOrganizationSetChangesNothing
--- PASS: TestBillableSet_AnUnreadOrganizationSetChangesNothing (0.00s)
=== RUN   TestBillableSet_ParentEstateIsOwnedWithoutACR
--- PASS: TestBillableSet_ParentEstateIsOwnedWithoutACR (0.00s)
=== RUN   TestBillableSet_UnownedRollupOrdersBeforePlatformOverhead
--- PASS: TestBillableSet_UnownedRollupOrdersBeforePlatformOverhead (0.00s)
=== RUN   TestBillableSet_VacuityCheck_PreFixBehaviourFailsBothAssertions
--- PASS: TestBillableSet_VacuityCheck_PreFixBehaviourFailsBothAssertions (0.00s)
PASS
ok  	github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/handler	0.018s
```

## The control

`TestBillableSet_GenuineOrganizationsAreStillBilledInFull` shares the suspect property — `acme` and `beta` are attributed through the exact same label join key that mis-billed `g7doora`, and they sit in the same aggregation as an orphan. It asserts the full billed values (802 and 302), the per-app ordering, the percent share summing to 100, and the estate total of 1204 including the orphan's 100. Failing this test in either direction catches the over-correction: a fix that billed nothing, or one that let the orphan through, both move those numbers.

Two further guards against over-correcting into "nothing is billed":

- `TestBillableSet_AnUnreadOrganizationSetChangesNothing` — a `nil` (unread) Organization set leaves `acme` at 201 and `g7doora` at 1008, i.e. exactly the pre-fix attribution, and produces no unowned entries. An unread set is not an empty one.
- `TestBillableSet_ParentEstateIsOwnedWithoutACR` — the parent estate keeps its 100 units even when the CR set does not contain its slug, so the Sovereign's own row cannot vanish from its own showback page.

Every assertion is on a **value** — the unit count, the joined set, the row order — never on key presence. The whole pre-existing suite is untouched and green (`ok ... 304.989s` for the full `internal/handler` package), including `TestAggregateConsumption_RealSecondOrgViaLabelJoinKey`, `TestAggregateConsumption_PerAppPercentSumsTo100WithinOrg` and `TestFleetOrgItemsForSovereign_SeparatesCustomerFromPlatform`.

## The vacuity check

`TestBillableSet_VacuityCheck_PreFixBehaviourFailsBothAssertions` reconstructs the pre-#6114 resolver and aggregation inline and asserts that the reconstruction **does** bill `g7doora` and **does not** produce a `uat107org` row — i.e. that both new assertions would have failed before the fix. It then runs the same rows through the shipped aggregation and asserts both invert. If the new assertions were ever weakened to the point of passing on the old behaviour, this test fails first and says which half went inert.

## A second defect found while wiring the console (commit 2)

`getConsumption` (`organizations.api.ts:368`) rebuilds the response object field by field instead of passing the body through, and named only `totalCostUnits`, `orgs` and `pending`. The orphan banner was therefore **unreachable in a browser** — the API would send `unownedOrgs`, the mapper would discard them, and the panel would render nothing — while every `ShowbackPanel` test still passed, because they all seed the feed through the `initialOverride` prop and never traverse that function. A guard on a surface that cannot fail.

`organizations.api.consumption-unowned-6114.test.ts` asserts the mapping on `getConsumption` itself with `authedFetch` mocked, so it exercises the path the live page calls. Proven red without the fix:

```
$ npx vitest run src/lib/organizations.api.consumption-unowned-6114.test.ts
⎯⎯⎯⎯⎯⎯⎯ Failed Tests 3 ⎯⎯⎯⎯⎯⎯⎯
AssertionError: expected undefined to deeply equal [ 'g7doora' ]
AssertionError: expected undefined to deeply equal []
AssertionError: expected undefined to deeply equal []
 Test Files  1 failed (1)
      Tests  3 failed (3)
```

Green after: `Test Files 3 passed (3) · Tests 20 passed (20)` across the mapper test, the panel suite and the existing `organizations.api` suite. `tsc --noEmit` clean.

## A third defect, self-reviewed out of commit 1 (commit 4)

`orgForRow`'s "always owned" escape keys on `org == parentOrg`, and `collectFleetOrgItems` derived its `parentOrg` as the **raw Sovereign FQDN** while showback derives it as the CR slug. That was harmless while an unmatched parent merely failed to group. Under the new CR cross-check it is not: an FQDN matches no label value, so the escape would have been denied to the Sovereign's own slug-labelled namespaces, and on an estate whose self-org CR is absent the treemap would have rendered **the operator's own workloads as "Unowned namespaces"** while showback correctly placed them on the parent row. Commit 1 would have shipped that regression.

`#5819` fixed exactly this on the showback side. It survived on the treemap because the identifier was derived a second time in a second place. The treemap now goes through `showbackParentSlug`, and `TestShowbackParentSlug_IsOneDerivationForBothSurfaces` pins its value against `consumptionParentOrg` for the same FQDN so they cannot drift again silently.

`TestBillableSet_TreemapAgreesWithShowbackOnTheSameEstate` asserts both surfaces bucket the same three rows identically, **and** asserts the stake directly — feeding the pure function an FQDN-shaped parent sweeps the estate's own 100 units into the unowned bucket (150 total with the orphan's 50). Without that second assertion the test would have passed on a value the test itself chose correctly, which is the "guard on a surface that cannot fail" shape.

Two pre-existing guards caught real defects in the first attempt and are worth recording, because both were right:

- `orgNamespace("")` returns `"org"`, not `""` (`namespace_ensure.go:79`). A guard written on the *output* being empty would have handed an unidentifiable estate the real-looking slug `org`. `TestConsumptionParentOrg_UnknownDeploymentKeepsSyntheticFallback` failed on exactly that. The check is on the **input**.
- `TestConsumptionParentOrg_RoutesThroughTheCanonicalSeam` walks the AST and requires that function to call `orgNamespace` **directly**. Routing it through a wrapper broke the letter of an invariant worth keeping, so `consumptionParentOrg` is left byte-identical to `main` and the two derivations are pinned together by value instead of by refactor. No existing guard was weakened to make this PR pass.

## What this does NOT close on row 25

Row 25's clause (b) also observes that the **directory** lists eight sub-Orgs while `kubectl get organizations` holds five. This PR makes showback and the treemap agree with the Organization CR set; it does not change the directory, which is backed by the provisioning store, not the CRs. The reason those diverge is upstream and worth naming: `createOrgOrganizationCR` (`org_tenant_org_cr.go:84`) is deliberately best-effort — it returns early on a slug the CRD would reject and logs-and-returns on a create failure, without failing the Organization pipeline. So a failed create leaves a directory record and a labelled namespace with no CR, which is exactly how `g7doora` came to exist. Closing that half is a change to the funnel's failure handling, not to the metering feed, and it is a separate piece of work.

## Not claimed

hw293 no longer exists, so this is source-and-test work. No runtime evidence is claimed here; the numbers above are unit-test values chosen to mirror the recorded hw293 measurement, not fresh cluster reads. Live re-walk of row 25 belongs to hw294 once #6172 clears.

Refs #6114

