### PR TITLE
fix(bp-keycloak): the realm import named a Service that the realm import is what creates (Refs #6172)

### DIFF
--- a/clusters/_template/bootstrap-kit/09-keycloak.yaml
+++ b/clusters/_template/bootstrap-kit/09-keycloak.yaml
@@ -236,7 +236,19 @@ spec:
       #   catalystAPIInternalURL, with a ClusterMesh-safe toEndpoints selector so the
       #   region-B Keycloak (this slot is NOT SECONDARY_HR_SUSPEND'd) can reach the
       #   region-A catalyst-api over the mesh. Ingress half in bp-catalyst-platform.
-      version: 1.5.9
+      # 1.5.10 — #6172: 1.5.8's backchannel named `catalyst-api.catalyst-system`,
+      #   a Service bp-catalyst-platform creates at slot 13 — behind bp-gitea,
+      #   behind THIS slot. Keycloak accepts a PLAINTEXT identity-provider URL
+      #   only while its host resolves to a private address (UriUtils.checkUrl →
+      #   SslRequired.EXTERNAL → InetAddress.getByName) and the sovereign realm
+      #   ships sslRequired: external, so on fresh prov hw294 the import 400'd
+      #   with `The url [token_url] requires secure connections` and Phase 1
+      #   stalled at 51/67 behind 16 HelmReleases. The chart now renders its own
+      #   ClusterIP anchor at `catalyst-api-backchannel.catalyst-system` — a
+      #   ClusterIP resolves with zero endpoints and routes to catalyst-api once
+      #   slot 13 lands. Also: the config-cli Job now prints the SERVER's error
+      #   body on a failed import instead of a bare 400.
+      version: 1.5.10
       sourceRef:
         kind: HelmRepository
         name: bp-keycloak

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1389,7 +1389,7 @@ spec:
       #   guacamole-pg and the shared-pg family as well. Egress half in
       #   bp-keycloak 1.5.9; neither half alone restores a brokered login.
       #   Lockstep w/ products/catalyst/chart/Chart.yaml.
-      version: 1.4.1409
+      version: 1.4.1411
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/platform/keycloak/blueprint.yaml
+++ b/platform/keycloak/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.5.9
+  version: 1.5.10
   card:
     title: keycloak
     summary: Keycloak — user identity. Topology decided by Sovereign CRD spec.keycloakTopology (per-organization for Organizations, shared-sovereign for corporate).

--- a/platform/keycloak/chart/Chart.yaml
+++ b/platform/keycloak/chart/Chart.yaml
@@ -499,7 +499,64 @@ name: bp-keycloak
 # (baseline-allow-keycloak-oidc-backchannel); neither half alone restores a
 # brokered login. Gated on the cilium.io/v2 Capabilities check so CRD-less
 # clusters still install. Guarded by tests/catalyst-backchannel-netpol-6106.sh.
-version: 1.5.9
+# 1.5.10 (#6172): 1.5.8's backchannel pointed the realm at a Service that
+# does not exist yet, and the realm import is what unblocks the chart that
+# creates it. Fresh prov hw294 stalled Phase 1 at 51/67 with 16 HelmReleases
+# -- cutover, the per-Org workspace and every SSO consumer -- parked behind
+# bp-keycloak, because keycloak-config-cli's post-install Job failed
+# BackoffLimitExceeded on an unattributed `Create method returned status Bad
+# Request (Code: 400)`.
+#   Keycloak validates an identity provider's URLs at CREATE. From
+# org.keycloak.common.util.UriUtils.checkUrl in 26.3.3:
+#     if (!"https".equals(protocol) && sslRequired.isRequired(parsed.getHost()))
+#         throw new IllegalArgumentException(
+#             "The url [" + name + "] requires secure connections");
+# and SslRequired.EXTERNAL.isRequired(host) is !isLocal(host), where isLocal
+# is InetAddress.getByName(host) -> loopback / site-local / link-local / ULA.
+# The sovereign realm ships sslRequired: external, so a PLAINTEXT leg is legal
+# only while its host RESOLVES to a private address. It did not: bp-keycloak
+# is bootstrap-kit slot 09 and `catalyst-api` is created by
+# bp-catalyst-platform at slot 13, whose HelmRelease dependsOn bp-gitea ->
+# bp-keycloak. Measured inside keycloak-0 on hw294 region A: `getent hosts
+# catalyst-api.catalyst-system.svc.cluster.local` -> rc=2 (NXDOMAIN), control
+# `kubernetes.default.svc.cluster.local` -> 10.96.0.1. Reproduced against
+# Keycloak 26.3.3 with the realm's own IdP payload:
+#     POST /admin/realms/<realm>/identity-provider/instances
+#     HTTP/1.1 400 Bad Request
+#     {"errorMessage":"The url [token_url] requires secure connections"}
+#   New template `templates/catalyst-api-backchannel-service.yaml` renders the
+# backchannel host as a ClusterIP Service THIS chart owns. A ClusterIP is
+# allocated at create time and CoreDNS answers for it with zero endpoints, so
+# the name resolves to a site-local address from slot 09 and routes to
+# catalyst-api's Pods through the same selector once slot 13 lands. Proven
+# live on hw294 region B, where bp-catalyst-edge-routes renders the same shape
+# and catalyst-api runs only in region A: `endpoints catalyst-api -> <none>`
+# while the name answers 10.97.176.117. That asymmetry IS the defect -- region
+# B got its anchor for free from slot 13e, region A never had one.
+#   The host is `catalyst-api-backchannel`, deliberately NOT `catalyst-api`:
+# Helm refuses a resource another release owns, so reusing the name would
+# unwedge slot 09 by wedging bp-catalyst-platform at slot 13 instead. The
+# template fails the render loudly if the two are ever collapsed.
+#   #6087's split is untouched -- authorizationUrl and issuer stay PUBLIC
+# https (browser redirect; iss claim), only the three server-side legs move.
+#   The #6106 egress CNP now selects the catalyst-api WORKLOAD via the new
+# `catalystAPIWorkloadName` value instead of deriving the Pod label from the
+# URL's first DNS label. That derivation was correct only while the Service
+# name and the Pod label were the same string, and a CNP that selects nothing
+# renders exactly as green as one that selects the right endpoints. Both it
+# and the anchor read ONE parse, the new `bp-keycloak.catalystBackchannel`
+# helper, so the realm, the policy and the anchor cannot disagree.
+#   DIAGNOSTIC: keycloak-config-cli's Job now runs under a wrapper that, on a
+# NON-ZERO exit only, replays the same import with HTTP logging and prints the
+# request LINE, the 4xx/5xx status line and the error payload -- the server's
+# own answer, which upstream discards identically on v6.4.0, v6.4.1, v6.5.0
+# and main (IdentityProviderRepository.create hands the Response straight to
+# CreatedResponseUtil.getCreatedId). Request bodies and success-response
+# bodies are never printed and lines are capped, because the import carries
+# client secrets. The happy path pays nothing and the Job still exits with the
+# original code.
+#   Guarded by tests/catalyst-pin-backchannel-resolvable-6172.sh.
+version: 1.5.10
 description: |
   1.5.2 (#4246): the per-tenant `openclaw-oidc-client-secret` Secret now
   emits BOTH `client-secret` AND `OIDC_CLIENT_SECRET` keys (it previously

--- a/platform/keycloak/chart/templates/_helpers.tpl
+++ b/platform/keycloak/chart/templates/_helpers.tpl
@@ -212,3 +212,76 @@ don't rotate per-Org broker secrets.
 {{- end -}}
 {{- $seed | sha256sum -}}
 {{- end -}}
+
+{{/*
+bp-keycloak.catalystBackchannel (#6172) — parse `catalystAPIInternalURL`
+into its parts ONCE, for every consumer.
+
+Returns a YAML mapping the caller reads with `fromYaml`:
+
+  scheme     http | https
+  host       the authority's host  (no port)
+  port       explicit port, else 443/80 by scheme
+  svc        first DNS label  — the Service name, when inCluster
+  ns         second DNS label — the Service namespace, when inCluster
+  inCluster  true when the host is a Kubernetes Service DNS shape
+             (<svc>.<ns>, <svc>.<ns>.svc, <svc>.<ns>.svc.cluster.local)
+  url        the trimmed, trailing-slash-free URL
+
+An empty/absent value yields `url: ""` and `inCluster: false` — the
+all-public backchannel an operator restores on a hairpin-capable EIP.
+
+WHY THIS IS A HELPER AND NOT PARSED TWICE
+─────────────────────────────────────────────────────────────────────────
+Three templates now depend on the SAME parse and must never disagree:
+
+  * configmap-sovereign-realm.yaml   — writes the URL into the realm
+  * catalyst-backchannel-egress-cnp.yaml (#6106) — opens egress to it
+  * catalyst-api-backchannel-service.yaml (#6172) — MAKES IT RESOLVE
+
+If the third disagreed with the first by so much as a label, the realm
+would name a host nothing renders, and Keycloak would refuse the import
+with `The url [token_url] requires secure connections` — the hw294
+wedge this helper exists to make structurally impossible.
+*/}}
+{{- define "bp-keycloak.catalystBackchannel" -}}
+{{- $url := trimSuffix "/" (trim (.Values.catalystAPIInternalURL | default "")) -}}
+{{- if not $url -}}
+url: ""
+inCluster: false
+{{- else -}}
+{{- $scheme := "" -}}
+{{- $rest := "" -}}
+{{- if hasPrefix "http://" $url -}}
+{{- $scheme = "http" -}}
+{{- $rest = trimPrefix "http://" $url -}}
+{{- else if hasPrefix "https://" $url -}}
+{{- $scheme = "https" -}}
+{{- $rest = trimPrefix "https://" $url -}}
+{{- else -}}
+{{- fail (printf "bp-keycloak: catalystAPIInternalURL must be an http:// or https:// URL, got %q. An unparseable value would silently emit NO backchannel egress policy and no resolution anchor, and would re-break every catalyst-pin brokered login (#6106 #6172)." $url) -}}
+{{- end -}}
+{{- $authority := first (splitList "/" $rest) -}}
+{{- $hostport := splitList ":" $authority -}}
+{{- $host := index $hostport 0 -}}
+{{- $port := "" -}}
+{{- if gt (len $hostport) 1 -}}
+{{- $port = index $hostport 1 -}}
+{{- else if eq $scheme "https" -}}
+{{- $port = "443" -}}
+{{- else -}}
+{{- $port = "80" -}}
+{{- end -}}
+{{- $dnsLabels := splitList "." $host -}}
+{{- $inCluster := and (ge (len $dnsLabels) 2) (or (eq (len $dnsLabels) 2) (eq (index $dnsLabels 2) "svc")) -}}
+url: {{ $url | quote }}
+scheme: {{ $scheme | quote }}
+host: {{ $host | quote }}
+port: {{ $port | quote }}
+inCluster: {{ $inCluster }}
+{{- if $inCluster }}
+svc: {{ index $dnsLabels 0 | quote }}
+ns: {{ index $dnsLabels 1 | quote }}
+{{- end }}
+{{- end -}}
+{{- end -}}

--- a/platform/keycloak/chart/templates/catalyst-api-backchannel-service.yaml
+++ b/platform/keycloak/chart/templates/catalyst-api-backchannel-service.yaml
@@ -1,0 +1,156 @@
+{{- /*
+Resolution ANCHOR for the catalyst-pin OIDC backchannel (#6172).
+
+WHAT BROKE — fresh prov hw294, Phase 1 stalled at 51/67
+─────────────────────────────────────────────────────────────────────────
+#6087/#6089 (bp-keycloak 1.5.8) repointed the sovereign realm's
+`catalyst-pin` identity provider so its server-side legs — tokenUrl,
+userInfoUrl, jwksUrl — dial catalyst-api in-cluster over PLAINTEXT http
+instead of hairpinning through the Sovereign's own public EIP. Correct
+for the hairpin, and it is what UAT row 219 needs. But it made the realm
+import depend on a name that does not exist yet, and the import is what
+creates the realm.
+
+Keycloak 26.3.3 validates an identity provider's URLs at CREATE. From
+`org.keycloak.common.util.UriUtils.checkUrl`:
+
+    if (!"https".equals(protocol) && sslRequired.isRequired(parsed.getHost()))
+        throw new IllegalArgumentException(
+            "The url [" + name + "] requires secure connections");
+
+and `SslRequired.EXTERNAL.isRequired(host)` is `!isLocal(host)`, where
+`isLocal` is `InetAddress.getByName(host)` → loopback / site-local /
+link-local / IPv6-ULA. The sovereign realm ships `sslRequired: external`.
+
+So a PLAINTEXT backchannel is accepted only while its host RESOLVES to a
+private address. On a fresh Sovereign it does not:
+
+  * bp-keycloak is bootstrap-kit slot 09.
+  * `catalyst-api` (the Service) is created by bp-catalyst-platform, slot
+    13, whose HelmRelease `dependsOn` bp-gitea → bp-keycloak.
+
+The host therefore cannot resolve until bp-keycloak is Ready, and
+bp-keycloak cannot become Ready until the host resolves. Measured inside
+keycloak-0 on hw294 region A, 2026-08-11:
+
+    $ getent hosts catalyst-api.catalyst-system.svc.cluster.local ; echo rc=$?
+    rc=2                                              # NXDOMAIN
+    $ getent hosts kubernetes.default.svc.cluster.local ; echo rc=$?
+    10.96.0.1   kubernetes.default.svc.cluster.local  # control, rc=0
+
+…and the server's own answer, reproduced against Keycloak 26.3.3 with the
+realm's exact IdP payload:
+
+    POST /admin/realms/<realm>/identity-provider/instances
+    HTTP/1.1 400 Bad Request
+    {"errorMessage":"The url [token_url] requires secure connections"}
+
+keycloak-config-cli logs only `Create method returned status Bad Request
+(Code: 400)`, so the wedge presented as an unattributed 400 behind
+`BackoffLimitExceeded`, taking 16 HelmReleases — cutover, per-Org
+workspace and every SSO consumer — down with it.
+
+WHY A SERVICE IS THE FIX, AND WHY IT IS NOT NAMED `catalyst-api`
+─────────────────────────────────────────────────────────────────────────
+A ClusterIP Service is allocated its ClusterIP at CREATE and CoreDNS
+answers for it whether or not it has a single endpoint. It is the only
+construct that makes a name resolve to a site-local address before the
+workload behind it exists. Proven live on hw294 region B, where
+bp-catalyst-edge-routes renders the same shape and catalyst-api runs
+only in region A:
+
+    $ kubectl get endpoints -n catalyst-system catalyst-api
+    NAME           ENDPOINTS   AGE
+    catalyst-api   <none>      68m
+    $ kubectl exec -n catalyst-system k8s-ws-proxy-7j8jb -- \
+        getent hosts catalyst-api.catalyst-system.svc.cluster.local
+    10.97.176.117  catalyst-api.catalyst-system.svc.cluster.local
+
+That asymmetry is the whole defect: region B gets its anchor for free
+from slot 13e, region A does not, because on a primary control plane the
+Service comes from the umbrella chart that sits BEHIND this one.
+
+The anchor deliberately does NOT reuse the name `catalyst-api`. Helm
+refuses to install a resource another release already owns, so a
+same-named Service here would fail bp-catalyst-platform's install at slot
+13 with `exists and cannot be imported into the current release`, trading
+one wedge for a later one. A distinct name owned by THIS release routes
+to the same Pods through the same selector and collides with nothing.
+
+CLUSTERMESH
+─────────────────────────────────────────────────────────────────────────
+bp-keycloak carries no `SECONDARY_HR_SUSPEND`, so this Service renders in
+BOTH regions while catalyst-api runs only in region A (G2 #2574). The
+`service.cilium.io/global` + `shared` pair makes Cilium merge the two
+same-name+namespace Services, so a region-B Keycloak Pod falls through
+the mesh to region A's endpoints — the #5289 idiom that
+platform/catalyst-edge-routes/chart/templates/services.yaml and
+platform/openbao/.../cross-region-mesh-service.yaml already use.
+
+The sibling egress policy in catalyst-backchannel-egress-cnp.yaml (#6106)
+selects the catalyst-api WORKLOAD, not this Service, so ClusterIP DNAT
+leaves its identity match intact.
+
+GATING
+─────────────────────────────────────────────────────────────────────────
+Rendered only when the realm actually names an in-cluster PLAINTEXT
+backchannel. Point `catalystAPIInternalURL` at a public https endpoint —
+the all-public behaviour on a hairpin-capable EIP — and no anchor is
+emitted, because `checkUrl` never consults sslRequired for an https URL.
+Set it to "" and the same holds.
+
+This template is deliberately NOT default-off. `catalystAPIInternalURL`
+carries an in-cluster default, so a bare `helm template` DOES emit the
+anchor — and must, because the same bare render emits a realm that names
+that host. The anchor and the realm are one unit: any render that
+produces the plaintext backchannel has to produce the Service that makes
+it resolve, or it produces the hw294 wedge. That coupling is what
+tests/catalyst-pin-backchannel-resolvable-6172.sh asserts.
+*/ -}}
+{{- if .Values.sovereignRealm.enabled }}
+{{- $bc := fromYaml (include "bp-keycloak.catalystBackchannel" .) }}
+{{- if and $bc.url $bc.inCluster (eq $bc.scheme "http") }}
+{{- $workload := trim (.Values.catalystAPIWorkloadName | default "") }}
+{{- if not $workload }}
+{{- fail "bp-keycloak: catalystAPIWorkloadName must name the catalyst-api Pod label `app.kubernetes.io/name`. Empty would render a selector-less anchor Service that resolves but routes nowhere, turning the #6172 import wedge into a silent login failure." }}
+{{- end }}
+{{- if eq $bc.svc $workload }}
+{{- fail (printf "bp-keycloak: catalystAPIInternalURL names Service %q, which is the name bp-catalyst-platform's own api-service.yaml owns in the same namespace. Helm would refuse that release's install with `exists and cannot be imported into the current release`. Give the backchannel anchor a distinct name (#6172)." $bc.svc) }}
+{{- end }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $bc.svc | quote }}
+  namespace: {{ $bc.ns | quote }}
+  labels:
+    app.kubernetes.io/name: bp-keycloak
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    catalyst.openova.io/component: catalyst-pin-backchannel-anchor
+  annotations:
+    policies.openova.io/title: catalyst-pin OIDC backchannel resolution anchor
+    policies.openova.io/description: |
+      Makes catalystAPIInternalURL's host resolve to a site-local ClusterIP
+      from bootstrap-kit slot 09, before bp-catalyst-platform (slot 13)
+      creates catalyst-api. Without it Keycloak refuses the sovereign realm
+      import with "The url [token_url] requires secure connections" and
+      Phase 1 wedges (#6172).
+    # Cilium ClusterMesh: merge this Service with the same-name+namespace
+    # Service the peer region renders, so a region-B Keycloak Pod reaches
+    # region A's catalyst-api (#5289).
+    service.cilium.io/global: "true"
+    service.cilium.io/shared: "true"
+spec:
+  type: ClusterIP
+  # The ClusterIP is what makes the name resolve; the selector is what makes
+  # it ROUTE once bp-catalyst-platform lands. Zero matches until then is the
+  # intended state, and is exactly region B's steady state.
+  selector:
+    app.kubernetes.io/name: {{ $workload | quote }}
+  ports:
+    - name: http
+      port: {{ $bc.port | int }}
+      targetPort: {{ .Values.catalystAPIWorkloadPort | int }}
+      protocol: TCP
+{{- end }}
+{{- end }}

--- a/platform/keycloak/chart/templates/catalyst-backchannel-egress-cnp.yaml
+++ b/platform/keycloak/chart/templates/catalyst-backchannel-egress-cnp.yaml
@@ -99,39 +99,15 @@ plane-isolation default-deny — it grants one destination on one port and
 weakens nothing.
 */ -}}
 {{- if and .Values.sovereignRealm.enabled (not (and .Values.realmConfig (and .Values.realmConfig.tenant .Values.realmConfig.tenant.enabled))) }}
-{{- $url := trimSuffix "/" (trim (.Values.catalystAPIInternalURL | default "")) }}
-{{- if $url }}
-{{- $scheme := "" }}
-{{- $rest := "" }}
-{{- if hasPrefix "http://" $url }}
-{{- $scheme = "http" }}
-{{- $rest = trimPrefix "http://" $url }}
-{{- else if hasPrefix "https://" $url }}
-{{- $scheme = "https" }}
-{{- $rest = trimPrefix "https://" $url }}
-{{- else }}
-{{- fail (printf "bp-keycloak: catalystAPIInternalURL must be an http:// or https:// URL, got %q. An unparseable value would silently emit NO backchannel egress policy and re-break every catalyst-pin brokered login (#6106)." $url) }}
-{{- end }}
-{{- $authority := first (splitList "/" $rest) }}
-{{- $hostport := splitList ":" $authority }}
-{{- $host := index $hostport 0 }}
-{{- $port := "" }}
-{{- if gt (len $hostport) 1 }}
-{{- $port = index $hostport 1 }}
-{{- else if eq $scheme "https" }}
-{{- $port = "443" }}
-{{- else }}
-{{- $port = "80" }}
-{{- end }}
-{{- $dnsLabels := splitList "." $host }}
-{{- /* In-cluster Service DNS shapes ONLY: <svc>.<ns>, <svc>.<ns>.svc,
-       <svc>.<ns>.svc.cluster.local. A PUBLIC host (the all-public backchannel
-       an operator restores on a hairpin-capable EIP) is reached over the
-       existing world egress and needs no endpoint policy — emit nothing. */}}
-{{- $inCluster := and (ge (len $dnsLabels) 2) (or (eq (len $dnsLabels) 2) (eq (index $dnsLabels 2) "svc")) }}
-{{- if and $inCluster (.Capabilities.APIVersions.Has "cilium.io/v2") }}
-{{- $svc := index $dnsLabels 0 }}
-{{- $ns := index $dnsLabels 1 }}
+{{- /* #6172: the URL is parsed ONCE, in `bp-keycloak.catalystBackchannel`,
+       so this policy, the realm ConfigMap and the resolution-anchor Service
+       in catalyst-api-backchannel-service.yaml can never disagree about
+       which host the backchannel names. */ -}}
+{{- $bc := fromYaml (include "bp-keycloak.catalystBackchannel" .) }}
+{{- if $bc.url }}
+{{- $port := $bc.port }}
+{{- if and $bc.inCluster (.Capabilities.APIVersions.Has "cilium.io/v2") }}
+{{- $ns := $bc.ns }}
 ---
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
@@ -151,7 +127,7 @@ metadata:
       across the ClusterMesh from a secondary region where catalyst-api runs
       only in region A. Derived from catalystAPIInternalURL (#6106).
 spec:
-  description: "keycloak → {{ $svc }}.{{ $ns }}:{{ $port }} — catalyst-pin OIDC backchannel (#6106)."
+  description: "keycloak → {{ $bc.svc }}.{{ $ns }}:{{ $port }} — catalyst-pin OIDC backchannel (#6106)."
   # Every endpoint in the keycloak namespace — the Keycloak server Pod dials
   # the backchannel on each brokered login and the config-cli import Job
   # validates the IdP at import time. Matches the scope of the sibling
@@ -161,7 +137,13 @@ spec:
     - toEndpoints:
         - matchLabels:
             k8s:io.kubernetes.pod.namespace: {{ $ns | quote }}
-            k8s:app.kubernetes.io/name: {{ $svc | quote }}
+            {{- /* #6172: select the catalyst-api WORKLOAD, not the Service
+                   name parsed out of the URL. Those were the same string
+                   until the backchannel gained its own resolution anchor;
+                   deriving the Pod label from a Service name is a
+                   correct-by-coincidence match that renders green while
+                   selecting nothing the moment the two diverge. */}}
+            k8s:app.kubernetes.io/name: {{ required "bp-keycloak: catalystAPIWorkloadName must name the catalyst-api Pod label `app.kubernetes.io/name`; an empty value renders a policy that selects every endpoint in the namespace or none (#6172)." .Values.catalystAPIWorkloadName | quote }}
           matchExpressions:
             # Naming the cluster key suppresses Cilium's implicit
             # `cluster=<local>` AND-injection, so this ONE rule matches the

--- a/platform/keycloak/chart/tests/catalyst-backchannel-netpol-6106.sh
+++ b/platform/keycloak/chart/tests/catalyst-backchannel-netpol-6106.sh
@@ -129,7 +129,17 @@ if [ -z "$realm" ]; then
   echo "FAIL: the sovereign realm ConfigMap did not render — this pairing check would be vacuous." >&2
   exit 1
 fi
-backchannel="http://catalyst-api.catalyst-system.svc.cluster.local:8080"
+# #6172: read the backchannel from values.yaml rather than restating it. This
+# case exists to PAIR the realm against the policy; a literal here pins a third
+# copy of the same string and turns a legitimate host change into a red gate
+# that says nothing about the pairing. Case 1 already derives the policy side
+# from the same value, so the chain values -> policy -> realm stays closed.
+backchannel="$(grep -E '^catalystAPIInternalURL:' "$chart_dir/values.yaml" | head -1 | sed 's/^[^:]*: *//; s/"//g; s|/*$||')"
+if [ -z "$backchannel" ]; then
+  echo "FAIL: catalystAPIInternalURL is absent from values.yaml — this pairing check would be vacuous." >&2
+  exit 1
+fi
+backchannel_host="${backchannel#*://}"; backchannel_host="${backchannel_host%%:*}"
 for leg in tokenUrl userInfoUrl jwksUrl; do
   if ! grep -q "\"${leg}\": \\\\\"${backchannel}/oidc/" <<<"$realm"; then
     # The realm JSON is embedded, so quoting is escaped; fall back to a plain
@@ -160,7 +170,7 @@ if ! grep -q "https://api.${fqdn}/oidc/auth" <<<"$auth_line"; then
   echo "FAIL: authorizationUrl is no longer the public https://api.${fqdn}/oidc/auth. It is a BROWSER redirect; an in-cluster URL is unresolvable from the User's machine. Got: ${auth_line}" >&2
   exit 1
 fi
-if grep -q "catalyst-api.catalyst-system" <<<"$auth_line"; then
+if grep -qF "$backchannel_host" <<<"$auth_line"; then
   echo "FAIL: authorizationUrl was moved to the in-cluster backchannel host — the frontchannel must stay public (#6087)." >&2
   exit 1
 fi
@@ -211,7 +221,7 @@ if [ -z "$realm_off" ]; then
   echo "FAIL: the realm ConfigMap did not render with catalystAPIInternalURL='' — cannot verify the escape hatch." >&2
   exit 1
 fi
-if grep -q "catalyst-api.catalyst-system.svc" <<<"$realm_off"; then
+if grep -qF "$backchannel_host" <<<"$realm_off"; then
   echo "FAIL: with catalystAPIInternalURL='' the realm still carries the in-cluster backchannel — the chart would ship a dial with no policy behind it." >&2
   exit 1
 fi
@@ -238,14 +248,25 @@ if ! grep -q 'k8s:io.kubernetes.pod.namespace: "other-ns"' <<<"$alt_egress"; the
   echo "FAIL: the destination namespace did not follow catalystAPIInternalURL — it is hardcoded, so Case 1's catalyst-system assertion is a tautology." >&2
   exit 1
 fi
-if ! grep -q 'k8s:app.kubernetes.io/name: "cat-api"' <<<"$alt_egress"; then
-  echo "FAIL: the destination Pod label did not follow catalystAPIInternalURL — it is hardcoded." >&2
+# #6172: the Pod label follows catalystAPIWorkloadName, NOT the URL's first
+# DNS label. Those were the same string until the backchannel gained its own
+# resolution-anchor Service, and deriving a WORKLOAD selector from a SERVICE
+# name is correct only by coincidence — the moment they diverge the policy
+# selects nothing and renders exactly as green as one that selects the right
+# endpoints. So the derivation asserted here is the one that is actually true.
+if ! grep -q 'k8s:app.kubernetes.io/name: "catalyst-api"' <<<"$alt_egress"; then
+  echo "FAIL: the destination Pod label did not stay the catalyst-api workload while only the URL moved (#6172)." >&2
+  exit 1
+fi
+alt_wl="$(render --set catalystAPIInternalURL=http://cat-api.other-ns.svc.cluster.local:9090 --set catalystAPIWorkloadName=some-other-workload --show-only "$tpl" || true)"
+if ! grep -q 'k8s:app.kubernetes.io/name: "some-other-workload"' <<<"$(strip_comments <<<"$alt_wl")"; then
+  echo "FAIL: the destination Pod label did not follow catalystAPIWorkloadName — it is hardcoded, so the assertion above is a tautology (#6172)." >&2
   exit 1
 fi
 if ! grep -q 'port: "9090"' <<<"$alt_egress"; then
   echo "FAIL: the destination port did not follow catalystAPIInternalURL — it is hardcoded, so Case 1's 8080 assertion is a tautology." >&2
   exit 1
 fi
-echo "[bp-keycloak/6106] Case 7: PASS (namespace + Pod label + port all derived)"
+echo "[bp-keycloak/6106] Case 7: PASS (namespace + port derived from the URL, Pod label from catalystAPIWorkloadName)"
 
 echo "[bp-keycloak/6106] All gates green."

--- a/platform/keycloak/chart/tests/catalyst-pin-backchannel-resolvable-6172.sh
+++ b/platform/keycloak/chart/tests/catalyst-pin-backchannel-resolvable-6172.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+# bp-keycloak — the catalyst-pin backchannel must name a host THIS CHART
+# makes resolve (#6172).
+#
+# THE DEFECT THIS LOCKS OUT
+# ─────────────────────────────────────────────────────────────────────────
+# Keycloak validates an identity provider's URLs when it CREATES it.
+# org.keycloak.common.util.UriUtils.checkUrl, verbatim from 26.3.3:
+#
+#     if (!"https".equals(protocol) && sslRequired.isRequired(parsed.getHost()))
+#         throw new IllegalArgumentException(
+#             "The url [" + name + "] requires secure connections");
+#
+# and SslRequired.EXTERNAL.isRequired(host) is !isLocal(host), where isLocal
+# is InetAddress.getByName(host) → loopback / site-local / link-local / ULA.
+# The sovereign realm ships sslRequired: external.
+#
+# A PLAINTEXT backchannel leg is therefore legal only while its host
+# RESOLVES. #6089 pointed those legs at catalyst-api.catalyst-system, which
+# bp-catalyst-platform creates at bootstrap-kit slot 13 — behind bp-gitea,
+# behind THIS chart at slot 09. On fresh prov hw294 the name was NXDOMAIN at
+# import time (measured inside keycloak-0: `getent hosts
+# catalyst-api.catalyst-system.svc.cluster.local` → rc=2, while
+# kubernetes.default.svc.cluster.local answered 10.96.0.1), Keycloak replied
+#
+#     HTTP/1.1 400 Bad Request
+#     {"errorMessage":"The url [token_url] requires secure connections"}
+#
+# and Phase 1 stalled at 51/67 with 16 HelmReleases — cutover, the per-Org
+# workspace and every SSO consumer — parked behind bp-keycloak.
+#
+# The invariant: the realm may name an in-cluster PLAINTEXT backchannel ONLY
+# when this chart also renders the Service that makes that exact host
+# resolve. A ClusterIP is allocated at create time, so it answers DNS with a
+# site-local address before catalyst-api's Pods exist.
+#
+# Cases:
+#   1. the realm's plaintext backchannel host is rendered as a Service here
+#   2. that Service is ClusterIP — a headless Service with zero endpoints
+#      does NOT resolve, so it would satisfy Case 1 and still wedge
+#   3. that Service is NOT named `catalyst-api` — Helm refuses to install a
+#      resource another release owns, so the name bp-catalyst-platform uses
+#      would move the wedge to slot 13
+#   4. the Service SELECTS catalyst-api's Pods, so it routes once slot 13 lands
+#   5. the #6106 egress CNP selects the catalyst-api WORKLOAD label, not the
+#      anchor Service name
+#   6. CONTROL — authorizationUrl and issuer, URLs in the SAME IdP under the
+#      SAME validator, stay PUBLIC https (#6087's split is not undone)
+#   7. CONTROL — an all-public backchannel renders NO anchor and NO plaintext
+#      leg: the anchor is gated on the need, not always-on
+#   8. VACUITY — the render actually contains a catalyst-pin IdP with a
+#      backchannel, so Cases 1-6 cannot pass on an empty document
+
+set -euo pipefail
+
+chart_dir="${1:-$(cd "$(dirname "$0")/.." && pwd)}"
+helm="${HELM_BIN:-helm}"
+
+"$helm" dependency build "$chart_dir" >/dev/null 2>&1 || true
+
+fqdn="smoke.omani.works"
+render() {
+  "$helm" template keycloak "$chart_dir" \
+    --namespace keycloak \
+    --api-versions cilium.io/v2 \
+    --set sovereignFQDN="$fqdn" \
+    --set gateway.host="auth.${fqdn}" \
+    "$@"
+}
+
+out=$(render)
+
+# ── VACUITY (Case 8) — run FIRST: every later case is read off this block ──
+echo "[bp-keycloak] Case 8 (vacuity): the render carries a catalyst-pin IdP"
+if ! grep -q '"alias": "catalyst-pin"' <<<"$out"; then
+  echo "FAIL: no catalyst-pin identity provider in the render."
+  echo "(Cases 1-6 assert properties OF that block. Without it they would all"
+  echo " pass vacuously and this guard would be decorative.)"
+  exit 1
+fi
+token_url=$(grep -oE '"tokenUrl": "[^"]+"' <<<"$out" | head -1 | sed 's/.*: "//;s/"$//')
+if [[ -z "$token_url" ]]; then
+  echo "FAIL: the catalyst-pin IdP rendered no tokenUrl — nothing to validate."
+  exit 1
+fi
+echo "[bp-keycloak] Case 8: PASS (tokenUrl = ${token_url})"
+
+# ── Derive the host the realm actually names ──────────────────────────────
+scheme="${token_url%%://*}"
+authority="${token_url#*://}"; authority="${authority%%/*}"
+host="${authority%%:*}"
+svc="${host%%.*}"
+rest="${host#*.}"; ns="${rest%%.*}"
+
+# ── Case 1: a plaintext in-cluster leg MUST have its Service rendered here ─
+echo "[bp-keycloak] Case 1: plaintext backchannel host is anchored by a Service"
+if [[ "$scheme" == "http" && "$host" == *.* ]]; then
+  svc_block=$(awk -v RS='---' -v n="$svc" -v ns="$ns" '
+    $0 ~ /kind: Service/ && $0 ~ ("name: \"?" n "\"?\n") && $0 ~ ("namespace: \"?" ns "\"?\n") { print }
+  ' <<<"$out" || true)
+  if [[ -z "$svc_block" ]]; then
+    echo "FAIL: the realm names PLAINTEXT ${token_url}, but this chart renders no"
+    echo "      Service ${svc} in namespace ${ns}."
+    echo
+    echo "Keycloak accepts an http identity-provider URL only while its host"
+    echo "resolves to a private address (UriUtils.checkUrl → SslRequired.EXTERNAL"
+    echo "→ InetAddress.getByName). bp-catalyst-platform creates catalyst-api at"
+    echo "bootstrap-kit slot 13, behind bp-gitea, behind THIS chart at slot 09 —"
+    echo "so at import time the name is NXDOMAIN and Keycloak answers"
+    echo '      400 {"errorMessage":"The url [token_url] requires secure connections"}'
+    echo "That is #6172: hw294 Phase 1 stalled at 51/67, 16 HelmReleases behind it."
+    exit 1
+  fi
+else
+  echo "      (backchannel is ${scheme}:// — checkUrl exempts https, no anchor needed)"
+  svc_block=""
+fi
+echo "[bp-keycloak] Case 1: PASS"
+
+if [[ -n "$svc_block" ]]; then
+  # ── Case 2: ClusterIP, not headless ────────────────────────────────────
+  echo "[bp-keycloak] Case 2: the anchor Service is ClusterIP, not headless"
+  if grep -qE '^\s*clusterIP:\s*None' <<<"$svc_block"; then
+    echo "FAIL: the anchor Service is headless. CoreDNS answers a headless name"
+    echo "      with its ENDPOINT addresses, so with zero endpoints — the state"
+    echo "      it is in until slot 13 lands — it returns NXDOMAIN and the import"
+    echo "      400s exactly as before. The anchor must carry a ClusterIP."
+    echo "$svc_block"
+    exit 1
+  fi
+  echo "[bp-keycloak] Case 2: PASS"
+
+  # ── Case 3: distinct from bp-catalyst-platform's own Service name ──────
+  echo "[bp-keycloak] Case 3: the anchor does not steal bp-catalyst-platform's name"
+  if [[ "$svc" == "catalyst-api" ]]; then
+    echo "FAIL: the anchor Service is named 'catalyst-api' in ${ns} — the name"
+    echo "      products/catalyst/chart/templates/api-service.yaml owns. Helm"
+    echo "      refuses a resource another release owns ('exists and cannot be"
+    echo "      imported into the current release'), so this would unwedge slot"
+    echo "      09 by wedging slot 13 instead."
+    exit 1
+  fi
+  echo "[bp-keycloak] Case 3: PASS"
+
+  # ── Case 4: it routes, not just resolves ──────────────────────────────
+  echo "[bp-keycloak] Case 4: the anchor selects catalyst-api's Pods"
+  if ! grep -qE '^\s*app\.kubernetes\.io/name:\s*"?catalyst-api"?\s*$' <<<"$svc_block"; then
+    echo "FAIL: the anchor Service does not select app.kubernetes.io/name=catalyst-api."
+    echo "      A Service that resolves but selects nothing turns the import wedge"
+    echo "      into a silent brokered-login failure — strictly harder to find."
+    echo "$svc_block"
+    exit 1
+  fi
+  echo "[bp-keycloak] Case 4: PASS"
+fi
+
+# ── Case 5: the #6106 egress policy follows the WORKLOAD, not the Service ──
+echo "[bp-keycloak] Case 5: the egress CNP selects the catalyst-api workload"
+cnp_block=$(awk -v RS='---' '/kind: CiliumNetworkPolicy/ && /keycloak-allow-catalyst-api-backchannel-egress/ { print }' <<<"$out" || true)
+if [[ -z "$cnp_block" ]]; then
+  echo "FAIL: #6106's keycloak-allow-catalyst-api-backchannel-egress CNP is gone."
+  echo "(Without it the in-cluster backchannel is denied by the catalyst-system"
+  echo " baseline default-deny and every brokered login fails.)"
+  exit 1
+fi
+if ! grep -qE 'k8s:app\.kubernetes\.io/name:\s*"?catalyst-api"?\s*$' <<<"$cnp_block"; then
+  echo "FAIL: the egress CNP does not select app.kubernetes.io/name=catalyst-api."
+  echo "      It used to derive that label from the backchannel URL's first DNS"
+  echo "      label, which was correct only while the Service name and the Pod"
+  echo "      label were the same string. A CNP that selects nothing renders"
+  echo "      exactly as green as one that selects the right endpoints."
+  echo "$cnp_block"
+  exit 1
+fi
+echo "[bp-keycloak] Case 5: PASS"
+
+# ── Case 6: CONTROL — the frontchannel legs stay PUBLIC ───────────────────
+echo "[bp-keycloak] Case 6 (control): authorizationUrl + issuer stay public https"
+auth_url=$(grep -oE '"authorizationUrl": "[^"]+"' <<<"$out" | head -1 | sed 's/.*: "//;s/"$//')
+issuer=$(grep -oE '"issuer": "[^"]+"' <<<"$out" | head -1 | sed 's/.*: "//;s/"$//')
+for pair in "authorizationUrl=${auth_url}" "issuer=${issuer}"; do
+  name="${pair%%=*}"; val="${pair#*=}"
+  if [[ "$val" != "https://api.${fqdn}"* ]]; then
+    echo "FAIL: ${name} = ${val}, expected the public https://api.${fqdn} form."
+    echo "      These two are URLs in the SAME identity provider under the SAME"
+    echo "      validator as tokenUrl — they share the suspect property. They must"
+    echo "      stay PUBLIC: authorizationUrl is a BROWSER redirect, and issuer is"
+    echo "      compared against the iss claim catalyst-api mints from its own"
+    echo "      SOVEREIGN_FQDN. Pointing either inward trades a connectivity"
+    echo "      failure for a validation failure (#6087)."
+    exit 1
+  fi
+done
+echo "[bp-keycloak] Case 6: PASS"
+
+# ── Case 7: CONTROL — all-public restore needs no anchor ──────────────────
+echo "[bp-keycloak] Case 7 (control): an all-public backchannel renders no anchor"
+pub_out=$(render --set catalystAPIInternalURL="https://api.${fqdn}")
+if grep -qE '^\s*catalyst\.openova\.io/component:\s*catalyst-pin-backchannel-anchor' <<<"$pub_out"; then
+  echo "FAIL: the anchor Service rendered even though every backchannel leg is"
+  echo "      https. checkUrl never consults sslRequired for an https URL, so"
+  echo "      there is nothing to anchor — an always-on Service here would be a"
+  echo "      second owner of catalyst-api traffic on a hairpin-capable EIP."
+  exit 1
+fi
+if grep -qE '"tokenUrl": "http://' <<<"$pub_out"; then
+  echo "FAIL: catalystAPIInternalURL was set to an https endpoint and the realm"
+  echo "      still rendered a plaintext tokenUrl."
+  exit 1
+fi
+echo "[bp-keycloak] Case 7: PASS"
+
+echo "[bp-keycloak] catalyst-pin backchannel resolvability (#6172): ALL CASES PASS"

--- a/platform/keycloak/chart/values.yaml
+++ b/platform/keycloak/chart/values.yaml
@@ -72,7 +72,47 @@ sovereignFQDN: ""
 #
 # Set to "" to restore the all-public behaviour on clusters whose EIP does
 # hairpin.
-catalystAPIInternalURL: "http://catalyst-api.catalyst-system.svc.cluster.local:8080"
+#
+# #6172 — THE HOST IS `catalyst-api-backchannel`, NOT `catalyst-api`.
+#
+# Keycloak validates an identity provider's URLs when it CREATES it. A
+# plaintext http leg is accepted only while its host resolves to a private
+# address (`UriUtils.checkUrl` → `SslRequired.EXTERNAL.isRequired` →
+# `InetAddress.getByName`), and the sovereign realm ships
+# `sslRequired: external`. On a fresh Sovereign `catalyst-api` does not
+# resolve at slot 09: it is created by bp-catalyst-platform at slot 13,
+# whose HelmRelease dependsOn bp-gitea → bp-keycloak. The realm import
+# therefore waited on a Service that was waiting on the realm import, and
+# Keycloak answered
+#   400 {"errorMessage":"The url [token_url] requires secure connections"}
+# which keycloak-config-cli reports as a bare `Bad Request (Code: 400)`.
+# hw294 stalled Phase 1 at 51/67 with 16 HelmReleases behind it.
+#
+# So this chart now renders its OWN Service at this host — see
+# templates/catalyst-api-backchannel-service.yaml. A ClusterIP is allocated
+# at create time, so the name resolves to a site-local address immediately
+# and routes to catalyst-api's Pods through the same selector once slot 13
+# lands. The name must stay DISTINCT from `catalyst-api`: Helm refuses to
+# install a resource another release owns, and the template fails the render
+# loudly if the two are ever collapsed.
+catalystAPIInternalURL: "http://catalyst-api-backchannel.catalyst-system.svc.cluster.local:8080"
+
+# catalystAPIWorkloadName / catalystAPIWorkloadPort (#6172) — the catalyst-api
+# WORKLOAD behind the backchannel host, as opposed to the Service name that
+# fronts it.
+#
+# Two templates need the workload and not the hostname: the anchor Service's
+# `spec.selector` and the #6106 egress CiliumNetworkPolicy's `toEndpoints`
+# match. Both used to derive it from the URL's first DNS label, which was
+# correct only while the Service and the Pod label happened to share a
+# string. The moment the backchannel got its own Service name that identity
+# broke, and a policy that selects nothing renders exactly as green as one
+# that selects the right thing — so the value is now stated, not inferred.
+#
+# Must match `app.kubernetes.io/name` on catalyst-api's Pods and the port its
+# container listens on: products/catalyst/chart/templates/api-service.yaml.
+catalystAPIWorkloadName: catalyst-api
+catalystAPIWorkloadPort: 8080
 
 # G117.5b #2789 — SSO client-secret rotation knob.
 #
@@ -537,6 +577,65 @@ keycloak:
   #     can apply group-based RoleBindings (oidc:<group> prefix per
   #     k3s --oidc-groups-prefix flag)
   keycloakConfigCli:
+    # ─── #6172: report the SERVER's rejection, not just the status code ─────
+    #
+    # The bitnami subchart runs this Job as bare
+    # `java -jar /opt/bitnami/keycloak-config-cli/keycloak-config-cli.jar`.
+    # keycloak-config-cli's IdentityProviderRepository.create() hands the
+    # Response straight to `CreatedResponseUtil.getCreatedId`, which raises
+    #
+    #   jakarta.ws.rs.WebApplicationException: Create method returned status
+    #   Bad Request (Code: 400); expected status: Created (201)
+    #
+    # and that is ALL the Job ever prints — no response body, no resource
+    # path, not even which of the realm's elements was being created. The
+    # upstream code is the same on v6.4.0, v6.4.1, v6.5.0 and main, so there
+    # is no version to upgrade to. On hw294 that bare 400 sat behind
+    # `BackoffLimitExceeded` while 16 HelmReleases waited on it; the actual
+    # answer, `{"errorMessage":"The url [token_url] requires secure
+    # connections"}`, was on the wire the whole time and never reached a log.
+    #
+    # So on a NON-ZERO exit — and only then — the same import is replayed
+    # with keycloak-config-cli's own HTTP logging
+    # (`logging.group.http=org.apache.http.wire`) and filtered down to the
+    # three lines that identify the failure: the request LINE (method +
+    # path), the 4xx/5xx status line, and the error payload.
+    #
+    # The filter is deliberately narrow, because this repo is public and the
+    # realm import carries client secrets:
+    #   * request BODIES are never printed — only lines matching
+    #     `>> "<METHOD> /…`, which are request lines, never payload;
+    #   * response bodies are printed only when they START with `{"error`,
+    #     so a 200 client/serverinfo representation (which does carry
+    #     secrets, and does contain the substring `errorMessage` in its
+    #     serverinfo schema) can never match;
+    #   * every line is capped at 400 characters and the tail at 25 lines.
+    # `IMPORT_CACHE_ENABLED=false` forces the replay to re-attempt rather
+    # than skip on an unchanged checksum.
+    #
+    # The happy path pays nothing: the replay runs only after a failure, and
+    # the Job still exits with the original code so Helm's post-install hook
+    # fails exactly as before.
+    command:
+      - /bin/bash
+      - -ec
+    args:
+      - |
+        jar=/opt/bitnami/keycloak-config-cli/keycloak-config-cli.jar
+        java -jar "$jar" && exit 0
+        rc=$?
+        echo "###### keycloak-config-cli exited ${rc} — replaying with HTTP capture ######"
+        echo "# Printed below: request LINES (method + path), 4xx/5xx status lines"
+        echo "# and error payloads. Request bodies and success-response bodies are"
+        echo "# NEVER printed (they carry client secrets); lines are capped at 400"
+        echo "# characters. Refs #6172."
+        echo "############################################################################"
+        LOGGING_LEVEL_HTTP=debug IMPORT_CACHE_ENABLED=false java -jar "$jar" 2>&1 \
+          | cut -c1-400 \
+          | grep -aE '>> "(GET|POST|PUT|DELETE|PATCH) /|<< "HTTP/[0-9.]+ [45][0-9]{2} |<< "\{"error' \
+          | tail -25 || true
+        echo "############################################################################"
+        exit "$rc"
     # 100m: a config-import job does not need 500m; the bitnami default
     # request wedged 25m Pending on hw130 (4 nodes "Insufficient cpu" by
     # REQUESTS while real usage sat at 3-20%) blocking the admin seed.

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -2235,7 +2235,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "1.5.9",
+      "version": "1.5.10",
       "section": "pts-2-3-per-sovereign-supporting-services",
       "depends": [
         "bp-postgres"

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -2370,7 +2370,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "1.5.9",
+    "version": "1.5.10",
     "section": "pts-2-3-per-sovereign-supporting-services",
     "depends": [
       "bp-postgres"

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3874,7 +3874,22 @@ name: bp-catalyst-platform
 #   scripts/check-image-pin-writer-targets.sh plus the extended
 #   scripts/check-controller-image-tag-freshness.sh. Chart version bump is what
 #   actually delivers the three new tags, so it is the load-bearing half.
-version: 1.4.1409
+# 1.4.1411 — #6172: catalog-seed advances bp-keycloak 1.5.9 -> 1.5.10, the
+#   release that stops the sovereign realm import 400ing on a fresh Sovereign.
+#   1.5.8 pointed the catalyst-pin identity provider's server-side legs at
+#   `catalyst-api.catalyst-system.svc`, and Keycloak accepts a PLAINTEXT
+#   identity-provider URL only while its host resolves to a private address
+#   (UriUtils.checkUrl -> SslRequired.EXTERNAL -> InetAddress.getByName; the
+#   realm ships sslRequired: external). That Service is created by THIS chart
+#   at bootstrap-kit slot 13, behind bp-gitea, behind bp-keycloak at slot 09 —
+#   so on hw294 the name was NXDOMAIN at import time, Keycloak answered
+#   `{"errorMessage":"The url [token_url] requires secure connections"}` and
+#   Phase 1 stalled at 51/67 with 16 HelmReleases behind it. 1.5.10 renders its
+#   own ClusterIP anchor at `catalyst-api-backchannel.catalyst-system` instead.
+#   The seed pin is the delivery half: without this bump a pinned Sovereign
+#   resolves 1.5.9 and never sees the fix. This chart's own templates are
+#   unchanged.
+version: 1.4.1411
 # 1.4.1229 — #5389: catalog-seed bp-newapi declares its `ui` endpoint
 #   (newapi.<fqdn>, ssoEnabled, launchDefault, ssoInitPath "/") instead of
 #   `endpoints: []`. The empty list made userUIGatePasses fail closed, which
@@ -4029,7 +4044,7 @@ version: 1.4.1409
 # scripts/check-chart-version-forward.sh (#5743) fails unless the two match —
 # main was carrying a pre-existing 1.4.1330/1.4.1329 split, so this bump heals
 # it in the same commit, exactly as the documented self-heal contract does.
-appVersion: 1.4.1409
+appVersion: 1.4.1411
 # 1.4.239 — Wave 3 / Issue #2140 (2026-05-23): Huawei provider
 # implementation lands behind the Wave 2 CloudProvider interface.
 # Adds the OpenTofu module at infra/providers/huawei/ (VPC + Subnet +

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -592,7 +592,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "1.5.9"
+  version: "1.5.10"
   visibility: listed
   card:
     title: "Keycloak"
@@ -620,7 +620,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-keycloak
-    version: "1.5.9"
+    version: "1.5.10"
   # G117.1+G117.4+G117.6 #2744-followup (2026-06-03): bp-keycloak
   # catalog-seed needs topology + endpoints + sso so application-
   # controller can fan out HRs and operator console can mint silent-SSO

--- a/tests/e2e/bootstrap-kit/catalyst_pin_backchannel_6087_test.go
+++ b/tests/e2e/bootstrap-kit/catalyst_pin_backchannel_6087_test.go
@@ -200,9 +200,29 @@ func TestCatalystPin_BackchannelLegsAreInCluster(t *testing.T) {
 				"hairpin does not work on Huawei (#3241/#3844), which is the HTTP 502 at "+
 				"/broker/catalyst-pin/endpoint recorded in UAT row 219.", key, got, publicHost)
 		}
-		if !strings.HasPrefix(got, "http://catalyst-api.catalyst-system.svc") {
-			t.Errorf("catalyst-pin config.%s = %q — want the in-cluster catalyst-api "+
-				"Service, the same seam openova-mcp and bp-self-sovereign-cutover already use", key, got)
+		// #6172: the host is the backchannel ANCHOR Service bp-keycloak renders
+		// itself, NOT `catalyst-api`. Keycloak accepts a plaintext
+		// identity-provider URL only while its host resolves to a private
+		// address, and `catalyst-api` is created by bp-catalyst-platform at
+		// bootstrap-kit slot 13 — behind bp-gitea, behind bp-keycloak at slot
+		// 09 — so at import time it is NXDOMAIN and the realm import 400s with
+		// `The url [token_url] requires secure connections`. Asserting the
+		// literal `catalyst-api` here would re-pin the wedge.
+		if !strings.HasPrefix(got, "http://catalyst-api-backchannel.catalyst-system.svc") {
+			t.Errorf("catalyst-pin config.%s = %q — want the in-cluster backchannel anchor "+
+				"Service catalyst-api-backchannel.catalyst-system, which bp-keycloak renders "+
+				"at slot 09 so the host resolves before bp-catalyst-platform creates "+
+				"catalyst-api at slot 13 (#6172)", key, got)
+		}
+		// The anchor must not be collapsed back onto bp-catalyst-platform's own
+		// Service name: Helm refuses a resource another release owns, so that
+		// would move the wedge from slot 09 to slot 13.
+		if strings.HasPrefix(got, "http://catalyst-api.catalyst-system.svc") {
+			t.Errorf("catalyst-pin config.%s = %q — this is the Service name "+
+				"products/catalyst/chart/templates/api-service.yaml owns in the same "+
+				"namespace. bp-keycloak cannot render it without failing "+
+				"bp-catalyst-platform's install with `exists and cannot be imported "+
+				"into the current release` (#6172).", key, got)
 		}
 		if !strings.HasSuffix(got, oidcPath(key)) {
 			t.Errorf("catalyst-pin config.%s = %q — lost its %q path in the rewrite", key, got, oidcPath(key))


### PR DESCRIPTION
## 🛑 DO NOT MERGE — hw294 is mid-prov

A merge fires the deploy-bot image bump, which rolls catalyst-api **mid-provision and abandons it** (the hw265 failure). This PR is green-and-parked until hw294 finishes or is wiped.

---

## The wedge

hw294 (dep `336e2891743d6c98`) stalled Phase 1 at 51/67. `bp-keycloak@1.5.9`'s post-install realm import failed `BackoffLimitExceeded`, six attempts, each a bare `Create method returned status Bad Request (Code: 400)` about 2.9 s after connecting — with `keycloak-0` itself 1/1 Running.

The stack trace names the element the log did not: `IdentityProviderRepository.create`. The realm has exactly one identity provider, `catalyst-pin`.

## Keycloak's own answer

`keycloak-config-cli` throws away the response body, so I reproduced the realm's exact IdP payload against Keycloak 26.3.3:

```
POST /admin/realms/<realm>/identity-provider/instances
HTTP/1.1 400 Bad Request
{"errorMessage":"The url [token_url] requires secure connections"}
```

**The rejected element is the `catalyst-pin` identity provider, on its `tokenUrl`.**

`org.keycloak.common.util.UriUtils.checkUrl`, verbatim from 26.3.3:

```java
if (!"https".equals(protocol) && sslRequired.isRequired(parsed.getHost()))
    throw new IllegalArgumentException("The url [" + name + "] requires secure connections");
```

and `SslRequired.EXTERNAL.isRequired(host)` is `!isLocal(host)`, where `isLocal` is `InetAddress.getByName(host)` → loopback / site-local / link-local / ULA. The sovereign realm ships `sslRequired: external`.

So a **plaintext** identity-provider URL is legal only while its host **resolves to a private address**.

## What changed between 1.5.7 and 1.5.9

Only one thing touches the realm: `fa116941e` (#6089, bp-keycloak 1.5.8, 03:41 today) split the backchannel onto `http://catalyst-api.catalyst-system.svc.cluster.local:8080`. It renders exactly as designed — that part of the issue is correct. What it introduced is an **ordering cycle**:

- bp-keycloak is bootstrap-kit **slot 09**
- `catalyst-api` is created by bp-catalyst-platform at **slot 13**, whose HelmRelease `dependsOn` bp-gitea → **bp-keycloak**

The host cannot resolve until bp-keycloak is Ready, and bp-keycloak cannot become Ready until the host resolves. Measured inside `keycloak-0` on hw294 region A:

```
$ getent hosts catalyst-api.catalyst-system.svc.cluster.local ; echo rc=$?
rc=2                                              # NXDOMAIN
$ getent hosts kubernetes.default.svc.cluster.local ; echo rc=$?
10.96.0.1   kubernetes.default.svc.cluster.local  # control, rc=0
```

hw293 never hit it because it was provisioned on 1.5.7 (all-https) and only re-imported #6089's realm **after** catalyst-api existed and resolved to a site-local `10.96.1.11`. Fresh prov inverts the order — exactly the "never run on a fresh environment" gap.

### Reproduction, with controls

| case | backchannel | result |
|---|---|---|
| **RED** — 1.5.8/1.5.9 shape | `http://` + unresolvable host | **400** `The url [token_url] requires secure connections` |
| **CONTROL 1** — same plaintext http, host is a site-local IP literal | `http://10.96.1.11:8080` | 201 |
| **CONTROL 2** — 1.5.7 shape, every leg public https | `https://api.<fqdn>` | 201 |
| **CONTROL 3 (vacuity)** — SAME unresolvable host, https | `https://catalyst-api.catalyst-system…` | 201 |
| **CONTROL 4** — RED payload, realm `sslRequired: none` | `http://` + unresolvable host | 201 |

Control 1 shares the suspect property (plaintext backchannel) and stays green — so the defect is the **resolution**, not the scheme. Control 3 proves the harness can return 201 with that exact hostname.

## The fix

New `templates/catalyst-api-backchannel-service.yaml` renders the backchannel host as a **ClusterIP Service this chart owns**. A ClusterIP is allocated at create time and CoreDNS answers for it with zero endpoints, so the name resolves to a site-local address from slot 09 and routes to catalyst-api's Pods through the same selector once slot 13 lands.

Proven live on hw294 **region B**, where `bp-catalyst-edge-routes` renders the same shape and catalyst-api runs only in region A:

```
$ kubectl get endpoints -n catalyst-system catalyst-api
catalyst-api   <none>   68m
$ kubectl exec -n catalyst-system k8s-ws-proxy-7j8jb -- \
    getent hosts catalyst-api.catalyst-system.svc.cluster.local
10.97.176.117  catalyst-api.catalyst-system.svc.cluster.local
```

That asymmetry **is** the defect: region B gets its anchor for free from slot 13e; region A never had one.

The host is `catalyst-api-backchannel`, deliberately **not** `catalyst-api` — Helm refuses a resource another release owns, so reusing the name would unwedge slot 09 by wedging bp-catalyst-platform at slot 13. The template fails the render loudly if the two are ever collapsed.

**#6087's split is untouched**: `authorizationUrl` and `issuer` stay public https (browser redirect; `iss` claim). Only the three server-side legs move.

The #6106 egress CNP now selects the catalyst-api **workload** via a new `catalystAPIWorkloadName` value instead of deriving the Pod label from the URL's first DNS label — that was correct only while the Service name and the Pod label were the same string, and a CNP that selects nothing renders exactly as green as one that selects the right endpoints. Realm, policy and anchor now read one parse (`bp-keycloak.catalystBackchannel`), so they cannot disagree.

## The diagnostic gap

The Job reported `400` with no body and no resource path. Upstream discards it identically on **v6.4.0, v6.4.1, v6.5.0 and main** — `IdentityProviderRepository.create` hands the `Response` straight to `CreatedResponseUtil.getCreatedId` — so there is no version to upgrade to.

`keycloakConfigCli` now runs under a wrapper that, **on a non-zero exit only**, replays the same import with HTTP logging and prints the request line, the 4xx/5xx status line and the error payload. Verified by executing the rendered `command` + `args` verbatim against the real `keycloak-config-cli:6.4.0-debian-12-r11` image:

```
###### keycloak-config-cli exited 1 — replaying with HTTP capture ######
>> "POST /admin/realms/diag6172/identity-provider/instances HTTP/1.1"
<< "HTTP/1.1 400 Bad Request"
<< "{"errorMessage":"The url [token_url] requires secure connections"}"
```

Request bodies and success-response bodies are never printed and lines are capped — the import carries client secrets, and an earlier looser filter dumped a `serverinfo` body and was tightened. The happy path pays nothing, and the Job still exits with the original code so Helm's hook fails exactly as before.

## Evidence

**New guard `tests/catalyst-pin-backchannel-resolvable-6172.sh` — red on `origin/main`:**

```
[bp-keycloak] Case 8 (vacuity): PASS (tokenUrl = http://catalyst-api.catalyst-system.svc.cluster.local:8080/oidc/token)
[bp-keycloak] Case 1: plaintext backchannel host is anchored by a Service
FAIL: the realm names PLAINTEXT http://catalyst-api.catalyst-system.svc.cluster.local:8080/oidc/token, but this chart renders no
      Service catalyst-api in namespace catalyst-system.
RED_EXIT=1
```

**Green here:**

```
[bp-keycloak] Case 8 (vacuity): PASS (tokenUrl = http://catalyst-api-backchannel.catalyst-system.svc.cluster.local:8080/oidc/token)
[bp-keycloak] Case 1: PASS      # plaintext host is anchored by a Service
[bp-keycloak] Case 2: PASS      # ClusterIP, not headless
[bp-keycloak] Case 3: PASS      # does not steal bp-catalyst-platform's name
[bp-keycloak] Case 4: PASS      # selects catalyst-api's Pods
[bp-keycloak] Case 5: PASS      # egress CNP selects the catalyst-api workload
[bp-keycloak] Case 6: PASS      # CONTROL — authorizationUrl + issuer stay public https
[bp-keycloak] Case 7: PASS      # CONTROL — all-public backchannel renders no anchor
GREEN_EXIT=0
```

The vacuity check runs **first** and asserts the render actually contains a `catalyst-pin` IdP with a `tokenUrl`, so Cases 1-6 cannot pass on an empty document.

**End-to-end**: the fixed chart's full 27-key sovereign realm imports cleanly (`IMPORT_EXIT=0`) against real Keycloak 26.3.3 through the real config-cli image, with the split intact:

```
alias      : catalyst-pin
  authorizationUrl https://api.smoke.omani.works/oidc/auth
  tokenUrl         http://catalyst-api-backchannel.catalyst-system.svc.cluster.local:8080/oidc/token
  userInfoUrl      http://catalyst-api-backchannel.catalyst-system.svc.cluster.local:8080/oidc/userinfo
  jwksUrl          http://catalyst-api-backchannel.catalyst-system.svc.cluster.local:8080/oidc/certs
  issuer           https://api.smoke.omani.works
```

**Regression sweep** — all 16 bp-keycloak chart tests pass, `tests/e2e/bootstrap-kit` Go guards pass, `products/catalyst/chart/tests/baseline-cnp-allowlist.sh` (#6106 ingress half) passes, `check-bootstrap-kit-pin-sync.sh`, `check-catalog-seed-lockstep.sh`, `check-no-banned-words.sh`, `check-no-banned-object-names.sh`, `check-no-credential-prefix-logging.sh` and `check-lb-nodeport0.py` pass. `check-no-nodeports.sh` Phase 1 + 1b pass and `platform/keycloak/chart` renders zero NodePorts.

Two existing tests pinned the old host as a literal and were updated to assert the invariant instead of the string: the #6087 Go guard, and #6106's Case 2/5/7, which now read `catalystAPIInternalURL` from `values.yaml` so the chain values → policy → realm stays closed rather than restating a third copy.

### Lockstep — eight sites, two of which the shell guards do not see

bp-keycloak 1.5.9 → **1.5.10**, pinned across `blueprint.yaml`, `clusters/_template/bootstrap-kit/09-keycloak.yaml`, the catalog seed (2 sites), `blueprints.json`, and `catalog.generated.ts`.

Two were caught by gates rather than by me, and both are worth recording:

1. **`check-chart-version-bumped.sh`** — editing the catalog-seed pin changes `products/catalyst/chart`'s *rendered surface*, so that chart needed its own bump or a pinned Sovereign would resolve 1.4.1401 to the already-published artifact and never see the new seed. Bumped 1.4.1401 → **1.4.1411** (via `scripts/bump-chart-version.sh`, which consults open-PR claims), with the slot-13 pin moved in lockstep. That chart's templates are otherwise untouched.
2. **`regenerate and prove no diff` (#5520)** — `build-catalog.mjs` writes *both* `blueprints.json` **and** `catalog.generated.ts`. Hand-editing the JSON left the `.ts` copy on 1.5.9. Regenerated with the generator, not hand-edited.

So the lockstep here is **eight** sites, not seven — `catalog.generated.ts` is the one no shell pin-guard covers.

Refs #6172 #6089 #6087 #6106
