### PR TITLE
fix(guards, bp-harbor): a route's hostname must have a listener that admits it — provable from source (Refs #6140) [DO NOT MERGE]

### DIFF
--- a/.github/workflows/check-guard-selftests.yaml
+++ b/.github/workflows/check-guard-selftests.yaml
@@ -163,3 +163,43 @@ jobs:
       # fails if the guard passes, and equally if it fails for another reason.
       - name: the guard must be able to fail
         run: bash scripts/check-chart-route-listener-correspondence.sh --vacuity
+
+      # VACUITY on the SHARED admission module. scripts/lib/
+      # gateway_route_admission.py is now imported by this guard AND by
+      # check-live-route-backends.sh, so a regression there would weaken both
+      # at once. Regress it to the belief that makes the whole class invisible
+      # — "a wildcard listener admits everything" — and require this guard's
+      # fixtures to go RED. Its sibling workflow runs the same mutation against
+      # the live guard, so the shared rule is pinned from both consumers.
+      - name: the shared admission module must be able to fail
+        run: |
+          rm -rf /tmp/mutant-shared && cp -r scripts /tmp/mutant-shared
+          python3 - <<'PY'
+          p = "/tmp/mutant-shared/lib/gateway_route_admission.py"
+          s = open(p).read()
+          old = '    if listener_hostname.startswith("*."):\n        suffix = listener_hostname[1:]'
+          new = '    if listener_hostname.startswith("*."):\n        return True\n        suffix = listener_hostname[1:]'
+          assert old in s, "mutation anchor not found — update this step"
+          open(p, "w").write(s.replace(old, new, 1))
+          PY
+          if bash /tmp/mutant-shared/check-chart-route-listener-correspondence.sh \
+               --root "$PWD" --self-test >/tmp/mutant-shared.out 2>&1; then
+            echo "VACUITY FAIL: the fixtures passed against a module whose wildcard"
+            echo "listener admits every hostname. A hostname no listener admits is a"
+            echo "TLS reset, not a 503 — no status-code probe can see it."
+            cat /tmp/mutant-shared.out
+            exit 1
+          fi
+          # The CONTROLS that share the suspect property must stay green in the
+          # mutant, or the red cannot be attributed to the wildcard rule.
+          for ctl in 'ok  marketplace host admitted by the CONSOLE gateway' \
+                     'ok  the same mcp host on the SHARED gateway'; do
+            grep -qF "$ctl" /tmp/mutant-shared.out || {
+              echo "CONTROL FAIL: '$ctl' went red under the mutation, so the failing"
+              echo "fixtures cannot be attributed to the wildcard rule."
+              cat /tmp/mutant-shared.out
+              exit 1
+            }
+          done
+          echo "OK: mutation caught, both controls stayed green. Failing assertion:"
+          grep -m1 'FAIL:' /tmp/mutant-shared.out

--- a/.github/workflows/check-guard-selftests.yaml
+++ b/.github/workflows/check-guard-selftests.yaml
@@ -122,3 +122,44 @@ jobs:
 
       - name: live newapi SSO version classifier
         run: bash scripts/check-live-newapi-sso-version.sh --self-test
