### PR TITLE
fix(agenity): the credential init container WAITS instead of reading once

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1389,7 +1389,7 @@ spec:
       #   guacamole-pg and the shared-pg family as well. Egress half in
       #   bp-keycloak 1.5.9; neither half alone restores a brokered login.
       #   Lockstep w/ products/catalyst/chart/Chart.yaml.
-      version: 1.4.1434
+      version: 1.4.1435
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/agenity/blueprint.yaml
+++ b/products/agenity/blueprint.yaml
@@ -18,7 +18,7 @@ spec:
   # Keycloak backchannel + upstream) — the per-Org namespace is default-deny
   # and the gate's ingress-only CNP left the OAuth callback 500ing on a DNS
   # timeout. Lockstep with products/agenity/chart + the catalog-seed pin.
-  version: 0.5.22
+  version: 0.5.26
   card:
     title: Agenity
     summary: |

--- a/products/agenity/chart/Chart.yaml
+++ b/products/agenity/chart/Chart.yaml
@@ -1,5 +1,16 @@
 apiVersion: v2
 name: bp-agenity
+# 0.5.26 (#6163 FREEZE 2): the credential init container WAITS instead of
+# reading the mount once. The old branch printed "no credentials.json key in
+# Secret — key-only mode" and exited 0 on a miss, permanently. Measured on
+# hw293: a workspace held that line for EIGHT HOURS after the Sovereign's
+# OpenBao path was seeded, Pod Running throughout — which is exactly what let
+# UAT row R19 ("the init container validates the token and exits 0") read green
+# over a workspace that could not reach Anthropic at all. The wait is what makes
+# a late credential land with NO restart: kubelet re-projects a mounted Secret
+# on its own sync period, so a value seeded after the Pod started becomes
+# visible in-place. anthropic.credentialWait tunes it (timeoutSeconds 300,
+# intervalSeconds 5, onTimeout fail|continue) and the miss branch is fail-loud.
 # 0.5.20 (#4706-family, 2026-07-03): image repo moved ghcr.io/openova-io/
 # bp-agenity → ghcr.io/openova-io/agenity. The dashboard image (tag =
 # appVersion 0.9.7) squatted the bp-agenity CHART OCI repo, so any
@@ -188,7 +199,7 @@ type: application
 # same gateway bp-wordpress-tenant + the org console route attach to, #4054).
 # The old default rendered Accepted=False/InvalidHTTPRoute and the host 404'd
 # until the parentRef was hand-overridden. appVersion (image) unchanged.
-version: 0.5.22
+version: 0.5.26
 # 0.5.22 (#5617): the per-Org oidc-gate companion gains its EGRESS
 # CiliumNetworkPolicy (templates/oidc-gate.yaml `oidc-gate-<cid>-egress`).
 # The gate shipped an ingress-only gateway CNP into a DEFAULT-DENY per-Org

--- a/products/agenity/chart/templates/statefulset.yaml
+++ b/products/agenity/chart/templates/statefulset.yaml
@@ -84,6 +84,26 @@ spec:
             - |
               set -e
               mkdir -p /claudehome/.claude/projects
+              # ── #6163 FREEZE 2: WAIT for the credential, do not read once ──
+              # kubelet re-projects a mounted Secret on its own sync period, so a
+              # value seeded AFTER pod start appears in /creds while this loop is
+              # still running — that is what lets a late credential land with no
+              # restart. Retrying here also survives an init-container restart,
+              # because each attempt re-reads the mount rather than a snapshot.
+              _cw_timeout={{ (.Values.anthropic.credentialWait).timeoutSeconds | default 300 }}
+              _cw_interval={{ (.Values.anthropic.credentialWait).intervalSeconds | default 5 }}
+              _cw_ontimeout='{{ (.Values.anthropic.credentialWait).onTimeout | default "fail" }}'
+              _cw_waited=0
+              while [ ! -s /creds/{{ .Values.anthropic.credentialsKey }} ] && [ "$_cw_waited" -lt "$_cw_timeout" ]; do
+                if [ "$_cw_waited" = 0 ]; then
+                  echo "waiting for /creds/{{ .Values.anthropic.credentialsKey }} (up to ${_cw_timeout}s) — a credential seeded after pod start lands here with no restart (#6163)"
+                fi
+                sleep "$_cw_interval"
+                _cw_waited=$((_cw_waited + _cw_interval))
+              done
+              if [ -s /creds/{{ .Values.anthropic.credentialsKey }} ] && [ "$_cw_waited" -gt 0 ]; then
+                echo "credential arrived after ${_cw_waited}s of waiting (#6163)"
+              fi
               if [ -s /creds/{{ .Values.anthropic.credentialsKey }} ]; then
                 cp /creds/{{ .Values.anthropic.credentialsKey }} /claudehome/.claude/.credentials.json
                 chmod 600 /claudehome/.claude/.credentials.json
