### PR TITLE
docs(runbooks): §6.1's reverse leg covers the cnpg-pair pair only, not shared-pg

### DIFF
--- a/docs/RUNBOOKS.md
+++ b/docs/RUNBOOKS.md
@@ -1339,6 +1339,29 @@ The deterministic failover test for two independent CNPG clusters:
      never-acked WAL tail (the RPO=0 contract). Evidence:
      `dr-failback-started-at` / `-recloned-at` / `-converged-at` annotations
      on the region-A HR + both actors' pod logs.
+
+   🛑 **This reverse leg covers the bp-cnpg-pair pair ONLY — the three shared-pg
+   pairs are not in it (#6149).** All three moves above are bp-cnpg-pair
+   mechanisms (`SOVEREIGN_CNPG_PAIR_PROMOTED` / `_DEMOTED` and the dr-failback
+   actor). `shared-pg`, `shared-pg-b` and `shared-pg-c` run **bp-postgres**,
+   which ships `dr-promoter` but no `dr-failback`: measured against
+   bp-cnpg-pair's promoter it carries the suspend latch, arm gate, liveness gate,
+   anti-flap and readback-verify, and **zero** timeline-divergence machinery
+   (`ConsistentSystemID`, `pg_basebackup` and `IDENTIFY_SYSTEM` are absent from
+   it entirely). They appear in this section's **promotion** table above and
+   nowhere in this step.
+
+   Consequence on a real region-A return: those three pairs auto-promote in
+   region B, and then nothing detects that the returning region-A primary is on
+   a divergent line — two writable primaries with no automatic resolution. Note
+   that bp-postgres's own header comment defers to "the operator lifts it on
+   region-A recovery (RUNBOOKS §6.1)", and this step says the lift is automatic
+   via a component those pairs do not have; the manual procedure it implies has
+   never been written. Treat shared-pg failback as **operator-driven and
+   undefined** until #6149 lands the port, and prefer to recover those pairs by
+   re-cloning the returning side from the promoted one rather than letting both
+   sides serve.
+
    **End state**: region-B primary, region-A streaming replica, both HRs
    unsuspended, topology rendered from source. The **controlled switchback**
    to original roles stays a sovereign-admin action: demote region-B and


### PR DESCRIPTION
## The defect

`docs/RUNBOOKS.md` §6.1 step 5 — the region-kill **reverse** leg — opens:

> **AUTOMATIC (bp-cnpg-pair ≥ 0.2.18, #5245)** — the failback now converges with
> zero operator action, in three coordinated moves

All three moves are bp-cnpg-pair mechanisms: `SOVEREIGN_CNPG_PAIR_PROMOTED`,
`SOVEREIGN_CNPG_PAIR_DEMOTED`, and the `dr-failback` actor.

`shared-pg`, `shared-pg-b` and `shared-pg-c` run **bp-postgres**. They appear in
§6.1's **promotion** table (L1286-1288, "`dr-promoter`, ~2-4 min, zero touch") and
in **no line** of the reverse procedure. A reader reasonably concludes they are
covered by step 5. They are not.

## Measured, not assumed

Normalising away chart-specific naming and dropping comments/blanks:

| | value |
|---|---|
| bp-postgres dr-promoter, non-comment lines | 549 |
| shared with bp-cnpg-pair's promoter | **277** (73%) |

bp-postgres is **not** the unhardened one — it carries essentially every hardening chain:

| hardening | bp-postgres | bp-cnpg-pair |
|---|---|---|
| suspend latch (#5178/#5218) | 36 | 54 |
| arm gate / steady-state (#5220) | 14 | 28 |
| liveness gate (#5178) | 19 | 20 |
| anti-flap | 6 | 8 |
| readback-verify (#5218) | 3 | 4 |
| **timeline divergence** | **0** | **19** |

Exactly one capability is absent, and it is the one the reverse leg depends on.
`ConsistentSystemID` (0 vs 27), `pg_basebackup` (0 vs 5) and `IDENTIFY_SYSTEM`
(0 vs 5) are absent from the file entirely.

## The citation runs in a circle

`platform/postgres/chart/templates/dr-promoter.yaml` L18-23 defers to *"the
operator lifts it on region-A recovery (RUNBOOKS §6.1)"*. §6.1 says the lift is
automatic via a component those pairs do not ship. No manual procedure was ever
written for them. Each side points at the other.

## Consequence

On a real region-A return the three shared-pg pairs auto-promote in region B, and
then nothing detects that the returning region-A primary is on a divergent line —
two writable primaries, no automatic resolution, no documented manual one.
Keycloak is a shared-pg consumer, which is how the original hw292 finding surfaced.

This is not a smaller version of #6148: that one is a bounded 120s window that
self-resolves, this has no terminating condition.

## What this PR does

Docs only. It marks the gap exactly where a reader would otherwise assume
coverage, states the measurement behind the claim, and says what to do until the
port lands — treat shared-pg failback as operator-driven and undefined, and
recover by re-cloning the returning side rather than letting both sides serve.

The port itself is #6149. The header comment's stale citation is corrected in that
change, since touching the template requires a chart version bump and this
correction should not wait behind one.

Refs #6149
