### PR TITLE
fix(anthropic): read the operator's credential Secret live — rotation no longer needs a pod roll

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/sovereign_anthropic_seed.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sovereign_anthropic_seed.go
@@ -135,8 +135,32 @@ func (h *Handler) seedAnthropicToken(ctx context.Context) AnthropicSeedOutcome {
 		return AnthropicSeedOutcomeSkippedNoBao
 	}
 
-	apiKey := strings.TrimSpace(os.Getenv(anthropicSeedAPIKeyEnv))
-	credsJSON := strings.TrimSpace(os.Getenv(anthropicSeedCredentialsJSONEnv))
+	// #6163 FREEZE 1 — read the operator's Secret LIVE, with the process env
+	// as the fallback.
+	//
+	// `CATALYST_ANTHROPIC_API_KEY` / `CATALYST_ANTHROPIC_CREDENTIALS_JSON` are
+	// secretKeyRef env vars, and a container's environment is materialised ONCE
+	// at container start. Reading them with os.Getenv on every pass meant this
+	// ten-minute self-heal loop re-wrote, forever, the credential the process
+	// booted with. The seeded value is a claudeAiOauth pair whose accessToken
+	// lives hours; when it expired the operator edited
+	// catalyst-system/sovereign-anthropic-credentials and NOTHING changed,
+	// because the running process could not see the edit. Rotation only ever
+	// took effect on a catalyst-api roll, which nothing triggers — so the loop
+	// meant to heal the outage was re-applying the stale snapshot that caused
+	// it. A self-repeat, not a self-heal.
+	//
+	// Live read first, env second. The fallback is not politeness: a Sovereign
+	// that never adopted the Secret (or a Catalyst-Zero/CI process with no
+	// in-cluster identity) keeps exactly its previous behaviour, so this cannot
+	// regress an install that works today.
+	apiKey, credsJSON := anthropicCredentialFromSecret()
+	if apiKey == "" {
+		apiKey = strings.TrimSpace(os.Getenv(anthropicSeedAPIKeyEnv))
+	}
+	if credsJSON == "" {
+		credsJSON = strings.TrimSpace(os.Getenv(anthropicSeedCredentialsJSONEnv))
+	}
 	if apiKey == "" && credsJSON == "" {
 		// 🛑 FOUNDER-SUPPLIED-SECRET GAP: the platform holds no Anthropic
 		// credential. Surface loud + skip rather than seed an empty path

--- a/products/catalyst/bootstrap/api/internal/handler/sovereign_anthropic_seed_live.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sovereign_anthropic_seed_live.go
@@ -1,0 +1,69 @@
+package handler
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// #6163 FREEZE 1 — the operator's Anthropic credential, read LIVE.
+//
+// The catalyst-api receives this credential as secretKeyRef env vars, and a
+// container's environment is materialised once at container start. That made
+// the ten-minute seed loop re-apply the boot-time snapshot forever: an operator
+// who rotated catalyst-system/sovereign-anthropic-credentials saw nothing
+// change until the pod rolled, which nothing triggers. Since the seeded blob is
+// a claudeAiOauth pair whose accessToken lives hours, the outage re-created
+// itself on a timer while the loop meant to heal it re-applied the stale value.
+//
+// This reads the Secret the operator actually edits, on every pass.
+const (
+	anthropicCredentialNamespace = "catalyst-system"
+	anthropicCredentialSecret    = "sovereign-anthropic-credentials"
+	anthropicCredentialAPIKeyKey = "apiKey"
+	anthropicCredentialJSONKey   = "credentialsJson"
+	anthropicCredentialReadBudget = 5 * time.Second
+)
+
+// anthropicSecretClientFor is the seam the production path wires to an
+// in-cluster clientset. Tests override it; a nil return means "no in-cluster
+// identity" and the caller falls back to the process env, which is exactly the
+// pre-#6163 behaviour.
+var anthropicSecretClientFor = func() (kubernetes.Interface, error) {
+	cfg, err := inClusterConfigForMaterialize()
+	if err != nil {
+		return nil, err
+	}
+	return kubernetes.NewForConfig(cfg)
+}
+
+// anthropicCredentialFromSecret returns (apiKey, credentialsJSON) read live from
+// catalyst-system/sovereign-anthropic-credentials.
+//
+// Every failure path returns ("", "") rather than an error: this is a FALLBACK
+// SOURCE, not a gate. A Sovereign that never adopted the Secret, a Catalyst-Zero
+// process with no in-cluster identity, and a transient apiserver blip must all
+// leave the caller on its previous env-based behaviour instead of turning a
+// working install into a credential gap.
+func anthropicCredentialFromSecret() (string, string) {
+	cli, err := anthropicSecretClientFor()
+	if err != nil || cli == nil {
+		return "", ""
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), anthropicCredentialReadBudget)
+	defer cancel()
+
+	sec, err := cli.CoreV1().Secrets(anthropicCredentialNamespace).
+		Get(ctx, anthropicCredentialSecret, metav1.GetOptions{})
+	if err != nil || sec == nil {
+		return "", ""
+	}
+	// Read on the VALUE, never on the key: a present-but-empty key is a
+	// credential gap, not a credential, and returning "" for it lets the env
+	// fallback answer instead of seeding an empty path that pretends to work.
+	return strings.TrimSpace(string(sec.Data[anthropicCredentialAPIKeyKey])),
+		strings.TrimSpace(string(sec.Data[anthropicCredentialJSONKey]))
+}