@@ -112,7 +132,24 @@ spec:
                   *)        echo "could not parse claude-code OAuth expiry from credentials.json (non-fatal)." ;;
                 esac
               else
-                echo "no credentials.json key in Secret — key-only mode"
+                # #6163 FREEZE 2. This branch is NOT "key-only mode" — this init
+                # container only renders when `anthropic.credentialsKey` is set,
+                # i.e. when OAuth mode was REQUESTED. A genuinely key-only install
+                # sets it to "" and gets no init container. So the only thing this
+                # can mean is: the credential you asked for did not arrive.
+                #
+                # Saying "key-only mode" named a supported operating mode and made
+                # an outage look like a configuration choice — the reason a hw293
+                # workspace sat broken for eight hours while its Pod read Running.
+                echo "🛑 FATAL (#6163): no credential at /creds/{{ .Values.anthropic.credentialsKey }} after ${_cw_timeout}s."
+                echo "🛑 This is NOT key-only mode — this init container only runs when anthropic.credentialsKey is set, so OAuth mode WAS requested and the credential never arrived."
+                echo "🛑 The spawned agent cannot authenticate to Anthropic. Seed the Org's OpenBao path catalyst/anthropic/token with a credentialsJson and let the ExternalSecret sync (see README: Seeding)."
+                if [ "$_cw_ontimeout" = "continue" ]; then
+                  echo "🛑 anthropic.credentialWait.onTimeout=continue — starting anyway; the dashboard will serve but the agent will fail 401."
+                else
+                  echo "🛑 anthropic.credentialWait.onTimeout=fail — refusing to start, so this surfaces in kubectl get pod instead of a Running Pod that cannot work."
+                  exit 1
+                fi
               fi
               # Onboarding stub so claude-code does not re-run the first-run
               # /login flow AND does not block on the two interactive first-run

--- a/products/agenity/chart/values.yaml
+++ b/products/agenity/chart/values.yaml
@@ -87,6 +87,38 @@ anthropic:
   # solo agent can call Claude. Empty = key-only mode (only works for a real
   # sk-ant-api03 API key, which the OAuth journey does not use).
   credentialsKey: credentialsJson
