### PR TITLE
fix(catalyst-api): canonicalise placement mode before deciding role — active-hot-standby rendered TWO primaries

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/applications_preview.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications_preview.go
@@ -330,7 +330,7 @@ func (h *Handler) HandleApplicationPreview(w http.ResponseWriter, r *http.Reques
 	warnings := []string{}
 
 	for i, region := range body.Placement.Regions {
-		standby := body.Placement.Mode == "active-hotstandby" && i > 0
+		standby := canonicalizeTopology(body.Placement.Mode) == "active-hot-standby" && i > 0
 		role := previewRoleForPlacement(body.Placement.Mode, i)
 		in := render.Inputs{
 			AppName:          appName,
@@ -445,7 +445,7 @@ func (h *Handler) renderApplicationPreview(
 	warnings := []string{}
 
 	for i, region := range body.Placement.Regions {
-		standby := body.Placement.Mode == "active-hotstandby" && i > 0
+		standby := canonicalizeTopology(body.Placement.Mode) == "active-hot-standby" && i > 0
 		role := previewRoleForPlacement(body.Placement.Mode, i)
 		in := render.Inputs{
 			AppName:          appName,
@@ -595,10 +595,20 @@ func environmentTypeFromName(env string) string {
 // label. Mirrors the application-controller's reconcile contract so
 // preview labels match production labels.
 func previewRoleForPlacement(mode string, idx int) string {
-	switch mode {
+	// #6200 — canonicalise BEFORE comparing. This switch used to test the
+	// raw string against the LEGACY spelling "active-hotstandby" only, so
+	// the CANONICAL "active-hot-standby" — the spelling the validator
+	// advertises, the console sends, and 112 of the repo's 141 literals
+	// use — fell through to the default and returned "primary" for EVERY
+	// region. An active-hot-standby preview therefore rendered TWO
+	// primaries and no standby, silently: no error, no warning, just the
+	// wrong manifests. canonicalizeTopology, in this same package, is the documented
+	// alias mapping (it agrees with core placement.Canonicalize under the
+	// drift test); the bug was simply not using it.
+	switch canonicalizeTopology(mode) {
 	case "active-active":
 		return "active"
-	case "active-hotstandby":
+	case "active-hot-standby":
 		if idx == 0 {
 			return "primary"
 		}

--- a/products/catalyst/bootstrap/api/internal/handler/applications_preview_placement_role_6200_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications_preview_placement_role_6200_test.go
@@ -1,0 +1,74 @@
+// applications_preview_placement_role_6200_test.go — #6200.
+//
+// WHAT BROKE
+// ----------
+// `previewRoleForPlacement` and the two `standby :=` sites in
+// applications_preview.go compared the RAW placement mode against the LEGACY
+// spelling "active-hotstandby" only. The CANONICAL spelling is
+// "active-hot-standby" — it is what validPlacementMode advertises in its own
+// error text, what the console sends, and what 112 of the repo's 141 mode
+// literals use. Sent canonically, the switch fell through to `return
+// "primary"` and the standby flag stayed false, so an active-hot-standby
+// preview rendered EVERY region as primary.
+//
+// The failure mode is the dangerous kind: HTTP 200, no error, no warning, and
+// two `catalyst.openova.io/placement-role: primary` manifests where one should
+// have been the hot standby. Measured live on hw295 walking UAT row 60 — the
+// preview for {mode: active-hot-standby, regions:[me-east-215-a,
+// me-east-215-b]} returned role=primary for BOTH regions.
+//
+// WHY A TEST AND NOT JUST THE FIX
+// -------------------------------
+// The alias mapping already existed (canonicalizeTopology, same package, and
+// core placement.Canonicalize behind the drift test). Nothing failed when the
+// call sites bypassed it, because every existing test that exercised a standby
+// happened to pass the legacy spelling. This test pins the CANONICAL spelling
+// specifically, so re-introducing a raw comparison fails here.
+package handler
+
+import "testing"
+
+// The canonical spelling MUST yield primary/standby. This is the case that was
+// broken; asserting only the legacy spelling would pass on the buggy code.
+func TestPreviewRoleForPlacement_CanonicalHotStandby_6200(t *testing.T) {
+	if got := previewRoleForPlacement("active-hot-standby", 0); got != "primary" {
+		t.Fatalf("canonical active-hot-standby idx0: got %q, want primary", got)
+	}
+	if got := previewRoleForPlacement("active-hot-standby", 1); got != "standby" {
+		t.Fatalf("canonical active-hot-standby idx1: got %q, want standby — "+
+			"this is #6200: the raw comparison matched only the legacy "+
+			"spelling, so every region rendered primary", got)
+	}
+}
+
+// The legacy spelling must keep working — the fix canonicalises rather than
+// swapping one hard-coded literal for another.
+func TestPreviewRoleForPlacement_LegacyHotStandby_StillWorks_6200(t *testing.T) {
+	if got := previewRoleForPlacement("active-hotstandby", 1); got != "standby" {
+		t.Fatalf("legacy active-hotstandby idx1: got %q, want standby", got)
+	}
+	if got := previewRoleForPlacement("ACTIVE_HOT_STANDBY", 1); got != "standby" {
+		t.Fatalf("underscore/upper alias idx1: got %q, want standby", got)
+	}
+}
+
+// CONTROL — the exclusion must not leak. Modes that are NOT hot-standby keep
+// their own roles, or an over-broad canonicalisation would pass the two tests
+// above while silently mislabelling everything else.
+func TestPreviewRoleForPlacement_OtherModesUnaffected_6200(t *testing.T) {
+	for _, tc := range []struct{ mode, want0, want1 string }{
+		{"active-active", "active", "active"},
+		{"singleton", "primary", "primary"},
+		{"single-region", "primary", "primary"},
+		{"active-passive", "primary", "primary"},
+		{"", "primary", "primary"},
+		{"nonsense-mode", "primary", "primary"},
+	} {
+		if got := previewRoleForPlacement(tc.mode, 0); got != tc.want0 {
+			t.Errorf("mode %q idx0: got %q, want %q", tc.mode, got, tc.want0)
+		}
+		if got := previewRoleForPlacement(tc.mode, 1); got != tc.want1 {
+			t.Errorf("mode %q idx1: got %q, want %q", tc.mode, got, tc.want1)
+		}
+	}
+}


### PR DESCRIPTION
## What this fixes

An `active-hot-standby` placement preview renders **both** regions as
`placement-role: primary`. No standby, no error, no warning — HTTP 200 and the
wrong manifests.

Found walking UAT row 60 on hw295 (dep `952c564cab38d320`) with an authenticated
owner session. Detail and the live payload are on #6200.

## Root cause

Three sites compared the **raw** mode against the **legacy** spelling:

```go
// previewRoleForPlacement
case "active-hotstandby":            // ← legacy only; canonical falls through
...
standby := body.Placement.Mode == "active-hotstandby" && i > 0   // ×2
```

The canonical token is `active-hot-standby` — what `validPlacementMode` accepts
and names in its own error text, what the console sends, and what **112 of the
repo's 141** mode literals use (29 are legacy). Sent canonically, the switch
falls through to `return "primary"` and `standby` stays false.

The alias mapping already existed and was not used: `canonicalizeTopology` in
this same package, which core `placement.Canonicalize` agrees with under an
existing drift test.

## The change

Call `canonicalizeTopology(mode)` at all three sites. That is the whole fix.

I first reached for `core/controllers/internal/placement` — it is
import-restricted by Go's `internal/` rule and will not compile from the api
module. `canonicalizeTopology` is the in-package equivalent and is what the
drift test already pins.

## Test — `applications_preview_placement_role_6200_test.go`

Pins the **canonical** spelling specifically, because that is the case that was
broken; a test asserting only the legacy spelling passes on the buggy code.
Keeps legacy / underscore / uppercase aliases working. A **CONTROL** asserts
`active-active`, `singleton`, `single-region`, `active-passive`, empty and
nonsense modes keep their own roles, so an over-broad canonicalisation cannot
pass the first two assertions while mislabelling everything else.

**Vacuity-checked** — reverted the fix and confirmed the test fails with exactly
the live symptom, then restored it:

```
--- FAIL: TestPreviewRoleForPlacement_CanonicalHotStandby_6200
    canonical active-hot-standby idx1: got "primary", want standby
```

## Gates

- `go build ./...` → clean
- `go test ./internal/handler/ -count=1` → **ok, 298.557s** (full package)

## Deliberately not claimed

Only the **preview** path is fixed. The reconcile path sets `PlacementRole` from
`rp.Role` (`application_controller.go:1359`) — a different source, and I have not
proven whether it derives the role correctly for the canonical spelling. That
deserves its own check rather than an assumption, and I would rather flag it than
quietly widen this PR.

UAT row 60 stays red until this ships and the two-region pair renders with a real
standby.

Refs #6200, #3969, #3375
