### PR TITLE
fix(dr): preflight-02 can now Fail on a 2-region Sovereign — a standby outage blocks the playback

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/continuum_dr_extras.go
+++ b/products/catalyst/bootstrap/api/internal/handler/continuum_dr_extras.go
@@ -1104,7 +1104,7 @@ func (h *Handler) runDRPreflight(r *http.Request, depID string) []drRunbookPrefl
 		conts = contList.Items
 	}
 	preflightContinuumReady(&checks[0], conts, contErr)
-	preflightCNPGPairStreaming(ctx, client, &checks[1])
+	preflightCNPGPairStreaming(ctx, client, &checks[1], conts)
 	preflightWALLagUnderRTO(&checks[2], conts, contErr)
 	preflightQuorumWitnesses(ctx, client, &checks[3])
 	return checks
@@ -1163,7 +1163,7 @@ func preflightContinuumReady(check *drRunbookPreflightCheck, conts []unstructure
 // the per-region split (#5511 class — this client is scoped to region A and
 // the replica Cluster lives in region B), which is honestly UNVERIFIED, not a
 // Pass and not a Fail.
-func preflightCNPGPairStreaming(ctx context.Context, client dynamic.Interface, check *drRunbookPreflightCheck) {
+func preflightCNPGPairStreaming(ctx context.Context, client dynamic.Interface, check *drRunbookPreflightCheck, conts []unstructured.Unstructured) {
 	pairList, pairErr := client.Resource(drCNPGPairGVR()).Namespace("").List(ctx, metav1.ListOptions{})
 	if pairErr == nil && pairList != nil && len(pairList.Items) > 0 {
 		notStreaming := []string{}
@@ -1246,21 +1246,99 @@ func preflightCNPGPairStreaming(ctx context.Context, client dynamic.Interface, c
 		check.Severity = "critical"
 		check.Message = fmt.Sprintf("%d of %d cnpg pair(s) have a replica half that is present but NOT ready: %s",
 			len(down), len(names), strings.Join(down, ", "))
-	case len(unseen) == len(names):
-		check.Status = preflightWarn
-		check.Severity = "warning"
-		check.Message = fmt.Sprintf("no replica half visible from this cluster's API for %d pair(s) (%s) — a 2-region pair keeps its replica in the peer region, so streaming is unverified here",
-			len(unseen), strings.Join(unseen, ", "))
 	case len(unseen) > 0:
-		check.Status = preflightWarn
-		check.Severity = "warning"
-		check.Message = fmt.Sprintf("%d of %d cnpg pair(s) streaming; replica half not visible here for: %s",
-			len(names)-len(unseen), len(names), strings.Join(unseen, ", "))
+		// #6156 — the replica half of a 2-region pair is a Cluster in the PEER
+		// region and this handler's dynamic client is scoped to region A, so
+		// `unseen` is the permanent steady state here, not an anomaly. Warning
+		// unconditionally made this gate unable to reach Fail on any 2-region
+		// Sovereign: a genuine standby outage read exactly like a healthy one,
+		// and `classifyPreflight` only blocks a mutating playback on Fail.
+		//
+		// The continuum-controller does not share that blind spot — it probes
+		// the standby directly (pgprobe, #4901/#5311) and publishes the verdict
+		// as `status.standbyAvailable`. This is the SAME fallback
+		// augmentReplicationStandbyStatus already relies on, consulted the same
+		// way, and it is the probe that GOES FALSE during an outage. A pair
+		// whose Continuum omits the key still reports unverifiable — never a
+		// fabricated Pass.
+		probed, probedDown := continuumStandbyForPairs(conts, unseen)
+		switch {
+		case len(probedDown) > 0:
+			check.Status = preflightFail
+			check.Severity = "critical"
+			check.Message = fmt.Sprintf("the Continuum controller's standby probe reports the required hot-standby is UNAVAILABLE for %d of %d cnpg pair(s): %s — replication has no standby leg, so a mutating DR playback is unsafe",
+				len(probedDown), len(names), strings.Join(probedDown, ", "))
+		case len(probed) == len(unseen) && len(unseen) == len(names):
+			check.Status = preflightPass
+			check.Severity = "info"
+			check.Message = fmt.Sprintf("%d cnpg pair(s) reported streaming by the Continuum controller's standby probe (the replica half lives in the peer region and is not visible from this cluster's API — weaker provenance than reading the replica half directly)",
+				len(probed))
+		case len(probed) == len(unseen):
+			check.Status = preflightPass
+			check.Severity = "info"
+			check.Message = fmt.Sprintf("%d of %d cnpg pair(s) have a ready replica half here; the remaining %d (%s) are reported available by the Continuum controller's standby probe (peer-region replica, weaker provenance)",
+				len(names)-len(unseen), len(names), len(unseen), strings.Join(unseen, ", "))
+		case len(unseen) == len(names):
+			check.Status = preflightWarn
+			check.Severity = "warning"
+			check.Message = fmt.Sprintf("no replica half visible from this cluster's API for %d pair(s) (%s), and no Continuum CR carries a standbyAvailable verdict for them — a 2-region pair keeps its replica in the peer region, so streaming is unverified here",
+				len(unseen), strings.Join(unseen, ", "))
+		default:
+			check.Status = preflightWarn
+			check.Severity = "warning"
+			check.Message = fmt.Sprintf("%d of %d cnpg pair(s) streaming; replica half not visible here and no standbyAvailable verdict for: %s",
+				len(names)-len(unseen), len(names), strings.Join(unseen, ", "))
+		}
 	default:
 		check.Status = preflightPass
 		check.Severity = "info"
 		check.Message = fmt.Sprintf("%d cnpg pair(s) with a ready replica half", len(names))
 	}
+}
+
+// continuumStandbyForPairs resolves the continuum-controller's own
+// standby-probe verdict for cnpg pair names whose replica half was NOT visible
+// from this region's API (#6156).
+//
+// It reads `status.standbyAvailable` — the SAME key augmentReplicationStandbyStatus
+// falls back to, published by the controller's direct pgprobe of the standby
+// (#4901/#5311) — and matches a Continuum CR to a pair via `spec.cnpgPair.name`.
+//
+// Returns (available, unavailable). A pair is in NEITHER slice when no Continuum
+// CR names it or the CR omits the key: that is honest-unknown and must stay a
+// Warn, never a fabricated Pass. Absence of evidence is not evidence of health.
+func continuumStandbyForPairs(conts []unstructured.Unstructured, pairs []string) (available, unavailable []string) {
+	if len(pairs) == 0 || len(conts) == 0 {
+		return nil, nil
+	}
+	verdict := map[string]bool{}
+	for i := range conts {
+		name, _, _ := unstructured.NestedString(conts[i].Object, "spec", "cnpgPair", "name")
+		if name == "" {
+			continue
+		}
+		if v, found, _ := unstructured.NestedBool(conts[i].Object, "status", "standbyAvailable"); found {
+			// A false verdict from ANY CR naming the pair wins: an outage
+			// reported by one producer is not cancelled by another's silence.
+			if prev, seen := verdict[name]; !seen || prev {
+				verdict[name] = v
+			}
+		}
+	}
+	for _, p := range pairs {
+		v, found := verdict[p]
+		switch {
+		case !found:
+			// no verdict — leave it unknown
+		case v:
+			available = append(available, p)
+		default:
+			unavailable = append(unavailable, p)
+		}
+	}
+	sort.Strings(available)
+	sort.Strings(unavailable)
+	return available, unavailable
 }
 
 // preflightWALLagUnderRTO — preflight-03. Compares the lag key the Continuum

--- a/products/catalyst/bootstrap/api/internal/handler/continuum_dr_preflight02_6156_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/continuum_dr_preflight02_6156_test.go
@@ -1,0 +1,102 @@
+package handler
+
+import (
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// #6156 — preflight-02 could not reach Fail on a 2-region Sovereign. The
+// replica half lives in the peer region and this handler's client is scoped to
+// region A, so the "replica not visible" branch was the permanent steady state
+// and it reported Warn whether the standby was healthy or gone. classifyPreflight
+// only blocks a mutating DR playback on Fail, so a real outage did not block it.
+//
+// These exercise continuumStandbyForPairs, the seam that decides it.
+
+func contWithPair(pair string, standby *bool) unstructured.Unstructured {
+	obj := map[string]interface{}{
+		"spec": map[string]interface{}{
+			"cnpgPair": map[string]interface{}{"name": pair},
+		},
+		"status": map[string]interface{}{},
+	}
+	if standby != nil {
+		obj["status"].(map[string]interface{})["standbyAvailable"] = *standby
+	}
+	return unstructured.Unstructured{Object: obj}
+}
+
+func boolp(b bool) *bool { return &b }
+
+// THE BUG: a standby outage on a pair whose replica is in the peer region must
+// be reported unavailable, which is what lets preflight-02 reach Fail.
+func TestPreflight02_StandbyOutage_IsReportedUnavailable_6156(t *testing.T) {
+	conts := []unstructured.Unstructured{contWithPair("shared-pg", boolp(false))}
+	avail, unavail := continuumStandbyForPairs(conts, []string{"shared-pg"})
+	if len(avail) != 0 {
+		t.Fatalf("a standby reported UNAVAILABLE must never land in available: %v", avail)
+	}
+	if len(unavail) != 1 || unavail[0] != "shared-pg" {
+		t.Fatalf("standby outage must be reported unavailable so preflight-02 can Fail; got %v", unavail)
+	}
+}
+
+// The healthy peer-region case still passes, on weaker provenance.
+func TestPreflight02_HealthyPeerRegionStandby_IsAvailable_6156(t *testing.T) {
+	conts := []unstructured.Unstructured{
+		contWithPair("shared-pg", boolp(true)),
+		contWithPair("shared-pg-b", boolp(true)),
+	}
+	avail, unavail := continuumStandbyForPairs(conts, []string{"shared-pg", "shared-pg-b"})
+	if len(unavail) != 0 {
+		t.Fatalf("healthy standbys must not be reported unavailable: %v", unavail)
+	}
+	if len(avail) != 2 {
+		t.Fatalf("want both pairs available, got %v", avail)
+	}
+}
+
+// VACUITY GUARD / honest-unknown: no Continuum naming the pair, or a CR that
+// omits the key, must yield NEITHER verdict — so the caller keeps Warn and never
+// fabricates a Pass. This is the condition #4901 was about.
+func TestPreflight02_NoVerdict_StaysUnknown_6156(t *testing.T) {
+	cases := map[string][]unstructured.Unstructured{
+		"no continuum at all":     {},
+		"continuum omits the key": {contWithPair("shared-pg", nil)},
+		"continuum names another": {contWithPair("some-other-pair", boolp(true))},
+	}
+	for name, conts := range cases {
+		avail, unavail := continuumStandbyForPairs(conts, []string{"shared-pg"})
+		if len(avail) != 0 || len(unavail) != 0 {
+			t.Fatalf("%s: absence of evidence must stay unknown, got avail=%v unavail=%v",
+				name, avail, unavail)
+		}
+	}
+}
+
+// A false verdict from ANY producer wins over another's silence.
+func TestPreflight02_FalseWinsOverSilence_6156(t *testing.T) {
+	conts := []unstructured.Unstructured{
+		contWithPair("shared-pg", boolp(true)),
+		contWithPair("shared-pg", boolp(false)),
+	}
+	_, unavail := continuumStandbyForPairs(conts, []string{"shared-pg"})
+	if len(unavail) != 1 {
+		t.Fatalf("an outage reported by one producer must not be cancelled by another; got %v", unavail)
+	}
+}
+
+// CONTROL — prove the helper discriminates rather than always answering the same
+// way: the identical pair list yields opposite verdicts purely on the CR value.
+func TestPreflight02_Control_SamePairOppositeVerdicts_6156(t *testing.T) {
+	up, _ := continuumStandbyForPairs([]unstructured.Unstructured{contWithPair("p", boolp(true))}, []string{"p"})
+	_, down := continuumStandbyForPairs([]unstructured.Unstructured{contWithPair("p", boolp(false))}, []string{"p"})
+	if len(up) != 1 || len(down) != 1 {
+		t.Fatalf("control failed — helper is not discriminating: up=%v down=%v", up, down)
+	}
+	if strings.Join(up, "") != "p" || strings.Join(down, "") != "p" {
+		t.Fatalf("control failed on identity: up=%v down=%v", up, down)
+	}
+}


### PR DESCRIPTION
fix(dr): preflight-02 can now Fail on a 2-region Sovereign — a standby outage blocks the playback

preflight-02 cnpgpair-streaming is the DR runbook's replication gate, and it
could not reach Fail on any 2-region Sovereign. classifyPreflight only aborts a
mutating playback on Fail, so a genuine standby outage did not block one.

The cause is structural rather than a logic slip. The check resolves the pair
two ways and both are blind here: CNPGPair.dr.openova.io has no production
producer, and the cnpg Cluster fallback looks for the replica half through a
dynamic client scoped to region A while the replica of a 2-region pair is a
Cluster in region B. So "replica not visible" was the permanent steady state,
and it reported Warn whether the standby was healthy or gone.

The fix reuses a fallback already proven in this same file rather than adding a
mechanism. augmentReplicationStandbyStatus already consults
Continuum.status.standbyAvailable - the continuum-controller's own pgprobe
verdict, published from region A - when it cannot see the replica half.
preflight-02 now does the same, using the Continuum CRs runDRPreflight has
already listed and hands to preflight-01 and preflight-03. No new client, no new
call.

Behaviour in the replica-not-visible branches: any unseen pair whose Continuum
reports standbyAvailable=false is Fail at critical severity, so the outage
blocks the playback; every unseen pair reporting true is Pass with the weaker
provenance stated in the message; and a pair whose Continuum omits the key stays
Warn. Absence of evidence remains honest-unknown and never becomes a fabricated
Pass, which is the condition #4901 was about.

Tests are vacuity-checked rather than merely green: mutating the helper to treat
every unseen pair as available turns three of them red, including a control that
proves the helper discriminates by feeding the same pair opposite CR values.

Refs #6156
Refs #4901
Refs #4986

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HvMZTDx7W6EPZMmjyXmYh1
