### PR TITLE
fix(bp-openclaw): drop the NewAPI controller-token reference that never had a producer; settle the specter Blueprint contradiction

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,8 @@ openova/
 │   ├── fingate/       # Open Banking (PSD2/FAPI sandbox)
 │   ├── fabric/        # Data & Integration (event-driven + lakehouse)
 │   └── relay/         # Communication (email, video, chat, WebRTC)
-│                      # (specter and exodus are deliverable services, not Blueprints in this layout)
+│                      # (specter and exodus are deliverable services, not Blueprints in this layout —
+│                      #  docs/ARCHITECTURE.md §3.5 + docs/STATUS.md §1 agree; there is no products/specter/)
 └── docs/              # Platform documentation
 ```
 

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1389,7 +1389,7 @@ spec:
       #   guacamole-pg and the shared-pg family as well. Egress half in
       #   bp-keycloak 1.5.9; neither half alone restores a brokered login.
       #   Lockstep w/ products/catalyst/chart/Chart.yaml.
-      version: 1.4.1416
+      version: 1.4.1417
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/core/services/provisioning/gitops/helmrelease_apps.go
+++ b/core/services/provisioning/gitops/helmrelease_apps.go
@@ -333,11 +333,12 @@ spec:
       clientSecret:
         name: openclaw-oidc-client-secret
         key: OIDC_CLIENT_SECRET
+    # #6114: no apiKey here. It pinned openclaw-newapi-controller-token, a
+    # Secret nothing in the tree creates, for a secretKeyRef the chart no
+    # longer emits and the controller binary never read. The end-user token
+    # path (per-user newapi-key-{uuid} Secret, ADR-0003 3.3) is unchanged.
     llm:
       baseURL: %s
-      apiKey:
-        name: openclaw-newapi-controller-token
-        key: NEWAPI_KEY
       defaultModel: qwen3.6
     keycloak:
       realmURL: %s

--- a/core/services/provisioning/gitops/openclaw_secret_producer_6114_test.go
+++ b/core/services/provisioning/gitops/openclaw_secret_producer_6114_test.go
@@ -1,0 +1,301 @@
+package gitops
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// #6114 — a Secret REFERENCE whose producer was never written.
+//
+// `openclaw-newapi-controller-token` was consumed in three places (the chart's
+// controller Deployment via `llm.apiKey`, and both HelmRelease generators that
+// pin that value) while NOTHING in the tree ever created it. It was not a
+// producer that got deleted: `git log --all -S"openclaw-newapi-controller-token"
+// -- '*.yaml' '*.tpl'` returns ZERO commits, so no manifest ever carried the
+// name in a producing position.
+//
+// The two guards below encode the invariant that was missing, at the two seams
+// where it broke:
+//
+//	A. chart seam  — a helper used as the `name:` of a `secretKeyRef` must also
+//	   name a `kind: Secret` the SAME chart renders.
+//	B. overlay seam — a generator may only pin a Secret name at a values path
+//	   that some chart Secret template actually consumes.
+//
+// CONTROL (shares the suspect property, must stay green in both guards):
+// `bp-openclaw.oidc.clientSecretName` / values path `oidc.clientSecret`. It is
+// the SIBLING secret reference — same chart, same container, same
+// helper-indirection, same `optional: true` secretKeyRef shape, pinned by the
+// same generators. It differs from the phantom in exactly one respect: it has a
+// producer (`templates/oidc-client-secret.yaml`). If a change to these guards
+// stops distinguishing "has a producer" from "does not", the control goes red.
+
+// openclawTemplatesDir is the bp-openclaw chart's template dir, relative to
+// this package (core/services/provisioning/gitops → repo root is four up).
+const openclawTemplatesDir = "../../../../platform/openclaw/chart/templates"
+
+// controlSecretHelper / controlSecretPath are the CONTROL — a secret reference
+// that shares every structural property with the phantom except the one under
+// test (a producer exists).
+const (
+	controlSecretHelper = "bp-openclaw.oidc.clientSecretName"
+	controlSecretPath   = "oidc.clientSecret"
+)
+
+var (
+	// `secretKeyRef:` followed by `name: {{ include "helper" . }}`.
+	reSecretKeyRefHelper = regexp.MustCompile(`secretKeyRef:\s*\n\s*name:\s*\{\{-?\s*include\s+"([^"]+)"`)
+	// `metadata:` … `name: {{ include "helper" . }}` (direct form).
+	reMetaNameInclude = regexp.MustCompile(`\n\s*name:\s*\{\{-?\s*include\s+"([^"]+)"`)
+	// `metadata:` … `name: {{ $var }}` (indirect form — resolved via reAssign).
+	reMetaNameVar = regexp.MustCompile(`\n\s*name:\s*\{\{-?\s*(\$[A-Za-z0-9_]+)\s*\}\}`)
+	// `$var := include "helper" .`
+	reAssign = regexp.MustCompile(`(\$[A-Za-z0-9_]+)\s*:=\s*include\s+"([^"]+)"`)
+	// `.Values.a.b.c` inside a helper body.
+	reValuesPath = regexp.MustCompile(`\.Values\.([A-Za-z0-9_.]+)`)
+	// `{{- define "helper" -}}` … block header.
+	reDefine = regexp.MustCompile(`\{\{-?\s*define\s+"([^"]+)"`)
+)
+
+// readOpenClawTemplates returns every chart template keyed by base filename.
+func readOpenClawTemplates(t *testing.T) map[string]string {
+	t.Helper()
+	entries, err := os.ReadDir(openclawTemplatesDir)
+	if err != nil {
+		t.Fatalf("read bp-openclaw templates dir %s: %v", openclawTemplatesDir, err)
+	}
+	out := map[string]string{}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		b, err := os.ReadFile(filepath.Join(openclawTemplatesDir, e.Name()))
+		if err != nil {
+			t.Fatalf("read %s: %v", e.Name(), err)
+		}
+		out[e.Name()] = string(b)
+	}
+	if len(out) == 0 {
+		t.Fatal("VACUITY: bp-openclaw chart has no templates — the guard would pass on an empty tree")
+	}
+	return out
+}
+
+// producingHelpers returns the helpers that name a `kind: Secret` the chart
+// itself renders. Both the direct (`name: {{ include "h" . }}`) and the
+// indirect (`$v := include "h" .` … `name: {{ $v }}`) forms are resolved — the
+// indirect form is the one a literal grep for a secret name MISSES, and it is
+// the form the CONTROL producer uses.
+func producingHelpers(t *testing.T, tmpls map[string]string) map[string]bool {
+	t.Helper()
+	out := map[string]bool{}
+	for name, body := range tmpls {
+		if !strings.Contains(body, "kind: Secret") {
+			continue
+		}
+		vars := map[string]string{}
+		for _, m := range reAssign.FindAllStringSubmatch(body, -1) {
+			vars[m[1]] = m[2]
+		}
+		for _, m := range reMetaNameInclude.FindAllStringSubmatch(body, -1) {
+			out[m[1]] = true
+		}
+		for _, m := range reMetaNameVar.FindAllStringSubmatch(body, -1) {
+			if h, ok := vars[m[1]]; ok {
+				out[h] = true
+			} else {
+				t.Errorf("%s: Secret metadata.name uses %s but no `%s := include ...` assignment was found — the producer resolver cannot see this template", name, m[1], m[1])
+			}
+		}
+	}
+	return out
+}
+
+// TestOpenClawChartSecretRefsHaveProducers is guard A — the chart seam.
+//
+// Every helper the controller Deployment uses as a `secretKeyRef.name` must
+// also name a Secret this chart renders. `optional: true` on the ref means a
+// missing Secret does NOT fail the Pod — it silently leaves the env unset,
+// which is exactly why this went unnoticed: there is no runtime signal at all.
+func TestOpenClawChartSecretRefsHaveProducers(t *testing.T) {
+	tmpls := readOpenClawTemplates(t)
+
+	dep, ok := tmpls["controller-deployment.yaml"]
+	if !ok {
+		t.Fatal("VACUITY: controller-deployment.yaml not found — nothing would be checked")
+	}
+
+	consumed := map[string]bool{}
+	for _, m := range reSecretKeyRefHelper.FindAllStringSubmatch(dep, -1) {
+		consumed[m[1]] = true
+	}
+	produced := producingHelpers(t, tmpls)
+
+	// ── Vacuity: both sets must be non-empty and the CONTROL present in each.
+	// Without this a regex that matches nothing makes the guard trivially pass.
+	if len(consumed) == 0 {
+		t.Fatal("VACUITY: no secretKeyRef helper found in controller-deployment.yaml — the guard cannot fail")
+	}
+	if len(produced) == 0 {
+		t.Fatal("VACUITY: no Secret-producing helper found in the chart — the guard cannot fail")
+	}
+	if !consumed[controlSecretHelper] {
+		t.Fatalf("CONTROL missing from consumed set: %q is not used as a secretKeyRef name; the guard is no longer testing the surface it claims to", controlSecretHelper)
+	}
+	if !produced[controlSecretHelper] {
+		t.Fatalf("CONTROL missing from produced set: %q names no Secret template; the producer resolver is broken, so a negative result is worthless", controlSecretHelper)
+	}
+
+	var orphans []string
+	for h := range consumed {
+		if !produced[h] {
+			orphans = append(orphans, h)
+		}
+	}
+	sort.Strings(orphans)
+	if len(orphans) > 0 {
+		t.Errorf("bp-openclaw mounts a Secret no chart template creates (#6114).\n"+
+			"  consumed as secretKeyRef.name : %v\n"+
+			"  produced by a kind: Secret    : %v\n"+
+			"  ORPHANED (no producer)        : %v\n"+
+			"Either add the producer or drop the reference. `optional: true` hides this at\n"+
+			"runtime — the env is silently unset, so no Pod ever reports the gap.",
+			sortedSet(consumed), sortedSet(produced), orphans)
+	}
+}
+
+// TestOpenClawOverlayPinsOnlyProducedSecretPaths is guard B — the overlay seam.
+//
+// A generator may pin a Secret NAME only at a values path that some chart
+// Secret template consumes. Pinning `llm.apiKey.name` was writing a name for a
+// Secret the chart never creates.
+func TestOpenClawOverlayPinsOnlyProducedSecretPaths(t *testing.T) {
+	tmpls := readOpenClawTemplates(t)
+	helpers, ok := tmpls["_helpers.tpl"]
+	if !ok {
+		t.Fatal("VACUITY: _helpers.tpl not found — values paths cannot be resolved")
+	}
+
+	// values paths read by helpers that name a Secret the chart renders.
+	producedPaths := map[string]bool{}
+	for h := range producingHelpers(t, tmpls) {
+		for _, p := range valuesPathsOfHelper(helpers, h) {
+			producedPaths[strings.TrimSuffix(p, ".name")] = true
+		}
+	}
+
+	out := cartOrgFor(t, "acme", "s", []string{"openclaw"})
+	overlay, ok := out[testBasePath+"/acme/app-openclaw.yaml"]
+	if !ok {
+		t.Fatalf("VACUITY: bp-openclaw overlay not rendered — nothing to check (keys: %v)", keys(out))
+	}
+	pinned := pinnedSecretPaths(overlay)
+
+	// ── Vacuity + CONTROL.
+	if len(producedPaths) == 0 {
+		t.Fatal("VACUITY: no produced values path resolved — the guard cannot fail")
+	}
+	if len(pinned) == 0 {
+		t.Fatal("VACUITY: overlay pins no name/key secret reference — the guard cannot fail")
+	}
+	if !producedPaths[controlSecretPath] {
+		t.Fatalf("CONTROL %q absent from produced paths %v — the helper→values resolver is broken", controlSecretPath, sortedSet(producedPaths))
+	}
+	if !pinned[controlSecretPath] {
+		t.Fatalf("CONTROL %q is no longer pinned by the overlay — the guard is testing the wrong surface", controlSecretPath)
+	}
+
+	var orphans []string
+	for p := range pinned {
+		if !producedPaths[p] {
+			orphans = append(orphans, p)
+		}
+	}
+	sort.Strings(orphans)
+	if len(orphans) > 0 {
+		t.Errorf("the funnel overlay pins a Secret name the bp-openclaw chart never creates (#6114).\n"+
+			"  pinned by overlay        : %v\n"+
+			"  consumed by a producer   : %v\n"+
+			"  ORPHANED (no producer)   : %v\n%s",
+			sortedSet(pinned), sortedSet(producedPaths), orphans, overlay)
+	}
+}
+
+// valuesPathsOfHelper returns the `.Values.x.y` paths read inside one helper.
+func valuesPathsOfHelper(helpers, helper string) []string {
+	locs := reDefine.FindAllStringSubmatchIndex(helpers, -1)
+	for i, loc := range locs {
+		if helpers[loc[2]:loc[3]] != helper {
+			continue
+		}
+		end := len(helpers)
+		if i+1 < len(locs) {
+			end = locs[i+1][0]
+		}
+		var out []string
+		for _, m := range reValuesPath.FindAllStringSubmatch(helpers[loc[0]:end], -1) {
+			out = append(out, m[1])
+		}
+		return out
+	}
+	return nil
+}
+
+// pinnedSecretPaths finds every `name:`/`key:` pair in the overlay's values —
+// the shape of a Secret reference — and returns the dotted path of its parent
+// key (e.g. `oidc.clientSecret`).
+func pinnedSecretPaths(overlay string) map[string]bool {
+	out := map[string]bool{}
+	lines := strings.Split(overlay, "\n")
+	// indent → key, rebuilt as we descend.
+	stack := map[int]string{}
+	for i, ln := range lines {
+		trimmed := strings.TrimLeft(ln, " ")
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") || strings.HasPrefix(trimmed, "-") {
+			continue
+		}
+		indent := len(ln) - len(trimmed)
+		key, _, found := strings.Cut(trimmed, ":")
+		if !found {
+			continue
+		}
+		stack[indent] = key
+		if key != "name" || i+1 >= len(lines) {
+			continue
+		}
+		next := strings.TrimLeft(lines[i+1], " ")
+		nextIndent := len(lines[i+1]) - len(next)
+		if nextIndent != indent || !strings.HasPrefix(next, "key:") {
+			continue
+		}
+		// Walk enclosing keys, stopping at the `values:` block root.
+		var parts []string
+		for ind := indent - 2; ind >= 0; ind -= 2 {
+			k, ok := stack[ind]
+			if !ok {
+				continue
+			}
+			if k == "values" {
+				break
+			}
+			parts = append([]string{k}, parts...)
+		}
+		if len(parts) > 0 {
+			out[strings.Join(parts, ".")] = true
+		}
+	}
+	return out
+}
+
+func sortedSet(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -256,7 +256,7 @@ Every Catalyst control-plane component carries an open-source license that allow
 | `bp-relay` | Communication — stalwart, livekit, stunner, matrix, guacamole |
 | `bp-self-sovereign-cutover` | 8-tether pivot — see §5.6 |
 
-`bp-specter` (AIOps agents) and Exodus (migration program) sit alongside the above; Specter is a composite Blueprint typically installed in corporate Sovereigns, Exodus is a services engagement.
+**Specter (AIOps agents) and Exodus (migration program) are NOT composite Blueprints** — both are deliverable services, and neither appears in the table above. This corrects a long-standing contradiction (#6114): this line previously called Specter "a composite Blueprint typically installed in corporate Sovereigns", while [`README.md`](../README.md) §"What's in this repo" and [`STATUS.md`](STATUS.md) §1 both said the opposite. The code decides, and it is unambiguous: there is no `products/specter/` directory (zero paths in the tree match `specter`), no chart, no `blueprint.yaml`, no `bp-specter` OCI artifact, and no catalog-seed entry. `bp-specter` is in fact *unpublishable* as things stand — `.github/workflows/blueprint-release.yaml` enumerates release candidates by scanning for `(platform|products)/<name>/(chart/|blueprint.yaml)`, so a name with no such directory can never produce an artifact. `specter` survives only as a **wizard catalog component id** (`products/catalyst/bootstrap/ui/src/pages/wizard/steps/componentGroups.ts`), whose own comment states there is no `bp-specter` HelmRelease and which the catalog-integrity gate carries in an explicit `KNOWN_UNBUILT` debt allowlist. Removing that entry (or realizing a real `bp-specter`) is UAT row **W5**.
 
 ---
 

--- a/docs/DOD.md
+++ b/docs/DOD.md
@@ -713,7 +713,7 @@ backing services (Postgres, Redis, etc.) in their own section.
 | `kubectl` access for users | Off | On for `org-developer` and above |
 | Git access for users | Off (sovereign-admin can flip per-Org) | On |
 | Marketplace features (search, bundles, ratings) | All on | All on but de-emphasized |
-| Specter / AIOps Blueprint included by default | Optional | Recommended (Cortex + Specter on top) |
+| Specter / AIOps **service engagement** offered | Optional | Recommended (Cortex Blueprint + Specter engagement on top) |
 
 Each Sovereign sets its defaults at provisioning time; users within can
 override via per-user preferences within the role permissions allowed.

--- a/docs/RUNBOOKS.md
+++ b/docs/RUNBOOKS.md
@@ -1593,7 +1593,7 @@ grep -lE '<location-code>\.<sovereign-domain>|<env>\.<sovereign-domain>' \
 
 ### 8.4 Deep-read rotation
 
-After greps, deep-read **one canonical doc + one component README** per pass. Rotate through the canon and the 56 platform components + 7 products (catalyst, cortex, axon, fingate, fabric, relay, specter) over time. The next-most-stale entry should be the target.
+After greps, deep-read **one canonical doc + one component README** per pass. Rotate through the canon and the 56 platform components + the 13 `products/` dirs (agenity, axon, catalyst, catalyst-migrator, continuum, cortex, dmz-vcluster, fabric, fingate, openova-flow, openova-mcp, relay, sandbox) over time. The next-most-stale entry should be the target. (`specter` was listed here as a product folder until #6114; there is no `products/specter/` — it is a deliverable service, not a Blueprint. See [`ARCHITECTURE.md`](ARCHITECTURE.md) §3.5.)
 
 The deep-read confirms the doc's known anchors are present and consistent with the rest of the canon. For each:
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -37,7 +37,7 @@ Per [`DOD.md`](DOD.md), 🟦 CODE-COMPLETE does NOT mean shipped. A pillar is **
 | `products/axon/` | ✅ | Real implementation (chart/, src/, scripts/). |
 | `products/agenity/` + `products/openova-mcp/` | 🟦 | The **Pillar 4 pair** (re-scoped — see §2.2 and §9): `bp-agenity` (chart 0.5.20 — per-Org multi-agent runtime + dashboard) + `openova-mcp` (Go MCP server: RBAC-scoped thin facade over live catalyst-api, JSON-RPC over stdio). |
 | `products/catalyst/` umbrella (`bp-catalyst-platform`) | 🟦 | Has `bootstrap/{ui,api}/` (React SPA wizard + Go bootstrap API) + `chart/` with Chart.yaml + Helm templates for the full Catalyst-Zero deployment + `crds/` with the 13 CRDs enumerated in §4. Canonical Helm chart for Catalyst-Zero and every franchised Sovereign. |
-| `products/{cortex,fabric,fingate,relay}/` | 📐 | README only. No charts or manifests. (`products/specter/` does not exist — Specter is a deliverable service, not a Blueprint in this layout, per `README.md` §"What's in this repo".) |
+| `products/{cortex,fabric,fingate,relay}/` | 📐 | README only. No charts or manifests. (`products/specter/` does not exist — Specter is a deliverable service, not a Blueprint in this layout, per `README.md` §"What's in this repo" and [`ARCHITECTURE.md`](ARCHITECTURE.md) §3.5, which agreed with this row as of #6114.) |
 
 ---
 

--- a/platform/openclaw/README.md
+++ b/platform/openclaw/README.md
@@ -81,7 +81,6 @@ The chart fails to render if any of these are unset (see
 | `oidc.clientId` | `openclaw` |
 | `oidc.clientSecret.name` | `openclaw-oidc-client-secret` (Secret with key `OIDC_CLIENT_SECRET`) |
 | `llm.baseURL` | `https://api.acme.<parent-domain>/v1` (per-tenant NewAPI OpenAI-compatible endpoint) |
-| `llm.apiKey.name` | `openclaw-newapi-controller-token` (Secret with key `NEWAPI_KEY`) |
 | `llm.defaultModel` | `qwen3.6` (NewAPI maps this to a backing channel — e.g. a partner-hosted Qwen) |
 | `tenant.namespace` | `org-acme` |
 | `controller.image.tag` | SHA-pinned tag (Inviolable Principle 4) |
@@ -90,6 +89,16 @@ The chart fails to render if any of these are unset (see
 
 Legacy `keycloak.*` / `newapi.*` keys remain accepted for back-compat
 (see umbrella epic #915).
+
+There is deliberately **no `llm.apiKey`** knob (#6114). The chart used to
+mount a controller-side NewAPI service token from a Secret named
+`openclaw-newapi-controller-token`, which **nothing in this repo has ever
+created** — the reference was `optional: true`, so the env silently stayed
+unset and no Pod ever reported it, and the controller binary reads no
+api-key env in any case. The only NewAPI bearer token in this Blueprint is
+the per-user `newapi-key-{uuid}` Secret described under *Runtime image
+contract* below. Adding a Secret reference back without adding its producer
+in the same change fails `TestOpenClawChartSecretRefsHaveProducers`.
 
 ---
 

--- a/platform/openclaw/blueprint.yaml
+++ b/platform/openclaw/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: ai-runtime
     catalyst.openova.io/section: pts-4-7-agentic-workspace
 spec:
-  version: 0.2.17
+  version: 0.2.18
   card:
     title: OpenClaw
     summary: |

--- a/platform/openclaw/chart/Chart.yaml
+++ b/platform/openclaw/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-openclaw
-version: 0.2.17
+version: 0.2.18
 appVersion: "0.2.0"
 description: |
   Catalyst Blueprint chart for the OpenClaw workspace controller pattern
@@ -31,6 +31,36 @@ description: |
 
   Changelog
   ─────────
+  0.2.18 (2026-08-11, #6114 — drop the controller-side NewAPI token reference
+          that never had a producer)
+    - ROOT CAUSE: `llm.apiKey` named a Secret nothing in the repo creates. The
+      chart default was `openclaw-llm-apikey` and both HelmRelease generators
+      (the funnel generic generator and the BSS-door overlay) overrode it to
+      `openclaw-newapi-controller-token`. Neither name has ever appeared in a
+      producing position: `git log --all -S"openclaw-newapi-controller-token"
+      -- '*.yaml' '*.tpl'` returns ZERO commits, so this was never a producer
+      that got deleted — it was never written.
+    - WHY IT WAS SILENT: the two `secretKeyRef`s (LLM_API_KEY, OPENAI_API_KEY)
+      carried `optional: true`, so the kubelet left both envs unset instead of
+      failing the container. There was no runtime signal of any kind — unlike
+      the sibling `openclaw-oidc-client-secret`, whose non-optional ref DID
+      hard-fail and got a lookup-or-generate producer in #4272/#4307.
+    - WHY REMOVED RATHER THAN PRODUCED: the controller binary reads neither
+      env. `loadConfig` takes only PORT / OIDC_* / TENANT_NAMESPACE /
+      KUBERNETES_* / IDLE_TIMEOUT_MINUTES, and `/readyz` has exactly two legs
+      (api-server + OIDC JWKS) — no NewAPI leg. Both stated justifications for
+      the token ("/readyz probes", "a controller-side LLM call that pre-dates a
+      user session") describe code that does not exist. Minting a real NewAPI
+      service token into every Org namespace to satisfy a reference no code
+      reads would add a live credential with no consumer.
+    - UNCHANGED: the end-user credential path of ADR-0003 §3.3 — the per-user
+      `newapi-key-{uuid}` Secret (keys `api-key` + `base-url`) produced by
+      `K8sSecretApplier.ApplyNewAPIKeySecret` and mounted by the per-user pod
+      template. That is now the only NewAPI bearer token in this Blueprint.
+    - GUARD: `TestOpenClawChartSecretRefsHaveProducers` fails the build if a
+      `secretKeyRef` names a helper no `kind: Secret` template in this chart
+      renders; `TestOpenClawOverlayPinsOnlyProducedSecretPaths` fails if a
+      generator pins a Secret name at a values path no producer consumes.
   0.2.17 (2026-07-10, #4952 — per-Org install no longer targets a non-existent
           `org-example` namespace)
     - ROOT CAUSE: `tenant.namespace` defaulted to the truthy placeholder

--- a/platform/openclaw/chart/templates/_helpers.tpl
+++ b/platform/openclaw/chart/templates/_helpers.tpl
@@ -147,22 +147,17 @@ explicitly set to a non-placeholder value, it always wins.
 {{- end -}}
 {{- end }}
 
-{{- define "bp-openclaw.llm.apiKeySecretName" -}}
-{{- if and .Values.llm.apiKey .Values.llm.apiKey.name -}}
-{{- .Values.llm.apiKey.name -}}
-{{- else -}}
-{{- "openclaw-llm-apikey" -}}
-{{- end -}}
-{{- end }}
-
-{{- define "bp-openclaw.llm.apiKeySecretKey" -}}
-{{- if and .Values.llm.apiKey .Values.llm.apiKey.key -}}
-{{- .Values.llm.apiKey.key -}}
-{{- else -}}
-{{- "NEWAPI_KEY" -}}
-{{- end -}}
-{{- end }}
-
+{{- /*
+#6114 — `bp-openclaw.llm.apiKeySecretName` / `.apiKeySecretKey` are GONE.
+They resolved the name of a controller-side NewAPI service-token Secret that
+no template in this chart (or anywhere in the repo) has ever created, so the
+`secretKeyRef` they fed could only ever resolve to nothing. The chart default
+was `openclaw-llm-apikey` and both HelmRelease generators overrode it to
+`openclaw-newapi-controller-token`; neither name had a producer. The controller
+binary reads no api-key env, so nothing regressed by removing them. Do not
+reintroduce a secret-name helper without adding the Secret template alongside
+it — `TestOpenClawChartSecretRefsHaveProducers` fails the build if you do.
+*/ -}}
 {{- define "bp-openclaw.llm.defaultModel" -}}
 {{- default "qwen3.6" .Values.llm.defaultModel -}}
 {{- end }}

--- a/platform/openclaw/chart/templates/controller-deployment.yaml
+++ b/platform/openclaw/chart/templates/controller-deployment.yaml
@@ -85,32 +85,24 @@ spec:
 
             # ── LLM gateway: per-tenant NewAPI (OpenAI-compatible) ────
             # The controller knows the tenant's NewAPI /v1 endpoint and
-            # default model so it can run /readyz probes and any
-            # controller-side LLM call that pre-dates a user session.
-            # Per-user pods continue to read NEWAPI_BASE_URL/NEWAPI_KEY
+            # default model. Per-user pods read NEWAPI_BASE_URL/NEWAPI_KEY
             # from the per-user `newapi-key-{uuid}` Secret per ADR-0003
             # §3.3 — the controller does NOT inject its own service
             # token into the user-facing pod.
+            #
+            # #6114 — there is deliberately NO controller-side api-key env
+            # here. LLM_API_KEY / OPENAI_API_KEY used to mount a Secret this
+            # chart never created, the refs were optional so the envs silently
+            # stayed unset, and the controller binary reads neither. Full
+            # rationale in Chart.yaml's 0.2.18 changelog entry and values.yaml.
             - name: LLM_BASE_URL
               value: {{ include "bp-openclaw.llm.baseURL" . | quote }}
-            - name: LLM_API_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "bp-openclaw.llm.apiKeySecretName" . }}
-                  key: {{ include "bp-openclaw.llm.apiKeySecretKey" . }}
-                  optional: true
             - name: LLM_DEFAULT_MODEL
               value: {{ include "bp-openclaw.llm.defaultModel" . | quote }}
-            # OpenAI-SDK-compatible aliases (drop-in for any controller
+            # OpenAI-SDK-compatible alias (drop-in for any controller
             # subroutine that uses an off-the-shelf OpenAI client).
             - name: OPENAI_API_BASE
               value: {{ include "bp-openclaw.llm.baseURL" . | quote }}
-            - name: OPENAI_API_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "bp-openclaw.llm.apiKeySecretName" . }}
-                  key: {{ include "bp-openclaw.llm.apiKeySecretKey" . }}
-                  optional: true
 
             # ── NewAPI customer-facing base URL (fallback default) ───
             # Authoritative value per ADR-0003 §3.3 lives on each

--- a/platform/openclaw/chart/tests/render-toggles.sh
+++ b/platform/openclaw/chart/tests/render-toggles.sh
@@ -64,7 +64,6 @@ if ! helm template smoke-openclaw . \
     --set "oidc.issuerURL=https://kc.acme.example/realms/sme-acme" \
     --set "oidc.clientSecret.name=openclaw-oidc-client-secret" \
     --set "llm.baseURL=https://api.acme.example/v1" \
-    --set "llm.apiKey.name=openclaw-newapi-controller-token" \
     --set "llm.defaultModel=qwen3.6" \
     --set "tenant.namespace=sme-acme" \
     --set "controller.image.tag=sha-deadbeefdeadbeefdeadbeefdeadbeefdeadbeef" \
@@ -76,15 +75,35 @@ if ! helm template smoke-openclaw . \
   exit 1
 fi
 # Assert canonical envs are present on the controller.
+# #6114: LLM_API_KEY / OPENAI_API_KEY are NOT in this list. They carried a
+# secretKeyRef at `llm.apiKey.name` whose target Secret has no producer
+# anywhere in the repo, and the controller binary reads neither env — the
+# reference was removed rather than backed by a token nothing consumes.
 for env in OIDC_ISSUER_URL OIDC_CLIENT_ID OIDC_CLIENT_SECRET \
-           LLM_BASE_URL LLM_API_KEY LLM_DEFAULT_MODEL \
-           OPENAI_API_BASE OPENAI_API_KEY \
+           LLM_BASE_URL LLM_DEFAULT_MODEL \
+           OPENAI_API_BASE \
            KEYCLOAK_REALM_URL NEWAPI_BASE_URL_DEFAULT; do
   if ! grep -q "name: ${env}" "$TMP/real.yaml"; then
     echo "FAIL: controller env ${env} missing from rendered manifests" >&2
     exit 1
   fi
 done
+# #6114 regression guard: the controller must not MOUNT a Secret this chart
+# does not create. Match `name:` at a reference position only — a bare grep for
+# the dead names also hits the explanatory comments the templates render, which
+# would make this guard fail on its own documentation.
+if grep -qE "^[[:space:]]*name:[[:space:]]*(openclaw-newapi-controller-token|openclaw-llm-apikey)[[:space:]]*$" "$TMP/real.yaml"; then
+  echo "FAIL: rendered manifests reference a controller-side NewAPI token Secret," >&2
+  echo "      but no template in this chart creates one (#6114)." >&2
+  exit 1
+fi
+# Vacuity check for the guard above: the same matcher MUST fire on a known
+# reference, otherwise a typo'd pattern would let the defect back in silently.
+if ! printf '                  name: openclaw-newapi-controller-token\n' \
+     | grep -qE "^[[:space:]]*name:[[:space:]]*(openclaw-newapi-controller-token|openclaw-llm-apikey)[[:space:]]*$"; then
+  echo "FAIL: the #6114 reference matcher does not match a known-bad line — guard is vacuous." >&2
+  exit 1
+fi
 # Assert the per-user pod-template ConfigMap carries OPENAI_API_BASE +
 # LLM_DEFAULT_MODEL so OpenAI-SDK-based runtimes work without code change.
 if ! grep -q "OPENAI_API_BASE" "$TMP/real.yaml"; then

--- a/platform/openclaw/chart/values.yaml
+++ b/platform/openclaw/chart/values.yaml
@@ -9,7 +9,6 @@
 #   - oidc.issuerURL             (per-tenant Keycloak realm OIDC issuer)
 #   - oidc.clientSecret.name     (ExternalSecret with OIDC client_secret)
 #   - llm.baseURL                (per-tenant NewAPI OpenAI-compatible endpoint)
-#   - llm.apiKey.name            (Secret carrying NewAPI bearer token)
 #   - tenant.namespace           (Organization tenant namespace where per-user pods run)
 #   - ingress.host               (controller public hostname)
 #   - controller.image.tag       (SHA-pinned tag)
@@ -176,16 +175,23 @@ llm:
   # endpoint (i.e. NewAPI's /v1 surface). Placeholder default lets
   # smoke render pass.
   baseURL: "https://newapi.example.local/v1"
-  # Bearer token sourced from a K8s Secret (Inviolable Principle 10).
-  # Required Secret key: NEWAPI_KEY (or `api-key` for ADR-0003-aligned
-  # per-user secrets). Per-user pods continue to read the per-user
-  # `newapi-key-{uuid}` Secret per ADR-0003 §3.3; this controller-side
-  # secret is the controller's own service-token (used for /readyz
-  # probes and for any controller-side LLM call that pre-dates a user
-  # session).
-  apiKey:
-    name: "openclaw-llm-apikey"
-    key: "NEWAPI_KEY"
+  # #6114 — there is deliberately NO `apiKey:` block here.
+  #
+  # It used to name a controller-side NewAPI service-token Secret
+  # (default `openclaw-llm-apikey`, overridden by both HelmRelease
+  # generators to `openclaw-newapi-controller-token`). NEITHER name has
+  # ever had a producer anywhere in the repo, and the controller binary
+  # reads no api-key env at all — so the block configured a mount that
+  # could not resolve, for a consumer that does not exist.
+  #
+  # The end-user credential path is unaffected and IS built: per ADR-0003
+  # §3.3 each user gets a `newapi-key-{uuid}` Secret (keys `api-key` +
+  # `base-url`) produced by the unified-rbac hook, which the per-user pod
+  # template mounts. That is the ONLY NewAPI bearer token in this chart.
+  #
+  # If a controller-side token is ever genuinely needed, add the Secret
+  # producer in the SAME change as the reference — the chart guard
+  # `TestOpenClawChartSecretRefsHaveProducers` enforces that pairing.
   # The default OpenAI-compatible model identifier sent on /v1/chat/
   # completions when the client doesn't override. NewAPI uses the
   # `model` field to select a channel; for the umbrella #915 DoD this

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-11T08:18:06.242Z",
+  "generatedAt": "2026-08-11T11:30:54.855Z",
   "blueprints": [
     {
       "id": "bp-agenity",
@@ -3684,7 +3684,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "listed",
-      "version": "0.2.17",
+      "version": "0.2.18",
       "section": "pts-4-7-agentic-workspace",
       "depends": [
         "bp-newapi",

--- a/products/catalyst/bootstrap/api/internal/handler/organization_gitops.go
+++ b/products/catalyst/bootstrap/api/internal/handler/organization_gitops.go
@@ -1880,14 +1880,17 @@ spec:
     # newapi runs as a per-tenant HelmRelease (bp-newapi) — alice has
     # her own NewAPI at api.<org-domain>; OpenClaw points its OpenAI
     # client there. The per-user newapi-key-{uuid} Secret carries the
-    # end-user's bearer token (ADR-0003 §3.3); the controller-side
-    # service token below is used for /readyz probes and any
-    # controller-side LLM call that pre-dates a user session.
+    # end-user's bearer token (ADR-0003 §3.3).
+    #
+    # #6114: no apiKey here. This block used to pin a controller-side
+    # service token at openclaw-newapi-controller-token and justify it as
+    # "/readyz probes and any controller-side LLM call that pre-dates a user
+    # session". Both claims were false: /readyz has exactly two legs
+    # (api-server + OIDC JWKS) and no such controller-side call exists. No
+    # producer for that Secret has ever existed, and the chart no longer
+    # emits the secretKeyRef, so pinning a name here would configure nothing.
     llm:
       baseURL: https://api.{{.Subdomain}}.{{.ParentDomain}}/v1
-      apiKey:
-        name: openclaw-newapi-controller-token
-        key: NEWAPI_KEY
       # NewAPI uses the model name to select a backing channel. C4
       # provisions channel #1 = partner-hosted Qwen at tenant-create
       # time so this default routes to the correct upstream.

--- a/products/catalyst/bootstrap/api/internal/handler/organization_provisioning_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/organization_provisioning_test.go
@@ -924,15 +924,23 @@ func TestRenderOrganizationOverlay_OpenClawOIDCAndLLMBlocks(t *testing.T) {
 	wantLLM := []string{
 		"    llm:",
 		"      baseURL: https://api.alice.omantel.omani.works/v1",
-		"      apiKey:",
-		"        name: openclaw-newapi-controller-token",
-		"        key: NEWAPI_KEY",
 		"      defaultModel: qwen3.6",
 	}
 	for _, line := range wantLLM {
 		if !strings.Contains(body, line) {
 			t.Errorf("bp-openclaw llm block missing line %q\n--- rendered ---\n%s", line, body)
 		}
+	}
+	// #6114 — the llm block must NOT pin a controller-side api-key Secret.
+	// It used to name `openclaw-newapi-controller-token`, which nothing in
+	// the repo has ever created, for a chart `secretKeyRef` that is now gone
+	// and a controller binary that never read the env. Assert on the SHAPE
+	// (an apiKey secret reference under llm:) rather than on the dead name,
+	// so reintroducing the same defect under a different name still fails.
+	if strings.Contains(body, "      apiKey:") {
+		t.Errorf("bp-openclaw llm block pins an apiKey Secret reference, but no producer for a "+
+			"controller-side NewAPI token exists (#6114). The end-user path is the per-user "+
+			"newapi-key-{uuid} Secret (ADR-0003 §3.3), not a chart-level token.\n--- rendered ---\n%s", body)
 	}
 	// Per-tenant LLM endpoint MUST be the Organization's own api.<sub>.<parent>,
 	// NEVER the otech-wide newapi.<otech-fqdn> (that would route every

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -3819,7 +3819,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "listed",
-    "version": "0.2.17",
+    "version": "0.2.18",
     "section": "pts-4-7-agentic-workspace",
     "depends": [
       "bp-newapi",

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3578,6 +3578,16 @@ name: bp-catalyst-platform
 #   sovereign-fqdn) so GET /catalog/regions returns the Sovereign's REAL
 #   regions instead of [] — the marketplace BCP picker stops falling back to
 #   the hardcoded Hetzner list.
+# 1.4.1417 — #6114: catalog-seed bp-openclaw pin 0.2.17 -> 0.2.18 (lockstep w/
+#   platform/openclaw chart + blueprint.yaml) so the phantom-Secret removal
+#   reaches fresh Orgs. bp-openclaw 0.2.17 mounted LLM_API_KEY/OPENAI_API_KEY
+#   from `openclaw-newapi-controller-token`, a Secret NOTHING in the repo has
+#   ever created; the refs were `optional: true` so the envs silently stayed
+#   unset and no Pod reported it, and the controller binary reads neither env.
+#   0.2.18 drops the reference rather than minting a live NewAPI token with no
+#   consumer. The per-user `newapi-key-{uuid}` path (ADR-0003 §3.3) is
+#   unchanged. Without this seed bump the Sovereign keeps resolving 0.2.17 and
+#   the fix is a hollow pin (the #6040 class).
 # 1.4.1072 — #4952: catalog-seed bp-openclaw pin 0.2.16 -> 0.2.17 (lockstep w/
 #   platform/openclaw chart + blueprint.yaml) so the per-Org-namespace fix
 #   reaches fresh funnel Orgs. bp-openclaw 0.2.16 defaulted tenant.namespace to
@@ -3889,7 +3899,7 @@ name: bp-catalyst-platform
 #   The seed pin is the delivery half: without this bump a pinned Sovereign
 #   resolves 1.5.9 and never sees the fix. This chart's own templates are
 #   unchanged.
-version: 1.4.1416
+version: 1.4.1417
 # 1.4.1229 — #5389: catalog-seed bp-newapi declares its `ui` endpoint
 #   (newapi.<fqdn>, ssoEnabled, launchDefault, ssoInitPath "/") instead of
 #   `endpoints: []`. The empty list made userUIGatePasses fail closed, which
@@ -4044,7 +4054,7 @@ version: 1.4.1416
 # scripts/check-chart-version-forward.sh (#5743) fails unless the two match —
 # main was carrying a pre-existing 1.4.1330/1.4.1329 split, so this bump heals
 # it in the same commit, exactly as the documented self-heal contract does.
-appVersion: 1.4.1416
+appVersion: 1.4.1417
 # 1.4.239 — Wave 3 / Issue #2140 (2026-05-23): Huawei provider
 # implementation lands behind the Wave 2 CloudProvider interface.
 # Adds the OpenTofu module at infra/providers/huawei/ (VPC + Subnet +

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -2469,7 +2469,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.2.17"
+  version: "0.2.18"
   visibility: listed
   card:
     title: "OpenClaw"
@@ -2504,7 +2504,7 @@ hook (ADR-0003). Identity-blind by construction.
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-openclaw
-    version: "0.2.17"
+    version: "0.2.18"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
Refs #6114

Two unclaimed gaps from tonight's residue sweep. Read `origin/main`, not a dirty tree; live clusters were touched read-only or not at all.

## Gap 1 — `openclaw-newapi-controller-token` has no producer

### How absence was established

Not by grepping the literal name — that method has produced a false claim twice tonight. The sweep covered every creation mechanism: `kind: Secret` templates across the whole tree (name may be templated, so the literal name is invisible), Go construction including `unstructured.Unstructured` and dynamic-client applies, Jobs running `kubectl create secret`, ExternalSecret / reflector / sealed-secrets, kustomize `secretGenerator`, GitOps overlays, and catalog-seed.

The method was **validated on two contrast producers it had to find first**, both of which a literal-name grep misses because their `metadata.name` is templated:

- `platform/openclaw/chart/templates/oidc-client-secret.yaml` — lookup-or-generate, name via a helper bound to a variable.
- bp-keycloak's `configmap-tenant-realm.yaml` — name built by `printf` inside a realm-config script.

Both were found. Against the same sweep, `openclaw-newapi-controller-token` has **no producer**. It is also not a producer that was deleted: `git log --all -S"openclaw-newapi-controller-token" -- '*.yaml' '*.tpl'` returns **zero** commits, so the name has never once appeared in a producing position. Every hit in history is a consumer.

### Decision: remove the dead consumer, do not build the producer

| Evidence | Finding |
|---|---|
| Does the controller read it? | **No.** `loadConfig` takes only `PORT`, `OIDC_*`, `TENANT_NAMESPACE`, `KUBERNETES_*`, `IDLE_TIMEOUT_MINUTES`. Grep for `LLM_API_KEY`/`OPENAI_API_KEY` under `platform/openclaw/controller/` returns 0 hits. |
| Is it load-bearing for `/readyz`? | **No.** `readyzHandler` has exactly two legs — api-server and OIDC JWKS. No NewAPI leg. |
| The other stated purpose? | "a controller-side LLM call that pre-dates a user session" — no such code exists. |
| Runtime impact today? | **None.** Both `secretKeyRef`s carried `optional: true`, so the kubelet left the envs unset. There is no runtime signal of any kind. |

This is explicitly **not** the sibling shape that earned the OIDC secret a producer in #4272/#4307 — that ref was non-optional and hard-failed with `CreateContainerConfigError`, which is why it got a lookup-or-generate template. This one fails silently and feeds nothing.

Building a producer would mint a real, long-lived NewAPI service token into **every Org namespace** to satisfy a reference no code reads — a live credential with no consumer. Deleting is the better fix.

A further sign the block was never reconciled with the shipped design: it expected key `NEWAPI_KEY`, while the real per-user Secrets carry `api-key`.

**Unchanged:** the end-user credential path of ADR-0003 §3.3 — per-user `newapi-key-{uuid}` Secrets (keys `api-key` + `base-url`) produced by `K8sSecretApplier.ApplyNewAPIKeySecret` and mounted by the per-user pod template. That is now the only NewAPI bearer token in the Blueprint.

### Delivery lockstep (five sites)

So this is not a hollow pin per the #6040 class: bp-openclaw chart `0.2.17 → 0.2.18`, its `blueprint.yaml`, both catalog-seed pins, bp-catalyst-platform `1.4.1416 → 1.4.1417`, and the bootstrap-kit slot 13 pin. `check-chart-version-bumped.sh`, `check-bootstrap-kit-pin-sync.sh` and `check-catalog-seed-lockstep.sh` all pass.

## Gap 2 — the `specter` contradiction

**The code decides, and it is unambiguous.** No `products/specter/` directory (zero paths in the tree match `specter`), no chart, no `blueprint.yaml`, no catalog-seed entry, no build workflow. `bp-specter` is in fact *structurally unpublishable*: `blueprint-release.yaml` enumerates candidates by scanning for `(platform|products)/<name>/(chart/|blueprint.yaml)`, so a name with no such directory can never produce an artifact. `products/` holds 13 dirs, none of them specter.

So `README.md` and `STATUS.md` were **right**; `ARCHITECTURE.md:259` was **wrong**.

Corrected `ARCHITECTURE.md` §3.5, and swept the same false claim out of the two other canonical docs it had spread to — `DOD.md`'s Sovereign-defaults table ("Specter / AIOps Blueprint included by default") and `RUNBOOKS.md`'s doc-rotation list (which named specter as one of "7 products"). `README.md` and `STATUS.md` keep their correct text and now cross-cite, so the next reader finds three sources agreeing **with the tree** rather than two agreeing with each other.

## Tests — red then green, with a control

New guards in `core/services/provisioning/gitops/`, placed at the two seams that broke:

- **A. `TestOpenClawChartSecretRefsHaveProducers`** — a helper used as a `secretKeyRef.name` must also name a `kind: Secret` the same chart renders.
- **B. `TestOpenClawOverlayPinsOnlyProducedSecretPaths`** — a generator may pin a Secret name only at a values path some producer consumes.

**RED** (before, `go test -count=1`) — both named the phantom exactly:

```
--- FAIL: TestOpenClawChartSecretRefsHaveProducers (0.00s)
    bp-openclaw mounts a Secret no chart template creates (#6114).
      consumed as secretKeyRef.name : [bp-openclaw.llm.apiKeySecretName bp-openclaw.oidc.clientSecretName]
      produced by a kind: Secret    : [bp-openclaw.oidc.clientSecretName]
      ORPHANED (no producer)        : [bp-openclaw.llm.apiKeySecretName]
--- FAIL: TestOpenClawOverlayPinsOnlyProducedSecretPaths (0.00s)
    the funnel overlay pins a Secret name the bp-openclaw chart never creates (#6114).
      pinned by overlay        : [llm.apiKey oidc.clientSecret]
      consumed by a producer   : [keycloak.clientSecretName oidc.clientSecret]
      ORPHANED (no producer)   : [llm.apiKey]
```

**GREEN** (after):

```
=== RUN   TestOpenClawChartSecretRefsHaveProducers
--- PASS: TestOpenClawChartSecretRefsHaveProducers (0.00s)
=== RUN   TestOpenClawOverlayPinsOnlyProducedSecretPaths
--- PASS: TestOpenClawOverlayPinsOnlyProducedSecretPaths (0.00s)
PASS
ok  	github.com/openova-io/openova/core/services/provisioning/gitops	0.002s
```

**CONTROL** — `bp-openclaw.oidc.clientSecretName` / values path `oidc.clientSecret`. It shares every structural property with the phantom: same chart, same container, same helper indirection, same `optional: true` secretKeyRef shape, pinned by the same two generators. It differs in exactly one respect — it has a producer. It stays green before and after, and each guard `t.Fatal`s if the control drops out of either set, so a guard that stops distinguishing "has a producer" from "does not" goes red instead of quietly passing.

**VACUITY** — deleting the control's producer template turns both guards red on their vacuity assertions rather than passing on an empty set:

```
--- FAIL: TestOpenClawChartSecretRefsHaveProducers (0.00s)
    VACUITY: no Secret-producing helper found in the chart — the guard cannot fail
--- FAIL: TestOpenClawOverlayPinsOnlyProducedSecretPaths (0.00s)
    VACUITY: no produced values path resolved — the guard cannot fail
```

The template was restored immediately after. The `render-toggles.sh` reference matcher carries its own inline vacuity check against a known-bad line — worth noting because the first version of that matcher was a bare name grep that **matched the templates' own explanatory comments**, which Helm renders into every manifest; it would have failed on its own documentation.

Also green: full `gitops` suite, full catalyst-api `internal/handler` suite, all 12 `bp-openclaw` render-toggle gates, `check-no-banned-words.sh`.

## Follow-ups

Consolidated into a single tracking issue rather than filed separately — **#6183**: UAT row **W5** (the `specter` wizard-catalog entry), and the non-canonical `specter` residue in `docs/BUSINESS-STRATEGY.md` and `.claude/project-memory.md`.

### Note on W5's disposition

W5 is **not** movable by a Sovereign-side walk. The wizard is a Catalyst-Zero surface — `products/catalyst/bootstrap/ui/src/app/router.tsx:766-769` states the Sovereign build "never exposes the wizard so this route is effectively Catalyst-Zero only". No hw293 UI walk can produce evidence for it.

But the underlying defect is a real source fix, and this doc correction **sharpens rather than changes** its disposition: `specter` remains the one wizard component id that resolves to no Blueprint, currently held in an explicit `KNOWN_UNBUILT` debt allowlist in `componentGroups.catalog-integrity.5575.test.ts`. Now that the canon says plainly that specter is a service and not a Blueprint, the resolution is the removal side, not the "realize `bp-specter`" side — which is what the reclassification from cluster D to A3 already implied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



---

**Rebased onto current `main`.** Worth recording, because the original push exposed a real problem and a second, unrelated one:

1. **The version bump had gone stale.** `main`'s deploy-bot moved bp-catalyst-platform `1.4.1377 → 1.4.1416` while this branch was open, so the original `1.4.1378` was *behind* main and would have failed `check-chart-version-forward`. Re-applied on top as `1.4.1417` (chart + appVersion + bootstrap-kit slot 13 in lockstep). This is the known chart-version collision trap — the resolution is rebase, not a higher guess.
2. **CI had never dispatched.** This PR sat at 0 checks through two pushes and a close/reopen, while peer PRs opened minutes earlier and later had 23-24. It was not path filters (35 workflows match this diff: 7 unfiltered + 28 by path) and not runner capacity (the queue drained with this branch still empty). The tell was `mergeable: null` persisting for ~40 minutes — GitHub never computed the merge commit, and `pull_request` dispatch depends on it. The rebase cleared it: 30 checks dispatched immediately and `mergeable` flipped to `true`.