+  # #6163 FREEZE 2 — the seed init container WAITS for the credential instead
+  # of reading the mount once and asserting whatever it saw.
+  #
+  # The old branch printed "no credentials.json key in Secret — key-only mode"
+  # and exited 0 on a miss, forever. Measured on hw293: a workspace held that
+  # line for EIGHT HOURS after the Sovereign's OpenBao path was seeded, with the
+  # Pod reporting Running the whole time — which is what let UAT row R19 ("the
+  # init container validates the token and exits 0") read green over a workspace
+  # that could not talk to Anthropic at all.
+  #
+  # The wait is what makes a late credential land with NO restart: kubelet
+  # re-projects a mounted Secret on its own sync period, so a value seeded after
+  # pod start appears in /creds while this loop is still running.
+  #
+  # "key-only mode" was never a true description of that branch either. This
+  # init container renders ONLY under `anthropic.credentialsKey`, i.e. only when
+  # OAuth mode was requested; a genuinely key-only install sets credentialsKey
+  # to "" and gets no init container at all. So the miss could only ever mean
+  # "the credential you asked for did not arrive", and it named a supported
+  # operating mode instead.
+  credentialWait:
+    # Total seconds to wait for the credential to appear. Spans the ExternalSecret
+    # refreshInterval by default so a seed landing on the next ESO sync is caught.
+    timeoutSeconds: 300
+    intervalSeconds: 5
+    # What to do when the credential never arrives.
+    #   fail     — exit non-zero. The Pod shows Init:Error / CrashLoopBackOff in
+    #              `kubectl get pod`, which is the honest signal: the workspace
+    #              cannot do the thing it exists to do.
+    #   continue — start anyway, having said so loudly. Restores the pre-#6163
+    #              shape for anyone who wants a shell over an honest error.
+    onTimeout: fail
   externalSecret:
     enabled: true
     refreshInterval: 1h

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-13T08:57:29.376Z",
+  "generatedAt": "2026-08-13T09:30:53.174Z",
   "blueprints": [
     {
       "id": "bp-agenity",
@@ -11,7 +11,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "listed",
-      "version": "0.5.22",
+      "version": "0.5.26",
       "section": "pts-7-org-tenant",
       "depends": [
         "bp-external-secrets"

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -146,7 +146,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "listed",
-    "version": "0.5.22",
+    "version": "0.5.26",
     "section": "pts-7-org-tenant",
     "depends": [
       "bp-external-secrets"

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3899,7 +3899,7 @@ name: bp-catalyst-platform
 #   The seed pin is the delivery half: without this bump a pinned Sovereign
 #   resolves 1.5.9 and never sees the fix. This chart's own templates are
 #   unchanged.
-version: 1.4.1434
+version: 1.4.1435
 # 1.4.1229 — #5389: catalog-seed bp-newapi declares its `ui` endpoint
 #   (newapi.<fqdn>, ssoEnabled, launchDefault, ssoInitPath "/") instead of
 #   `endpoints: []`. The empty list made userUIGatePasses fail closed, which

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -6027,7 +6027,7 @@ spec:
   # 0.5.22 (#5617): the oidc-gate companion gains its egress CNP — the per-Org
   # namespace is default-deny and the gate's ingress-only CNP left DNS + the
   # Keycloak token exchange dropped, 500ing every OAuth callback after login.
-  version: "0.5.22"
+  version: "0.5.26"
   visibility: listed
   card:
     title: "Agenity"
@@ -6057,7 +6057,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-agenity
-    version: 0.5.22
+    version: 0.5.26
   topology:
     supported:
       - singleton


### PR DESCRIPTION
Supersedes #6217 — same fix, fresh ref. See the re-cut note at the bottom for why.

## The defect (#6163 FREEZE 2)

The seed init container read the projected Secret exactly once. On a miss it
printed:

```
no credentials.json key in Secret — key-only mode
```

…and exited **0**. Permanently, for the life of the Pod.

Measured on hw293: a workspace held that line for **eight hours** after the
Sovereign's OpenBao path was seeded, with the Pod reporting `Running` throughout.

That is what let UAT row **R19** — *"the init container validates the token and
exits 0"* — read green over a workspace that could not reach Anthropic at all.
The check was true; the conclusion it licensed was false.

## The fix

Poll instead of sampling once. This works without a restart because **kubelet
re-projects a mounted Secret on its own sync period** — a value seeded after the
Pod started becomes visible in place. Waiting for it converts an eight-hour
silent gap into a bounded one.

`anthropic.credentialWait` tunes it:

| key | default |
|---|---|
| `timeoutSeconds` | 300 |
| `intervalSeconds` | 5 |
| `onTimeout` | `fail` \| `continue` |

The miss branch is now **fail-loud** rather than a reassuring log line.

## Why this is a re-cut and not a new fix

PR #6217 carries identical behaviour and cannot be merged: GitHub stopped
scheduling workflow runs for that ref after 07:00Z.

| head | check-runs |
|---|---|
| `258ed7d8d` (predecessor) | **86** |
| every commit after it | **0** |

…while `main` was served normally throughout, and the three branches I cut since
drew 47 / 11 / 23 runs. So the fault is that one ref, not the repo or the
workflows.

Two remedies I tried first, and why neither applies:

- **close/reopen** — those workflows subscribe to `opened`/`synchronize`, not `reopened`
- **empty commit** — they are `paths:`-filtered, and an empty commit matches no path

A fresh ref is the remedy that fits the actual fault.

## Rebuilt, not replayed

The old branch's version chain went stale while it sat — it carried umbrella
`1.4.1430`; main is now `1.4.1434`. Versions re-taken by **enumerating** claims
across all open PR heads rather than guessing:

| version | claimed by |
|---|---|
| agenity 0.5.23 | #5964, #5968 |
| agenity 0.5.24 | #6164 |
| agenity 0.5.25 | #6217 itself |
| **agenity 0.5.26** | **free** |
| **umbrella 1.4.1435** | **free** |

Catalog-seed synced via `sync-catalog-seed-pin.py` and the catalog regenerated,
so the drift gate sees no diff.

Local gates green: bootstrap-kit pin-sync, umbrella-republish (#5734), commit-message
word gate.

Refs #6163
