### PR TITLE
fix(catalog): a retired product must not keep its price list

### DIFF
--- a/core/services/catalog/handlers/retired_products_test.go
+++ b/core/services/catalog/handlers/retired_products_test.go
@@ -67,6 +67,122 @@ func TestRetiredProductIsNotSeededIntoTheCatalog(t *testing.T) {
 	}
 }
 
+// Defends: a fresh Sovereign must not be seeded with a PRICE LIST for a product
+// that is not for sale (#5920).
+//
+// The App row and the Plan rows are two different producers, and only the App
+// row was closed. seedMissingSandboxPlans — the path that re-creates missing
+// tiers on an EXISTING Sovereign — already returns early on RetiredAppSlugs,
+// and its comment states the rule outright: "Retiring the product retires its
+// price list with it." The FRESH-seed path appended the same tiers
+// unconditionally, so every newly provisioned Sovereign was still seeded with
+// sandbox-free (0 OMR), sandbox-pro (9 OMR, Popular=true) and sandbox-ent
+// (49 OMR), and served them on the PUBLIC GET /catalog/plans.
+//
+// That is the same product being off the shelf and still in the price list.
+func TestRetiredProductHasNoPlanTiersOnAFreshSovereign(t *testing.T) {
+	plans := seedPlanRows()
+	if len(plans) == 0 {
+		t.Fatal("seedPlanRows returned no rows — nothing was checked")
+	}
+	retired := RetiredAppSlugs()
+	for _, p := range plans {
+		if why, bad := retired[p.ProductSlug]; bad {
+			t.Errorf("seedPlanRows still seeds plan %q at %d OMR for retired product %q (%s) — "+
+				"a fresh Sovereign would create the tier and GET /catalog/plans would serve it",
+				p.Slug, p.PriceOMR, p.ProductSlug, why)
+		}
+		// Belt and braces: catch a tier named for the retired product even if
+		// its ProductSlug were cleared, which would make it look like a generic
+		// compute tier and put it next to S/M/L/XL.
+		for slug := range retired {
+			if strings.HasPrefix(p.Slug, slug+"-") {
+				t.Errorf("seedPlanRows seeds plan %q, named for retired product %q, "+
+					"with ProductSlug=%q", p.Slug, slug, p.ProductSlug)
+			}
+		}
+	}
+}
+
+// Vacuity for the test above. If expectedSandboxPlans() ever returned an empty
+// slice, or stopped setting ProductSlug, then filtering it out of the fresh seed
+// would assert nothing and the test above would pass by examining nothing.
+//
+// This proves the excluded set has teeth: it is non-empty, it is priced, and it
+// carries the exact ProductSlug the filter keys on.
+func TestRetiredPlanExclusionIsNotVacuous(t *testing.T) {
+	excluded := expectedSandboxPlans()
+	if len(excluded) == 0 {
+		t.Fatal("expectedSandboxPlans() is empty — excluding it from the fresh seed " +
+			"would be a no-op and TestRetiredProductHasNoPlanTiersOnAFreshSovereign " +
+			"would pass against an unguarded seed")
+	}
+	if _, retired := RetiredAppSlugs()["sandbox"]; !retired {
+		t.Fatal("sandbox is not retired, so the exclusion never fires")
+	}
+	var priced int
+	for _, p := range excluded {
+		if p.ProductSlug != "sandbox" {
+			t.Errorf("excluded plan %q carries ProductSlug=%q, want %q — the fresh-seed "+
+				"filter keys on ProductSlug and would not catch this row",
+				p.Slug, p.ProductSlug, "sandbox")
+		}
+		if p.PriceOMR > 0 {
+			priced++
+		}
+	}
+	if priced == 0 {
+		t.Error("no excluded tier carries a price — the 'still on sale' claim this " +
+			"test defends would have no teeth")
+	}
+
+	// And the exclusion must actually remove them: every excluded slug must be
+	// absent from the fresh seed.
+	seeded := make(map[string]bool)
+	for _, p := range seedPlanRows() {
+		seeded[p.Slug] = true
+	}
+	for _, p := range excluded {
+		if seeded[p.Slug] {
+			t.Errorf("plan %q is in expectedSandboxPlans AND in the fresh seed — "+
+				"the retirement guard did not fire", p.Slug)
+		}
+	}
+}
+
+// Control. Without this, `return nil` from seedPlanRows would satisfy both tests
+// above and leave a Sovereign with no price list at all — checkout would fail
+// for every product, not just the retired one.
+func TestLiveComputeTiersAreStillSeeded(t *testing.T) {
+	plans := seedPlanRows()
+	seeded := make(map[string]int, len(plans))
+	for _, p := range plans {
+		seeded[p.Slug] = p.PriceOMR
+	}
+	// The generic compute ladder a customer actually buys.
+	for _, slug := range []string{"s", "m", "l", "xl", "flexi"} {
+		if _, ok := seeded[slug]; !ok {
+			t.Errorf("live compute tier %q is no longer seeded — the retirement change "+
+				"removed more than it should have", slug)
+		}
+	}
+	// Assert on a VALUE, not just presence: an empty/zeroed ladder would still
+	// have the keys. M is the Popular default at 9 OMR.
+	if got := seeded["m"]; got != 9 {
+		t.Errorf("tier m PriceOMR = %d, want 9 — the live price ladder was damaged", got)
+	}
+	var popular []string
+	for _, p := range plans {
+		if p.Popular {
+			popular = append(popular, p.Slug)
+		}
+	}
+	if len(popular) != 1 || popular[0] != "m" {
+		t.Errorf("Popular tiers = %v, want exactly [m] — the plan picker's default "+
+			"selection is broken (sandbox-pro also carried Popular=true)", popular)
+	}
+}
+
 // Defends: store.ListPublishedApps requires deployable==true. While the slug is
 // in DeployableAppSlugs, migrateAppDeployable keeps flipping existing rows back
 // to deployable, which is half of what keeps the card on sale.

