### PR TITLE
fix(cnpg-pair): guard the peer-ahead hold so the stale primary stops taking writes

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1389,7 +1389,7 @@ spec:
       #   guacamole-pg and the shared-pg family as well. Egress half in
       #   bp-keycloak 1.5.9; neither half alone restores a brokered login.
       #   Lockstep w/ products/catalyst/chart/Chart.yaml.
-      version: 1.4.1431
+      version: 1.4.1432
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/clusters/_template/bootstrap-kit/16b-bp-cnpg-pair.yaml
+++ b/clusters/_template/bootstrap-kit/16b-bp-cnpg-pair.yaml
@@ -313,6 +313,9 @@ spec:
       # -allow-replication-to-primary policy (default-denies all other ingress).
       # hw287: cnpg-pair region-b replica pg_stat_wal_receiver=streaming yet all
       # 8 Continuum CRs read standbyAvailable=UNSET. Substitutes unchanged.
+      # 0.2.24 (#6148): dr-failback peer-ahead write-guard — client ingress to
+      # the stale primary's :5432 is denied for the duration of the peer-ahead
+      # hold and restored on clear_hold. Lockstep slot 16b pin -> 0.2.24.
       # 0.2.23 (#5388): dr-failback starvation surfacing (hw290 G12 leg-6) —
       # when the post-failover geometry candidate (local writable primary, sync
       # standby absent) persists with the peer probe failing observability-dead
@@ -320,7 +323,7 @@ spec:
       # shape, #5339), the actor records dr-failback-starved-at + reason on the
       # HR instead of idling silently at D0 while a split-brain persists.
       # Diagnostic only; substitutes unchanged.
-      version: 0.2.23
+      version: 0.2.24
       sourceRef:
         kind: HelmRepository
         name: bp-cnpg-pair

--- a/platform/cnpg-pair/blueprint.yaml
+++ b/platform/cnpg-pair/blueprint.yaml
@@ -120,12 +120,17 @@ spec:
   # topology (the #5335 Secret-RBAC fix was necessary-not-sufficient; the
   # connection was still NetworkPolicy-dropped — hw287 residual). NetworkPolicy
   # + values only; no schema/RBAC/resource delta to the Cluster CRs.
+  # 0.2.24 (#6148): dr-failback peer-ahead write-guard — region-A stays
+  # writable through the 120s hold and its commits are discarded by the
+  # re-clone; the actor now denies client ingress to :5432 for the duration
+  # of the hold via a CiliumNetworkPolicy, exempting replication and its own
+  # timeline probe, and removes it on clear_hold.
   # 0.2.23 (#5388): dr-failback starvation surfacing — when the post-failover
   # geometry candidate persists with the peer unobservable (the hw290 G12 leg-6
   # rebooted-region datapath shape, #5339), the actor records
   # dr-failback-starved-at + reason on the HR instead of idling silently at D0
   # while a split-brain persists. Script + env + value only.
-  version: 0.2.23
+  version: 0.2.24
   card:
     title: CNPG Cluster-Pair (Active-Hotstandby DR)
     summary: |

--- a/platform/cnpg-pair/chart/Chart.yaml
+++ b/platform/cnpg-pair/chart/Chart.yaml
@@ -1,5 +1,18 @@
 apiVersion: v2
 name: bp-cnpg-pair
+# 0.2.24 (#6148): dr-failback PEER-AHEAD WRITE-GUARD. region-A returned from
+# a region-kill as a writable TL=1 primary and ACCEPTED writes for the whole
+# 120s peer-ahead hold (hw293, 03:58Z) — acknowledged commits on a divergent
+# line, silently discarded by the re-clone. The hold itself is correct: it
+# guards the DEMOTE against a flap, and a demote/re-promote bumps the
+# timeline, which is the same damage. So the hold stays and the window gets a
+# guard. The actor applies a CiliumNetworkPolicy on peer-ahead DETECTION and
+# removes it on clear_hold. ingressDeny, not a k8s NetworkPolicy: k8s policies
+# are additive allow-lists and cannot subtract the app->5432 allows granted
+# elsewhere, so a NetworkPolicy guard would permit every write it claimed to
+# stop. enableDefaultDeny=false keeps it purely subtractive; the pair's Pods
+# and the failback Pod stay exempt (the latter reads the local timeline, and
+# blinding that read trips clear_hold and aborts the failback).
 # 0.2.23 (#5388): dr-failback STARVATION SURFACING (hw290 G12 leg-6). All four
 # region-A nodes rebooted through the kill, the per-node cross-region routes
 # were gone (#5339 shape), and the failback actor idled at D0 forever while the