--- a/products/catalyst/bootstrap/api/internal/handler/sovereign_anthropic_seed_live_6163_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sovereign_anthropic_seed_live_6163_test.go
@@ -1,0 +1,97 @@
+package handler
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+// #6163 FREEZE 1. seedAnthropicToken read its credential with os.Getenv, and a
+// secretKeyRef env var is materialised ONCE at container start — so the
+// ten-minute self-heal loop re-applied the boot-time snapshot forever and an
+// operator's rotation never took effect without a pod roll.
+
+func withAnthropicSecretClient(t *testing.T, c kubernetes.Interface, err error) {
+	t.Helper()
+	prev := anthropicSecretClientFor
+	anthropicSecretClientFor = func() (kubernetes.Interface, error) { return c, err }
+	t.Cleanup(func() { anthropicSecretClientFor = prev })
+}
+
+func anthropicSecret(apiKey, credsJSON string) *corev1.Secret {
+	d := map[string][]byte{}
+	if apiKey != "" {
+		d[anthropicCredentialAPIKeyKey] = []byte(apiKey)
+	}
+	if credsJSON != "" {
+		d[anthropicCredentialJSONKey] = []byte(credsJSON)
+	}
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      anthropicCredentialSecret,
+			Namespace: anthropicCredentialNamespace,
+		},
+		Data: d,
+	}
+}
+
+// THE BUG: a rotated Secret must be visible without a pod roll.
+func TestAnthropicCredential_RotationIsVisibleLive_6163(t *testing.T) {
+	sec := anthropicSecret("sk-ant-ROTATED", `{"claudeAiOauth":{"accessToken":"fresh"}}`)
+	withAnthropicSecretClient(t, fake.NewSimpleClientset(sec), nil)
+
+	key, creds := anthropicCredentialFromSecret()
+	if key != "sk-ant-ROTATED" {
+		t.Fatalf("live apiKey not read — rotation would still need a pod roll; got %q", key)
+	}
+	if creds != `{"claudeAiOauth":{"accessToken":"fresh"}}` {
+		t.Fatalf("live credentialsJson not read; got %q", creds)
+	}
+}
+
+// FALLBACK MUST HOLD: no in-cluster identity => ("",""), so the caller keeps its
+// env-based behaviour. This is what stops the fix regressing installs that work.
+func TestAnthropicCredential_NoClientFallsBack_6163(t *testing.T) {
+	withAnthropicSecretClient(t, nil, errNoInCluster{})
+	if k, c := anthropicCredentialFromSecret(); k != "" || c != "" {
+		t.Fatalf("no-client path must yield empty so env wins; got %q/%q", k, c)
+	}
+}
+
+// Secret absent entirely — same fallback, no error surfaced.
+func TestAnthropicCredential_SecretAbsentFallsBack_6163(t *testing.T) {
+	withAnthropicSecretClient(t, fake.NewSimpleClientset(), nil)
+	if k, c := anthropicCredentialFromSecret(); k != "" || c != "" {
+		t.Fatalf("absent Secret must yield empty so env wins; got %q/%q", k, c)
+	}
+}
+
+// VALUE not KEY: a present-but-empty key is a gap, not a credential.
+func TestAnthropicCredential_EmptyValueIsNotACredential_6163(t *testing.T) {
+	sec := anthropicSecret("", "")
+	sec.Data[anthropicCredentialAPIKeyKey] = []byte("   ")
+	sec.Data[anthropicCredentialJSONKey] = []byte("")
+	withAnthropicSecretClient(t, fake.NewSimpleClientset(sec), nil)
+	if k, c := anthropicCredentialFromSecret(); k != "" || c != "" {
+		t.Fatalf("whitespace/empty values must not count as a credential; got %q/%q", k, c)
+	}
+}
+
+// CONTROL — the reader discriminates rather than always answering the same way:
+// two different Secrets yield two different answers.
+func TestAnthropicCredential_Control_Discriminates_6163(t *testing.T) {
+	withAnthropicSecretClient(t, fake.NewSimpleClientset(anthropicSecret("A", "")), nil)
+	a, _ := anthropicCredentialFromSecret()
+	withAnthropicSecretClient(t, fake.NewSimpleClientset(anthropicSecret("B", "")), nil)
+	b, _ := anthropicCredentialFromSecret()
+	if a != "A" || b != "B" {
+		t.Fatalf("control failed — reader is not discriminating: %q vs %q", a, b)
+	}
+}
+
+type errNoInCluster struct{}
+
+func (errNoInCluster) Error() string { return "no in-cluster identity" }


