### PR TITLE
fix(api): per-Org app hosts resolve to a gateway that has no listener for them (UAT 90/234)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/organization_dns.go
+++ b/products/catalyst/bootstrap/api/internal/handler/organization_dns.go
@@ -161,16 +161,46 @@ type Resolver interface {
 // parentZone is operator-supplied (one of the Sovereign's
 // role:org-pool entries) — never inferred from a hardcoded OTECHFQDN.
 //
-// #4732(3): the `console` record and the app records target DIFFERENT
-// front doors. App hosts (wordpress/openclaw/mail/keycloak + the per-Org
-// wildcard) ride the SHARED gateway (ingressIPv4). The Org console rides
-// the DEDICATED console gateway/ELB (#4053/#4718) — the same door
-// `console.<sovereign-fqdn>` serves — so its record must carry
-// consoleIPv4. Writing the console record with the shared-gateway IP is
-// exactly the nstar failure: the shared gateway has no console listener
-// for the Org zone, so the browser got the pool `*.<parent>` cert + 404.
-// consoleIPv4 == "" falls back to ingressIPv4 (single-gateway Sovereigns
-// and older callers keep their prior behaviour).
+// #4732(3): the Org console rides the DEDICATED console gateway/ELB
+// (#4053/#4718) — the same door `console.<sovereign-fqdn>` serves — so its
+// record must carry consoleIPv4. Writing the console record with the
+// shared-gateway IP is exactly the nstar failure: the shared gateway has no
+// console listener for the Org zone, so the browser got the pool
+// `*.<parent>` cert + 404.
+//
+// UAT rows 90 + 234 — EVERY host in the Org's pool subtree rides that same
+// door, not just `console`. This block previously read "App hosts
+// (wordpress/openclaw/mail/keycloak + the per-Org wildcard) ride the SHARED
+// gateway (ingressIPv4)", and that premise is false on this platform:
+//
+//   - The ONLY writer of a per-Org wildcard listener is
+//     core/controllers/organization/internal/controller/tenant_console_tls.go:307,
+//     which builds WildcardHost = "*.<slug>.<parentDomain>" and appends the
+//     `console-https-<slug>` / `console-http-<slug>` pair to
+//     consoleGatewayName() — `cilium-gateway-console`. Nothing appends a
+//     per-Org listener to the shared gateway, and the matching wildcard
+//     Certificate is mounted only there. An app host resolving to the shared
+//     gateway therefore arrives with an SNI that gateway holds no listener
+//     for, and the connection is RESET at the TLS handshake — before any HTTP
+//     status, which is why it presents as a dead site rather than a 404.
+//
+//   - The org-controller already writes the SAME `*` record at
+//     core/controllers/organization/internal/controller/tenant_dns.go:182-192
+//     and targets consoleIP. Two writers emitting one RRset with different
+//     targets is an inconsistency on its face. Because that reconciler
+//     re-asserts `*` but never touches the four app prefixes, the app records
+//     stayed orphaned at the shared IP — and being EXPLICIT records they then
+//     shadow the corrected wildcard, so the fault survived reconciliation.
+//
+// Measured read-only on hw293 Org `g7freea`: mail/wordpress resolved to the
+// shared EIP and failed with curl exit 35 (TLS reset), while forcing the same
+// SNI onto the console EIP returned 503 behind a publicly-trusted cert —
+// listener, cert and route all present on the console gateway. 503 (route
+// matched, no upstream) versus exit 35 (no listener) is what separates
+// "wrong front door" from "broken app".
+//
+// consoleIPv4 == "" falls back to ingressIPv4 (single-gateway Sovereigns and
+// older callers keep their prior behaviour).
 func (p DefaultOrganizationDNSProvisioner) ProvisionFreeSubdomain(ctx context.Context, subdomain, parentZone, ingressIPv4, consoleIPv4 string) error {
 	// #4218: pool-domain console A-records (omani.*) live on the CENTRAL
 	// authoritative PowerDNS (pdns.openova.io), not the Sovereign-local
@@ -212,10 +242,12 @@ func (p DefaultOrganizationDNSProvisioner) ProvisionFreeSubdomain(ctx context.Co
 	}
 	for _, prefix := range theFreeSubdomainPrefixes {
 		fqdn := fmt.Sprintf("%s.%s.%s.", prefix, subdomain, parentZone)
-		content := ingressIPv4
-		if prefix == "console" {
-			content = consoleIP
-		}
+		// Every prefix in this Org's subtree — the wildcard and the app hosts
+		// as much as `console` — is served by the console gateway, because
+		// that is the only gateway carrying a `*.<slug>.<parent>` listener and
+		// cert (see the rationale above). consoleIP already collapses to
+		// ingressIPv4 on a single-gateway Sovereign.
+		content := consoleIP
 		rrsets = append(rrsets, pdnsRRSet{
 			Name:       fqdn,
 			Type:       "A",

--- a/products/catalyst/bootstrap/api/internal/handler/organization_dns_console_gateway_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/organization_dns_console_gateway_test.go
@@ -1,0 +1,207 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// UAT rows 90 + 234 — the per-Org app A-records point at the WRONG front door.
+//
+// ProvisionFreeSubdomain writes six A-records for an Org's pool subtree. Five of
+// them (`*`, `wordpress`, `openclaw`, `mail`, `keycloak`) were written at
+// ingressIPv4 -- the SHARED gateway -- and only `console` at consoleIPv4.
+//
+// The premise for that split is stated at organization_dns.go:164-167:
+//
+//	"App hosts (wordpress/openclaw/mail/keycloak + the per-Org wildcard) ride
+//	 the SHARED gateway (ingressIPv4)."
+//
+// That premise is false on this platform, and two independent facts show it:
+//
+//  1. The ONLY writer of a per-Org wildcard listener is
+//     core/controllers/organization/internal/controller/tenant_console_tls.go:307,
+//     which builds WildcardHost = "*.<slug>.<parent>" and appends the
+//     `console-https-<slug>` / `console-http-<slug>` listener pair to
+//     consoleGatewayName() -- `cilium-gateway-console`. Nothing appends a
+//     per-Org listener to the shared gateway, and the matching wildcard cert
+//     (same file, the SAN block) is mounted only there. So an app host that
+//     resolves to the shared gateway arrives with an SNI that gateway holds no
+//     listener for, and the TLS connection is RESET before any HTTP status.
+//
+//  2. The platform already contains a SECOND writer of the very same `*`
+//     record -- the org-controller at
+//     core/controllers/organization/internal/controller/tenant_dns.go:182-192 --
+//     and it writes BOTH `console` and `*` at consoleIP. Two writers emitting
+//     the same RRset with different targets is an inconsistency on its face,
+//     independent of which one reads better. The reconciler re-asserts, so `*`
+//     converges to the console IP while the four app prefixes -- which the
+//     reconciler never touches -- stay orphaned at the shared IP. Being
+//     EXPLICIT records they then shadow the corrected wildcard, which is why
+//     the fault survives reconciliation.
+//
+// Live corroboration on hw293 (dep a0077ba47e3720e5), Org `g7freea`, captured
+// read-only shortly before that env was wiped:
+//
+//	mail.g7freea.omani.homes       -> 212.72.24.74 (shared)  curl exit 35, TLS reset
+//	wordpress.g7freea.omani.homes  -> 212.72.24.74 (shared)  curl exit 35, TLS reset
+//	console.g7freea.omani.homes    -> 212.72.24.49 (console) HTTP 200, ssl_verify 0
+//
+// and the discriminating experiment -- forcing the SAME SNI onto the console
+// EIP -- returns 503 with a publicly-trusted cert, i.e. the listener, the
+// wildcard cert and the HTTPRoute are all present and correct on the console
+// gateway:
+//
+//	curl --resolve mail.g7freea.omani.homes:443:212.72.24.49  -> 503, ssl_verify 0
+//
+// 503 (route matched, no healthy upstream) versus exit 35 (no listener for this
+// SNI) is what separates "wrong front door" from "broken app".
+func TestProvisionFreeSubdomain_AppHostsTargetConsoleGateway_UAT90_234(t *testing.T) {
+	const (
+		ingressIP = "203.0.113.74" // shared gateway
+		consoleIP = "203.0.113.49" // console gateway — where the listener lives
+	)
+
+	captured, srv := captureRRSets(t)
+	defer srv.Close()
+
+	p := DefaultOrganizationDNSProvisioner{
+		PoolWriter: &PowerDNSWriter{
+			BaseURL:    srv.URL,
+			ServerID:   "localhost",
+			APIKey:     "test-key",
+			HTTPClient: srv.Client(),
+		},
+	}
+
+	if err := p.ProvisionFreeSubdomain(context.Background(), "g7freea", "omani.homes", ingressIP, consoleIP); err != nil {
+		t.Fatalf("ProvisionFreeSubdomain: %v", err)
+	}
+
+	got := *captured
+
+	// VACUITY CHECK — the writer really emitted the full prefix set. Without
+	// this, an empty capture would make every assertion below pass on nothing.
+	if len(got) != len(theFreeSubdomainPrefixes) {
+		t.Fatalf("vacuity: expected %d RRsets (one per prefix), got %d: %+v",
+			len(theFreeSubdomainPrefixes), len(theFreeSubdomainPrefixes), got)
+	}
+
+	// Every host in the per-Org pool subtree must land on the console gateway,
+	// because that is the only gateway carrying a listener + cert for
+	// `*.<slug>.<parent>`.
+	for _, rr := range got {
+		if len(rr.Records) != 1 {
+			t.Fatalf("%s: expected exactly 1 record, got %d", rr.Name, len(rr.Records))
+		}
+		if content := rr.Records[0].Content; content != consoleIP {
+			t.Errorf("%s targets %s (the SHARED gateway); the only per-Org listener for *.g7freea.omani.homes is on the CONSOLE gateway (%s), so this host resets at the TLS handshake",
+				rr.Name, content, consoleIP)
+		}
+	}
+}
+
+// CONTROL 1 — shares the suspect property (same function, same prefix loop) but
+// must stay GREEN both before and after. A single-gateway Sovereign passes
+// consoleIPv4 == "" and every record must fall back to the ingress IP. A fix
+// that hardcoded the console IP, or that dropped the fallback, would turn this
+// red.
+func TestProvisionFreeSubdomain_SingleGatewaySovereignStillFallsBack(t *testing.T) {
+	const ingressIP = "203.0.113.74"
+
+	captured, srv := captureRRSets(t)
+	defer srv.Close()
+
+	p := DefaultOrganizationDNSProvisioner{
+		PoolWriter: &PowerDNSWriter{
+			BaseURL: srv.URL, ServerID: "localhost", APIKey: "test-key", HTTPClient: srv.Client(),
+		},
+	}
+
+	if err := p.ProvisionFreeSubdomain(context.Background(), "solo", "omani.rest", ingressIP, ""); err != nil {
+		t.Fatalf("ProvisionFreeSubdomain: %v", err)
+	}
+
+	got := *captured
+	if len(got) != len(theFreeSubdomainPrefixes) {
+		t.Fatalf("vacuity: expected %d RRsets, got %d", len(theFreeSubdomainPrefixes), len(got))
+	}
+	for _, rr := range got {
+		if content := rr.Records[0].Content; content != ingressIP {
+			t.Errorf("%s: single-gateway Sovereign must fall back to the ingress IP %s, got %s", rr.Name, ingressIP, content)
+		}
+	}
+}
+
+// CONTROL 2 — the #4459 write/delete-drift guard. Both paths must keep walking
+// the SAME prefix list, so a fix to the write path cannot silently orphan
+// records on delete (write N, delete <N: the surplus survives the Org and
+// shadows a re-prov's wildcard with a dead IP).
+func TestProvisionAndDeprovision_WalkTheSamePrefixSet(t *testing.T) {
+	const ingressIP = "203.0.113.74"
+	const consoleIP = "203.0.113.49"
+
+	provisioned, srv1 := captureRRSets(t)
+	defer srv1.Close()
+	p1 := DefaultOrganizationDNSProvisioner{PoolWriter: &PowerDNSWriter{
+		BaseURL: srv1.URL, ServerID: "localhost", APIKey: "k", HTTPClient: srv1.Client(),
+	}}
+	if err := p1.ProvisionFreeSubdomain(context.Background(), "drift", "omani.trade", ingressIP, consoleIP); err != nil {
+		t.Fatalf("provision: %v", err)
+	}
+
+	deprovisioned, srv2 := captureRRSets(t)
+	defer srv2.Close()
+	p2 := DefaultOrganizationDNSProvisioner{PoolWriter: &PowerDNSWriter{
+		BaseURL: srv2.URL, ServerID: "localhost", APIKey: "k", HTTPClient: srv2.Client(),
+	}}
+	if err := p2.DeprovisionFreeSubdomain(context.Background(), "drift", "omani.trade"); err != nil {
+		t.Fatalf("deprovision: %v", err)
+	}
+
+	names := func(rrs []pdnsRRSet) map[string]bool {
+		m := map[string]bool{}
+		for _, r := range rrs {
+			m[r.Name] = true
+		}
+		return m
+	}
+	pn, dn := names(*provisioned), names(*deprovisioned)
+	if len(pn) == 0 {
+		t.Fatal("vacuity: provision emitted no RRsets")
+	}
+	for n := range pn {
+		if !dn[n] {
+			t.Errorf("#4459 drift: provision writes %s but deprovision never deletes it", n)
+		}
+	}
+}
+
+// captureRRSets stands up a PowerDNS-shaped test server that records the RRsets
+// of the last PATCH it received.
+func captureRRSets(t *testing.T) (*[]pdnsRRSet, *httptest.Server) {
+	t.Helper()
+	captured := &[]pdnsRRSet{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read body: %v", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		var payload struct {
+			RRSets []pdnsRRSet `json:"rrsets"`
+		}
+		if err := json.Unmarshal(body, &payload); err != nil {
+			t.Errorf("unmarshal %q: %v", string(body), err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		*captured = payload.RRSets
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	return captured, srv
+}

--- a/products/catalyst/bootstrap/api/internal/handler/organization_provisioning_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/organization_provisioning_test.go
@@ -1889,10 +1889,30 @@ func TestDeleteOrganization_DeprovisionsDNS(t *testing.T) {
 
 // TestProvisionFreeSubdomain_ConsoleTargetsConsoleIPv4 locks #4732 item 3:
 // the `console.<slug>.<parent>` record must target the DEDICATED console
-// gateway/ELB EIP (consoleIPv4) while the per-Org wildcard + app hosts stay
-// on the shared-gateway ingress IP. Writing the console record with the
-// shared IP is the nstar failure (pool-wildcard cert + 404 — the shared
-// gateway has no console listener for the Org zone).
+// gateway/ELB EIP (consoleIPv4). Writing the console record with the shared IP
+// is the nstar failure (pool-wildcard cert + 404 — the shared gateway has no
+// console listener for the Org zone).
+//
+// UAT rows 90 + 234 — the app-host half of this test was INVERTED and is
+// corrected here. It previously required `*`, `wordpress` and `keycloak` to
+// stay on the shared-gateway ingress IP, which pinned the very defect those
+// rows record. The premise it encoded ("app hosts ride the shared gateway")
+// does not hold on this platform:
+//
+//   - The ONLY writer of a per-Org wildcard listener is
+//     core/controllers/organization/internal/controller/tenant_console_tls.go:307,
+//     which appends `console-https-<slug>` / `console-http-<slug>` for
+//     `*.<slug>.<parent>` to the CONSOLE gateway. Nothing appends a per-Org
+//     listener to the shared gateway, and the wildcard cert is mounted only
+//     there — so an app host pointed at the shared gateway is reset at the TLS
+//     handshake, before any HTTP status.
+//   - The org-controller writes the SAME `*` record at
+//     core/controllers/organization/internal/controller/tenant_dns.go:182-192
+//     and targets consoleIP. Two writers disagreeing on one RRset is the
+//     defect; this test was holding the losing side.
+//
+// The console assertion below is unchanged — #4732 item 3 is still correct and
+// is what the shared expectation now extends to the rest of the subtree.
 func TestProvisionFreeSubdomain_ConsoleTargetsConsoleIPv4(t *testing.T) {
 	var gotBody string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1928,8 +1948,8 @@ func TestProvisionFreeSubdomain_ConsoleTargetsConsoleIPv4(t *testing.T) {
 		t.Errorf("console record = %q, want console ELB EIP 212.72.24.33", got)
 	}
 	for _, appHost := range []string{"*.nstar.omani.homes.", "wordpress.nstar.omani.homes.", "keycloak.nstar.omani.homes."} {
-		if got := byName[appHost]; got != "212.72.24.14" {
-			t.Errorf("%s = %q, want shared ingress 212.72.24.14", appHost, got)
+		if got := byName[appHost]; got != "212.72.24.33" {
+			t.Errorf("%s = %q, want console gateway EIP 212.72.24.33 — the only gateway carrying a *.nstar.omani.homes listener + cert; the shared ingress 212.72.24.14 resets these SNIs at the TLS handshake", appHost, got)
 		}
 	}
 }


### PR DESCRIPTION
## Problem

UAT rows **90** and **234** have been red for the entire two-day window. They share **one** root cause, and it is a DNS record pointing at the wrong front door.

`ProvisionFreeSubdomain` writes six A-records for an Org's pool subtree. Five of them — `*`, `wordpress`, `openclaw`, `mail`, `keycloak` — targeted the **shared** gateway; only `console` targeted the console gateway.

The premise for that split is stated in the code at `organization_dns.go:164-167`:

> "App hosts (wordpress/openclaw/mail/keycloak + the per-Org wildcard) ride the SHARED gateway (ingressIPv4)."

That premise does not hold on this platform. Two independent facts show it:

1. **The only writer of a per-Org wildcard listener is the console gateway.** `core/controllers/organization/internal/controller/tenant_console_tls.go:307` builds `WildcardHost = "*.<slug>.<parent>"` and appends the `console-https-<slug>` / `console-http-<slug>` pair to `consoleGatewayName()` — `cilium-gateway-console`. Nothing appends a per-Org listener to the shared gateway, and the matching wildcard `Certificate` is mounted only there. An app host resolving to the shared gateway therefore arrives with an SNI that gateway holds no listener for, and the connection is **reset at the TLS handshake** — before any HTTP status, which is why it presents as a dead site rather than a 404.

2. **The platform already contains a second writer of the same `*` record, and it disagrees.** `core/controllers/organization/internal/controller/tenant_dns.go:182-192` writes both `console` and `*` at `consoleIP`. Two writers emitting one RRset with different targets is an inconsistency on its face, independent of which reads better.

Fact 2 also explains the *shape* of the failure. That reconciler re-asserts `*` but never touches the four app prefixes, so those stayed orphaned at the shared IP — and being **explicit** records they then shadow the corrected wildcard. The fault survives reconciliation, which is why this presents as a partial, per-host failure rather than a clean outage.

**Row 234 is the same defect on the `mail` prefix.** That is why its webmail was unreachable even in the window when `bp-stalwart-tenant` was Running and its HTTPRoute existed — the row was parked as ENV-STATE, but a mail-bearing Org would have failed on this regardless.

### Live evidence

Measured read-only on hw293 (dep `a0077ba47e3720e5`), Org `g7freea`, shortly before that environment was wiped:

```
mail.g7freea.omani.homes       -> 212.72.24.74 (shared)   curl exit 35, TLS reset
wordpress.g7freea.omani.homes  -> 212.72.24.74 (shared)   curl exit 35, TLS reset
console.g7freea.omani.homes    -> 212.72.24.49 (console)  HTTP 200, ssl_verify 0
```

The discriminating experiment — forcing the **same SNI** onto the console EIP:

```
curl --resolve mail.g7freea.omani.homes:443:212.72.24.49  ->  503, ssl_verify 0
```

`503` (route matched, no healthy upstream) versus `exit 35` (no listener for this SNI) is what separates *wrong front door* from *broken app*. Listener, wildcard cert and HTTPRoute are all present and correct on the console gateway.

## Remediation

Every prefix in the Org's pool subtree targets `consoleIP`. `consoleIP` already collapses to `ingressIPv4` when `consoleIPv4` is empty, so single-gateway Sovereigns are unaffected.

The false premise in the comment block is replaced with the evidence above, so the next reader does not re-derive the same wrong conclusion.

## Expected

A purchased app and a provisioned mailbox serve at their own FQDN on every attempt, instead of resetting on the fraction of visits that resolve to the shared gateway.

## Tests — red before, green after, two controls and a vacuity check

`organization_dns_console_gateway_test.go`, driven through a PowerDNS-shaped `httptest` server so the real serialization path is exercised.

RED:

```
*.g7freea.omani.homes. targets 203.0.113.74 (the SHARED gateway); the only per-Org
  listener for *.g7freea.omani.homes is on the CONSOLE gateway (203.0.113.49), so
  this host resets at the TLS handshake
wordpress.g7freea.omani.homes. targets 203.0.113.74 ...
openclaw.g7freea.omani.homes.  targets 203.0.113.74 ...
mail.g7freea.omani.homes.      targets 203.0.113.74 ...
keycloak.g7freea.omani.homes.  targets 203.0.113.74 ...
--- FAIL: TestProvisionFreeSubdomain_AppHostsTargetConsoleGateway_UAT90_234
--- PASS: TestProvisionFreeSubdomain_SingleGatewaySovereignStillFallsBack
--- PASS: TestProvisionAndDeprovision_WalkTheSamePrefixSet
```

GREEN:

```
--- PASS: TestProvisionFreeSubdomain_AppHostsTargetConsoleGateway_UAT90_234
--- PASS: TestProvisionFreeSubdomain_SingleGatewaySovereignStillFallsBack
--- PASS: TestProvisionAndDeprovision_WalkTheSamePrefixSet
ok  .../internal/handler  0.097s
```

- **CONTROL 1** (green before *and* after) — a single-gateway Sovereign passes `consoleIPv4 == ""` and every record must still fall back to the ingress IP. A fix that hardcoded the console IP, or dropped the fallback, turns this red.
- **CONTROL 2** (green before *and* after) — the #4459 write/delete-drift guard: both paths keep walking the same prefix list, so this change cannot orphan records on delete.
- **VACUITY CHECK** — each case asserts the writer emitted one RRset per prefix, so no assertion can pass on an empty capture.

## An existing test pinned the losing side

`TestProvisionFreeSubdomain_ConsoleTargetsConsoleIPv4` required `*`, `wordpress` and `keycloak` to stay on the shared ingress — it was holding the defect in place. It is **corrected, not worked around**, with the rationale recorded at the test.

Its console assertion is **unchanged**: #4732 item 3 is still right, and this change extends that same reasoning to the rest of the subtree rather than contradicting it.

## Gates

- Full `internal/handler` package green (295s), `go build ./...` and `go vet` clean.

Refs #5635 #5359 #4307 #3376