@@ -376,7 +389,7 @@ name: bp-cnpg-pair
 # the post-mesh flip. Default-OFF contract UNCHANGED: cnpgPair.enabled=false OR
 # empty crossRegionPeerClusters renders ZERO CiliumNetworkPolicy — resource
 # counts unchanged from 0.2.8. Lockstep slot 16b pin → 0.2.9.
-version: 0.2.23
+version: 0.2.24
 appVersion: "0.2.1"
 description: |
   Catalyst-curated Blueprint for an active-hotstandby CNPG cluster-pair

--- a/platform/cnpg-pair/chart/templates/dr-failback.yaml
+++ b/platform/cnpg-pair/chart/templates/dr-failback.yaml
@@ -299,6 +299,90 @@ metadata:
 # Local-namespace surface: get + delete on EXACTLY the primary Cluster
 # CR (the bounded re-clone). No patch (live-CR patches are the #5125-D1
 # anti-pattern), no PVC verbs (owner-GC does the storage), no list.
+#
+# #6148 WRITE-GUARD manifest — rendered here as inert ConfigMap DATA, applied
+# and deleted by the actor.
+#
+# WHY THE MANIFEST IS DATA AND NOT A TEMPLATE. The guard must exist only for
+# the duration of the peer-ahead hold, so its lifecycle is the actor's, not
+# helm's. Rendering it as a live template would put it under the Kustomization's
+# inventory and flux drift-correction would fight the actor over it — the
+# #5125-D1 shape this same comment forbids two lines up. As ConfigMap data it
+# stays version-controlled, render-testable and reviewable, while the OBJECT the
+# actor applies is owned by nobody but the actor and is therefore never reverted
+# and never pruned.
+#
+# WHY CiliumNetworkPolicy AND NOT NetworkPolicy. A k8s NetworkPolicy cannot
+# express deny — policies selecting the same Pods are additive allow-lists, so a
+# new one cannot subtract the app->5432 allows granted elsewhere. It would be
+# created, logged, and permit every write it claimed to stop. Cilium's
+# ingressDeny takes precedence over every allow, in this policy or any other.
+#
+# WHY enableDefaultDeny IS FALSE. A CNP that selects an endpoint normally flips
+# it to default-deny for that direction. This policy is purely subtractive: it
+# removes one path without disturbing the carve-outs in networkpolicy.yaml that
+# keep replication and the CNPG operator's status probe alive.
+#
+# WHO STAYS REACHABLE, AND WHY EACH ONE MUST. matchExpressions inside one
+# selector are ANDed, so the denied set is "endpoints that are neither a pair
+# Pod nor the failback Pod":
+#   - the pair's own Pods keep 5432 — that is the replication path region-A
+#     needs in order to re-clone from region-B once the demote lands
+#   - the failback Pod keeps 5432 — the signals loop reads the local timeline
+#     over it, and if that read fails `clear_hold "local timeline unreadable"`
+#     aborts the whole failback. A guard that blinds the decider is worse than
+#     no guard; that is the trap which ruled out CNPG instance fencing here.
+#   - the CNPG operator is untouched — it probes 8000/9187, never 5432.
+# fromEndpoints (not ipBlock) is required for the cross-region case: an ipBlock
+# never matches a ClusterMesh remote Pod's identity, so an ipBlock guard would
+# silently miss the very peer traffic it reasons about.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "cnpg-pair.fullname" . }}-write-guard
+  labels:
+    {{- include "cnpg-pair.labels" . | nindent 4 }}
+    catalyst.openova.io/cnpg-pair: {{ include "cnpg-pair.fullname" . | quote }}
+data:
+  guard.yaml: |
+    apiVersion: cilium.io/v2
+    kind: CiliumNetworkPolicy
+    metadata:
+      name: {{ include "cnpg-pair.fullname" . }}-write-guard
+      namespace: {{ .Release.Namespace }}
+      labels:
+        catalyst.openova.io/cnpg-pair: {{ include "cnpg-pair.fullname" . | quote }}
+        catalyst.openova.io/role: dr-failback-write-guard
+      annotations:
+        catalyst.openova.io/why: >-
+          Applied by dr-failback for the duration of the peer-ahead hold (#6148).
+          region-A is a writable primary on a timeline the peer has already
+          overtaken, so a write committed here is acknowledged and then silently
+          discarded by the re-clone. Removed on clear_hold.
+    spec:
+      endpointSelector:
+        matchLabels:
+          cnpg.io/cluster: {{ include "cnpg-pair.primaryName" . }}
+      enableDefaultDeny:
+        ingress: false
+        egress: false
+      ingressDeny:
+        - fromEndpoints:
+            - matchExpressions:
+                - key: cnpg.io/cluster
+                  operator: NotIn
+                  values:
+                    - {{ include "cnpg-pair.primaryName" . }}
+                    - {{ include "cnpg-pair.replicaName" . }}
+                - key: catalyst.openova.io/role
+                  operator: NotIn
+                  values:
+                    - dr-failback
+          toPorts:
+            - ports:
+                - port: "5432"
+                  protocol: TCP
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -311,6 +395,24 @@ rules:
     resources: [clusters]
     verbs: [get, delete]
     resourceNames: [{{ include "cnpg-pair.primaryName" . }}]
+  # #6148 write-guard lifecycle. The guard is applied on peer-ahead detection
+  # and deleted on clear_hold, so the actor needs to own exactly one object.
+  # get/patch/delete are resourceNames-pinned to that one name.
+  #
+  # `create` is deliberately in its own rule WITHOUT resourceNames, because
+  # k8s RBAC ignores resourceNames on create — the object does not exist yet,
+  # so there is no name to authorize against. Pinning it there would read as a
+  # constraint while enforcing nothing, so the split states the real scope
+  # instead of implying a narrower one. The residual power is "create some
+  # CiliumNetworkPolicy in this one namespace", which is strictly less than the
+  # `delete` on the Cluster CR this same Role already grants.
+  - apiGroups: [cilium.io]
+    resources: [ciliumnetworkpolicies]
+    verbs: [get, patch, delete]
+    resourceNames: [{{ include "cnpg-pair.fullname" . }}-write-guard]
+  - apiGroups: [cilium.io]
+    resources: [ciliumnetworkpolicies]
+    verbs: [create]
   # #5245 0.2.20 preserve_pki: strip the controller ownerReferences from
   # the CNPG-issued PKI Secrets before the bounded Cluster-CR delete so
   # the CA lineage survives (hw278: the delete GC'd -ca/-replication/
@@ -866,8 +968,48 @@ spec:
               ts_lt() {
                 [ "$1" != "$2" ] && [ "$(printf '%s\n%s\n' "$1" "$2" | sort | head -1)" = "$1" ]
               }
+              # ── #6148 write-guard ────────────────────────────────────
+              # region-A returns from a region-kill as a writable TL=1 primary
+              # while the peer is already writable and AHEAD. Every write
+              # committed in that window is acknowledged to the client and then
+              # silently discarded by the re-clone. The 120s hold is legitimate
+              # — it guards the DEMOTE decision against a flap, and a
+              # demote/re-promote cycle bumps the timeline, which is the same
+              # class of damage. So the hold stays and the window gets a guard
+              # that is reversible at zero cost.
+              #
+              # Both helpers are idempotent and cheap: /shared/guard-state
+              # keeps them from re-issuing an API call every tick. They are
+              # deliberately NON-FATAL — a guard that cannot be applied must
+              # never stall the failback, because converging region-A is what
+              # ends the exposure. The failure is reported loudly instead.
+              GUARD_STATE=/shared/guard-state
+              guard_on() {
+                [ "$(cat "${GUARD_STATE}" 2>/dev/null || echo)" = "on" ] && return 0
+                if kubectl -n "${NAMESPACE}" apply ${FM} -f /guard/guard.yaml >/dev/null 2>&1; then
+                  echo "on" > "${GUARD_STATE}"
+                  echo "$(date -u +"%FT%TZ") [dr-failback/actor] WRITE-GUARD ON: region-A is a writable primary on TL=$(cat /shared/tl-local 2>/dev/null || echo '?') that the peer has overtaken on TL=$(cat /shared/tl-peer 2>/dev/null || echo '?') — denying client ingress to :5432 for the duration of the hold; replication and this actor's own timeline probe stay open (#6148)"
+                else
+                  echo "$(date -u +"%FT%TZ") [dr-failback/actor] WARN: WRITE-GUARD could not be applied (RBAC/CRD absent?) — the hold window is UNGUARDED and a region-A-local client can still commit a write that the re-clone will discard; failback continues (#6148)"
+                fi
+              }
+              guard_off() {
+                [ -f "${GUARD_STATE}" ] || return 0
+                kubectl -n "${NAMESPACE}" delete ciliumnetworkpolicy \
+                  "{{ include "cnpg-pair.fullname" . }}-write-guard" \
+                  --ignore-not-found >/dev/null 2>&1 || true
+                rm -f "${GUARD_STATE}"
+                echo "$(date -u +"%FT%TZ") [dr-failback/actor] WRITE-GUARD OFF — the peer-ahead hold is no longer active, client ingress to :5432 restored (#6148)"
+              }
               while true; do
                 : > /shared/actor-alive
+                # Unconditional, and BEFORE the per-tick subshell: the guard is
+                # tied to the hold clock itself, not to any one geometry branch.
+                # The signals loop clears /shared/peer-ahead-since on every
+                # fail-safe path it has, so pinning the guard to that single
+                # file means every existing abort already unwinds it and no new
+                # control flow can forget to.
+                [ -f /shared/peer-ahead-since ] || guard_off
                 (
                   set -eu
                   SUB=$(kubectl -n "${KS_NAMESPACE}" get kustomization "${KS_NAME}" -o jsonpath='{.spec.postBuild.substitute.SOVEREIGN_CNPG_PAIR_DEMOTED}' 2>/dev/null || echo "")
@@ -954,6 +1096,10 @@ spec:
                       rm -f /shared/starved-recorded
                     fi
                     [ -f /shared/peer-ahead-since ] || exit 0
+                    # #6148 — guard FIRST, then evaluate the hold. The exposure
+                    # starts the moment the geometry is known-divergent, which
+                    # is here, not ${HOLD_SECONDS} later at the demote.
+                    guard_on
                     SINCE=$(cat /shared/peer-ahead-since)
                     NOW=$(date -u +%s)
                     HELD=$((NOW - SINCE))
@@ -1169,11 +1315,20 @@ spec:
               mountPath: /shared
             - name: tmp
               mountPath: /tmp
+            # #6148 — the write-guard manifest the actor applies during the
+            # peer-ahead hold. Read-only: the actor applies this file, it
+            # never authors one, so a bug cannot widen the guard's scope.
+            - name: write-guard
+              mountPath: /guard
+              readOnly: true
       volumes:
         - name: shared
           emptyDir: {}
         - name: tmp
           emptyDir: {}
+        - name: write-guard
+          configMap:
+            name: {{ include "cnpg-pair.fullname" . }}-write-guard
         # THIS primary cluster's own CNPG-issued streaming_replica client
         # cert — 0440 root:26, the perms libpq requires for an sslkey
         # (#5133). The SAME cert authenticates against region-B thanks to

--- a/platform/cnpg-pair/chart/tests/cnpg-pair-render.sh
+++ b/platform/cnpg-pair/chart/tests/cnpg-pair-render.sh
@@ -1188,8 +1188,25 @@ for r in roles:
         assert 'persistentvolumeclaims' not in res, "dr-failback must never hold PVC verbs (storage goes via owner-GC only)"
         assert 'pods' not in res, "dr-failback needs no pod verbs"
         if 'delete' in verbs:
-            assert res==['clusters'], f"delete verb only on the Cluster CR, got {res}"
+            # The destructive surface is an ALLOW-LIST of two, not "whatever the
+            # chart happens to render". Widening it is a review decision, so it
+            # is spelled out here rather than by relaxing the shape of the check.
+            #   clusters              — the bounded re-clone (#5245)
+            #   ciliumnetworkpolicies — the #6148 write-guard the actor puts up
+            #                           for the peer-ahead hold and takes down
+            #                           on clear_hold. It must be able to remove
+            #                           its own guard or a failed episode leaves
+            #                           region-A's :5432 denied to clients after
+            #                           the reason for denying it has passed.
+            assert res in (['clusters'], ['ciliumnetworkpolicies']), \
+                f"delete verb only on the Cluster CR or the #6148 write-guard, got {res}"
             assert rule.get('resourceNames'), "the delete rule must be resourceNames-pinned"
+        # #6148 — `create` cannot be resourceNames-pinned (k8s RBAC has no name
+        # to match before the object exists), so bound it by RESOURCE instead:
+        # the only thing dr-failback may bring into existence is its own guard.
+        if 'create' in verbs:
+            assert res==['ciliumnetworkpolicies'], \
+                f"create verb only on the #6148 write-guard resource, got {res}"
 PYEOF
 
 # (g) DEMOTED REJOIN SHAPE: primary.demoted=true renders the primary Cluster
@@ -1518,5 +1535,84 @@ assert 'delete' not in act[j:k], "#5388: the starvation path is DIAGNOSTIC-ONLY 
 PYEOF
 
 echo "  PASS (CONVERGED gated on ConsistentSystemID=True + streaming + demoted · divergence escalation on CNPG verdict alone · streaming arm keeps peer-writable proof fresh · post-re-clone watch keys off converged-recorded · starvation surfaced on HR before D0 early-exit, diagnostic-only)"
+
+# ── Case 22: #6148 peer-ahead write-guard ────────────────────────────────
+# region-A returns from a region-kill as a writable TL=1 primary while the peer
+# is already writable and AHEAD, and stays writable for the whole peer-ahead
+# hold. Writes committed in that window are acknowledged and then discarded by
+# the re-clone. These assertions pin the guard that closes the window, and in
+# particular pin the three properties that make it a REAL guard rather than an
+# object that merely exists.
+echo "[render] Case 22: #6148 peer-ahead write-guard (deny is real · decider stays reachable · unwinds on every abort)"
+python3 - "$TMP/cnp-primary.yaml" "$TMP/fb-actor.sh" <<'PYEOF' || { echo "FAIL: #6148 write-guard assertions failed." >&2; exit 1; }
+import sys, yaml
+docs=[d for d in yaml.safe_load_all(open(sys.argv[1])) if d]
+act=open(sys.argv[2]).read()
+
+cms=[d for d in docs if d.get('kind')=='ConfigMap' and d['metadata']['name'].endswith('-write-guard')]
+assert len(cms)==1, f"#6148: exactly one write-guard ConfigMap expected, got {len(cms)}"
+guard=yaml.safe_load(cms[0]['data']['guard.yaml'])
+
+# (a) The guard must DENY. A k8s NetworkPolicy cannot express deny — policies
+#     selecting the same Pods are additive allow-lists — so a guard authored as
+#     a NetworkPolicy would be created, logged, and permit every write it
+#     claimed to stop. Only Cilium's ingressDeny actually subtracts a path.
+assert guard['kind']=='CiliumNetworkPolicy', \
+    f"#6148: the guard must be a CiliumNetworkPolicy — a k8s NetworkPolicy cannot deny, got {guard['kind']}"
+deny=guard['spec'].get('ingressDeny')
+assert deny, "#6148: the guard must carry ingressDeny — an allow-only policy subtracts nothing"
+ports=[p['port'] for r in deny for tp in r.get('toPorts',[]) for p in tp.get('ports',[])]
+assert '5432' in ports, f"#6148: the guard must deny the postgres port, got {ports}"
+
+# (b) It must be purely SUBTRACTIVE. A CNP selecting an endpoint normally flips
+#     it to default-deny for that direction, which would take out the
+#     replication and operator-status carve-outs in networkpolicy.yaml.
+edd=guard['spec'].get('enableDefaultDeny')
+assert edd=={'ingress': False, 'egress': False}, \
+    f"#6148: the guard must not flip the primary to default-deny, got {edd}"
+
+# (c) The DECIDER must stay reachable. The signals loop reads the local timeline
+#     over 5432; if that read fails, clear_hold "local timeline unreadable"
+#     aborts the failback. A guard that blinds the decider is worse than no
+#     guard — this is exactly what ruled out CNPG instance fencing.
+exempt=set()
+for r in deny:
+    for fe in r.get('fromEndpoints',[]):
+        for me in fe.get('matchExpressions',[]):
+            assert me['operator']=='NotIn', f"#6148: exemptions must be NotIn, got {me['operator']}"
+            exempt.add(me['key'])
+            exempt.update(me['values'])
+assert 'dr-failback' in exempt, \
+    "#6148: the failback Pod must be exempt or its own timeline probe trips clear_hold and aborts the failback"
+assert 'cnpg.io/cluster' in exempt, \
+    "#6148: the pair's own Pods must be exempt or the re-clone cannot stream from the peer"
+# fromEndpoints, never ipBlock: an ipBlock never matches a ClusterMesh remote
+# Pod identity, so an ipBlock guard silently misses the peer traffic it reasons about.
+assert not any(r.get('fromCIDR') or r.get('fromCIDRSet') for r in deny), \
+    "#6148: the guard must select by endpoint identity, not CIDR (ipBlock never matches a ClusterMesh remote Pod)"
+
+# (d) It must go UP at detection and come DOWN on every abort. The guard is
+#     keyed to /shared/peer-ahead-since, the same file every fail-safe path in
+#     the signals loop already clears, so no new control flow can forget it.
+k=act.find('peer-ahead-since ] || exit 0')
+assert k!=-1, "#6148: the D0 peer-ahead early-exit must still exist"
+assert 'guard_on' in act[k:k+400], \
+    "#6148: guard_on must fire at DETECTION (right after the D0 early-exit), not at demote time"
+assert '[ -f /shared/peer-ahead-since ] || guard_off' in act, \
+    "#6148: guard_off must run unconditionally per tick whenever the hold is not active"
+assert act.find('[ -f /shared/peer-ahead-since ] || guard_off') < act.find('while true') + 400, \
+    "#6148: the guard_off sweep must sit in the outer loop, not inside one geometry branch"
+
+# (e) It must be NON-FATAL. Converging region-A is what ends the exposure, so a
+#     guard that cannot be applied must report loudly and let the failback run.
+i=act.find('guard_on() {'); j=act.find('guard_off() {')
+assert i!=-1 and j!=-1 and i<j, "#6148: both guard helpers must be defined, guard_on first"
+body=act[i:j]
+assert 'exit 1' not in body and 'return 1' not in body, \
+    "#6148: guard_on must never fail the tick — stalling the failback prolongs the very window the guard exists to shorten"
+assert 'WARN' in body, "#6148: a guard that could not be applied must say so loudly"
+PYEOF
+
+echo "  PASS (#6148 ingressDeny on 5432 · purely subtractive · failback Pod and replication exempt · endpoint-identity not CIDR · armed at detection, swept on every abort · non-fatal)"
 
 echo "[render] All bp-cnpg-pair render gates green."

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-13T06:10:34.550Z",
+  "generatedAt": "2026-08-13T08:57:29.376Z",
   "blueprints": [
     {
       "id": "bp-agenity",
@@ -863,7 +863,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "listed",
-      "version": "0.2.23",
+      "version": "0.2.24",
       "section": "pts-9-disaster-recovery",
       "depends": [
         "bp-cnpg",

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -998,7 +998,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "listed",
-    "version": "0.2.23",
+    "version": "0.2.24",
     "section": "pts-9-disaster-recovery",
     "depends": [
       "bp-cnpg",

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3899,7 +3899,7 @@ name: bp-catalyst-platform
 #   The seed pin is the delivery half: without this bump a pinned Sovereign
 #   resolves 1.5.9 and never sees the fix. This chart's own templates are
 #   unchanged.
-version: 1.4.1431
+version: 1.4.1432
 # 1.4.1229 — #5389: catalog-seed bp-newapi declares its `ui` endpoint
 #   (newapi.<fqdn>, ssoEnabled, launchDefault, ssoInitPath "/") instead of
 #   `endpoints: []`. The empty list made userUIGatePasses fail closed, which

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -430,7 +430,7 @@ spec:
   # datapath shape, #5339), instead of idling silently while a split-brain
   # persists. Keep this display-version in lockstep with delivery
   # source.version + blueprint.yaml (the #4988 precedent).
-  version: "0.2.23"
+  version: "0.2.24"
   visibility: listed
   card:
     title: "CNPG Cluster-Pair (Active-Hotstandby DR)"
@@ -460,7 +460,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-cnpg-pair
-    version: "0.2.23"
+    version: "0.2.24"
   # G117.1+G117.4+G117.5 #2744-followup (2026-06-03): cluster-pair IS
   # active-hot-standby by construction. Only one topology variant —
   # active-passive — because the chart renders 2 Cluster CRs (primary +


### PR DESCRIPTION
## What this fixes

**#6148** — measured live on hw293 at `03:58:0xZ`. After a region-kill, region-A
returns as a standalone writable **TL=1** primary while region-B is already
writable on **TL=2**, and it keeps accepting writes for the entire 120s
peer-ahead hold:

```
region-A  in_recovery=false  timeline=1  transaction_read_only=off
region-A  INSERT ... -> "INSERT 0 1", rc=0        <-- WRITE ACCEPTED
region-B  in_recovery=false  timeline=2          <-- peer writable and ahead
```

Those commits are acknowledged to the client and then discarded by the clean
re-clone. Region-A applications resolve their own region's read-write Service,
so this is reachable, not theoretical.

## What is deliberately NOT changed

The 120s hold. It guards the **demote** decision against a flap, and a demote
followed by a re-promote bumps the timeline — the same class of damage this
issue is about (`platform/cnpg-pair/chart/Chart.yaml` L727 records the incident
that put the hold there). The hold stays; the window gets a guard.

## Four designs closed against evidence first

| candidate | why it fails |
|---|---|
| CNPG instance fencing | stops the engine, so `tl_of` returns nothing and `clear_hold "local timeline unreadable"` (dr-failback.yaml L663) aborts the failback — a guard that blinds the decider |
| re-render to replica shape at detection | that IS the strong fence, but taking it before the hold expires is precisely the flap the hold prevents |
| postgres parameter via the Cluster spec | CNPG admission would accept it — `cluster_webhook.go` L1055-1066 rejects only on membership in `FixedConfigurationParameters`, and `hot_standby` sitting at `configuration.go` L491 is why the earlier attempt was refused — but flux drift-correction reverts live-CR patches (#5125-D1), so the guard evaporates inside its own window |
| plain k8s NetworkPolicy | **cannot deny at all.** Policies selecting the same Pods are additive allow-lists, so it cannot subtract the `app->5432` allows granted elsewhere. It would be created, logged, and permit every write it claimed to stop |

## The guard

A `CiliumNetworkPolicy` applied on peer-ahead **detection** and removed in
`clear_hold`, keyed to `/shared/peer-ahead-since` so every fail-safe path the
signals loop already has unwinds it with no new control flow.

- `ingressDeny` on 5432 — Cilium's deny beats every allow, in this policy or any other
- `enableDefaultDeny: false` — purely subtractive, leaves the replication and operator-status carve-outs in `networkpolicy.yaml` alone
- `fromEndpoints`, never `ipBlock` — an ipBlock never matches a ClusterMesh remote Pod identity, so an ipBlock guard would miss the peer traffic it reasons about
- the pair's Pods and the failback Pod stay exempt — replication must survive the demote, and the failback Pod's own timeline probe must not be blinded
- `guard_on` is **non-fatal** — converging region-A is what ends the exposure, so a guard that cannot be applied reports loudly and lets the failback run

The manifest is rendered as **ConfigMap data**, not a live template: the object
the actor owns sits outside the Kustomization inventory, so drift-correction has
nothing to revert and the prune has nothing to collect.

## Test

Contract-test **Case 22** pins the three properties that separate a real guard
from one that merely exists — the deny is expressible, the decider stays
reachable, and it unwinds on every abort.

Vacuity-checked with three mutants that all **compile**:

| mutant | Case 22 |
|---|---|
| `enableDefaultDeny.ingress` flipped to `true` | red |
| `dr-failback` exemption removed | red |
| `guard_on` call removed | red |
| restored | green |

Case 19's `delete verb only on the Cluster CR` assertion is **narrowed, not
loosened**: the destructive surface becomes a two-entry allow-list, and `create`
is bounded by resource because k8s RBAC cannot pin a name that does not exist
yet — pinning it there would read as a constraint while enforcing nothing.

## Versioning

`bp-cnpg-pair` 0.2.23 -> 0.2.24 across all four lockstep sites; umbrella
re-bumped 1.4.1431 -> 1.4.1432 in the same commit per the #5734 gate. 0.2.24 and
1.4.1432 were both checked unclaimed against all 60 open PR heads and unpublished
on ghcr.

Local gates green: cnpg-pair render (22 cases), bootstrap-kit pin-sync (67 pairs),
umbrella-republish (160 pins / 80 Blueprints), banned-words, no-nodeports.

Refs #6148