+
+      # #6140 — the SOURCE-side route/listener correspondence guard. Fixture
+      # mode only here (no helm, no cluster); the render is a separate job
+      # below because it needs helm and pyyaml.
+      - name: chart route/listener correspondence classifier (#6140)
+        run: bash scripts/check-chart-route-listener-correspondence.sh --self-test
+
+  chart-route-listener-correspondence:
+    name: routes a chart renders must have a listener that admits them (#6140)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: bash syntax
+        run: bash -n scripts/check-chart-route-listener-correspondence.sh
+
+      - uses: azure/setup-helm@v4
+        with:
+          version: v3.16.3
+
+      - name: pyyaml
+        run: python3 -m pip install --quiet pyyaml
+
+      # THE GUARD. Renders the listener producer
+      # (platform/sovereign-tls-vars/chart, the one chart that emits BOTH
+      # Gateways' listener arrays) plus every apex-route-bearing chart, and
+      # joins them. No cluster and no registry: the dependency blocks are
+      # stripped from throwaway chart copies, which is sound because every
+      # HTTPRoute in this repo comes from its chart's OWN templates/.
+      - name: route/listener correspondence on both port profiles
+        run: bash scripts/check-chart-route-listener-correspondence.sh
+
+      # VACUITY. A guard that has only ever been observed passing proves
+      # nothing. This re-runs the SAME real scenario with one extra route —
+      # mcp.<fqdn> re-parented onto the console gateway, i.e. exactly the
+      # #5341 misconfiguration — against the real rendered console listener
+      # set, and requires the guard to go RED with NO-LISTENER on it. The step
+      # fails if the guard passes, and equally if it fails for another reason.
+      - name: the guard must be able to fail
+        run: bash scripts/check-chart-route-listener-correspondence.sh --vacuity

--- a/.github/workflows/check-live-route-backends-selftest.yaml
+++ b/.github/workflows/check-live-route-backends-selftest.yaml
@@ -86,16 +86,21 @@ jobs:
       # rule and not merely on being per-Org routes.
       - name: listener pass must be able to fail
         run: |
-          cp scripts/check-live-route-backends.sh /tmp/mutant-listener.sh
+          # `listener_admits` moved to scripts/lib/gateway_route_admission.py
+          # (#6140), shared with the source-side guard. The guard resolves that
+          # module relative to its OWN path, so the mutation copies the whole
+          # scripts/ tree and regresses the module inside the copy — mutating a
+          # lone .sh would leave the real module imported and prove nothing.
+          rm -rf /tmp/mutant-listener && cp -r scripts /tmp/mutant-listener
           python3 - <<'PY'
-          p = "/tmp/mutant-listener.sh"
+          p = "/tmp/mutant-listener/lib/gateway_route_admission.py"
           s = open(p).read()
-          old = '    if lh.startswith("*."):\n        suffix = lh[1:]'
-          new = '    if lh.startswith("*."):\n        return True\n        suffix = lh[1:]'
+          old = '    if listener_hostname.startswith("*."):\n        suffix = listener_hostname[1:]'
+          new = '    if listener_hostname.startswith("*."):\n        return True\n        suffix = listener_hostname[1:]'
           assert old in s, "mutation anchor not found — update this step"
           open(p, "w").write(s.replace(old, new, 1))
           PY
-          if bash /tmp/mutant-listener.sh --self-test >/tmp/mutant-listener.out 2>&1; then
+          if bash /tmp/mutant-listener/check-live-route-backends.sh --self-test >/tmp/mutant-listener.out 2>&1; then
             echo "VACUITY FAIL: the self-test passed against a classifier whose"
             echo "wildcard listener admits every hostname. A route nothing listens"
             echo "for is a TLS reset, not a 503 — no status-code probe can see it."

--- a/.github/workflows/check-live-route-backends-selftest.yaml
+++ b/.github/workflows/check-live-route-backends-selftest.yaml
@@ -56,24 +56,49 @@ jobs:
       # annotation pointed at nothing.
       - name: self-test must be able to fail
         run: |
-          cp scripts/check-live-route-backends.sh /tmp/mutant.sh
+          # The guard imports scripts/lib/gateway_route_admission.py relative to
+          # its OWN path (#6140), so every mutation below copies the whole
+          # scripts/ tree. Copying the lone .sh to /tmp leaves no lib/ beside it
+          # and the classifier dies with ModuleNotFoundError — which exits
+          # non-zero and would be misread by the `if` below as "mutation
+          # caught". That is why each step now also requires the mutant to print
+          # the SPECIFIC failing fixture and to keep a control green: a crash
+          # must never be able to masquerade as a vacuity proof.
+          rm -rf /tmp/mutant && cp -r scripts /tmp/mutant
           python3 - <<'PY'
-          p = "/tmp/mutant.sh"
+          p = "/tmp/mutant/check-live-route-backends.sh"
           s = open(p).read()
           old = "            if mesh > 0:"
           new = "            if True:"
           assert old in s, "mutation anchor not found — update this step"
           open(p, "w").write(s.replace(old, new, 1))
           PY
-          if bash /tmp/mutant.sh --self-test >/tmp/mutant.out 2>&1; then
+          if bash /tmp/mutant/check-live-route-backends.sh --self-test >/tmp/mutant.out 2>&1; then
             echo "VACUITY FAIL: the self-test passed against a classifier that"
             echo "excuses every global-annotated Service without ever checking"
             echo "whether a remote cluster exists. That is the #6040 blind spot."
             cat /tmp/mutant.out
             exit 1
           fi
-          echo "OK: the mutated classifier is caught. Failing assertion:"
-          grep -m1 'SELF-TEST FAIL' /tmp/mutant.out || cat /tmp/mutant.out
+          # The mutation targets the MESH belief, so the fixture that must go red
+          # is the 0-remote-clusters stub — named explicitly so a crash, or a red
+          # from any other fixture, cannot be scored as this proof.
+          grep -qF "fixture 'mesh stub, 0 remote clusters'" /tmp/mutant.out || {
+            echo "VACUITY FAIL: the run failed, but not on the mesh-stub fixture —"
+            echo "the non-zero exit came from something other than the mutation."
+            cat /tmp/mutant.out
+            exit 1
+          }
+          # CONTROL: a fixture that shares the suspect property (a zero-endpoint
+          # Service) but is NOT decided by the mesh belief must stay green.
+          grep -qF 'ok  dead backend, no mesh annotation' /tmp/mutant.out || {
+            echo "CONTROL FAIL: the unannotated dead-backend fixture went red too,"
+            echo "so the red cannot be attributed to the mesh belief."
+            cat /tmp/mutant.out
+            exit 1
+          }
+          echo "OK: mutation caught, control stayed green. Failing assertion:"
+          grep -m1 'SELF-TEST FAIL' /tmp/mutant.out
 
       # Second vacuity check, for the listener pass (UAT rows 87/90/95, and the
       # g7doora shape behind row 234). Regress `listener_admits` to the belief
@@ -127,16 +152,17 @@ jobs:
       # defect that produced those three rows.
       - name: region-symmetry pass must be able to fail
         run: |
-          cp scripts/check-live-route-backends.sh /tmp/mutant-peer.sh
+          # Whole tree, not the lone .sh — see the first vacuity step.
+          rm -rf /tmp/mutant-peer && cp -r scripts /tmp/mutant-peer
           python3 - <<'PY'
-          p = "/tmp/mutant-peer.sh"
+          p = "/tmp/mutant-peer/check-live-route-backends.sh"
           s = open(p).read()
           old = 'peer_known = "peerHosts" in b'
           new = 'peer_known = False'
           assert old in s, "mutation anchor not found — update this step"
           open(p, "w").write(s.replace(old, new, 1))
           PY
-          if bash /tmp/mutant-peer.sh --self-test >/tmp/mutant-peer.out 2>&1; then
+          if bash /tmp/mutant-peer/check-live-route-backends.sh --self-test >/tmp/mutant-peer.out 2>&1; then
             echo "VACUITY FAIL: the self-test passed against a classifier that never"
             echo "compares regions. A hostname only one region routes is a coin flip"
             echo "for every customer behind the shared front door."

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1389,7 +1389,7 @@ spec:
       #   guacamole-pg and the shared-pg family as well. Egress half in
       #   bp-keycloak 1.5.9; neither half alone restores a brokered login.
       #   Lockstep w/ products/catalyst/chart/Chart.yaml.
-      version: 1.4.1402
+      version: 1.4.1408
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1389,7 +1389,7 @@ spec:
       #   guacamole-pg and the shared-pg family as well. Egress half in
       #   bp-keycloak 1.5.9; neither half alone restores a brokered login.
       #   Lockstep w/ products/catalyst/chart/Chart.yaml.
-      version: 1.4.1408
+      version: 1.4.1410
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/clusters/_template/bootstrap-kit/19-harbor.yaml
+++ b/clusters/_template/bootstrap-kit/19-harbor.yaml
@@ -230,7 +230,7 @@ spec:
       # camelCase; the s3 overlay above now sets the correct lowercase key).
       # 1.2.45: #5406 — ONE session/queue/cache store per Sovereign. See the
       # crossRegion block in `values:` below for the full wiring + rationale.
-      version: 1.2.47
+      version: 1.2.48
       sourceRef:
         kind: HelmRepository
         name: bp-harbor

--- a/docs/RUNBOOKS.md
+++ b/docs/RUNBOOKS.md
@@ -1117,6 +1117,70 @@ classifies these automatically** — it fails only when a hostname cannot serve 
 the gateway that *owns* it, and reports a reading from the peer gateway's port as
 `EXPECTED-ISOLATION`, never as a defect.
 
+##### 5.1.3 The source-side half — correspondence without a cluster (#6140)
+
+§5.1.2 and `check-live-route-backends.sh` both need a running Sovereign. That
+left the whole class decidable **only after a provision**, which is how region B
+shipped HTTPRoutes with zero admitting listeners without CI objecting once.
+
+`scripts/check-chart-route-listener-correspondence.sh` closes that half. It
+renders the listener producer and the route producers and joins them, so a
+hostname with no listener fails in the pull request rather than on a customer's
+TLS handshake. **No cluster, no registry, no credentials.**
+
+What makes it decidable from source: **no chart in this repo renders a
+`kind: Gateway`.** Both Gateways are Kustomize manifests under
+`clusters/_template/sovereign-tls/` whose entire `spec.listeners` is a Flux
+`postBuild` placeholder, and both placeholders are filled by ONE chart:
+
+| Gateway manifest | Placeholder | Rendered by |
+|---|---|---|
+| `cilium-gateway.yaml` | `${PARENT_DOMAINS_LISTENERS_YAML}` | `platform/sovereign-tls-vars/chart` — one `*.<zone>` pair per `parentZones[]` + the per-prov `*.<fqdn>` pair |
+| `cilium-gateway-console.yaml` | `${CONSOLE_LISTENERS_YAML}` | same chart — one **exact** `<prefix>.<fqdn>` pair per `consoleGateway.hostPrefixes[]` |
+
+Three rules the guard encodes, each of which has already been got wrong here:
+
+- **Ownership is the `parentRef`, never a hostname prefix.**
+  `marketplace.<fqdn>` is on the **console** gateway (and is in
+  `hostPrefixes`); `mcp.<fqdn>` is on the **shared** one (#5341 — a console
+  wildcard collided with the shared `*.<fqdn>` chain and 404'd ~50% of every
+  other subdomain). Per-Org `mcp.<slug>.<pool>` *is* on the console gateway but
+  is stamped by catalyst-api at install time, not by any chart. A `console.*`
+  prefix rule gets all three wrong.
+- **Wildcards are suffix matches of one or MORE labels.** `*.a.b` admits
+  `x.a.b` and `x.y.a.b`, never the bare `a.b`. (Distinct from Let's Encrypt
+  wildcard SANs, which match exactly one label — that different rule is why the
+  per-prov `*.<fqdn>` listener pair exists at all. Conflating them is a trap in
+  both directions.)
+- **`sectionName` and `port` are pins.** A pin that names nothing leaves the
+  route with zero candidate listeners. Both listener sets are asserted under
+  the Hetzner (`:443/:80`) **and** Huawei (`:8443/:8080`) console-port profiles,
+  because that split is the mechanism behind the §5.1.2 false 404.
+
+Verdicts are deliberately split by owner: **`NO-LISTENER`** = the Gateway exists
+and its listener set does not cover the host (owner: `consoleGateway.hostPrefixes`
+/ `parentZones`, or the route's own pin). **`NO-GATEWAY`** = the parentRef names
+a Gateway nothing installs (owner: a bootstrap slot). Collapsing them sends every
+one of them to the wrong person.
+
+```bash
+scripts/check-chart-route-listener-correspondence.sh              # repo render
+scripts/check-chart-route-listener-correspondence.sh --self-test  # fixtures only
+scripts/check-chart-route-listener-correspondence.sh --vacuity    # must go RED
+```
+
+Admission semantics live in `scripts/lib/gateway_route_admission.py`, **shared**
+with `check-live-route-backends.sh` — one implementation, so the live and source
+guards cannot drift onto two different readings of the spec.
+
+The first defect it caught: harbor's `harbor.<fqdn>` alias-redirect route read
+`.Values.gateway.sectionName` (a key that does not exist; the real one is
+`.Values.gateway.parentRef.sectionName`) and so always fell back to
+`sectionName: "https"`. That listener name exists only on a **single-zone**
+Sovereign — every Org-pool Sovereign renames it `https-<zone-dashed>` — so the
+route attached to zero listeners and envoy reset the handshake. Fixed in
+bp-harbor 1.2.48.
+
 ### 5.2 The walk — Phase 0 + Phase 1 deterministic test
 
 Per [`DOD.md`](DOD.md), every walk must move at least one of the 5 inseparable pillars:

--- a/platform/harbor/blueprint.yaml
+++ b/platform/harbor/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-3-5-storage-and-data
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.2.47  # lockstep with chart/Chart.yaml (#5406 cross-region Redis anchor — see Chart.yaml changelog)
+  version: 1.2.48  # lockstep with chart/Chart.yaml (#5406 cross-region Redis anchor — see Chart.yaml changelog)
   card:
     title: Harbor
     family: foundation

--- a/platform/harbor/chart/Chart.yaml
+++ b/platform/harbor/chart/Chart.yaml
@@ -215,8 +215,24 @@ type: application
 #   ${SOVEREIGN_ENABLE_CNPG_PAIR}, which catalyst-api stamps true only once
 #   ClusterMesh is established) — a single-region render is byte-identical.
 #   Guarded by tests/redis-crossregion.sh.
-version: 1.2.47
+version: 1.2.48
 appVersion: "2.14.3"
+# 1.2.48 (#6140, 2026-08-11): the harbor.<fqdn> alias-redirect HTTPRoute read
+#   three values keys that do not exist — `.Values.gateway.{name,namespace,
+#   sectionName}`, where the real ones are `.Values.gateway.parentRef.*`. Two
+#   fell through to the right default. The third did not: `sectionName |
+#   default "https"` pinned a listener name that exists ONLY on a single-zone
+#   Sovereign. Every Org-pool Sovereign declares multiple parentZones, so
+#   sovereign-tls-vars names that listener `https-<zone-dashed>` and the pin
+#   matched nothing — the route attached to ZERO listeners, Gateway API
+#   answered `Accepted=False NoMatchingListenerHostname`, and envoy reset the
+#   TLS handshake for harbor.<fqdn> instead of returning any HTTP status a
+#   probe could see. values.yaml already carried the warning on
+#   `gateway.parentRef.sectionName` ("pinning sectionName: https breaks
+#   NoMatchingListener", PR #1888 / #1902); this one route was not reading it.
+#   Now uses the identical parentRef block as the main route, so a sectionName
+#   is emitted only when an operator sets one. Caught source-side by
+#   scripts/check-chart-route-listener-correspondence.sh.
 # 1.2.23 (G117.5 #2744, 2026-06-02): SSO defense-in-depth via Harbor's
 # `oidc_extra_redirect_parms` config field. The configure-oauth Job now
 # PUTs the field with `{"kc_idp_hint":"catalyst-pin"}` (per top-level

--- a/platform/harbor/chart/templates/httproute.yaml
+++ b/platform/harbor/chart/templates/httproute.yaml
@@ -150,10 +150,28 @@ metadata:
   labels:
     {{- include "bp-harbor.labels" . | nindent 4 }}
 spec:
+  {{- /* #6140 — this block used to read `.Values.gateway.{name,namespace,
+     sectionName}`, three keys that DO NOT EXIST in values.yaml (the real ones
+     are under `.Values.gateway.parentRef.*`). Two of the three failed
+     harmlessly into the correct default, but the third did not:
+     `sectionName | default "https"` pinned a listener name that only exists on
+     a SINGLE-zone Sovereign. Every Org-pool Sovereign declares more than one
+     parentZone, so sovereign-tls-vars names the listener `https-<zone-dashed>`
+     (e.g. `https-omani-works`) and the pin matched NOTHING — the route
+     attached to zero listeners, Gateway API answered
+     `Accepted=False NoMatchingListenerHostname`, and envoy reset the TLS
+     handshake for harbor.<fqdn> rather than returning any HTTP status a probe
+     could have noticed. harbor's own values.yaml already carries the warning
+     ("pinning sectionName: https breaks NoMatchingListener", PR #1888 /
+     issue #1902) on `gateway.parentRef.sectionName`; this route simply was not
+     reading that key. It now uses the identical parentRef block as the main
+     route above, so a sectionName is emitted only when an operator sets one. */}}
   parentRefs:
-    - name: {{ .Values.gateway.name | default "cilium-gateway" }}
-      namespace: {{ .Values.gateway.namespace | default "kube-system" }}
-      sectionName: {{ .Values.gateway.sectionName | default "https" | quote }}
+    - name: {{ .Values.gateway.parentRef.name | default "cilium-gateway" | quote }}
+      namespace: {{ .Values.gateway.parentRef.namespace | default "kube-system" | quote }}
+      {{- with .Values.gateway.parentRef.sectionName }}
+      sectionName: {{ . | quote }}
+      {{- end }}
   hostnames:
     - {{ $aliasHost | quote }}
   rules:

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-11T08:18:06.242Z",
+  "generatedAt": "2026-08-11T10:25:56.189Z",
   "blueprints": [
     {
       "id": "bp-agenity",
@@ -1887,7 +1887,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "1.2.47",
+      "version": "1.2.48",
       "section": "pts-3-5-storage-and-data",
       "depends": [
         "bp-cnpg",

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -2022,7 +2022,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "1.2.47",
+    "version": "1.2.48",
     "section": "pts-3-5-storage-and-data",
     "depends": [
       "bp-cnpg",

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3874,7 +3874,7 @@ name: bp-catalyst-platform
 #   scripts/check-image-pin-writer-targets.sh plus the extended
 #   scripts/check-controller-image-tag-freshness.sh. Chart version bump is what
 #   actually delivers the three new tags, so it is the load-bearing half.
-version: 1.4.1409
+version: 1.4.1410
 # 1.4.1229 — #5389: catalog-seed bp-newapi declares its `ui` endpoint
 #   (newapi.<fqdn>, ssoEnabled, launchDefault, ssoInitPath "/") instead of
 #   `endpoints: []`. The empty list made userUIGatePasses fail closed, which
@@ -4029,7 +4029,7 @@ version: 1.4.1409
 # scripts/check-chart-version-forward.sh (#5743) fails unless the two match —
 # main was carrying a pre-existing 1.4.1330/1.4.1329 split, so this bump heals
 # it in the same commit, exactly as the documented self-heal contract does.
-appVersion: 1.4.1409
+appVersion: 1.4.1410
 # 1.4.239 — Wave 3 / Issue #2140 (2026-05-23): Huawei provider
 # implementation lands behind the Wave 2 CloudProvider interface.
 # Adds the OpenTofu module at infra/providers/huawei/ (VPC + Subnet +

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -3374,7 +3374,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "1.2.47"
+  version: "1.2.48"
   visibility: unlisted
   card:
     title: "Harbor"
@@ -3398,7 +3398,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-harbor
-    version: "1.2.47"
+    version: "1.2.48"
   topology:
     supported:
     - active-hot-standby

--- a/scripts/check-chart-route-listener-correspondence.sh
+++ b/scripts/check-chart-route-listener-correspondence.sh
@@ -1,0 +1,770 @@
+#!/usr/bin/env bash
+# check-chart-route-listener-correspondence.sh — SOURCE-side guard (#6140):
+# every hostname a chart renders an HTTPRoute for must be admitted by a
+# listener the parent Gateway will actually carry. Proven from `helm template`
+# output alone. NO CLUSTER.
+#
+# WHY A SOURCE-SIDE CHECK, WHEN TWO LIVE ONES ALREADY EXIST
+# ---------------------------------------------------------
+# `scripts/check-live-route-backends.sh` (#6165) and
+# `scripts/check-live-gateway-host-ports.sh` (#6143) both answer questions
+# about route/listener correspondence — and both need a running Sovereign to
+# say anything at all. That is the whole gap: a defect that is fully decided
+# by the chart source could only be discovered after a provision, on an
+# environment, by a walker. Region B shipped HTTPRoutes with zero admitting
+# listeners and nothing in CI could have objected, because nothing in CI ever
+# looked at the rendered pair.
+#
+# This guard looks at the pair. It renders the listener producer and the
+# route producers and joins them, so the same class fails in a pull request
+# instead of on a customer's TLS handshake.
+#
+# WHAT MAKES THIS DECIDABLE FROM SOURCE
+# -------------------------------------
+# No chart in this repo renders a `kind: Gateway`. Both Sovereign Gateways are
+# Kustomize manifests under `clusters/_template/sovereign-tls/` whose entire
+# `spec.listeners` is a Flux `postBuild` substitution placeholder:
+#
+#     cilium-gateway.yaml          listeners: ${PARENT_DOMAINS_LISTENERS_YAML}
+#     cilium-gateway-console.yaml  listeners: ${CONSOLE_LISTENERS_YAML}
+#
+# Both values are rendered — as JSON arrays — by ONE chart,
+# `platform/sovereign-tls-vars/chart`. So the listener set IS source, and this
+# guard reconstructs each Gateway exactly as Flux would: Gateway name and
+# namespace read out of the cluster template (never hardcoded here, so a
+# rename shows up as NO-GATEWAY rather than as a silent pass), listeners
+# parsed out of the rendered ConfigMap.
+#
+# THE OWNERSHIP RULE IS THE parentRef, NOT A HOSTNAME PREFIX
+# ----------------------------------------------------------
+# The Sovereign runs TWO Gateways, and which one serves a hostname is the
+# thing that produced the false `404` this work started from: the console sits
+# on its own isolated Gateway (#4053/#4706, because two Gateways cannot both
+# bind node:443 under hostNetwork), the shared gateway serves everything else,
+# and BOTH terminate the same wildcard cert — so a probe on the wrong port
+# completes TLS and only then meets an envoy with no matching vhost.
+#
+# A guard that decided ownership by hostname prefix would be wrong in both
+# directions on this repo's real data:
+#
+#   * `marketplace.<fqdn>` is on the CONSOLE gateway
+#     (products/catalyst/chart/values.yaml `ingress.gateway.parentRef.name:
+#     cilium-gateway-console`, and `marketplace` is in
+#     `consoleGateway.hostPrefixes`). A `console.*` prefix rule sends it to
+#     the shared gateway, where the `*.<fqdn>` wildcard admits it — a PASS
+#     for entirely the wrong reason.
+#   * `mcp.<fqdn>` is on the SHARED gateway
+#     (products/openova-mcp/chart/values.yaml, and
+#     catalyst-edge-routes' deliberately separate `ingress.mcpGateway` key),
+#     because #5341 found that a console-gateway wildcard collided with the
+#     shared gateway's own `*.<fqdn>` filter chain and 404'd ~50% of every
+#     other subdomain. Per-Org `mcp.<slug>.<pool>` IS on the console gateway,
+#     but it is stamped at install time by catalyst-api
+#     (bootstrap/api/internal/handler/application_parameters.go), not by a
+#     chart, so no prefix rule could have known.
+#
+# So ownership here is resolved the only way that cannot drift: each route's
+# own `parentRefs[].name`/`namespace` selects the Gateway, and only THAT
+# Gateway's listeners are considered. `sectionName` and `port` on the
+# parentRef are honoured as PINS — a route that names a section attaches only
+# to the listener of that exact name, and a route that pins a port attaches
+# only to listeners on that port.
+#
+# THE TWO PORT PROFILES
+# ---------------------
+# `consoleGateway.httpsPort`/`httpPort` are 443/80 on Hetzner and 8443/8080 on
+# Huawei (infra/providers/_shared/cloudinit-control-plane.tftpl threads
+# CONSOLE_GATEWAY_HTTPS_PORT into bootstrap-kit slot 12a). The port split is
+# the mechanism behind the false 404, so correspondence is asserted under BOTH
+# profiles — a route that only works on one of them is a defect on the other.
+#
+# THE TWO LISTENER PRODUCERS
+# --------------------------
+# Static listeners come from the chart. Per-Organization listeners do not:
+# catalyst-api's org_console_tls.go appends `console-https-<slug>` /
+# `console-http-<slug>` hostnamed `*.<slug>.<parentDomain>` to the console
+# Gateway, reading its ports from the apex `console-https`/`console-http`
+# listeners. A source-side guard that ignored that producer would report every
+# per-Org hostname as NO-LISTENER; one that merely SKIPPED per-Org hostnames
+# would be fail-open. So the minter is MODELLED, and `--self-test` asserts the
+# Go producer still declares the shape being modelled — if that source stops
+# saying `console-https-` / `"*." + slug`, this guard goes red rather than
+# quietly continuing to model something that no longer exists.
+#
+# WILDCARDS: TWO DIFFERENT RULES THAT LOOK ALIKE
+# ----------------------------------------------
+# Gateway API listener wildcards are SUFFIX matches of one or MORE labels:
+# `*.a.b` admits `x.a.b` AND `x.y.a.b`, never the bare `a.b`. Let's Encrypt
+# wildcard SAN certs are a different rule — exactly ONE label — which is why
+# the per-prov `*.<fqdn>` listener pair exists at all. Conflating the two is a
+# trap in both directions, so admission lives in ONE place,
+# `scripts/lib/gateway_route_admission.py`, shared with
+# check-live-route-backends.sh rather than re-typed here.
+#
+# Exit codes:
+#   0 — every rendered hostname is admitted by a listener of its parent Gateway.
+#   1 — at least one is not (NO-LISTENER), or its Gateway is absent (NO-GATEWAY).
+#   2 — setup error (missing helm/python3/pyyaml, unrenderable declared chart,
+#       a scenario that rendered fewer routes than declared). Never a pass.
+#
+# Usage:
+#   scripts/check-chart-route-listener-correspondence.sh              # repo mode
+#   scripts/check-chart-route-listener-correspondence.sh --self-test  # fixtures
+#   scripts/check-chart-route-listener-correspondence.sh --vacuity    # must go RED
+#
+# 🛑 This repo is PUBLIC. The guard renders charts with fixture hostnames on
+#    the canonical test domains only, reads no Secret data, and prints object
+#    names and hostnames only.
+
+set -euo pipefail
+
+SELF_TEST=0
+VACUITY=0
+ROOT="${ROOT:-.}"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --self-test) SELF_TEST=1; shift ;;
+    --vacuity)   VACUITY=1; shift ;;
+    --root)      ROOT="$2"; shift 2 ;;
+    *) echo "Unknown arg: $1" >&2
+       echo "Usage: $0 [--root <repo-root>] [--self-test] [--vacuity]" >&2
+       exit 2 ;;
+  esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+export GUARD_LIB="$SCRIPT_DIR/lib"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# The classifier. Reads ONE normalized JSON bundle on stdin, exactly like
+# check-live-route-backends.sh does, and delegates the verdict to the SHARED
+# admission module so the two guards cannot drift apart on the wildcard rule.
+#
+# bundle = {
+#   "profile":  "<label>",
+#   "routes":   [{"ns","name","hosts":[..],
+#                 "parents":[{"ns","name","sectionName","port"}]}],
+#   "gateways": [{"ns","name","listeners":[{"name","hostname","port"}]}]
+# }
+# ─────────────────────────────────────────────────────────────────────────────
+read -r -d '' CLASSIFY_PY <<'PY' || true
+import json, os, sys
+sys.path.insert(0, os.environ["GUARD_LIB"])
+from gateway_route_admission import correspondence_rows
+
+b = json.load(sys.stdin)
+rows, _ = correspondence_rows(b.get("routes", []), b.get("gateways", []))
+
+order = {"NO-GATEWAY": 0, "NO-LISTENER": 1, "SERVING": 2}
+rows.sort(key=lambda r: (order[r[0]], r[1], r[2]))
+bad = [r for r in rows if r[0] != "SERVING"]
+
+print("profile:                      %s" % b.get("profile", "(unnamed)"))
+print("Gateways reconstructed:       %d" % len(b.get("gateways", [])))
+for g in b.get("gateways", []):
+    print("    %s/%s  %d listener(s)" % (g["ns"], g["name"], len(g.get("listeners") or [])))
+print("HTTPRoute hostnames examined: %d" % len(rows))
+print("  SERVING       %d" % sum(1 for r in rows if r[0] == "SERVING"))
+print("  NO-LISTENER   %d" % sum(1 for r in rows if r[0] == "NO-LISTENER"))
+print("  NO-GATEWAY    %d" % sum(1 for r in rows if r[0] == "NO-GATEWAY"))
+print()
+for v, h, who, why in rows:
+    if v == "SERVING":
+        continue
+    print("  %-13s host=%-42s route=%-46s %s" % (v, h, who, why))
+
+if bad:
+    print()
+    print("FAIL: %d rendered hostname(s) have no listener that admits them." % len(bad))
+    print("      NO-LISTENER  — the Gateway exists; its listener set does not cover")
+    print("                     this host. Owner: the listener declaration")
+    print("                     (consoleGateway.hostPrefixes / parentZones), or the")
+    print("                     route's sectionName/port pin. Gateway API answers")
+    print("                     Accepted=False NoMatchingListenerHostname and envoy")
+    print("                     RESETS the TLS handshake — there is no HTTP status")
+    print("                     for a probe to see.")
+    print("      NO-GATEWAY   — the parentRef names a Gateway nothing installs here.")
+    print("                     Different owner: a bootstrap slot, not a values key.")
+    sys.exit(1)
+
+print()
+print("PASS: every rendered hostname is admitted by a listener of its parent Gateway.")
+PY
+
+classify() { python3 -c "$CLASSIFY_PY"; }
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Self-test — fixtures only. No helm, no cluster, no repo render.
+#
+# Every must-fail fixture is paired with a CONTROL that shares its suspect
+# property and must stay GREEN, so a red can never be read as "this classifier
+# bans a shape" when it should be reading one specific fact about that shape.
+#
+# Org hostnames deliberately span THREE pool TLDs (omani.homes / .rest /
+# .trade). A fixture set on one TLD would pass a classifier that hardcoded it.
+# ─────────────────────────────────────────────────────────────────────────────
+if [ "$SELF_TEST" -eq 1 ]; then
+  fails=0
+
+  # An exit code alone is not evidence — a crashed classifier also exits
+  # non-zero. Each fixture must ALSO print the verdict token that only the
+  # decision path can print, and the must-fail ones must print the SPECIFIC
+  # verdict expected, so NO-LISTENER can never be scored by a NO-GATEWAY.
+  run_fixture() { # run_fixture <name> <pass|fail> <expected-verdict|-> <bundle>
+    local name="$1" want="$2" verdict="$3" bundle="$4" out rc
+    set +e
+    out="$(printf '%s' "$bundle" | classify 2>&1)"; rc=$?
+    set -e
+    if [ "$want" = "pass" ] && [ "$rc" -ne 0 ]; then
+      echo "  FAIL: '$name' expected exit 0, got $rc"; echo "$out"; fails=1; return
+    fi
+    if [ "$want" = "fail" ] && [ "$rc" -eq 0 ]; then
+      echo "  FAIL: '$name' expected non-zero but the guard PASSED —"
+      echo "        a guard that cannot fail on this input is vacuous."
+      echo "$out"; fails=1; return
+    fi
+    local token; [ "$want" = "pass" ] && token="PASS:" || token="FAIL:"
+    if ! printf '%s' "$out" | grep -q "^${token}"; then
+      echo "  FAIL: '$name' exited $rc but never printed '${token}' —"
+      echo "        the exit code came from a crash, not from a verdict."
+      echo "$out"; fails=1; return
+    fi
+    if [ "$verdict" != "-" ] && ! printf '%s' "$out" | grep -q "  ${verdict} "; then
+      echo "  FAIL: '$name' failed, but not with '${verdict}' — wrong reason."
+      echo "$out"; fails=1; return
+    fi
+    echo "  ok  $name (want=$want${verdict:+, verdict=$verdict})"
+  }
+
+  # The two Gateways as this repo really shapes them, Hetzner profile.
+  GW_443='"gateways":[
+    {"ns":"kube-system","name":"cilium-gateway","listeners":[
+      {"name":"https-t99-omani-works","hostname":"*.t99.omani.works","port":443},
+      {"name":"http-t99-omani-works","hostname":"*.t99.omani.works","port":80},
+      {"name":"https-omani-homes","hostname":"*.omani.homes","port":443},
+      {"name":"https-omani-rest","hostname":"*.omani.rest","port":443},
+      {"name":"https-omani-trade","hostname":"*.omani.trade","port":443}]},
+    {"ns":"kube-system","name":"cilium-gateway-console","listeners":[
+      {"name":"console-https","hostname":"console.t99.omani.works","port":443},
+      {"name":"api-https","hostname":"api.t99.omani.works","port":443},
+      {"name":"marketplace-https","hostname":"marketplace.t99.omani.works","port":443},
+      {"name":"console-https-walkone","hostname":"*.walkone.omani.homes","port":443}]}]'
+
+  # The SAME Sovereign on the Huawei profile: the console gateway moved to
+  # 8443, and the minter carried the per-Org pair with it.
+  GW_8443='"gateways":[
+    {"ns":"kube-system","name":"cilium-gateway","listeners":[
+      {"name":"https-t99-omani-works","hostname":"*.t99.omani.works","port":443}]},
+    {"ns":"kube-system","name":"cilium-gateway-console","listeners":[
+      {"name":"console-https","hostname":"console.t99.omani.works","port":8443},
+      {"name":"marketplace-https","hostname":"marketplace.t99.omani.works","port":8443},
+      {"name":"console-https-walktwo","hostname":"*.walktwo.omani.trade","port":8443}]}]'
+
+  echo "self-test: 14 fixtures (7 must pass, 7 must fail) over 3 pool TLDs"
+
+  # ── OWNERSHIP: the parentRef decides, not the hostname prefix ─────────────
+
+  # 1. CONTROL for 2. `marketplace.` does NOT start with `console.` and IS on
+  #    the console gateway. A prefix rule would have checked the shared
+  #    gateway, whose `*.<fqdn>` admits it — passing for the wrong reason.
+  #    Here it is admitted by its OWN gateway's exact listener.
+  run_fixture "marketplace host admitted by the CONSOLE gateway" pass - '{
+    "profile":"ownership", '"$GW_443"',
+    "routes":[{"ns":"catalyst-system","name":"marketplace",
+               "hosts":["marketplace.t99.omani.works"],
+               "parents":[{"ns":"kube-system","name":"cilium-gateway-console"}]}]}'
+
+  # 2. The #5341 shape: a host re-parented onto the console gateway without
+  #    its prefix added to consoleGateway.hostPrefixes. The console listeners
+  #    are EXACT 2-label hosts, so nothing admits it — even though the shared
+  #    gateway's wildcard would have. This is the defect the chart comment
+  #    calls "the deliberate, testable cost of a specific listener".
+  run_fixture "mcp re-parented to console without a hostPrefix" fail NO-LISTENER '{
+    "profile":"ownership", '"$GW_443"',
+    "routes":[{"ns":"catalyst-system","name":"openova-mcp",
+               "hosts":["mcp.t99.omani.works"],
+               "parents":[{"ns":"kube-system","name":"cilium-gateway-console"}]}]}'
+
+  # 3. CONTROL for 2 — the SAME hostname on the gateway that really owns it.
+  #    Proves fixture 2 fails on the OWNERSHIP fact and not on the hostname.
+  run_fixture "the same mcp host on the SHARED gateway" pass - '{
+    "profile":"ownership", '"$GW_443"',
+    "routes":[{"ns":"catalyst-system","name":"openova-mcp",
+               "hosts":["mcp.t99.omani.works"],
+               "parents":[{"ns":"kube-system","name":"cilium-gateway"}]}]}'
+
+  # ── WILDCARD SEMANTICS ───────────────────────────────────────────────────
+
+  # 4. `*.a.b` must NEVER admit the bare apex `a.b` it wildcards.
+  run_fixture "wildcard must not admit its own apex" fail NO-LISTENER '{
+    "profile":"wildcard", '"$GW_443"',
+    "routes":[{"ns":"walkone","name":"apex","hosts":["walkone.omani.homes"],
+               "parents":[{"ns":"kube-system","name":"cilium-gateway-console"}]}]}'
+
+  # 5. CONTROL for 4 — the SAME wildcard MUST admit a deeper host, because
+  #    Gateway API wildcards are suffix matches, not single-label matches.
+  #    Paired with 4 this pins the rule from both sides; a classifier that
+  #    passed one and failed the other is caught here.
+  run_fixture "wildcard admits a deeper sub-host" pass - '{
+    "profile":"wildcard", '"$GW_443"',
+    "routes":[{"ns":"walkone","name":"deep","hosts":["a.b.walkone.omani.homes"],
+               "parents":[{"ns":"kube-system","name":"cilium-gateway-console"}]}]}'
+
+  # 6. CONTROL — a near-miss that a bare `endswith` would wrongly admit:
+  #    `notwalkone.omani.homes` shares the suffix `walkone.omani.homes`'s
+  #    TAIL but is a different zone. Must be admitted by `*.omani.homes` on
+  #    the SHARED gateway and NOT by the console per-Org listener.
+  run_fixture "sibling zone admitted by the pool wildcard, not the Org one" pass - '{
+    "profile":"wildcard", '"$GW_443"',
+    "routes":[{"ns":"other","name":"sibling","hosts":["notwalkone.omani.homes"],
+               "parents":[{"ns":"kube-system","name":"cilium-gateway"}]}]}'
+
+  # ── sectionName PIN — the harbor alias-redirect shape ────────────────────
+
+  # 7. A route pinning `sectionName: https` on a MULTI-ZONE Sovereign, where
+  #    the listener is named `https-omani-homes` because more than one parent
+  #    zone is declared. The pin matches no listener, so the route attaches to
+  #    nothing even though a hostname-compatible listener is sitting right
+  #    there. Real instance: harbor's alias-redirect route.
+  run_fixture "sectionName pin naming a listener that multi-zone renamed" fail NO-LISTENER '{
+    "profile":"sectionName", '"$GW_443"',
+    "routes":[{"ns":"harbor","name":"harbor-alias-redirect",
+               "hosts":["harbor.t99.omani.works"],
+               "parents":[{"ns":"kube-system","name":"cilium-gateway","sectionName":"https"}]}]}'
+
+  # 8. CONTROL for 7 — the SAME route with the pin removed. Proves 7 fails on
+  #    the PIN and not on the hostname, the gateway, or the zone count.
+  run_fixture "the same route with no sectionName pin" pass - '{
+    "profile":"sectionName", '"$GW_443"',
+    "routes":[{"ns":"harbor","name":"harbor-alias-redirect",
+               "hosts":["harbor.t99.omani.works"],
+               "parents":[{"ns":"kube-system","name":"cilium-gateway"}]}]}'
+
+  # 9. CONTROL for 7 — a sectionName pin that NAMES A REAL listener must pass,
+  #    so the guard is not merely "bans sectionName".
+  run_fixture "sectionName pin that names a real listener" pass - '{
+    "profile":"sectionName", '"$GW_443"',
+    "routes":[{"ns":"harbor","name":"harbor",
+               "hosts":["registry.t99.omani.works"],
+               "parents":[{"ns":"kube-system","name":"cilium-gateway","sectionName":"https-t99-omani-works"}]}]}'
+
+  # ── PORT PIN — the isolation split that produced the false 404 ───────────
+
+  # 10. The console gateway is on 8443 (Huawei). A route pinning :443 —
+  #     the shared gateway's port — attaches to nothing. This is the exact
+  #     shape of the measurement artifact: TLS completes on the wrong port
+  #     because both gateways carry the same wildcard cert, and only then
+  #     does the request meet an envoy with no matching vhost.
+  run_fixture "port pin 443 against a console gateway on 8443" fail NO-LISTENER '{
+    "profile":"huawei", '"$GW_8443"',
+    "routes":[{"ns":"catalyst-system","name":"catalyst-ui",
+               "hosts":["console.t99.omani.works"],
+               "parents":[{"ns":"kube-system","name":"cilium-gateway-console","port":443}]}]}'
+
+  # 11. CONTROL for 10 — the SAME route, same gateway, same 8443 listeners,
+  #     with no port pin. Proves 10 fails on the PORT and not on the profile.
+  run_fixture "the same console route with no port pin on 8443" pass - '{
+    "profile":"huawei", '"$GW_8443"',
+    "routes":[{"ns":"catalyst-system","name":"catalyst-ui",
+               "hosts":["console.t99.omani.works"],
+               "parents":[{"ns":"kube-system","name":"cilium-gateway-console"}]}]}'
+
+  # 12. CONTROL — a per-Org host on the THIRD pool TLD, admitted by the
+  #     minted `*.<slug>.<parent>` listener that org_console_tls.go writes,
+  #     on the 8443 profile where the minter carried the apex port across.
+  run_fixture "per-Org host admitted by the minted listener on 8443" pass - '{
+    "profile":"huawei", '"$GW_8443"',
+    "routes":[{"ns":"walktwo","name":"wordpress",
+               "hosts":["wordpress.walktwo.omani.trade"],
+               "parents":[{"ns":"kube-system","name":"cilium-gateway-console"}]}]}'
+
+  # ── NO-GATEWAY stays a DIFFERENT verdict from NO-LISTENER ────────────────
+
+  # 13. A parentRef naming a Gateway nothing installs. Different owner (a
+  #     bootstrap slot, not a values key), so it must not be collapsed into
+  #     NO-LISTENER — asserted by verdict token, not just by exit code.
+  run_fixture "parentRef to a Gateway that is not installed" fail NO-GATEWAY '{
+    "profile":"owners", '"$GW_443"',
+    "routes":[{"ns":"walkone","name":"orphan","hosts":["x.walkone.omani.rest"],
+               "parents":[{"ns":"kube-system","name":"cilium-gateway-typo"}]}]}'
+
+  # 14. The region-B shape that started this: the Gateway is installed but
+  #     carries ZERO listeners. That is NOT NO-GATEWAY — the object exists —
+  #     and a guard that reported it as one would send it to the wrong owner.
+  run_fixture "Gateway present but carrying zero listeners" fail NO-LISTENER '{
+    "profile":"owners",
+    "gateways":[{"ns":"kube-system","name":"cilium-gateway-console","listeners":[]}],
+    "routes":[{"ns":"catalyst-system","name":"catalyst-ui",
+               "hosts":["console.t99.omani.works"],
+               "parents":[{"ns":"kube-system","name":"cilium-gateway-console"}]}]}'
+
+  # ── The MODEL must track the producers it models ─────────────────────────
+  #
+  # This guard models two things it does not itself render: the runtime per-Org
+  # listener minter, and the Gateway names in the cluster template. If either
+  # source changes shape, the model silently becomes fiction and the guard
+  # keeps passing. So assert the shapes still exist. These are not style
+  # checks — they are the guard's own tripwires.
+  echo
+  echo "self-test: the modelled producers still declare the modelled shape"
+  MINTER="$ROOT/products/catalyst/bootstrap/api/internal/handler/org_console_tls.go"
+  assert_source() { # assert_source <label> <file> <grep-pattern>
+    if [ ! -f "$2" ]; then
+      echo "  FAIL: $1 — modelled source is gone: $2"; fails=1; return
+    fi
+    if grep -qF -- "$3" "$2"; then
+      echo "  ok  $1"
+    else
+      echo "  FAIL: $1 — '$3' no longer present in $2."
+      echo "        This guard MODELS that producer; the model is now fiction."
+      fails=1
+    fi
+  }
+  assert_source "minter still names listeners console-https-<slug>" "$MINTER" '"console-https-" + slug'
+  assert_source "minter still hostnames them *.<slug>.<parent>"     "$MINTER" '"*." + slug + "." + parent'
+  assert_source "shared Gateway is still named cilium-gateway" \
+      "$ROOT/clusters/_template/sovereign-tls/cilium-gateway.yaml" 'name: cilium-gateway'
+  assert_source "console Gateway is still named cilium-gateway-console" \
+      "$ROOT/clusters/_template/sovereign-tls/cilium-gateway-console.yaml" 'name: cilium-gateway-console'
+  assert_source "shared listeners still come from PARENT_DOMAINS_LISTENERS_YAML" \
+      "$ROOT/clusters/_template/sovereign-tls/cilium-gateway.yaml" 'listeners: ${PARENT_DOMAINS_LISTENERS_YAML}'
+  assert_source "console listeners still come from CONSOLE_LISTENERS_YAML" \
+      "$ROOT/clusters/_template/sovereign-tls/cilium-gateway-console.yaml" 'listeners: ${CONSOLE_LISTENERS_YAML}'
+
+  echo
+  [ "$fails" -eq 0 ] || { echo "SELF-TEST FAILED" >&2; exit 1; }
+  echo "SELF-TEST PASSED — ownership by parentRef, wildcard apex/depth, sectionName"
+  echo "and port pins, and NO-GATEWAY vs NO-LISTENER are each pinned by a must-fail"
+  echo "fixture AND a control that shares its suspect property."
+  echo "OK: --self-test only; no cluster and no helm render was used."
+  exit 0
+fi
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Repo mode — render the real charts and join them.
+# ─────────────────────────────────────────────────────────────────────────────
+command -v helm    >/dev/null 2>&1 || { echo "helm not found"    >&2; exit 2; }
+command -v python3 >/dev/null 2>&1 || { echo "python3 not found" >&2; exit 2; }
+python3 -c 'import yaml' 2>/dev/null || {
+  echo "python3 pyyaml not found (pip install pyyaml)" >&2; exit 2; }
+
+cd "$ROOT" || { echo "cannot cd to $ROOT" >&2; exit 2; }
+
+FQDN="t99.omani.works"          # canonical test Sovereign per DOD.md domains-canon
+ORG_SLUG="walkone"
+ORG_PARENT="omani.homes"        # pool TLDs deliberately differ across the
+ORG2_SLUG="walktwo"             # scenario so a hardcoded TLD cannot pass
+ORG2_PARENT="omani.trade"
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/route-listener.XXXXXX")"
+trap 'rm -rf "$WORK"' EXIT
+
+# prep_chart <chart-dir> — a throwaway copy with `dependencies:` removed.
+#
+# 67 charts in this repo declare external Helm dependencies that only resolve
+# with network access, so a plain `helm template` cannot run offline in CI.
+# Every HTTPRoute in this repo is rendered by its chart's OWN templates/, never
+# by a subchart, so dropping the dependency block renders exactly the objects
+# this guard is about — and keeps the guard runnable with no registry.
+prep_chart() {
+  local chart="$1" dst="$WORK/$(printf '%s' "$1" | tr '/' '_')"
+  rm -rf "$dst"; mkdir -p "$dst"; cp -r "$chart/." "$dst/"
+  python3 - "$dst/Chart.yaml" <<'PY'
+import sys, re
+p = sys.argv[1]; out, skip = [], False
+for ln in open(p).read().split("\n"):
+    if re.match(r'^dependencies:\s*$', ln):
+        skip = True; continue
+    if skip:
+        if ln.startswith((' ', '\t', '-')) or ln.strip() == '':
+            continue
+        skip = False
+    out.append(ln)
+open(p, "w").write("\n".join(out))
+PY
+  printf '%s' "$dst"
+}
+
+# render_chart <label> <min-routes> <chart-dir> [--set ...]
+#
+# `min-routes` is the NON-VACUITY contract. Almost every chart here is
+# default-off ("smoke-render-mode:default-off"), so a scenario whose values
+# stopped matching the chart would render ZERO HTTPRoutes and this guard would
+# report a serene PASS over nothing at all. Declaring the expected count turns
+# that into a setup error (exit 2), which is the whole difference between a
+# guard and a decoration.
+render_chart() {
+  local label="$1" min="$2" chart="$3"; shift 3
+  local dst; dst="$(prep_chart "$chart")"
+  local out="$WORK/render-$label.yaml"
+  if ! helm template "$label" "$dst" "$@" >"$out" 2>"$WORK/err-$label.txt"; then
+    echo "SETUP ERROR: declared chart $chart failed to render:" >&2
+    sed 's/^/    /' "$WORK/err-$label.txt" >&2
+    exit 2
+  fi
+  local got; got="$(grep -c '^kind: HTTPRoute' "$out" || true)"
+  if [ "$got" -lt "$min" ]; then
+    echo "SETUP ERROR: $chart rendered $got HTTPRoute(s), scenario declares >= $min." >&2
+    echo "    The scenario values no longer switch this chart's routes on, so this" >&2
+    echo "    guard would have passed over an empty render. Fix the scenario or the" >&2
+    echo "    chart — do NOT lower the floor to match." >&2
+    exit 2
+  fi
+  echo "  rendered $label: $got HTTPRoute(s)" >&2
+}
+
+# ── The scenario ─────────────────────────────────────────────────────────────
+#
+# Charts whose HTTPRoutes carry SOVEREIGN-APEX hostnames — the set whose
+# admitting listeners are chart-rendered and therefore decidable from source.
+# Per-Org charts (agenity / wordpress-tenant / stalwart-tenant / openclaw)
+# carry `<x>.<slug>.<pool>` hostnames whose listeners the runtime minter
+# writes; they are covered by the modelled per-Org listeners below and by the
+# coverage assertion, not by an apex render.
+scenario() {
+  render_chart edge-routes 4 platform/catalyst-edge-routes/chart \
+    --set ingress.gateway.enabled=true \
+    --set "ingress.hosts.console.host=console.$FQDN" \
+    --set "ingress.hosts.api.host=api.$FQDN" \
+    --set "ingress.hosts.marketplace.host=marketplace.$FQDN" \
+    --set "ingress.hosts.mcp.host=mcp.$FQDN" \
+    --set ingress.marketplace.enabled=true
+  render_chart catalyst 3 products/catalyst/chart \
+    --set "ingress.hosts.console.host=console.$FQDN" \
+    --set "ingress.hosts.api.host=api.$FQDN" \
+    --set "ingress.hosts.marketplace.host=marketplace.$FQDN"
+  render_chart openova-mcp 1 products/openova-mcp/chart --set "sovereignFqdn=$FQDN"
+  render_chart harbor        2 platform/harbor/chart        --set "gateway.host=registry.$FQDN"
+  render_chart keycloak      1 platform/keycloak/chart      --set "gateway.host=auth.$FQDN"
+  render_chart gitea         1 platform/gitea/chart         --set "gateway.host=gitea.$FQDN"
+  render_chart grafana       1 platform/grafana/chart       --set "gateway.host=grafana.$FQDN"
+  render_chart openbao       1 platform/openbao/chart       --set "gateway.host=bao.$FQDN"
+  render_chart powerdns-admin 1 platform/powerdns-admin/chart --set "gateway.host=pdns-admin.$FQDN"
+}
+
+# The listener producer. One chart renders BOTH Gateways' listener arrays.
+render_listeners() { # render_listeners <console-https-port> <console-http-port>
+  local dst; dst="$(prep_chart platform/sovereign-tls-vars/chart)"
+  helm template stv "$dst" \
+    --set "global.sovereignFQDN=$FQDN" \
+    --set "parentZones[0].name=$FQDN"       --set 'parentZones[0].role=primary' \
+    --set "parentZones[1].name=$ORG_PARENT"  --set 'parentZones[1].role=org-pool' \
+    --set "parentZones[2].name=omani.rest"   --set 'parentZones[2].role=org-pool' \
+    --set "parentZones[3].name=$ORG2_PARENT" --set 'parentZones[3].role=org-pool' \
+    --set "consoleGateway.httpsPort=$1" \
+    --set "consoleGateway.httpPort=$2" \
+    >"$WORK/listeners.yaml" 2>"$WORK/err-stv.txt" || {
+      echo "SETUP ERROR: the listener producer failed to render:" >&2
+      sed 's/^/    /' "$WORK/err-stv.txt" >&2; exit 2; }
+}
+
+# ── Bundle assembly ──────────────────────────────────────────────────────────
+read -r -d '' BUNDLE_PY <<'PY' || true
+import json, os, re, sys, glob
+import yaml
+
+work    = sys.argv[1]
+profile = sys.argv[2]
+root    = sys.argv[3]
+orgs    = json.loads(sys.argv[4])       # [{"slug","parent"}]
+extra   = json.loads(sys.argv[5])       # extra routes injected by --vacuity
+
+def docs(path):
+    with open(path) as fh:
+        for d in yaml.safe_load_all(fh):
+            if isinstance(d, dict) and d.get("kind"):
+                yield d
+
+# ── 1. Listeners, out of the ConfigMap the producer chart renders ───────────
+cm = None
+for d in docs(os.path.join(work, "listeners.yaml")):
+    if d.get("kind") == "ConfigMap" and d["metadata"]["name"] == "sovereign-tls-vars":
+        cm = d
+if cm is None:
+    print("SETUP ERROR: sovereign-tls-vars ConfigMap absent from the render", file=sys.stderr)
+    sys.exit(2)
+
+# ── 2. Gateway identity, out of the CLUSTER TEMPLATE — never hardcoded here.
+# The template is the thing Flux applies, so if a Gateway is renamed there the
+# routes' parentRefs stop resolving and this guard must report NO-GATEWAY. A
+# hardcoded name in this script would keep resolving and hide exactly that.
+gateways, gw_key = [], {}
+for fname, cmkey in (("cilium-gateway.yaml", "PARENT_DOMAINS_LISTENERS_YAML"),
+                     ("cilium-gateway-console.yaml", "CONSOLE_LISTENERS_YAML")):
+    path = os.path.join(root, "clusters/_template/sovereign-tls", fname)
+    text = open(path).read()
+    name = re.search(r'^\s*name:\s*(\S+)\s*$', text, re.M)
+    ns   = re.search(r'^\s*namespace:\s*(\S+)\s*$', text, re.M)
+    if not name or not ns:
+        print("SETUP ERROR: cannot read Gateway identity from %s" % path, file=sys.stderr)
+        sys.exit(2)
+    if ("listeners: ${%s}" % cmkey) not in text:
+        print("SETUP ERROR: %s no longer substitutes %s — the listener source moved."
+              % (path, cmkey), file=sys.stderr)
+        sys.exit(2)
+    listeners = json.loads(cm["data"][cmkey])
+    g = {"ns": ns.group(1), "name": name.group(1), "listeners": listeners}
+    gateways.append(g)
+    gw_key[cmkey] = g
+
+# ── 3. The per-Organization listeners catalyst-api mints at install time.
+# products/catalyst/bootstrap/api/internal/handler/org_console_tls.go appends
+# `console-https-<slug>` / `console-http-<slug>` hostnamed `*.<slug>.<parent>`
+# to the console Gateway, taking its ports from the apex console-https /
+# console-http listeners (consoleApexListenerPorts). Modelled here so per-Org
+# hostnames are DECIDED rather than skipped; --self-test asserts that Go source
+# still declares this shape, so the model cannot outlive the producer.
+console = gw_key["CONSOLE_LISTENERS_YAML"]
+apex_https = next((l["port"] for l in console["listeners"] if l.get("name") == "console-https"), None)
+apex_http  = next((l["port"] for l in console["listeners"] if l.get("name") == "console-http"), None)
+if apex_https is None or apex_http is None:
+    print("SETUP ERROR: console gateway has no apex console-https/console-http listener;"
+          " the minter reads its ports from there.", file=sys.stderr)
+    sys.exit(2)
+for o in orgs:
+    zone = "*.%s.%s" % (o["slug"], o["parent"])
+    console["listeners"].append({"name": "console-https-" + o["slug"],
+                                 "hostname": zone, "port": apex_https})
+    console["listeners"].append({"name": "console-http-" + o["slug"],
+                                 "hostname": zone, "port": apex_http})
+
+# ── 4. Routes, out of every scenario render ─────────────────────────────────
+routes = []
+for path in sorted(glob.glob(os.path.join(work, "render-*.yaml"))):
+    for d in docs(path):
+        if d.get("kind") != "HTTPRoute":
+            continue
+        md, spec = d.get("metadata") or {}, d.get("spec") or {}
+        parents = []
+        for p in (spec.get("parentRefs") or []):
+            parents.append({"ns": p.get("namespace"), "name": p.get("name"),
+                            "sectionName": p.get("sectionName") or None,
+                            "port": p.get("port") or None})
+        routes.append({"ns": md.get("namespace") or "default",
+                       "name": md.get("name") or "(unnamed)",
+                       "hosts": list(spec.get("hostnames") or []),
+                       "parents": parents})
+routes.extend(extra)
+
+if not routes:
+    print("SETUP ERROR: the scenario produced ZERO HTTPRoutes.", file=sys.stderr)
+    sys.exit(2)
+
+json.dump({"profile": profile, "gateways": gateways, "routes": routes}, sys.stdout)
+PY
+
+ORGS_JSON="$(printf '[{"slug":"%s","parent":"%s"},{"slug":"%s","parent":"%s"}]' \
+             "$ORG_SLUG" "$ORG_PARENT" "$ORG2_SLUG" "$ORG2_PARENT")"
+
+# The vacuity injection. A guard observed only passing is worthless, so the
+# --vacuity run re-runs the REAL scenario with ONE extra route: mcp.<fqdn>
+# re-parented onto the console gateway. That is not a synthetic string — it is
+# precisely the #5341 misconfiguration, against the real rendered console
+# listener set, and the guard MUST go red on it.
+VACUITY_ROUTE='[{"ns":"catalyst-system","name":"VACUITY-mcp-on-console-gateway",
+  "hosts":["mcp.'"$FQDN"'"],
+  "parents":[{"ns":"kube-system","name":"cilium-gateway-console"}]}]'
+
+echo "Rendering the scenario (no cluster, no registry)..." >&2
+scenario
+echo >&2
+
+rc_total=0
+run_profile() { # run_profile <label> <https-port> <http-port> <extra-routes-json>
+  echo "═══ profile: $1 (console gateway on :$2/:$3) ═══"
+  render_listeners "$2" "$3"
+  local bundle
+  bundle="$(python3 -c "$BUNDLE_PY" "$WORK" "$1" "$ROOT" "$ORGS_JSON" "$4")"
+  set +e
+  printf '%s' "$bundle" | classify
+  local rc=$?
+  set -e
+  echo
+  return $rc
+}
+
+if [ "$VACUITY" -eq 1 ]; then
+  # Vacuity is proven only if the guard goes RED, and only if it goes red with
+  # the RIGHT verdict on the RIGHT route — a crash or an unrelated failure
+  # would otherwise be scored as proof.
+  out="$(run_profile "vacuity-hetzner" 443 80 "$VACUITY_ROUTE" 2>&1)" && {
+    echo "$out"
+    echo "VACUITY FAIL: the guard PASSED with mcp.$FQDN re-parented onto the"
+    echo "console gateway, whose listeners are the exact hosts console./api./"
+    echo "marketplace. only. A guard that cannot fail on the #5341 shape cannot"
+    echo "fail on anything." >&2
+    exit 1
+  }
+  echo "$out"
+  printf '%s' "$out" | grep -q 'NO-LISTENER .*VACUITY-mcp-on-console-gateway' || {
+    echo "VACUITY FAIL: the guard exited non-zero but not with NO-LISTENER on the"
+    echo "injected route — the exit code came from something else." >&2
+    exit 1
+  }
+  echo "OK — vacuity proven: the guard goes RED, with NO-LISTENER, on the"
+  echo "injected #5341 shape, against the real rendered listener set."
+  exit 0
+fi
+
+# Both port profiles. Hetzner keeps the console gateway on :443/:80; Huawei
+# moves it to :8443/:8080 so two Gateways can coexist under hostNetwork. A
+# route that only corresponds under one profile is broken under the other.
+run_profile "hetzner" 443  80   '[]' || rc_total=1
+run_profile "huawei"  8443 8080 '[]' || rc_total=1
+
+# ── Coverage. A scenario is only as good as the set of charts it renders, and
+# a new route-bearing chart that nobody adds here would be invisible — the
+# guard would keep passing while the thing it guards grew a hole. So every
+# chart in the repo that renders an HTTPRoute naming a cilium Gateway must be
+# accounted for: either rendered above, or listed here with the reason its
+# hostnames are not apex-decidable.
+echo "═══ coverage ═══"
+RENDERED="platform/catalyst-edge-routes/chart products/catalyst/chart
+products/openova-mcp/chart platform/harbor/chart platform/keycloak/chart
+platform/gitea/chart platform/grafana/chart platform/openbao/chart
+platform/powerdns-admin/chart"
+
+# Charts whose HTTPRoute hostnames are per-ORGANIZATION (`<x>.<slug>.<pool>`),
+# admitted by the listener the runtime minter writes rather than by any
+# chart-rendered listener. Modelled by the per-Org listeners above; an apex
+# render of them would assert a hostname shape they never carry in production.
+PER_ORG="platform/wordpress-tenant/chart platform/stalwart-tenant/chart
+platform/openclaw/chart products/agenity/chart"
+
+# Charts whose route hostname is not derivable without per-Sovereign values
+# this guard has no source for. Listed EXPLICITLY so the hole is visible and
+# reviewable, never silent.
+DEFERRED="platform/cilium/chart platform/newapi/chart platform/guacamole/chart
+platform/netbird/chart platform/oidc-gate/chart platform/openova-flow-server/chart
+platform/powerdns/chart products/dmz-vcluster/chart"
+
+uncovered=0
+for chart in $(grep -rl 'kind: HTTPRoute' --include='*.yaml' platform/ products/ core/ 2>/dev/null \
+               | grep '/templates/' | sed 's#/templates/.*##' | sort -u); do
+  grep -rq 'cilium-gateway' "$chart" 2>/dev/null || continue    # no Gateway parentRef
+  case " $(echo $RENDERED) $(echo $PER_ORG) $(echo $DEFERRED) " in
+    *" $chart "*) ;;
+    *) echo "  UNCOVERED: $chart renders an HTTPRoute on a cilium Gateway but is in"
+       echo "             no scenario list. Add it to RENDERED (with values and a"
+       echo "             minimum route count), or to PER_ORG / DEFERRED with the"
+       echo "             reason its hostnames are not apex-decidable."
+       uncovered=$((uncovered + 1)) ;;
+  esac
+done
+if [ "$uncovered" -gt 0 ]; then
+  echo "FAIL: $uncovered route-bearing chart(s) are outside the scenario."
+  rc_total=1
+else
+  echo "  OK — every chart rendering an HTTPRoute on a cilium Gateway is either"
+  echo "       rendered by the scenario, modelled as per-Organization, or listed"
+  echo "       as deferred with a reason."
+fi
+
+echo
+if [ "$rc_total" -ne 0 ]; then
+  echo "RESULT: FAIL — see the rows above."
+  exit 1
+fi
+echo "RESULT: PASS — route/listener correspondence holds on both port profiles,"
+echo "        and every route-bearing chart is accounted for."