### PR DESCRIPTION
fix(anthropic): read the operator's credential Secret live — rotation no longer needs a pod roll

FREEZE 1 of #6163. seedAnthropicToken read CATALYST_ANTHROPIC_API_KEY and
CATALYST_ANTHROPIC_CREDENTIALS_JSON with os.Getenv on every pass. Those are
secretKeyRef env vars, and a container's environment is materialised once at
container start, so the ten-minute self-heal loop re-applied the credential the
process booted with - forever.

The consequence is not cosmetic. The seeded value is a claudeAiOauth pair whose
accessToken lives hours. When it expired, the operator edited
catalyst-system/sovereign-anthropic-credentials and nothing changed, because the
running process could not see the edit. Rotation only ever took effect on a
catalyst-api roll, which nothing triggers. So an expiring credential re-created
the outage on a timer while the loop meant to heal it re-applied the stale
snapshot that caused it - a self-repeat rather than a self-heal.

seedAnthropicToken now reads the Secret the operator actually edits, live, and
falls back to the process env. The fallback is deliberate: a Sovereign that
never adopted the Secret, and any process without in-cluster identity, keeps
exactly its previous behaviour, so this cannot regress an install that works
today. Every failure path returns empty rather than an error - this is a source,
not a gate.

It reads on the value, not the key: a present-but-empty key is a credential gap,
so it yields empty and lets the env answer instead of seeding a path that
pretends to work.

The client is behind a var seam matching the file's existing
inClusterConfigForMaterialize pattern, so the tests drive it with a fake
clientset. They are vacuity-checked: a compiling mutant that swaps the two
Secret keys turns the rotation test AND the discrimination control red. Full
handler suite green at 298s.

FREEZE 2 (the seed-claude-creds init container's one-shot read) is not in this
change and stays open on the issue.

Refs #6163
Refs #4277

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HvMZTDx7W6EPZMmjyXmYh1