--- a/core/services/catalog/handlers/seed.go
+++ b/core/services/catalog/handlers/seed.go
@@ -92,28 +92,7 @@ func (h *Handler) seedAllData(ctx context.Context) {
 	// -----------------------------------------------------------------------
 	// Plans
 	// -----------------------------------------------------------------------
-	seedPlans := []store.Plan{
-		{Slug: "s", Name: "S", Description: "For personal projects and small teams", CPU: "2 vCPU", Memory: "4 GB", Storage: "25 GB", PriceOMR: 5, Popular: false, SortOrder: 1,
-			Features: []string{"Unlimited apps", "SSO included", "API access", "TLS certificates", "Daily snapshots"}},
-		{Slug: "m", Name: "M", Description: "For growing businesses up to 30 users", CPU: "4 vCPU", Memory: "8 GB", Storage: "50 GB", PriceOMR: 9, Popular: true, SortOrder: 2,
-			Features: []string{"Unlimited apps", "SSO included", "API access", "TLS certificates", "Daily backups", "Priority support", "Custom domain"}},
-		{Slug: "l", Name: "L", Description: "For teams with 30\u2013100 users", CPU: "8 vCPU", Memory: "16 GB", Storage: "100 GB", PriceOMR: 16, Popular: false, SortOrder: 3,
-			Features: []string{"Unlimited apps", "SSO included", "API access", "TLS certificates", "Hourly backups", "Priority support", "Custom domain", "WAF/IPS", "Dedicated support"}},
-		{Slug: "xl", Name: "XL", Description: "For enterprises with 100+ users", CPU: "16 vCPU", Memory: "32 GB", Storage: "200 GB", PriceOMR: 30, Popular: false, SortOrder: 4,
-			Features: []string{"Unlimited apps", "SSO included", "API access", "TLS certificates", "Continuous backups", "Priority support", "Custom domain", "WAF/IPS", "Dedicated support", "SLA 99.9%", "Audit logs"}},
-		{Slug: "flexi", Name: "Flexi", Description: "Pay as you go \u2014 scale resources on demand", CPU: "On demand", Memory: "On demand", Storage: "On demand", PriceOMR: 0, Popular: false, SortOrder: 5,
-			Features: []string{"Unlimited apps", "SSO included", "API access", "TLS certificates", "Pay per use", "Scale on demand"}},
-	}
-
-	// Sandbox product plans \u2014 PR #1633 added the Sandbox app to seedApps
-	// but never wired the matching plan rows, so the marketplace checkout
-	// hit "plan_id not found" the moment a customer picked Sandbox.
-	// Sandbox plans are product-scoped (ProductSlug="sandbox") and carry
-	// IncludedQuotas the sandbox-orchestrator (#1639) reads via the
-	// `openova.io/plan-id` annotation on the Sandbox CR to derive
-	// spec.quota (sessions, agents, storage). Sort orders start at 10 to
-	// stay clear of the generic compute-tier bucket above.
-	seedPlans = append(seedPlans, expectedSandboxPlans()...)
+	seedPlans := seedPlanRows()
 
 	for i := range seedPlans {
 		if err := h.Store.CreatePlan(ctx, &seedPlans[i]); err != nil {
@@ -151,6 +130,48 @@ func (h *Handler) seedAllData(ctx context.Context) {
 	slog.Info("seed: created bundles", "count", len(seedBundles))
 
 	slog.Info("seed: catalog seeding complete")
+}
+
+// seedPlanRows returns the plan rows a FRESH Sovereign is seeded with.
+//
+// Extracted from seedAllData (#5920) to mirror seedAppRows: a pure function
+// with no store, so the retired-product assertions in retired_products_test.go
+// can read what a fresh Sovereign would actually be sold.
+func seedPlanRows() []store.Plan {
+	plans := []store.Plan{
+		{Slug: "s", Name: "S", Description: "For personal projects and small teams", CPU: "2 vCPU", Memory: "4 GB", Storage: "25 GB", PriceOMR: 5, Popular: false, SortOrder: 1,
+			Features: []string{"Unlimited apps", "SSO included", "API access", "TLS certificates", "Daily snapshots"}},
+		{Slug: "m", Name: "M", Description: "For growing businesses up to 30 users", CPU: "4 vCPU", Memory: "8 GB", Storage: "50 GB", PriceOMR: 9, Popular: true, SortOrder: 2,
+			Features: []string{"Unlimited apps", "SSO included", "API access", "TLS certificates", "Daily backups", "Priority support", "Custom domain"}},
+		{Slug: "l", Name: "L", Description: "For teams with 30\u2013100 users", CPU: "8 vCPU", Memory: "16 GB", Storage: "100 GB", PriceOMR: 16, Popular: false, SortOrder: 3,
+			Features: []string{"Unlimited apps", "SSO included", "API access", "TLS certificates", "Hourly backups", "Priority support", "Custom domain", "WAF/IPS", "Dedicated support"}},
+		{Slug: "xl", Name: "XL", Description: "For enterprises with 100+ users", CPU: "16 vCPU", Memory: "32 GB", Storage: "200 GB", PriceOMR: 30, Popular: false, SortOrder: 4,
+			Features: []string{"Unlimited apps", "SSO included", "API access", "TLS certificates", "Continuous backups", "Priority support", "Custom domain", "WAF/IPS", "Dedicated support", "SLA 99.9%", "Audit logs"}},
+		{Slug: "flexi", Name: "Flexi", Description: "Pay as you go \u2014 scale resources on demand", CPU: "On demand", Memory: "On demand", Storage: "On demand", PriceOMR: 0, Popular: false, SortOrder: 5,
+			Features: []string{"Unlimited apps", "SSO included", "API access", "TLS certificates", "Pay per use", "Scale on demand"}},
+	}
+
+	// Sandbox product plans \u2014 PR #1633 added the Sandbox app to seedApps but
+	// never wired the matching plan rows, so the marketplace checkout hit
+	// "plan_id not found" the moment a customer picked Sandbox. Sandbox plans
+	// are product-scoped (ProductSlug="sandbox") and carry IncludedQuotas the
+	// orchestrator (#1639) reads via the `openova.io/plan-id` annotation.
+	//
+	// #5920: Sandbox was RETIRED on 2026-06-30. Its App row is already gone
+	// from seedAppRows and seedMissingSandboxPlans already refuses to re-create
+	// these tiers on an existing Sovereign \u2014 with the note "retiring the product
+	// retires its price list with it". This call site was the other half of that
+	// same decision and was left unguarded, so every FRESH Sovereign was still
+	// seeded with sandbox-free / sandbox-pro (9 OMR, Popular) / sandbox-ent
+	// (49 OMR) and served them on the public GET /catalog/plans.
+	//
+	// One switch (RetiredAppSlugs) now governs both paths, so un-retiring the
+	// product would restore both without a second edit.
+	if _, retired := RetiredAppSlugs()["sandbox"]; !retired {
+		plans = append(plans, expectedSandboxPlans()...)
+	}
+
+	return plans
 }
 
 // expectedSandboxPlans returns the canonical set of Sandbox product plans.


### PR DESCRIPTION
## The half of #5920 that delisting does not reach

PR #5978 flips `platform/sandbox/blueprint.yaml` to `visibility: unlisted` and
regenerates both catalog artifacts. PR #6037 removed the `sandbox` App row and
made `migrateAppPublished` converge retired rows to `published=false`. Both are
right. Neither takes the product off the **price list**.

`seedAllData` appended the Sandbox tiers unconditionally:

```go
seedPlans = append(seedPlans, expectedSandboxPlans()...)
```

That runs on **every fresh Sovereign** and creates three priced SKUs:

| slug | price | flags |
|---|---|---|
| `sandbox-free` | 0 OMR | |
| `sandbox-pro` | **9 OMR** | `Popular: true` |
| `sandbox-ent` | **49 OMR** | |

all carrying `ProductSlug: "sandbox"`, all served by the **public**
`GET /catalog/plans` (routed `Public: true` in `core/services/gateway`), and
returned unfiltered when no `?product=` is supplied.

## The asymmetry is the tell

The sibling path was already closed. `seedMissingSandboxPlans` — which re-creates
missing tiers on an **existing** Sovereign — carries this guard and this comment:

```go
// Sandbox is retired (#5920). This routine ran on EVERY seed pass and
// re-created any sandbox-* tier that was missing, so taking the product off
// sale while leaving this active would have quietly restored its priced
// tiers on the next catalyst-api start. Retiring the product retires its
// price list with it.
if _, retired := RetiredAppSlugs()["sandbox"]; retired {
    return
}
```

The rule was already written down. It was applied to the migration path and not
to the fresh-seed path, so existing Sovereigns stopped regrowing the tiers while
every newly provisioned one was still seeded with them.

This is why a card-level sweep comes back clean: **the price list is a different
producer from the card.** A retired product with a live price list is the same
defect the issue names, one layer down.

## The change

One guard on the same switch, so a single edit governs both paths:

```go
if _, retired := RetiredAppSlugs()["sandbox"]; !retired {
    plans = append(plans, expectedSandboxPlans()...)
}
```

Plus `seedPlanRows()` extracted out of `seedAllData` — mirroring the
`seedAppRows()` pattern this file already uses for apps — so the assertion can
read what a fresh Sovereign would actually be sold without standing up a store.
That part is a pure move; the diff shows the literal unchanged.

`expectedSandboxPlans()` is deliberately kept. It is the single definition both
paths consult, and `RetiredAppSlugs` is the only switch; un-retiring the product
would restore both call sites without a second edit.

## Delist vs remove, and the blast radius

**Delist. Not remove.** Same conclusion as #5978, different reason — and #5978's
stated reason no longer holds, which is worth recording:

> "Bootstrap-kit slot 19a still auto-installs the sandbox controller on every
> Sovereign"

That is stale. Slot 19a was **retired 2026-07-15** (#5114); there is no `19a`
file in `clusters/_template/bootstrap-kit/`, and `kustomization.yaml` carries an
explicit tombstone plus a note on `13d-bp-openova-mcp.yaml` that openova-mcp
"REPLACES the retired Sandbox slot 19a".

The reason to keep the Blueprint is narrower and still real: existing `Sandbox`
CRs on already-provisioned Sovereigns must keep resolving against a Blueprint,
and the Agenity workspace UI is still built on the internal Sandbox plumbing
(`SandboxSettings.tsx`, `SandboxProvisioningPanel.tsx`, and the `/sandbox` route
id behind the `Agenity` label). Deleting the Blueprint strands those.

**Blast radius of this PR specifically: fresh Sovereigns only.** It changes what
a new Sovereign is seeded with. It does not delete existing `Plan` rows, so an
Organization mid-checkout against a `sandbox-*` plan_id is unaffected, and no
migration is required for this change to be safe. Taking the tiers off Sovereigns
that already have them is a separate, riskier decision and is **not** in this PR.

**What a card-level fix cannot reach, and what remains open.** These are still
live and out of this PR's scope — filed here rather than fixed, because several
are product calls rather than cleanup:

- `org_commerce.go:60,72` — the sovereign-admin commerce proxy applies **no**
  product filter, so the console's plan table renders the retired tiers. (The
  customer storefront does filter: `?product=generic` plus a client-side
  `!p.product_slug` drop.)
- `core/marketplace/src/lib/cart.ts:64` (`SANDBOX_AGENTS`),
  `components/AppDetail.svelte:39,267` ("Pick your agents"),
  `lib/api.ts:530` (logo map) — live rendering and cart code for a product with
  no row. Inert today only because the App row is gone.
- `platform/newapi/blueprint.yaml:45-50` — a **listed** Blueprint whose operator-
  visible `contextSchema` copy markets `bp-sandbox` by chart name.
- `catalog-seed/blueprints.yaml:5693` — the `bp-rtz-vcluster` card summary sells
  "Sandbox sessions"; also a seed↔source drift, since the source blueprint has no
  such string.

Deciding which of these are copy fixes and which are product decisions is not
something this PR should settle unilaterally.

## Red, then green

Reverting only the guard to the pre-fix unconditional append:

```
--- FAIL: TestRetiredProductHasNoPlanTiersOnAFreshSovereign
    seedPlanRows still seeds plan "sandbox-free" at 0 OMR for retired product "sandbox" (retired 2026-06-30 by founder decision; superseded by products/agenity (the per-Org Agenity workspace) and products/openova-mcp) — a fresh Sovereign would create the tier and GET /catalog/plans would serve it
    seedPlanRows still seeds plan "sandbox-pro" at 9 OMR for retired product "sandbox" ...
    seedPlanRows still seeds plan "sandbox-ent" at 49 OMR for retired product "sandbox" ...
--- FAIL: TestRetiredPlanExclusionIsNotVacuous
    plan "sandbox-free" is in expectedSandboxPlans AND in the fresh seed — the retirement guard did not fire
    plan "sandbox-pro" is in expectedSandboxPlans AND in the fresh seed — the retirement guard did not fire
    plan "sandbox-ent" is in expectedSandboxPlans AND in the fresh seed — the retirement guard did not fire
--- FAIL: TestLiveComputeTiersAreStillSeeded
    Popular tiers = [m sandbox-pro], want exactly [m] — the plan picker's default selection is broken (sandbox-pro also carried Popular=true)
FAIL
```

With the guard:

```
--- PASS: TestRetiredAppSlugsIsNotEmpty
--- PASS: TestRetiredProductIsNotSeededIntoTheCatalog
--- PASS: TestRetiredProductHasNoPlanTiersOnAFreshSovereign
--- PASS: TestRetiredPlanExclusionIsNotVacuous
--- PASS: TestLiveComputeTiersAreStillSeeded
--- PASS: TestRetiredProductIsNotDeployable
--- PASS: TestPublishMigrationUnpublishesRetiredProducts
--- PASS: TestLiveProductsStayPublishedByDefault
ok  github.com/openova-io/openova/core/services/catalog/handlers
```

The red run surfaced something the issue did not mention: `sandbox-pro` carried
`Popular: true` alongside tier `m`, so the retired product was competing to be
the plan picker's **default selection**, not merely present in the list.

**CONTROL — `TestLiveComputeTiersAreStillSeeded`.** Shares the suspect property:
same function, same slice, same seeding path, differing only in not being
retired. `return nil` from `seedPlanRows` would satisfy both red tests above and
leave a Sovereign with **no price list at all**, breaking checkout for every
product. The control asserts the s/m/l/xl/flexi ladder survives and reads a
**value** (`m == 9 OMR`, exactly one `Popular`), not key presence — an empty
zeroed ladder still has the keys.

**VACUITY CHECK — `TestRetiredPlanExclusionIsNotVacuous`.** If
`expectedSandboxPlans()` ever returned empty, or stopped setting `ProductSlug`,
filtering it out would be a no-op and the main test would pass by examining
nothing. This proves the excluded set has teeth: non-empty, priced, and carrying
the exact `ProductSlug` the filter keys on — then asserts every excluded slug is
actually absent from the seed. The file's existing
`TestRetiredAppSlugsIsNotEmpty` covers the same class for the retired set itself.

## Not covered

No live evidence — hw294 is wedged at 51/67 on #6172, so nothing here was walked
on a Sovereign. Source-and-test only; confirming a fresh prov comes up with no
`sandbox-*` rows on `GET /catalog/plans` needs a prov.

`expected-unpublished-catalog-seed-pins.yaml` is untouched and must stay that
way here: it waives only the "pinned version exists on GHCR" assertion, requires
permanent GHCR absence, and `bp-sandbox` **is** published (as package `sandbox`,
`0.3.12`) — registering it there would be a false waiver. The Sandbox absence is
already correctly declared in the sibling `expected-unseeded-blueprints.yaml`.

No chart files are touched, so the eight-site chart-version lockstep does not
apply to this PR.

Refs #5920