--- a/scripts/check-chart-route-listener-correspondence.sh
+++ b/scripts/check-chart-route-listener-correspondence.sh
@@ -460,16 +460,28 @@ ORG2_PARENT="omani.trade"
 WORK="$(mktemp -d "${TMPDIR:-/tmp}/route-listener.XXXXXX")"
 trap 'rm -rf "$WORK"' EXIT
 
-# prep_chart <chart-dir> — a throwaway copy with `dependencies:` removed.
+# prep_chart <chart-dir> — a throwaway copy that renders the chart's OWN
+# templates and nothing else.
 #
 # 67 charts in this repo declare external Helm dependencies that only resolve
 # with network access, so a plain `helm template` cannot run offline in CI.
 # Every HTTPRoute in this repo is rendered by its chart's OWN templates/, never
-# by a subchart, so dropping the dependency block renders exactly the objects
-# this guard is about — and keeps the guard runnable with no registry.
+# by a subchart, so dropping the dependencies renders exactly the objects this
+# guard is about — and keeps it runnable with no registry.
+#
+# BOTH the `dependencies:` block AND any vendored `charts/` + `Chart.lock` are
+# removed, and that second half is not belt-and-braces. A clean CI checkout has
+# no `charts/` directory, but a developer who has ever run `helm dependency
+# build` or `helm lint` locally does — and then the subcharts render, the guard
+# sees a completely different document set, and it can even crash on upstream
+# YAML this repo does not own (bitnami's harbor redis StatefulSet carries a
+# literal tab, which pyyaml refuses outright). A guard whose verdict depends on
+# whether someone once ran a helm command is not a guard, so the copy is
+# normalised to parent-only every time.
 prep_chart() {
   local chart="$1" dst="$WORK/$(printf '%s' "$1" | tr '/' '_')"
   rm -rf "$dst"; mkdir -p "$dst"; cp -r "$chart/." "$dst/"
+  rm -rf "$dst/charts" "$dst/Chart.lock"
   python3 - "$dst/Chart.yaml" <<'PY'
 import sys, re
 p = sys.argv[1]; out, skip = [], False
@@ -571,10 +583,22 @@ orgs    = json.loads(sys.argv[4])       # [{"slug","parent"}]
 extra   = json.loads(sys.argv[5])       # extra routes injected by --vacuity
 
 def docs(path):
-    with open(path) as fh:
-        for d in yaml.safe_load_all(fh):
-            if isinstance(d, dict) and d.get("kind"):
-                yield d
+    """Every k8s object in a rendered file.
+
+    A render this cannot parse is a SETUP ERROR (exit 2), never a correspondence
+    verdict. Letting the YAML exception escape would exit 1, which reads as
+    "a hostname has no listener" — a wrong answer dressed as a real one.
+    """
+    try:
+        with open(path) as fh:
+            loaded = list(yaml.safe_load_all(fh))
+    except yaml.YAMLError as e:
+        print("SETUP ERROR: cannot parse the render %s:\n    %s"
+              % (path, str(e).replace("\n", "\n    ")), file=sys.stderr)
+        sys.exit(2)
+    for d in loaded:
+        if isinstance(d, dict) and d.get("kind"):
+            yield d
 
 # ── 1. Listeners, out of the ConfigMap the producer chart renders ───────────
 cm = None

--- a/scripts/check-live-route-backends.sh
+++ b/scripts/check-live-route-backends.sh
@@ -119,6 +119,11 @@
 
 set -euo pipefail
 
+# The shared admission module lives next to this script, so the classifier can
+# import it no matter what directory the guard is invoked from.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+export GUARD_LIB="$SCRIPT_DIR/lib"
+
 KUBECTL_ARGS=()
 PEER_ARGS=()
 PEER_SUPPLIED=0
@@ -169,7 +174,17 @@ done
 # controls proving this change did not disturb it.
 # ─────────────────────────────────────────────────────────────────────────────
 read -r -d '' CLASSIFY_PY <<'PY' || true
-import json, sys
+import json, os, sys
+
+# Hostname admission + the route/listener correspondence pass live in
+# scripts/lib/gateway_route_admission.py, shared with the SOURCE-side guard
+# scripts/check-chart-route-listener-correspondence.sh (#6140). They were
+# inline here until that guard needed the identical rule from `helm template`
+# output instead of from a cluster. A second copy of the wildcard semantics
+# would have been a copy free to drift, and the drift would have been silent —
+# both guards would have kept passing, each against its own idea of the spec.
+sys.path.insert(0, os.environ["GUARD_LIB"])
+from gateway_route_admission import listener_admits, correspondence_rows
 
 b = json.load(sys.stdin)
 mesh = int(b.get("meshRemoteClusters", 0))
@@ -177,30 +192,6 @@ grace = int(b.get("graceSeconds", 300))
 svc = {(s["ns"], s["name"]): s for s in b.get("services", [])}
 ready = {(e["ns"], e["name"]): int(e.get("ready", 0)) for e in b.get("endpoints", [])}
 
-
-def listener_admits(lh, h):
-    """Gateway API hostname intersection: does listener hostname `lh` admit
-    route hostname `h`?
-
-    Spec (gateway-api Listener.hostname / HTTPRoute.hostnames): a listener
-    with NO hostname admits every host; a wildcard is a SUFFIX match one or
-    more labels deep, so `*.a.b` admits `x.a.b` AND `x.y.a.b` but never the
-    bare `a.b`. Getting that last clause wrong in either direction is the
-    whole bug class — `endswith("a.b")` would wrongly admit the apex and
-    wrongly admit `nota.b`, and a single-label rule would wrongly reject a
-    legitimate deep host."""
-    if not lh:
-        return True
-    if not h:
-        return True          # a route with no hostnames inherits the listener's
-    if lh.startswith("*."):
-        suffix = lh[1:]      # "*.a.b" -> ".a.b"
-        if h.startswith("*."):
-            return h[1:] == suffix or h[1:].endswith(suffix)
-        return h.endswith(suffix)
-    if h.startswith("*."):
-        return False         # a concrete listener cannot admit a wildcard route
-    return lh == h
 
 rows, seen = [], set()
 for r in b.get("routes", []):
@@ -237,42 +228,17 @@ pending = [r for r in rows if r[0] == "PENDING"]
 # ── Pass 2: listener coverage. A hostname nothing listens for is not a 503,
 # it is a TLS reset — which is why the backend pass above cannot see it.
 gws = {(g["ns"], g["name"]): g for g in b.get("gateways", [])}
-hostrows, local_hosts = [], set()
 listener_pass = "gateways" in b
-for r in b.get("routes", []):
-    parents = r.get("parents") or []
-    for h in (r.get("hosts") or []):
-        local_hosts.add(h)
-    if not listener_pass or not parents:
-        continue
-    for h in (r.get("hosts") or [""]):
-        admitted, absent_gws, seen_listeners = False, [], 0
-        for p in parents:
-            key = (p.get("ns") or r["ns"], p["name"])
-            g = gws.get(key)
-            if g is None:
-                absent_gws.append(f"{key[0]}/{key[1]}")
-                continue
-            for ls in (g.get("listeners") or []):
-                if p.get("sectionName") and ls.get("name") != p["sectionName"]:
-                    continue
-                if p.get("port") and int(ls.get("port") or 0) != int(p["port"]):
-                    continue
-                seen_listeners += 1
-                if listener_admits(ls.get("hostname"), h):
-                    admitted = True
-                    break
-            if admitted:
-                break
-        who = f"{r['ns']}/{r['name']}"
-        if admitted:
-            hostrows.append(("SERVING", h or "(inherits listener)", who, "admitted by a parent listener"))
-        elif absent_gws and seen_listeners == 0:
-            hostrows.append(("NO-GATEWAY", h or "(inherits listener)", who,
-                             "parent Gateway absent here: " + ",".join(sorted(set(absent_gws)))))
-        else:
-            hostrows.append(("NO-LISTENER", h or "(inherits listener)", who,
-                             f"no parent listener admits it ({seen_listeners} listener(s) considered)"))
+# `local_hosts` is needed by the region-symmetry pass below even when the
+# listener pass is skipped, so it is collected from the SAME shared helper —
+# which returns it alongside the rows — rather than from a second walk here.
+hostrows, local_hosts = correspondence_rows(b.get("routes", []), b.get("gateways", []))
+if not listener_pass:
+    # No `gateways` key means the caller asked for the backend pass alone (the
+    # four original backend fixtures). Every row would be NO-GATEWAY against an
+    # empty Gateway set, which is not a verdict anyone asked for — but the
+    # hostnames still have to reach pass 3. So keep the hosts, drop the rows.
+    hostrows = []
 
 # ── Pass 3: region symmetry. Both regions' nodes sit in ONE round-robin pool,
 # so a hostname either region cannot route is a coin-flip failure for the

--- a/scripts/lib/gateway_route_admission.py
+++ b/scripts/lib/gateway_route_admission.py
@@ -1,0 +1,130 @@
+"""Gateway API route <-> listener admission — the ONE implementation.
+
+WHY THIS MODULE EXISTS
+----------------------
+Two guards need to answer the same question, "does any listener of this
+route's parent Gateway admit this hostname?", from two different inputs:
+
+  * scripts/check-live-route-backends.sh   — from a running cluster (#6165)
+  * scripts/check-chart-route-listener-correspondence.sh
+                                           — from `helm template` output,
+                                             no cluster at all (#6140)
+
+The rule they share is small, subtle, and wrong in interesting ways if
+re-typed: Gateway API wildcards are SUFFIX matches, so `*.a.b` admits
+`x.a.b` AND `x.y.a.b` but never the bare apex `a.b`. A second copy of that
+rule in a second file is a copy that will drift, and the drift would be
+invisible — both guards would keep passing, each against its own idea of
+the spec. So the rule lives here once and both import it.
+
+Nothing in this module touches a cluster, a network, or the filesystem.
+
+Reference: gateway-api Listener.hostname / HTTPRoute.hostnames.
+"""
+
+
+def listener_admits(listener_hostname, route_hostname):
+    """Does listener hostname `listener_hostname` admit `route_hostname`?
+
+    Spec, and every clause is load-bearing:
+
+      * a listener with NO hostname admits every host;
+      * a route with NO hostname inherits the listener's, so it is admitted;
+      * `*.a.b` is a SUFFIX match one or more labels deep — it admits
+        `x.a.b` and `x.y.a.b`, and NEVER the bare `a.b` it wildcards;
+      * a concrete listener cannot admit a wildcard route.
+
+    The apex clause is the whole bug class. A naive `endswith("a.b")` gets
+    it wrong in BOTH directions at once: it would wrongly admit the apex
+    `a.b`, and it would wrongly admit `nota.b`. A "exactly one label" rule
+    is the opposite error — it would reject the legitimate deep host
+    `x.y.a.b` that Gateway API requires a wildcard to accept.
+    """
+    if not listener_hostname:
+        return True
+    if not route_hostname:
+        return True
+    if listener_hostname.startswith("*."):
+        suffix = listener_hostname[1:]          # "*.a.b" -> ".a.b"
+        if route_hostname.startswith("*."):
+            return route_hostname[1:] == suffix or route_hostname[1:].endswith(suffix)
+        return route_hostname.endswith(suffix)
+    if route_hostname.startswith("*."):
+        return False
+    return listener_hostname == route_hostname
+
+
+def correspondence_rows(routes, gateways):
+    """Classify every advertised hostname against its parent Gateways.
+
+    `routes`   [{"ns","name","hosts":[..],
+                 "parents":[{"ns","name","sectionName","port"}]}]
+    `gateways` [{"ns","name","listeners":[{"name","hostname","port"}]}]
+
+    Returns (rows, all_hosts) where rows are
+    (verdict, hostname, "ns/name", why) and verdict is one of:
+
+      SERVING     — some parent listener admits the hostname.
+      NO-LISTENER — the parent Gateway EXISTS but no listener of it admits
+                    the hostname. Owner: whoever declares the listener set
+                    (for the console gateway that is
+                    `consoleGateway.hostPrefixes`; for the shared gateway,
+                    `parentZones`). Gateway API reports
+                    `Accepted=False NoMatchingListenerHostname`, and envoy
+                    resets the TLS handshake before any HTTP status exists.
+      NO-GATEWAY  — the parentRef names a Gateway that is not present at
+                    all. Owner: whoever installs the Gateway (a bootstrap
+                    slot / a region's Kustomization), NOT the listener set.
+
+    Keeping those two apart matters because they route to different people:
+    NO-LISTENER is a one-line values change, NO-GATEWAY is a missing
+    install. Collapsing them into "route is broken" sends every one of them
+    to the wrong owner.
+
+    `sectionName` and `port` on a parentRef are PINS: a route that names a
+    section only attaches to the listener of that exact name, and a route
+    that pins a port only attaches to listeners on that port. A pin that
+    matches nothing leaves the route with zero candidate listeners, which
+    is NO-LISTENER — not a pass.
+    """
+    gws = {(g["ns"], g["name"]): g for g in gateways}
+    rows, all_hosts = [], set()
+
+    for r in routes:
+        parents = r.get("parents") or []
+        for h in (r.get("hosts") or []):
+            all_hosts.add(h)
+        if not parents:
+            continue
+        for h in (r.get("hosts") or [""]):
+            admitted, absent_gws, seen_listeners = False, [], 0
+            for p in parents:
+                key = (p.get("ns") or r["ns"], p["name"])
+                g = gws.get(key)
+                if g is None:
+                    absent_gws.append("%s/%s" % key)
+                    continue
+                for ls in (g.get("listeners") or []):
+                    if p.get("sectionName") and ls.get("name") != p["sectionName"]:
+                        continue
+                    if p.get("port") and int(ls.get("port") or 0) != int(p["port"]):
+                        continue
+                    seen_listeners += 1
+                    if listener_admits(ls.get("hostname"), h):
+                        admitted = True
+                        break
+                if admitted:
+                    break
+            who = "%s/%s" % (r["ns"], r["name"])
+            shown = h or "(inherits listener)"
+            if admitted:
+                rows.append(("SERVING", shown, who, "admitted by a parent listener"))
+            elif absent_gws and seen_listeners == 0:
+                rows.append(("NO-GATEWAY", shown, who,
+                             "parent Gateway absent here: "
+                             + ",".join(sorted(set(absent_gws)))))
+            else:
+                rows.append(("NO-LISTENER", shown, who,
+                             "no parent listener admits it "
+                             "(%d listener(s) considered)" % seen_listeners))
+    return rows, all_hosts


### PR DESCRIPTION
## 🛑 DO NOT MERGE — hw294 is mid-provision

Opened for review only. Refs #6140.

---

## The gap this closes

`scripts/check-live-gateway-host-ports.sh` (#6143) and
`scripts/check-live-route-backends.sh` (#6165) both answer route/listener
questions, and **both need a running Sovereign**. So a defect fully decided by
the chart source could only be found *after* a provision, on an environment, by
a walker. That is how region B shipped HTTPRoutes with zero admitting listeners
without CI objecting once.

This adds the source-side half: render the listener producer and the route
producers, join them, fail in the pull request instead of on a customer's TLS
handshake. **No cluster, no registry, no credentials.**

## Extended or new?

**New guard + extracted shared classifier.** Both halves of that choice matter:

- The **classifier seam fits and is shared.** Admission and the correspondence
  pass move out of `check-live-route-backends.sh` into
  `scripts/lib/gateway_route_admission.py`, imported by both guards. A second
  copy of the wildcard rule would have been free to drift, and the drift would
  have been *silent* — both guards passing, each against its own reading of the
  spec.
- The **entry-point seam does not fit.** The live guard needs `kubectl` and a
  cluster, and its own preamble argues at length why a source scan cannot
  replace it; this one needs `helm`, chart discovery, and the Flux `${VAR}`
  substitution model. A `--source` mode on a script named `check-live-*` would
  have misnamed it and muddled the CI story.

The live guard's 11 fixtures are **byte-identical before and after** the
extraction (`diff` of the two self-test runs is empty).

## Why this is decidable from source at all

**No chart in this repo renders a `kind: Gateway`.** Both Gateways are
Kustomize manifests under `clusters/_template/sovereign-tls/` whose entire
`spec.listeners` is a Flux `postBuild` placeholder, and *one* chart fills both:

| Gateway manifest | Placeholder | Rendered by |
|---|---|---|
| `cilium-gateway.yaml` | `${PARENT_DOMAINS_LISTENERS_YAML}` | `platform/sovereign-tls-vars/chart` — a `*.<zone>` pair per `parentZones[]` + the per-prov `*.<fqdn>` pair |
| `cilium-gateway-console.yaml` | `${CONSOLE_LISTENERS_YAML}` | same chart — an **exact** `<prefix>.<fqdn>` pair per `consoleGateway.hostPrefixes[]` |

Gateway names and namespaces are read **out of the cluster template**, never
hardcoded in the guard — so a rename surfaces as `NO-GATEWAY` instead of a
silent pass.

## Rules encoded

**Ownership is the `parentRef`, not a hostname prefix.** A prefix rule is wrong
in three ways on this repo's real data:

| Hostname | Gateway | A `console.*` prefix rule would… |
|---|---|---|
| `marketplace.<fqdn>` | **console** (is in `hostPrefixes`) | check the shared gateway, whose `*.<fqdn>` admits it — **pass for the wrong reason** |
| `mcp.<fqdn>` | **shared** (#5341) | check the console gateway — false red |
| `mcp.<slug>.<pool>` | **console**, stamped by catalyst-api at install time, not by any chart | never see it at all |

**Wildcards are suffix matches of one or MORE labels.** `*.a.b` admits `x.a.b`
and `x.y.a.b`, **never** the bare `a.b`. This is deliberately *not* the Let's
Encrypt wildcard-SAN rule (exactly one label) — that different rule is why the
per-prov `*.<fqdn>` listener pair exists at all, and conflating the two is a
trap in both directions.

**`sectionName` and `port` are pins.** A pin naming nothing leaves the route
with zero candidate listeners. Correspondence is asserted under **both**
console-port profiles — Hetzner `:443/:80` and Huawei `:8443/:8080` — because
that split is the mechanism behind the false 404 this work started from: both
gateways terminate the same wildcard cert, so a probe on the wrong port
completes TLS and only then meets an envoy with no matching vhost.

**`NO-LISTENER` is not `NO-GATEWAY`.** The first is a values declaration
(`consoleGateway.hostPrefixes` / `parentZones`, or the route's own pin); the
second is a missing install (a bootstrap slot). Collapsing them routes every
one of them to the wrong owner. Both are asserted by verdict token, not just by
exit code.

## First defect caught — bp-harbor 1.2.48

harbor's `harbor.<fqdn>` alias-redirect route read
`.Values.gateway.{name,namespace,sectionName}` — three keys that **do not
exist** (the real ones are `.Values.gateway.parentRef.*`). Two fell through to
the correct default. The third did not:

```
sectionName: {{ .Values.gateway.sectionName | default "https" | quote }}
```

`https` is the listener name **only on a single-zone Sovereign**. Every
Org-pool Sovereign declares multiple `parentZones`, so `sovereign-tls-vars`
names it `https-<zone-dashed>` — the pin matched nothing, the route attached to
zero listeners, Gateway API answered `Accepted=False
NoMatchingListenerHostname`, and envoy **reset the TLS handshake** rather than
returning any HTTP status a probe could have noticed.

harbor's own `values.yaml` already carries exactly that warning on
`gateway.parentRef.sectionName` ("pinning `sectionName: https` breaks
NoMatchingListener", PR #1888 / #1902). This one route simply was not reading
that key. It now uses the identical `parentRef` block as the main route.

## Evidence — all cluster-free

**RED before the fix** (repo mode, verbatim):

```
HTTPRoute hostnames examined: 15
  SERVING       14
  NO-LISTENER   1
  NO-GATEWAY    0

  NO-LISTENER   host=harbor.t99.omani.works   route=default/harbor-alias-redirect   no parent listener admits it (0 listener(s) considered)

FAIL: 1 rendered hostname(s) have no listener that admits them.
```

**GREEN after the fix** (verbatim, and identical on the Huawei `:8443` profile):

```
HTTPRoute hostnames examined: 15
  SERVING       15
  NO-LISTENER   0
  NO-GATEWAY    0

PASS: every rendered hostname is admitted by a listener of its parent Gateway.
```

`0 listener(s) considered` vs the vacuity run's `10 listener(s) considered` is
the diagnostic that separates *"the pin matched nothing"* from *"listeners
existed and none admitted"*.

**CONTROL — a hostname correctly admitted by its own gateway stays green.**
`marketplace.<fqdn>` shares every suspect property of the failing case (console
gateway, apex host, exact-hostname listener) and must not be flagged; so must
the per-Org hosts admitted by their `*.<slug>.<pool>` wildcard. Both are green
in repo mode and pinned as fixtures. Without them, a classifier that simply
rejected console-gateway or per-Org hostnames would have scored the failures as
"caught".

**VACUITY — the guard is proven able to fail.** `--vacuity` re-runs the *real*
scenario against the *real* rendered listener set with one extra route:
`mcp.<fqdn>` re-parented onto the console gateway — the #5341 misconfiguration,
not a synthetic string. It requires RED **with `NO-LISTENER` on that specific
route**, so a crash or an unrelated failure cannot be scored as proof:

```
  NO-LISTENER   host=mcp.t99.omani.works   route=catalyst-system/VACUITY-mcp-on-console-gateway   no parent listener admits it (10 listener(s) considered)
OK — vacuity proven: the guard goes RED, with NO-LISTENER, on the
injected #5341 shape, against the real rendered listener set.
```

**14 fixtures over THREE pool TLDs** (`omani.homes` / `.rest` / `.trade` — a
single-TLD set would pass a classifier that hardcoded one). Every must-fail is
paired with a control sharing its suspect property: the apex-rejection is
paired with the deep-host acceptance; the `sectionName` pin failure is paired
both with the same route unpinned *and* with a pin that names a real listener,
so the guard is not merely "bans sectionName"; the `:443`-against-`:8443`
failure is paired with the same route unpinned on the same profile.

**Anti-vacuity beyond the classifier**, because a source guard has two extra
ways to pass over nothing:

- **Per-chart minimum route counts.** Almost every chart here is
  `smoke-render-mode:default-off`, so a scenario whose values drifted would
  render zero HTTPRoutes and the guard would report a serene PASS. A shortfall
  is exit 2 (setup error), with the message saying explicitly not to lower the
  floor to match.
- **A coverage assertion.** Every chart in the repo rendering an HTTPRoute on a
  cilium Gateway must be in the scenario, or listed as per-Organization or
  deferred *with a reason*. A new route-bearing chart cannot slip past.
- **Producer tripwires.** The guard *models* two things it does not render —
  the Go per-Org listener minter (`org_console_tls.go`, which appends
  `console-https-<slug>` hostnamed `*.<slug>.<parent>`) and the Gateway names
  in the cluster template. `--self-test` asserts those sources still declare
  the modelled shape, so the model cannot outlive its producer.

## CI wiring, verified as wired

Added to `check-guard-selftests.yaml`: fixtures in the aggregator job, plus a
dedicated job with helm + pyyaml running the render **and** the vacuity check.

`check-guards-are-wired.sh` reports `21/21`. Proven in both directions — with
the invocation stripped from a copy of the tree it goes red and **names this
guard**:

```
ORPHANED GUARD: scripts/check-chart-route-listener-correspondence.sh advertises --self-test but no workflow INVOKES it
FAIL: 1 of 21 self-test-capable guard(s) are never run by CI.
```

## No runtime evidence claimed

hw293 is wiped and hw294 is wedged at 51/67 on #6172. Everything above is
source-and-test only — `helm template` renders and fixtures. The harbor fix's
runtime effect is **not** claimed and needs a walk on the next healthy
multi-zone Sovereign.

## What the first CI run caught (all fixed in the second commit)

Five gates went red on the first push. None was a flake; each is recorded here
because "the gate caught your defect" is the default reading, not "expected
race".

1. **`classifier self-test`** — `check-live-route-backends-selftest.yaml`
   mutates `listener_admits` to prove its *own* vacuity check can fail. Moving
   that function into the shared module broke the anchor, so the step aborted.
   It now copies the whole `scripts/` tree and regresses the **module** inside
   the copy — mutating a lone `.sh` would leave the real module imported and
   prove nothing. The same mutation is now also run against **this** guard, so
   the shared rule is pinned from both consumers instead of losing a vacuity
   check on the move.
2. **`Chart-version-bumped` / `regenerate and prove no diff` / `pin-sync-audit`**
   — the bp-harbor bump touches products/catalyst's catalog seed, which is part
   of bp-catalyst-platform's rendered surface. Bumped 1.4.1402 → **1.4.1408**
   via `scripts/bump-chart-version.sh`, re-run at push time: it read a ceiling
   of 1.4.1407 from open PR #6168 across 39 open heads, so a naive +1 would have
   collided. `blueprints.json` + `catalog.generated.ts` regenerated — **the 6th
   and 7th lockstep sites, which no shell pin-sync guard covers.**
3. **A defect in this guard itself**, surfaced while fixing the above. It
   rendered whatever was on disk, so anyone who had ever run `helm dependency
   build` or `helm lint` got a *different* document set than CI — and on harbor
   that meant parsing bitnami's redis StatefulSet, which carries a literal tab
   pyyaml refuses. The guard died with a traceback and **exit 1**, i.e. it
   reported "a hostname has no listener" when it had merely failed to read the
   file. Fixed twice over: the throwaway copy now drops any vendored `charts/` +
   `Chart.lock` so rendering is parent-only regardless of local state, and an
   unparseable render is a **setup error (exit 2)**, never a correspondence
   verdict. Proven by running the guard with harbor's real subchart vendored and
   again without — identical green.

The branch was then rebased onto `main`; the first push had gone
`CONFLICTING`, which is why **zero** checks had registered. Zero registered
checks is not a pass — after the rebase 85 registered.

## The second CI run caught a better one

`classifier self-test` went red, and it was right to. That workflow carries
**three** vacuity steps, each copying the guard to `/tmp` and regressing one
belief. Moving `listener_admits` into the shared module broke **all three** —
the guard resolves that module relative to its own path, and `cp scripts/x.sh
/tmp/` leaves no `lib/` beside it. I had updated only the one I edited.

The two failure modes were not equally visible, which is the part worth
recording:

- **Step 3 (region symmetry) went loudly red** — `ModuleNotFoundError` on all
  11 fixtures — because it greps for a control fixture staying green, and a
  crashed run prints no `ok` lines.
- **Step 1 (mesh) went quietly GREEN.** Its only assertion was
  `if bash mutant --self-test; then VACUITY FAIL; fi`, and a
  `ModuleNotFoundError` exits non-zero — indistinguishable from "the mutation
  was caught". It would have reported OK forever while testing nothing. That is
  the *exact* "guard that cannot fail" family this PR exists to close,
  introduced by the fix for it.

All three now copy the whole `scripts/` tree. Step 1 additionally gets what the
other two already had and it lacked: it must name the **specific** fixture the
mutation should break (`mesh stub, 0 remote clusters`) and must keep a
**control** green (`dead backend, no mesh annotation` — a zero-endpoint Service
that shares the suspect property but is not decided by the mesh belief). A
crash can no longer masquerade as a vacuity proof.

**The verification method changed too**, because "I verified the step I edited,
not the steps my edit affected" is the real defect here. Transcribing a step
into a hand-written check tests the transcription. So the workflow YAML is now
parsed and each `run:` block executed **verbatim**, against every job this PR
touches:

```
check-live-route-backends-selftest.yaml / self-test         5 steps, all ok
check-guard-selftests.yaml / chart-route-listener-...        7 steps, all ok
check-guard-selftests.yaml / guards-are-wired                4 steps, all ok
check-guard-selftests.yaml / orphaned-guard-selftests       10 steps, all ok
```

A second rebase followed: main's deploy-bot published bp-catalyst-platform
**1.4.1409** while this branch was open, making the branch's 1.4.1408 a
*backward* version — a pinned Sovereign would resolve it to the
already-published artifact and this PR's catalog-seed edit could never reach a
cluster. Re-bumped to **1.4.1410**. This is precisely the collision that
re-running the bump at push time exists to catch: the version was correct when
written and wrong twenty minutes later.

## Two findings left unfixed here, deliberately

Both are real and both are a different owner's call; filing them as follow-ups
rather than widening this PR:

1. `products/catalyst/chart/templates/org-services/marketplace-routes.yaml` —
   the `tenant-<slug>` routes inherit the console gateway's `$gwName` but carry
   `<slug>.<sovereignFQDN>` hostnames, which no console listener admits.
   Latent only because `ingress.marketplace.tenantSlugs` defaults to `[]`. The
   guard's fixture 2 is exactly this shape.
2. `products/catalyst/chart/templates/org-services/organization-public-routes.yaml`
   defaults `$gwName` to `cilium-gateway`, while its runtime twin
   (`core/controllers/organization/.../tenant_route.go`) parents
   `cilium-gateway-console` with a comment saying the old default "attached but
   TLS still closed the connection". The chart-side analogue was never
   corrected.

Also noted in passing, unrelated to this change and untouched:
`docs/RUNBOOKS.md:1734` still describes the Hetzner LB as "targeting NodePorts
31080/31443", which contradicts current canon and will mislead future sessions.

## Holds honoured

- **Not merged.** hw294 is mid-provision.
- `catalyst-platform` not unsuspended; catalyst-ui's live `priorityClassName`
  patch untouched.
- No live-cluster access of any kind — this guard cannot contact one.
- No NodePorts. Every port literal added is 80 / 443 / 8080 / 8443.
- Test domains are `t99.omani.works` plus the three `omani.*` pool TLDs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
