### PR TITLE
fix(bp-postgres): the shared-pg pairs get a dr-failback AND the #6148 write-guard (Refs #6149)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1389,7 +1389,10 @@ spec:
       #   guacamole-pg and the shared-pg family as well. Egress half in
       #   bp-keycloak 1.5.9; neither half alone restores a brokered login.
       #   Lockstep w/ products/catalyst/chart/Chart.yaml.
-      version: 1.4.1436
+      # 1.4.1437 — #6149 (Refs #6148): catalog-seed advances bp-postgres 0.2.20 ->
+      #   0.2.23 (region-A dr-failback for the three shared-pg DR pairs + the
+      #   #6148 peer-ahead write-guard). Lockstep w/ products/catalyst/chart/Chart.yaml.
+      version: 1.4.1437
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/clusters/_template/bootstrap-kit/16a-bp-postgres-shared.yaml
+++ b/clusters/_template/bootstrap-kit/16a-bp-postgres-shared.yaml
@@ -179,7 +179,18 @@ spec:
       # 14 Secrets silently missing. Readiness reports loop-liveness ONLY — it must
       # never gate on the synced state, because this HR keeps Helm wait with
       # install.remediation.retries: -1. Lockstep 16a/16c/16d.
-      version: 0.2.20
+      # 0.2.23 (#6149, Refs #6148 #5623 #5245): region-A AUTOMATIC DR FAILBACK — the
+      # SYMMETRIC half of 0.2.18's promoter. hw293 G12 (2026-08-11) promoted all four
+      # DR pairs and only bp-cnpg-pair could come back (census: 4 promoters / 1
+      # failback), leaving shared-pg + shared-pg-b permanently DUAL-WRITABLE on
+      # divergent timelines with keycloak on one of them. Both actors now ride ONE
+      # side-independent gate (bp-postgres.drPairCapable), so a promoter without a
+      # failback is not expressible, and a one-sided operator gate FAILS the render.
+      # Carries the #6148 write-guard: on peer-ahead DETECTION the actor applies a
+      # CiliumNetworkPolicy denying :5432 to everything but the pair's own Pods and
+      # itself, and removes it on every fail-safe path — so the 120s hold no longer
+      # accepts consumer writes it is about to discard. Lockstep 16a/16c/16d.
+      version: 0.2.23
       sourceRef:
         kind: HelmRepository
         name: bp-postgres
@@ -262,6 +273,40 @@ spec:
       autoPromote:
         hr:
           name: bp-postgres-shared
+      # -- Region-A automatic DR FAILBACK (#6149) ---------------------------
+      # THE SYMMETRIC HALF of autoPromote, and not optional relative to it.
+      # On the hw293 G12 region-kill (2026-08-11, dep a0077ba47e3720e5) all four
+      # DR pairs promoted and exactly ONE could come back: the census was 4
+      # dr-promoters in region B against 1 dr-failback in region A
+      # (bp-cnpg-pair's). shared-pg and its siblings were left DUAL-WRITABLE on
+      # divergent timelines -- both sides pg_is_in_recovery()=false, different
+      # row counts of the same table, nothing scheduled to ever reconcile them.
+      # shared-pg carries keycloak. Chart 0.2.21 makes the two actors ride ONE
+      # gate (bp-postgres.drPairCapable), so this block is not an opt-in: it
+      # names the seams the region-A actor writes through.
+      #
+      # hr.name MUST be this slot's own HelmRelease -- the actor renders the
+      # demotion onto spec.values.topology.demoted there.
+      #
+      # demotedSubstituteKey MUST be UNIQUE PER INSTANCE. bp-cnpg-pair (slot
+      # 16b) hard-codes SOVEREIGN_CNPG_PAIR_DEMOTED because there is exactly one
+      # pair; the three bp-postgres instances share ONE bootstrap-kit
+      # Kustomization, so a shared key would demote and re-clone all three the
+      # moment any single one of them failed back. Each slot owns its own key,
+      # and cloud-init never needs to stamp it -- the substitute is CREATED by
+      # the actor's merge patch and consumed by the SAME Kustomization on the
+      # next reconcile, exactly as SOVEREIGN_CNPG_PAIR_DEMOTED is for 16b.
+      failback:
+        hr:
+          name: bp-postgres-shared
+        demotedSubstituteKey: SOVEREIGN_SHARED_PG_DEMOTED
+      # The DEMOTED (rejoin) seam the failback actor drives. Default false;
+      # kustomize renders it true from the substitute above once the actor has
+      # proven region-B writable and equal-or-ahead for the full peer-ahead
+      # hold, which flips this instance's primary Cluster CR into a
+      # pg_basebackup replica of region-B. Flipping it back to false is the
+      # sovereign-admin's controlled switchback (RUNBOOKS 6.1).
+      demoted: ${SOVEREIGN_SHARED_PG_DEMOTED:-false}
       # #4442 — HOST shared-data instance: the singleton operator-probe NP
       # (networkpolicy-singleton-operator-probe.yaml) default-denies 5432 to
       # cross-namespace consumers (keycloak/gitea/harbor in OTHER namespaces,

--- a/clusters/_template/bootstrap-kit/16c-bp-postgres-shared-b.yaml
+++ b/clusters/_template/bootstrap-kit/16c-bp-postgres-shared-b.yaml
@@ -103,7 +103,18 @@ spec:
       # dr-promoter + failover-readiness + topology.promoted HR-value seam on the
       # active-hot-standby replica half (autoPromote.hr.name above targets THIS HR,
       # bp-postgres-shared-b). sync-only fence. Lockstep 16a/16c/16d.
-      version: 0.2.20
+      # 0.2.23 (#6149, Refs #6148 #5623 #5245): region-A AUTOMATIC DR FAILBACK — the
+      # SYMMETRIC half of 0.2.18's promoter. hw293 G12 (2026-08-11) promoted all four
+      # DR pairs and only bp-cnpg-pair could come back (census: 4 promoters / 1
+      # failback), leaving shared-pg + shared-pg-b permanently DUAL-WRITABLE on
+      # divergent timelines with keycloak on one of them. Both actors now ride ONE
+      # side-independent gate (bp-postgres.drPairCapable), so a promoter without a
+      # failback is not expressible, and a one-sided operator gate FAILS the render.
+      # Carries the #6148 write-guard: on peer-ahead DETECTION the actor applies a
+      # CiliumNetworkPolicy denying :5432 to everything but the pair's own Pods and
+      # itself, and removes it on every fail-safe path — so the 120s hold no longer
+      # accepts consumer writes it is about to discard. Lockstep 16a/16c/16d.
+      version: 0.2.23
       sourceRef:
         kind: HelmRepository
         name: bp-postgres
@@ -152,6 +163,40 @@ spec:
       autoPromote:
         hr:
           name: bp-postgres-shared-b
+      # -- Region-A automatic DR FAILBACK (#6149) ---------------------------
+      # THE SYMMETRIC HALF of autoPromote, and not optional relative to it.
+      # On the hw293 G12 region-kill (2026-08-11, dep a0077ba47e3720e5) all four
+      # DR pairs promoted and exactly ONE could come back: the census was 4
+      # dr-promoters in region B against 1 dr-failback in region A
+      # (bp-cnpg-pair's). shared-pg-b and its siblings were left DUAL-WRITABLE on
+      # divergent timelines -- both sides pg_is_in_recovery()=false, different
+      # row counts of the same table, nothing scheduled to ever reconcile them.
+      # shared-pg carries keycloak. Chart 0.2.21 makes the two actors ride ONE
+      # gate (bp-postgres.drPairCapable), so this block is not an opt-in: it
+      # names the seams the region-A actor writes through.
+      #
+      # hr.name MUST be this slot's own HelmRelease -- the actor renders the
+      # demotion onto spec.values.topology.demoted there.
+      #
+      # demotedSubstituteKey MUST be UNIQUE PER INSTANCE. bp-cnpg-pair (slot
+      # 16b) hard-codes SOVEREIGN_CNPG_PAIR_DEMOTED because there is exactly one
+      # pair; the three bp-postgres instances share ONE bootstrap-kit
+      # Kustomization, so a shared key would demote and re-clone all three the
+      # moment any single one of them failed back. Each slot owns its own key,
+      # and cloud-init never needs to stamp it -- the substitute is CREATED by
+      # the actor's merge patch and consumed by the SAME Kustomization on the
+      # next reconcile, exactly as SOVEREIGN_CNPG_PAIR_DEMOTED is for 16b.
+      failback:
+        hr:
+          name: bp-postgres-shared-b
+        demotedSubstituteKey: SOVEREIGN_SHARED_PG_B_DEMOTED
+      # The DEMOTED (rejoin) seam the failback actor drives. Default false;
+      # kustomize renders it true from the substitute above once the actor has
+      # proven region-B writable and equal-or-ahead for the full peer-ahead
+      # hold, which flips this instance's primary Cluster CR into a
+      # pg_basebackup replica of region-B. Flipping it back to false is the
+      # sovereign-admin's controlled switchback (RUNBOOKS 6.1).
+      demoted: ${SOVEREIGN_SHARED_PG_B_DEMOTED:-false}
       # #4442 — HOST shared-data instance: open 5432 to cross-namespace
       # consumers (the singleton operator-probe NP otherwise default-denies
       # them). See slot 16a for the full rationale.

--- a/clusters/_template/bootstrap-kit/16d-bp-postgres-shared-c.yaml
+++ b/clusters/_template/bootstrap-kit/16d-bp-postgres-shared-c.yaml
@@ -91,7 +91,18 @@ spec:
       # dr-promoter + failover-readiness + topology.promoted HR-value seam on the
       # active-hot-standby replica half (autoPromote.hr.name above targets THIS HR,
       # bp-postgres-shared-c). sync-only fence. Lockstep 16a/16c/16d.
-      version: 0.2.20
+      # 0.2.23 (#6149, Refs #6148 #5623 #5245): region-A AUTOMATIC DR FAILBACK — the
+      # SYMMETRIC half of 0.2.18's promoter. hw293 G12 (2026-08-11) promoted all four
+      # DR pairs and only bp-cnpg-pair could come back (census: 4 promoters / 1
+      # failback), leaving shared-pg + shared-pg-b permanently DUAL-WRITABLE on
+      # divergent timelines with keycloak on one of them. Both actors now ride ONE
+      # side-independent gate (bp-postgres.drPairCapable), so a promoter without a
+      # failback is not expressible, and a one-sided operator gate FAILS the render.
+      # Carries the #6148 write-guard: on peer-ahead DETECTION the actor applies a
+      # CiliumNetworkPolicy denying :5432 to everything but the pair's own Pods and
+      # itself, and removes it on every fail-safe path — so the 120s hold no longer
+      # accepts consumer writes it is about to discard. Lockstep 16a/16c/16d.
+      version: 0.2.23
       sourceRef:
         kind: HelmRepository
         name: bp-postgres
@@ -140,6 +151,40 @@ spec:
       autoPromote:
         hr:
           name: bp-postgres-shared-c
+      # -- Region-A automatic DR FAILBACK (#6149) ---------------------------
+      # THE SYMMETRIC HALF of autoPromote, and not optional relative to it.
+      # On the hw293 G12 region-kill (2026-08-11, dep a0077ba47e3720e5) all four
+      # DR pairs promoted and exactly ONE could come back: the census was 4
+      # dr-promoters in region B against 1 dr-failback in region A
+      # (bp-cnpg-pair's). shared-pg-c and its siblings were left DUAL-WRITABLE on
+      # divergent timelines -- both sides pg_is_in_recovery()=false, different
+      # row counts of the same table, nothing scheduled to ever reconcile them.
+      # shared-pg carries keycloak. Chart 0.2.21 makes the two actors ride ONE
+      # gate (bp-postgres.drPairCapable), so this block is not an opt-in: it
+      # names the seams the region-A actor writes through.
+      #
+      # hr.name MUST be this slot's own HelmRelease -- the actor renders the
+      # demotion onto spec.values.topology.demoted there.
+      #
+      # demotedSubstituteKey MUST be UNIQUE PER INSTANCE. bp-cnpg-pair (slot
+      # 16b) hard-codes SOVEREIGN_CNPG_PAIR_DEMOTED because there is exactly one
+      # pair; the three bp-postgres instances share ONE bootstrap-kit
+      # Kustomization, so a shared key would demote and re-clone all three the
+      # moment any single one of them failed back. Each slot owns its own key,
+      # and cloud-init never needs to stamp it -- the substitute is CREATED by
+      # the actor's merge patch and consumed by the SAME Kustomization on the
+      # next reconcile, exactly as SOVEREIGN_CNPG_PAIR_DEMOTED is for 16b.
+      failback:
+        hr:
+          name: bp-postgres-shared-c
+        demotedSubstituteKey: SOVEREIGN_SHARED_PG_C_DEMOTED
+      # The DEMOTED (rejoin) seam the failback actor drives. Default false;
+      # kustomize renders it true from the substitute above once the actor has
+      # proven region-B writable and equal-or-ahead for the full peer-ahead
+      # hold, which flips this instance's primary Cluster CR into a
+      # pg_basebackup replica of region-B. Flipping it back to false is the
+      # sovereign-admin's controlled switchback (RUNBOOKS 6.1).
+      demoted: ${SOVEREIGN_SHARED_PG_C_DEMOTED:-false}
       # #4442 — HOST shared-data instance: open 5432 to cross-namespace
       # consumers (the singleton operator-probe NP otherwise default-denies
       # them). See slot 16a for the full rationale.

--- a/docs/RUNBOOKS.md
+++ b/docs/RUNBOOKS.md
@@ -1339,36 +1339,54 @@ The deterministic failover test for two independent CNPG clusters:
      never-acked WAL tail (the RPO=0 contract). Evidence:
      `dr-failback-started-at` / `-recloned-at` / `-converged-at` annotations
      on the region-A HR + both actors' pod logs.
-
-   🛑 **This reverse leg covers the bp-cnpg-pair pair ONLY — the three shared-pg
-   pairs are not in it (#6149).** All three moves above are bp-cnpg-pair
-   mechanisms (`SOVEREIGN_CNPG_PAIR_PROMOTED` / `_DEMOTED` and the dr-failback
-   actor). `shared-pg`, `shared-pg-b` and `shared-pg-c` run **bp-postgres**,
-   which ships `dr-promoter` but no `dr-failback`: measured against
-   bp-cnpg-pair's promoter it carries the suspend latch, arm gate, liveness gate,
-   anti-flap and readback-verify, and **zero** timeline-divergence machinery
-   (`ConsistentSystemID`, `pg_basebackup` and `IDENTIFY_SYSTEM` are absent from
-   it entirely). They appear in this section's **promotion** table above and
-   nowhere in this step.
-
-   Consequence on a real region-A return: those three pairs auto-promote in
-   region B, and then nothing detects that the returning region-A primary is on
-   a divergent line — two writable primaries with no automatic resolution. Note
-   that bp-postgres's own header comment defers to "the operator lifts it on
-   region-A recovery (RUNBOOKS §6.1)", and this step says the lift is automatic
-   via a component those pairs do not have; the manual procedure it implies has
-   never been written. Treat shared-pg failback as **operator-driven and
-   undefined** until #6149 lands the port, and prefer to recover those pairs by
-   re-cloning the returning side from the promoted one rather than letting both
-   sides serve.
+   🛑 **Sample the failback on ALL FOUR pairs, not just `cnpg-pair` (#6149).**
+   Until `bp-postgres` 0.2.23 this whole step was true of exactly ONE pair. On
+   the hw293 G12 walk (2026-08-11, dep `a0077ba47e3720e5`) the deployment census
+   after region-A returned was **4 `dr-promoter`s in region B against 1
+   `dr-failback` in region A** — `cnpg-pair`'s. The three `shared-pg` pairs
+   promoted correctly and then had nothing to bring them back: `shared-pg` (which
+   carries **keycloak**) and `shared-pg-b` were left **DUAL-WRITABLE on divergent
+   timelines**, both sides `pg_is_in_recovery()=false` with different row counts
+   of the same table. That state does not self-resolve and is invisible to a
+   region-B-only sample. `bp-postgres` 0.2.23 ships the same `dr-failback` with
+   the same chain, per-instance substitutes
+   (`SOVEREIGN_SHARED_PG{,_B,_C}_DEMOTED` — three installs share ONE
+   bootstrap-kit Kustomization), and a producer-side invariant that makes a
+   promoter without a failback unrenderable
+   (`bp-postgres.drPairCapable`). **The walk assertion is the CENSUS, not the
+   presence of any one actor**: `dr-promoter` count in region B must equal
+   `dr-failback` count in region A. Anything else is the #6149 geometry.
+   ```
+   kubectl --context <region-b> get deploy -A -l catalyst.openova.io/role=dr-promoter
+   kubectl --context <region-a> get deploy -A -l catalyst.openova.io/role=dr-failback
+   ```
+   🛑 **#6148 — the peer-ahead hold is WRITE-GUARDED; sample the guard, do not
+   assume it.** region A comes back a writable primary on a doomed line and would
+   otherwise accept writes for the whole ~120s hold, which the re-clone then
+   discards. `bp-cnpg-pair` 0.2.24 and `bp-postgres` 0.2.23 close that window: on
+   peer-ahead DETECTION the failback actor applies a `CiliumNetworkPolicy` named
+   `<pair>-write-guard` that denies `:5432` to everything except the pair's own
+   Pods and the failback Pod, and removes it on every path that clears the hold
+   clock. Two things to sample, because both failure modes are silent:
+   ```
+   # during the hold — the guard must EXIST
+   kubectl --context <region-a> get ciliumnetworkpolicy -A | grep write-guard
+   # after convergence — it must be GONE (a stuck guard leaves :5432 denied)
+   kubectl --context <region-a> logs deploy/<instance>-dr-failback -c actor | grep WRITE-GUARD
+   ```
+   `guard_on` is deliberately non-fatal, so a `WARN: WRITE-GUARD could not be
+   applied` line means the failback ran with the window OPEN — the end state will
+   still be correct, but a region-A-local client may hold an acknowledged write
+   that later vanishes.
 
    **End state**: region-B primary, region-A streaming replica, both HRs
    unsuspended, topology rendered from source. The **controlled switchback**
    to original roles stays a sovereign-admin action: demote region-B and
    restore region-A by resetting BOTH substitutes
-   (`SOVEREIGN_CNPG_PAIR_PROMOTED`/`_DEMOTED` → `"false"` on each region's
-   bootstrap-kit Kustomization) during a maintenance window — automate via
-   the CNPG demotion-token handshake is follow-up on #5245.
+   (`SOVEREIGN_CNPG_PAIR_PROMOTED`/`_DEMOTED` for slot 16b, and
+   `SOVEREIGN_SHARED_PG{,_B,_C}_DEMOTED` for slots 16a/16c/16d → `"false"` on
+   each region's bootstrap-kit Kustomization) during a maintenance window —
+   automate via the CNPG demotion-token handshake is follow-up on #5245.
    🛑 **Timeline-divergence signal (#5220/#5245)**: the dr-promoter still
    records `catalyst.openova.io/dr-timeline-diverged-at` on the region-B HR
    when a side cannot stream from a REACHABLE peer — on ≥ 0.2.18 the wedge

--- a/platform/postgres/blueprint.yaml
+++ b/platform/postgres/blueprint.yaml
@@ -37,7 +37,17 @@ spec:
   # consumer-hub sync's absence as a Warning Event + status ConfigMap instead
   # of leaving 14 Secrets silently missing behind a green release. Readiness
   # never gates on the synced state, so it cannot wedge Helm wait.
-  version: 0.2.20
+  # 0.2.22 (#6149): region-A AUTOMATIC DR FAILBACK — the symmetric half of
+  # 0.2.18, plus the invariant that makes it non-optional. hw293 G12
+  # (2026-08-11) shipped 4 dr-promoters against 1 dr-failback and left
+  # shared-pg (keycloak's database) and shared-pg-b permanently DUAL-WRITABLE
+  # on divergent timelines with nothing scheduled to reconcile them: 0.2.18 had
+  # converted "does not fail over" into "fails over and never comes back". The
+  # ported bp-cnpg-pair dr-failback now demotes region A through a durable
+  # Kustomization-substitute seam and re-clones it onto region B's line, and
+  # both DR actors render off ONE side-independent gate so a promoter without a
+  # failback is not expressible. New: topology.demoted, topology.failback.*.
+  version: 0.2.23
   card:
     title: PostgreSQL
     summary: |

--- a/platform/postgres/chart/Chart.yaml
+++ b/platform/postgres/chart/Chart.yaml
@@ -1,5 +1,91 @@
 apiVersion: v2
 name: bp-postgres
+# 0.2.23 — #6149 (Refs #5623 #5245 #5331 #5388 #6148): region-A AUTOMATIC DR
+#   FAILBACK, the PAIRING INVARIANT that makes it non-optional, and the #6148
+#   write-guard that fences the hold window.
+#   0.2.18 gave this chart a region-B dr-promoter and it works — on the hw293 G12
+#   region-kill (2026-08-11, dep a0077ba47e3720e5) all three shared-pg pairs
+#   promoted. Nothing gave them the symmetric half. The deployment census taken
+#   after region A returned: dr-promoter deployments in region B = 4 (all four
+#   pairs), dr-failback deployments in region A = 1 (bp-cnpg-pair ONLY). The one
+#   pair carrying a failback converged (region A back as in_recovery=true on TL=2,
+#   streaming from B); `shared-pg` (writable TL=3, 1 row | writable TL=3, 2 rows)
+#   and `shared-pg-b` (writable TL=2, 1 row | writable TL=3, 2 rows) were left
+#   permanently DUAL-WRITABLE on divergent timelines with nothing scheduled to
+#   ever reconcile them. `shared-pg` carries keycloak. That means 0.2.18 converted
+#   "does not fail over" into "fails over and never comes back" — strictly worse,
+#   because it fails OPEN and SILENT where #5623 failed closed and obvious.
+#     - templates/dr-failback.yaml — a FAITHFUL PORT of bp-cnpg-pair's dr-failback
+#       (chart 0.2.23), side=primary-gated: signals detects the post-failover
+#       geometry (local writable + pinned sync standby ABSENT + peer WRITABLE on an
+#       EQUAL-or-higher TL over `-replica-mesh`, IDENTIFY_SYSTEM timelines over the
+#       replication protocol), holds peerAheadHoldSeconds, then the actor demotes
+#       through the DURABLE SOURCE SEAM (patch the bootstrap-kit Kustomization's
+#       per-instance demotion substitute → kustomize renders topology.demoted onto
+#       this HR → helm re-renders the CR as a replica cluster — never a live
+#       Cluster-CR patch, #5125-D1), escalates on CNPG's own ConsistentSystemID=
+#       False divergence verdict (#5331 — the bare 'streaming' signal is the hw285
+#       data-loss trap), and deletes exactly once for a clean pg_basebackup
+#       re-clone with the PKI ownerReferences stripped first (#5245 hw278).
+#       Bounded destruction, every destructive step re-gated on a <60s-fresh
+#       writable-peer proof, starvation surfaced on the HR (#5388).
+#     - THE INVARIANT (bp-postgres.drPairCapable + assertDRPairSymmetry): the two
+#       actors no longer carry independent precondition sets. One SIDE-INDEPENDENT
+#       gate (active-hot-standby + sync + clusterMesh + ≥1 peer ClusterMesh name)
+#       decides whether this pair has a DR chain at all, and both the promoter
+#       (side=replica) and the failback (side=primary) render off it — so a
+#       promoter without a failback is not expressible. The promoter previously
+#       rendered with peers=[] and could never promote (#5178's
+#       PRIMARY_LIVENESS_ENABLED is exactly `clusterMesh AND peers`); it is now
+#       honestly absent instead of silently inert. Setting exactly ONE of
+#       autoPromote.enabled / failback.enabled FAILS THE RENDER naming both keys.
+#     - templates/peer-mesh-service.yaml — the side=primary zero-backend stub for
+#       `<instance>-replica-mesh`, so the reverse-direction global service merges
+#       by name and region-B's writable endpoint resolves on cluster-A.
+#     - replica-cluster.yaml — certificates.clientCASecret pinned to the shared
+#       `<instance>-ca` (so region-A's own client cert authenticates against
+#       region-B) + the `<instance>-replica-mesh` managed Service, selectorType rw
+#       so it tracks promotion (#5473: `r` would let a standby serve as the
+#       failback source).
+#     - cluster.yaml — the DEMOTED (rejoin) shape: replica.enabled + pg_basebackup
+#       from `<instance>-replica-mesh` with NO sslRootCert (#5245 hw278 x509
+#       FATAL-loop), sync fence off, managed.roles off (a read-only standby can
+#       never reconcile CREATE/ALTER ROLE); database.yaml likewise skipped.
+#     - #6148 WRITE-GUARD (ported from bp-cnpg-pair 0.2.24 / PR #6219): region A
+#       is a writable primary on an already-doomed line for the whole 120s hold,
+#       so every commit it accepts is acknowledged to a consumer and then
+#       discarded by the re-clone — and on THIS chart those consumers are
+#       keycloak, gitea, harbor, grafana, powerdns and the Organization mesh, not
+#       a dedicated DR pair with no clients. On peer-ahead DETECTION the actor now
+#       applies a CiliumNetworkPolicy (rendered as inert ConfigMap DATA so its
+#       lifecycle is the actor's and flux drift-correction has nothing to revert,
+#       #5125-D1) that DENIES ingress to :5432 for everything except the pair's
+#       own Pods and the failback Pod itself. Four load-bearing properties:
+#       `ingressDeny` on a CNP — a k8s NetworkPolicy CANNOT deny and would not
+#       subtract this chart's own `namespaceSelector: {}` consumer allow (#3577),
+#       so it would be created, logged and permit every write it claimed to stop;
+#       `enableDefaultDeny: {ingress:false, egress:false}` so it is purely
+#       subtractive and leaves the replication + CNPG-operator carve-outs intact;
+#       the failback Pod stays exempt or its own timeline probe trips
+#       `clear_hold "local timeline unreadable"` and aborts the whole failback
+#       (the trap that ruled out CNPG instance fencing); and `guard_on` is
+#       NON-FATAL, because converging region A is what ENDS the exposure. The
+#       guard is keyed to /shared/peer-ahead-since and `guard_off` sweeps
+#       unconditionally per tick, so every fail-safe path the signals loop
+#       already has takes it back down. RBAC adds ciliumnetworkpolicies
+#       get/patch/delete resourceNames-pinned to that one object, plus `create`
+#       in its own rule (k8s RBAC ignores resourceNames on create, so pinning it
+#       there would read as a constraint while enforcing nothing).
+#   New values under topology: demoted, failback.* (incl. the PER-INSTANCE
+#   demotedSubstituteKey — three installs share ONE bootstrap-kit Kustomization,
+#   so a shared key would demote all three at once). Default-OFF preserved:
+#   singleton / async / no-peers render ZERO DR resources, write-guard included.
+#   LIVE region-kill proof on the shared-pg pairs is owed on the next 2-region G12
+#   walk. tests/postgres-render.sh Cases 21a-21g added (21g vacuity-checked with
+#   five COMPILING mutants: default-deny flipped on, failback exemption removed,
+#   guard_on removed, the guard_off sweep removed, CNP downgraded to a k8s
+#   NetworkPolicy — each renders cleanly and each turns 21g red).
+#   Lockstep: 16a/16c/16d HR pins + blueprint.yaml + catalog-seed.
 # 0.2.18 — #5623 (Refs #5137 #5178 #5218 #5220 #5133 #5157): region-B AUTOMATIC DR
 #   promotion for the shared-pg pairs. The three shared-pg instances render the EXACT
 #   bp-cnpg-pair split-side replica shape but shipped NO region-local promoter, so on
@@ -329,8 +415,8 @@ name: bp-postgres
 #   honoured — sprig's `default` swallows boolean false). Primary render is
 #   byte-identical. Lockstep slot pins 16a/16c/16d → 0.2.20.
 #   tests/postgres-render.sh Case 21 added.
-version: 0.2.20
-appVersion: 0.2.20
+version: 0.2.23
+appVersion: 0.2.23
 description: |
   Catalyst-authored data-instance Blueprint for a shareable, reusable
   PostgreSQL engine. Each install of bp-postgres = ONE

--- a/platform/postgres/chart/templates/_helpers.tpl
+++ b/platform/postgres/chart/templates/_helpers.tpl
@@ -109,13 +109,184 @@ TRUE only when ALL of (mirrors bp-cnpg-pair.autoPromoteActive exactly):
                                   no fence → the promoter does NOT render there.)
 renderReplicaHalf is already false when the whole chart is disabled or singleton;
 dr-promoter.yaml additionally guards on `ne (toString .Values.enabled) "false"`.
+
+0.2.21 (#6149): the promoter no longer carries its own precondition set. Both DR
+actors now ride the single SIDE-INDEPENDENT `bp-postgres.drPairCapable` gate
+below, so it is structurally impossible for this chart to render a promoter on
+cluster-B without rendering the matching failback on cluster-A. See
+drPairCapable + assertDRPairSymmetry.
 */}}
 {{- define "bp-postgres.autoPromoteActive" -}}
+{{- include "bp-postgres.assertDRPairSymmetry" . -}}
 {{- $topology := .Values.topology | default dict -}}
 {{- $ap := dig "autoPromote" dict $topology -}}
 {{- $apEnabled := true -}}
 {{- if hasKey $ap "enabled" }}{{- $apEnabled = $ap.enabled -}}{{- end -}}
-{{- if and (include "bp-postgres.renderReplicaHalf" .) $apEnabled (eq (dig "replication" "mode" "sync" $topology) "sync") -}}true{{- end -}}
+{{- if and (eq (include "bp-postgres.drPairCapable" .) "true") (eq (include "bp-postgres.side" .) "replica") $apEnabled -}}true{{- end -}}
+{{- end -}}
+
+{{/*
+DR PAIR CAPABILITY — the SIDE-INDEPENDENT preconditions under which this pair
+has an automatic DR chain at all (#6149, chart 0.2.21).
+
+WHY THIS EXISTS — the #6149 defect, measured
+--------------------------------------------
+hw293 G12 region-kill (2026-08-11, dep a0077ba47e3720e5). Deployment census
+after region-A returned:
+
+    dr-promoter deployments in region B : 4   <- all four pairs
+    dr-failback deployments in region A : 1   <- bp-cnpg-pair ONLY
+
+`shared-pg` and `shared-pg-b` were left DUAL-WRITABLE on divergent timelines —
+both sides `pg_is_in_recovery()=false`, different row counts of the same table,
+neither following the other, nothing scheduled to ever reconcile them.
+`shared-pg` carries keycloak, the authoritative identity store.
+
+That is the SYMMETRIC half of #5623: #5623 added the promoter to this chart and
+converted "does not fail over" into "fails over and never comes back" — strictly
+worse, because a split-brain accepting writes on BOTH sides silently diverges
+rather than simply being unavailable.
+
+THE INVARIANT — a pair that can be PROMOTED must be able to FAIL BACK
+---------------------------------------------------------------------
+A promoter without a failback is not a partial feature; it is a data-integrity
+hazard. So the two actors do NOT get independent precondition sets. Everything
+STRUCTURAL is resolved once, here, side-independently, and BOTH actors gate on
+it — the promoter (side=replica, cluster-B) and the failback (side=primary,
+cluster-A). The two sides render in SEPARATE helm invocations, but the only
+input that differs between them is `topology.side`, so this helper — which
+never reads `side` — computes the same answer on both clusters. Rendering one
+actor without the other is therefore not a thing the chart can express.
+
+TRUE only when ALL of:
+  - activeHotStandby          (the pair shape is on at all)
+  - replication.mode == sync  (the anti-split-brain DATA FENCE. remote_apply +
+                               FIRST 1 pinned to the cross-region replica means
+                               the old primary cannot durably commit while its
+                               sync standby is unreachable or diverged, so the
+                               promote cannot fork committed data AND the
+                               failback's "region-B's line ⊇ region-A's acked
+                               history" premise holds. async has neither.)
+  - clusterMesh.enabled AND crossRegionPeerClusters non-empty
+                              (the cross-region probe path. The failback has
+                               ALWAYS required this — without a positive
+                               peer-writable proof it has no safe action at
+                               all. The promoter required it too, in substance:
+                               #5178's PRIMARY_LIVENESS_ENABLED is exactly
+                               `clusterMesh AND peers`, and with it false the
+                               promoter renders but can NEVER promote. Making
+                               the requirement structural turns an actor that
+                               was silently inert into one that is honestly
+                               absent, and — the point — makes the promoter's
+                               precondition set IDENTICAL to the failback's.)
+
+SAFE AGAINST THE RUNTIME FLIP ORDER: catalyst-api stamps
+SOVEREIGN_ENABLE_CNPG_PAIR and SOVEREIGN_PEER_CLUSTERMESH_NAMES in ONE merge
+patch (handler/clustermesh.go patchOne — "Both keys land in ONE merge patch so
+the CNP appears atomically with the crossRegion netpol half it gates"), so
+crossRegion=true with peers=[] is not a window this chart is rendered through.
+And where it is reachable at all, this gate FAILS CLOSED (no actors) rather than
+erroring the render — a template `fail` there would break the atomic bootstrap-
+kit apply and land ZERO HelmReleases, which is the trap clustermesh.go already
+guards its region precondition against.
+*/}}
+{{- define "bp-postgres.drPairCapable" -}}
+{{- $topology := .Values.topology | default dict -}}
+{{- $peers := dig "networkPolicy" "crossRegionPeerClusters" (list) $topology -}}
+{{- $meshOn := ne (toString (dig "clusterMesh" "enabled" true $topology)) "false" -}}
+{{- if and (include "bp-postgres.activeHotStandby" .) (eq (dig "replication" "mode" "sync" $topology) "sync") $meshOn (gt (len $peers) 0) -}}true{{- end -}}
+{{- end -}}
+
+{{/*
+Region-A automatic DR FAILBACK — active? (#6149, chart 0.2.21)
+
+The exact mirror of autoPromoteActive: the SAME drPairCapable structural gate,
+the OTHER side, and its own operator gate. The actor runs ON cluster-A, the half
+being rejoined — by definition it only matters once region-A is back.
+*/}}
+{{- define "bp-postgres.failbackActive" -}}
+{{- include "bp-postgres.assertDRPairSymmetry" . -}}
+{{- $topology := .Values.topology | default dict -}}
+{{- $fb := dig "failback" dict $topology -}}
+{{- $fbEnabled := true -}}
+{{- if hasKey $fb "enabled" }}{{- $fbEnabled = $fb.enabled -}}{{- end -}}
+{{- if and (eq (include "bp-postgres.drPairCapable" .) "true") (eq (include "bp-postgres.side" .) "primary") $fbEnabled -}}true{{- end -}}
+{{- end -}}
+
+{{/*
+THE PAIRING INVARIANT, enforced at the producer (#6149, chart 0.2.21).
+
+drPairCapable makes the STRUCTURAL preconditions common to both actors, so the
+only remaining way to render a promoter without a failback is for an operator to
+switch exactly one of the two `enabled` gates off. That is a values mistake, not
+a runtime state, and it must not render — it re-creates the hw293 geometry by
+hand: region B promotes on a kill and region A comes back dual-writable forever.
+
+So it FAILS THE RENDER, loudly, naming both keys. Unlike the structural gate this
+`fail` is reachable ONLY from a hand-edited values file — never from a substitute
+the bootstrap-kit stamps (16a/16c/16d set neither key; the chart defaults are
+both true) — so it cannot wedge an atomic bootstrap-kit apply.
+
+Both directions are refused. `failback.enabled=false` with a live promoter is the
+#6149 hazard itself. `autoPromote.enabled=false` with a live failback is the
+inverse trap: an actor armed to demote region A on a peer-ahead proof, with
+nothing that could ever legitimately produce one — the only way its peer goes
+ahead is an operator promoting region B by hand mid-incident, and it would then
+demote + re-clone region A underneath them.
+*/}}
+{{- define "bp-postgres.assertDRPairSymmetry" -}}
+{{- $topology := .Values.topology | default dict -}}
+{{- $ap := dig "autoPromote" dict $topology -}}
+{{- $apEnabled := true -}}
+{{- if hasKey $ap "enabled" }}{{- $apEnabled = $ap.enabled -}}{{- end -}}
+{{- $fb := dig "failback" dict $topology -}}
+{{- $fbEnabled := true -}}
+{{- if hasKey $fb "enabled" }}{{- $fbEnabled = $fb.enabled -}}{{- end -}}
+{{- if and (eq (include "bp-postgres.drPairCapable" .) "true") (ne (toString $apEnabled) (toString $fbEnabled)) -}}
+{{- fail (printf "bp-postgres: DR PAIRING INVARIANT VIOLATED — topology.autoPromote.enabled=%v but topology.failback.enabled=%v. A pair that can be PROMOTED must be able to FAIL BACK, and vice versa; the two are one feature. Shipping only the promoter is #6149: on the hw293 G12 region-kill (2026-08-11) region B promoted and region A came back a writable primary on a divergent timeline with nothing scheduled to reconcile them — shared-pg (which carries keycloak) and shared-pg-b were left permanently DUAL-WRITABLE. Shipping only the failback is the inverse trap: an actor armed to demote and re-clone region A on a peer-ahead proof that only a hand-promotion could produce. Set BOTH to the same value." $apEnabled $fbEnabled) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+DEMOTED (rejoin) shape — active? (#6149, chart 0.2.21)
+
+TRUE when this install is the active-hot-standby PRIMARY half AND
+`topology.demoted` is set — the region-A rejoin after a region-kill promote.
+The dr-failback actor drives this through the DURABLE SOURCE SEAM: it patches
+the bootstrap-kit Kustomization's per-instance demotion substitute, kustomize
+renders `topology.demoted: true` onto this instance's HelmRelease, and helm
+re-renders the primary Cluster CR as a REPLICA CLUSTER of region-B. Never a live
+`kubectl patch` of the Cluster CR — flux drift-correction reverts that mid-outage
+(#5125-D1, hw256 G12).
+
+Only consulted on the primary side: on side=replica the primary Cluster CR is not
+rendered at all, so a stray `demoted: true` there is inert rather than confusing.
+Flipping it back to false is the sovereign-admin's controlled switchback
+(RUNBOOKS §6.1), after region-B has been demoted in turn.
+*/}}
+{{- define "bp-postgres.primaryDemoted" -}}
+{{- $topology := .Values.topology | default dict -}}
+{{- if and (include "bp-postgres.activeHotStandby" .) (eq (include "bp-postgres.side" .) "primary") (ne (toString (dig "demoted" false $topology)) "false") -}}true{{- end -}}
+{{- end -}}
+
+{{/*
+Peer replication Service name (#6149) — the REVERSE-direction ClusterMesh alias.
+
+`<instance>-mesh` carries region-A's primary read endpoint to region-B (the
+forward WAL stream). `<instance>-replica-mesh` is its mirror: region-B's replica
+Cluster publishes its `rw` (designated/promoted primary) endpoint under this
+name, and region-A reaches it here. Declared on side=replica via the replica
+Cluster CR's `spec.managed.services.additional[]` (selectorType rw, so it
+follows the promotion), plus a zero-backend local stub on side=primary
+(peer-mesh-service.yaml) because Cilium merges global services by name+namespace
+— without the stub the name is NXDOMAIN on cluster-A.
+
+Consumed by the dr-failback actor's peer probe AND by the demoted primary
+Cluster's externalCluster (the region-A rejoin stream). Mirrors bp-cnpg-pair's
+`cnpg-pair.peerReplicationServiceName` exactly.
+*/}}
+{{- define "bp-postgres.peerReplicationServiceName" -}}
+{{- printf "%s-replica-mesh" (include "bp-postgres.instanceName" .) | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*

--- a/platform/postgres/chart/templates/cluster.yaml
+++ b/platform/postgres/chart/templates/cluster.yaml
@@ -28,7 +28,12 @@ ClusterMesh-global `-mesh` Service. The REPLICA half is replica-cluster.yaml
 */ -}}
 {{- if and (ne (toString .Values.enabled) "false") (.Capabilities.APIVersions.Has "postgresql.cnpg.io/v1") (not (include "bp-postgres.renderReplicaHalf" .)) }}
 {{- $ahs := eq (include "bp-postgres.activeHotStandby" .) "true" }}
-{{- $sync := and $ahs (eq (default "sync" .Values.topology.replication.mode) "sync") }}
+{{- /* #6149 REJOIN shape — this primary CR renders as a REPLICA CLUSTER of
+     region-B. See bp-postgres.primaryDemoted. A demoted half carries NO sync
+     fence (a standby has no synchronous standby of its own), so $sync is forced
+     off here rather than at every use site. */ -}}
+{{- $demoted := eq (include "bp-postgres.primaryDemoted" .) "true" }}
+{{- $sync := and $ahs (not $demoted) (eq (default "sync" .Values.topology.replication.mode) "sync") }}
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
@@ -76,6 +81,75 @@ spec:
   instances: {{ .Values.topology.instances | default 1 }}
   imageName: {{ include "bp-postgres.imageRef" . | quote }}
   {{- end }}
+
+{{- if $demoted }}
+  {{- $bootFirst := first .Values.databases }}
+  {{- $rejoinDb := (default (dict) $bootFirst).name | default "app" }}
+  {{- $rejoinOwner := (default (dict) $bootFirst).owner | default "app" }}
+  # ── #6149 REJOIN shape — replica cluster of region-B ──────────────
+  # `replica.enabled: true` + pg_basebackup from the `-replica`
+  # externalCluster (region-B's promoted primary over `-replica-mesh`).
+  # bootstrap runs only at Cluster CREATION — the dr-failback actor deletes
+  # the stale Cluster CR once this desired state is rendered, so helm
+  # re-creates it fresh and the basebackup clones region-B's CURRENT
+  # timeline. That discard is what makes the pair converge: a TL-N line
+  # cannot follow a TL-M source (walreceiver FATAL 55000 "highest timeline
+  # … is behind recovery timeline …" every 5s, forever), and on hw293
+  # nothing discarded it, so shared-pg and shared-pg-b stayed dual-writable
+  # on divergent timelines indefinitely (#6149).
+  #
+  # pg_rewind is deliberately NOT used: CNPG has no cross-cluster rewind
+  # trigger, and a rewind's fork-point arithmetic depends on WAL-tail
+  # geometry the actor cannot verify. The basebackup re-clone is
+  # deterministic for every geometry.
+  replica:
+    enabled: true
+    source: {{ include "bp-postgres.replicaName" . }}
+  bootstrap:
+    pg_basebackup:
+      source: {{ include "bp-postgres.replicaName" . }}
+      database: {{ $rejoinDb | quote }}
+      owner:    {{ $rejoinOwner | quote }}
+  externalClusters:
+    - name: {{ include "bp-postgres.replicaName" . }}
+      connectionParameters:
+        # Reverse-direction ClusterMesh global alias: region-B's replica
+        # Cluster publishes its `rw` (designated/promoted primary) as
+        # `<instance>-replica-mesh` (replica-cluster.yaml managed additional
+        # Service); the side=primary local stub (peer-mesh-service.yaml)
+        # makes the name resolve here with zero local backends → traffic
+        # crosses the mesh.
+        host: {{ include "bp-postgres.peerReplicationServiceName" . }}
+        port: "5432"
+        user: streaming_replica
+        sslmode: require
+        dbname: {{ $rejoinDb | quote }}
+      # Region-A's OWN CNPG-issued streaming_replica client cert — accepted
+      # by region-B because the replica Cluster pins its client CA to this
+      # same `<instance>-ca` (replica-cluster.yaml, #6149). Both Secrets
+      # exist natively on cluster-A (CNPG issued them for this Cluster).
+      #
+      # 🛑 NO sslRootCert HERE (#5245 hw278 live-proof): the SERVER this
+      # connection dials is region-B's replica Cluster, whose server chain
+      # is signed by region-B's OWN `<instance>-replica-ca` — a Secret
+      # cluster-A does not hold. Because libpq/pgx upgrade sslmode=require
+      # to verify-ca semantics the moment a root cert IS supplied, pinning
+      # one here makes the re-clone's pgbasebackup bootstrap FATAL-loop on
+      # `x509: certificate signed by unknown authority` (5+ hours on hw278).
+      # With no root cert, sslmode=require is encrypted without server-chain
+      # verification — the same posture as every other in-mesh streaming
+      # hop; peer authenticity rides the client-cert requirement (region-B
+      # verifies THIS cert against the shared client CA) plus the Cilium
+      # ClusterMesh identity path. The FORWARD direction
+      # (replica-cluster.yaml) KEEPS its root pin — there `<instance>-ca`
+      # genuinely signs the server it dials.
+      sslKey:
+        name: {{ include "bp-postgres.instanceName" . }}-replication
+        key: tls.key
+      sslCert:
+        name: {{ include "bp-postgres.instanceName" . }}-replication
+        key: tls.crt
+{{- else }}
 
   bootstrap:
     initdb:
@@ -154,6 +228,7 @@ spec:
       secret:
         name: {{ include "bp-postgres.roleSecretName" (dict "ctx" $ "db" $first) | quote }}
       {{- end }}
+{{- end }}
 
   {{- /*
   managed.roles — one declarative per-consumer login role per binding.
@@ -189,9 +264,17 @@ spec:
   local pre-flip singleton DB.
   */ -}}
   {{- $meshSvc := and (eq (include "bp-postgres.meshGlobalServices" .) "true") (eq (include "bp-postgres.side" .) "primary") }}
-  {{- if or .Values.databases $meshSvc }}
+  {{- /* #6149 — managed.roles is a WRITE reconcile (CREATE/ALTER ROLE). In the
+       demoted rejoin shape this Cluster is a read-only standby of region-B, so
+       CNPG can never satisfy the declaration and would report it pending
+       forever; the roles themselves arrive with the basebackup. The mesh
+       Services stay — they are the names the switchback needs to keep
+       resolving. Mirrors bp-cnpg-pair's demoted primary (no managed roles at
+       all, managed.services unconditional). */ -}}
+  {{- $mgdRoles := and .Values.databases (not $demoted) }}
+  {{- if or $mgdRoles $meshSvc }}
   managed:
-    {{- if .Values.databases }}
+    {{- if $mgdRoles }}
     roles:
       {{- $seenOwners := dict }}
       {{- range .Values.databases }}

--- a/platform/postgres/chart/templates/database.yaml
+++ b/platform/postgres/chart/templates/database.yaml
@@ -24,8 +24,15 @@ active-hot-standby the replica half is a streaming follower that inherits
 every database via the WAL stream (CNPG forbids writes there until promoted),
 so a Database CR on the replica cluster would be rejected / meaningless. The
 renderReplicaHalf gate skips this whole template on side=replica.
+
+#6149 — the SAME reasoning applies to the DEMOTED (rejoin) primary. Once the
+dr-failback actor has demoted region-A, this Cluster is a read-only standby of
+region-B for exactly the same reason, and a Database CR against it is a CREATE
+DATABASE that can never succeed. The databases arrive with the basebackup; the
+CRs return on the controlled switchback (RUNBOOKS §6.1) when `topology.demoted`
+goes back to false.
 */ -}}
-{{- if and (ne (toString .Values.enabled) "false") (.Capabilities.APIVersions.Has "postgresql.cnpg.io/v1") (not (include "bp-postgres.renderReplicaHalf" .)) }}
+{{- if and (ne (toString .Values.enabled) "false") (.Capabilities.APIVersions.Has "postgresql.cnpg.io/v1") (not (include "bp-postgres.renderReplicaHalf" .)) (not (include "bp-postgres.primaryDemoted" .)) }}
 {{- $ctx := . }}
 {{- range .Values.databases }}
 ---

--- a/platform/postgres/chart/templates/dr-failback.yaml
+++ b/platform/postgres/chart/templates/dr-failback.yaml
@@ -1,0 +1,1252 @@
+{{- /*
+Region-A DR auto-FAILBACK for the shared-pg pairs (#6149 - chart 0.2.21).
+
+WHY THIS EXISTS
+---------------
+#5623 gave this chart a region-B `dr-promoter` and it works: on the hw293 G12
+region-kill (2026-08-11, dep a0077ba47e3720e5) all three shared-pg pairs
+promoted. Nothing gave them the SYMMETRIC half. The deployment census taken
+after region A returned:
+
+    dr-promoter deployments in region B : 4   <- all four pairs
+    dr-failback deployments in region A : 1   <- bp-cnpg-pair ONLY
+
+`cnpg-pair` - the one pair carrying a failback - converged cleanly: region A
+came back `in_recovery=true` on TL=2, streaming from B. `shared-pg` and
+`shared-pg-b` did not, and could not:
+
+    shared-pg    region A: WRITABLE TL=3, 1 row | region B: WRITABLE TL=3, 2 rows
+    shared-pg-b  region A: WRITABLE TL=2, 1 row | region B: WRITABLE TL=3, 2 rows
+
+Both sides `pg_is_in_recovery()=false`, different row counts of the SAME table,
+neither following the other, and nothing anywhere scheduled to ever reconcile
+them. `shared-pg` carries keycloak - the authoritative identity store. A
+split-brained auth database fails OPEN and SILENT: two live writable copies
+accumulating divergent state, which is strictly worse than #5623's read-only
+outage, because that one failed closed and was obvious.
+
+So adding the promoter without the failback converted "does not fail over" into
+"fails over and never comes back". This Deployment closes that loop, and
+`bp-postgres.drPairCapable` (_helpers.tpl) makes the two actors share ONE
+structural gate so the asymmetry cannot be re-created: a pair that can be
+PROMOTED can always FAIL BACK.
+
+This is a FAITHFUL PORT of bp-cnpg-pair's dr-failback (chart 0.2.23) - the same
+region-A-local actor, the same signals/actor split, the same peer-ahead hold,
+the same divergence detector, the same bounded re-clone, the same fail-safes -
+templated with bp-postgres's own naming helpers and value seams. The logic was
+not invented here; it was proven on hw293 in the very walk that measured this
+defect, on the one pair that had it.
+
+RENDER GATING
+-------------
+Renders ONLY on side=primary (it acts on cluster-A, which by definition exists
+again exactly when failback matters) and ONLY under `bp-postgres.drPairCapable`
+- active-hot-standby + sync replication + clusterMesh + at least one peer
+ClusterMesh name. Without a positive peer proof there is no safe action, so the
+actor does not render at all; and because the promoter now rides the SAME gate,
+it does not render either.
+
+WHAT IT DOES - demote + re-clone region-A onto region-B's line
+--------------------------------------------------------------
+The correct failback direction is fixed by the data, not by preference:
+region-B's promoted line contains every ACKNOWLEDGED commit region-A ever made.
+Structurally: sync remote_apply + FIRST 1 pinned to the cross-region replica
+means (a) before the kill, no commit was acked on A that B had not already
+applied; (b) the dead window adds nothing; (c) post-recovery region-A is
+write-fenced by the same unsatisfiable FIRST 1 (its only allowed sync standby
+has left the timeline), so it acks nothing new. Discarding region-A's line loses
+only never-acked local WAL - exactly what the RPO=0 contract already discards.
+The reverse direction (re-cloning region-B from region-A) would destroy the
+acknowledged post-promote writes and is therefore never automatic. This is why
+the actor renders only in sync mode: the fence IS the authority proof.
+
+  1. DETECT (signals container, psql as streaming_replica with this cluster's
+     own client cert): local cluster WRITABLE (in_recovery=f) on timeline N, the
+     pinned sync standby ABSENT from pg_stat_replication, AND the peer REACHABLE
+     + WRITABLE + on an EQUAL-OR-HIGHER timeline over the `-replica-mesh` global
+     Service. Timelines come from IDENTIFY_SYSTEM over a replication-protocol
+     connection - the one surface streaming_replica is guaranteed to have (no
+     pg_control privileges, the #5239 lesson). TL_peer >= TL_local, NOT strictly
+     greater (#5245 hw277: region-A's os-start recovery ran a LOCAL HA failover
+     that bumped its own timeline to the SAME number as region-B's promote, so a
+     strict `>` gate is structurally unsatisfiable and both regions served writes
+     for 57 minutes). Equality is safe to act on because the sync fence, not the
+     TL number, carries the authority.
+  2. HOLD peerAheadHoldSeconds (120s default) - a mesh blip or a replica restart
+     clears the clock. The stale region-A line is WRITE-GUARDED for the whole
+     window (#6148) - see the FENCING section below.
+  3. DEMOTE through the DURABLE SOURCE SEAM: patch the bootstrap-kit
+     Kustomization's `postBuild.substitute.<DEMOTED_SUB_KEY>` to "true" and let
+     kustomize render `topology.demoted: true` onto this instance's HelmRelease.
+     NEVER a live `kubectl patch` of the Cluster CR - flux drift-correction
+     reverts that mid-outage (#5125-D1, hw256 G12). The substitute key is
+     PER-INSTANCE (see $demotedSubKey): this chart is installed three times
+     against ONE bootstrap-kit Kustomization, so a shared key would demote all
+     three the moment any one of them failed back.
+  4. RE-CLONE, bounded: once the demoted shape is rendered, delete the stale
+     Cluster CR exactly once so helm re-creates it and pg_basebackup clones
+     region-B's current timeline. A Cluster created AFTER the episode started is
+     NEVER deleted. PKI Secrets are ownerReference-stripped first so the delete
+     does not GC the CA lineage (#5245 hw278).
+  5. CONVERGE: record `dr-failback-converged-at` ONLY when region-A is streaming
+     from region-B AND CNPG reports `ConsistentSystemID=True`. The bare
+     'streaming' signal is NOT sufficient - a divergent in-place-demoted standby
+     attaches at a coincidentally-equal LSN and reads 'streaming' while missing
+     region-B's post-failover writes (#5331, hw285 data-loss trap).
+
+FENCING THE HOLD WINDOW (#6148) - the write-guard
+--------------------------------------------------
+The hold is legitimate and must not be shortened: it guards the DEMOTE decision
+against a flap, and a demote/re-promote cycle bumps the timeline, which is the
+same class of damage the failback exists to repair. But for those 120s region-A
+is a writable primary on a line that is already doomed, so every commit it
+accepts is acknowledged to a consumer and then destroyed by the re-clone. On
+`shared-pg` those consumers are keycloak, gitea and harbor.
+
+So the window gets a guard rather than a shorter hold. On peer-ahead DETECTION
+the actor applies a CiliumNetworkPolicy (rendered as inert ConfigMap data below,
+never as a live template - see that comment for why) that DENIES ingress to
+:5432 for everything except the pair's own Pods and this actor. It is removed by
+`guard_off`, which runs unconditionally on every tick where the hold clock is
+not set - so every fail-safe path the signals loop already has takes the guard
+back down with it, and no future control flow can forget to.
+
+Four properties are load-bearing, each for a reason that was measured, not
+guessed:
+  - CiliumNetworkPolicy, NOT NetworkPolicy. k8s policies are additive
+    allow-lists and cannot subtract the consumer->5432 allow this chart's own
+    networkpolicy.yaml grants; a NetworkPolicy guard would be created, logged,
+    and permit every write it claimed to stop.
+  - `enableDefaultDeny: {ingress:false, egress:false}` - purely subtractive, so
+    it cannot take out the replication and CNPG-operator carve-outs.
+  - the failback Pod stays exempt. The signals loop reads the LOCAL timeline
+    over 5432; blind that read and `clear_hold "local timeline unreadable"`
+    aborts the whole failback. This is exactly what ruled out CNPG instance
+    fencing as the mechanism.
+  - `guard_on` is NON-FATAL. Converging region-A is what ENDS the exposure, so a
+    guard that cannot be applied must warn loudly and let the failback run.
+
+WHY A DEPLOYMENT, NOT A CronJob (#5157)
+---------------------------------------
+A region-local actor that must run DURING and AFTER a region outage is a
+continuous Deployment loop; a CronJob's scheduler is the regional control plane
+and does not reliably resume after recovery. side=primary-gated so it runs ON
+cluster-A with no dependency on anything in region-B beyond the peer probe.
+
+SAFETY - what it will NEVER do
+------------------------------
+Never patches a live Cluster CR (#5125-D1). Never deletes PVCs directly
+(owner-GC only), never any object but the one resourceNames-pinned Cluster CR.
+Never acts when the peer is unreachable, in recovery, or on a LOWER timeline - a
+mere mesh partition, a healthy pair, or the pre-promote outage window all read as
+"no peer-ahead proof" and clear the hold clock. Never re-promotes region-B (that
+is the dr-promoter's job, on cluster-B). Every destructive step re-checks a
+<60s-fresh peer proof.
+*/ -}}
+{{- if (include "bp-postgres.failbackActive" .) }}
+{{- $topology := .Values.topology | default dict }}
+{{- $fb := dig "failback" dict $topology }}
+{{- $hr := $fb.hr | default dict }}
+{{- $hrName := $hr.name | default "bp-postgres-shared" }}
+{{- $hrNamespace := $hr.namespace | default "flux-system" }}
+{{- $ks := $fb.kustomization | default dict }}
+{{- $ksName := $ks.name | default "bootstrap-kit" }}
+{{- $ksNamespace := $ks.namespace | default "flux-system" }}
+{{- /* Per-INSTANCE demotion substitute key (#6149). bp-cnpg-pair hard-codes
+       SOVEREIGN_CNPG_PAIR_DEMOTED because there is exactly one pair; this chart
+       is installed THREE times (shared-pg / -b / -c) against the SAME
+       bootstrap-kit Kustomization, so a shared key would demote all three the
+       moment any one of them failed back. Slots 16a/16c/16d stamp their own. */ -}}
+{{- $demotedSubKey := $fb.demotedSubstituteKey | default "SOVEREIGN_SHARED_PG_DEMOTED" }}
+{{- $kimg := $fb.kubectlImage | default dict }}
+{{- $krepo := $kimg.repository | default "harbor.openova.io/proxy-dockerhub/alpine/k8s" }}
+{{- $ktag := $kimg.tag | default "1.30.0" }}
+{{- $kpull := $kimg.pullPolicy | default "IfNotPresent" }}
+{{- $interval := $fb.intervalSeconds | default 10 }}
+{{- $hold := $fb.peerAheadHoldSeconds | default 120 }}
+{{- $startupGrace := $fb.startupGraceSeconds | default 300 }}
+{{- $probeTimeout := $fb.livenessProbeTimeoutSeconds | default 5 }}
+{{- $wedgeHold := $fb.wedgeHoldSeconds | default 600 }}
+{{- $divergenceGrace := $fb.divergenceGraceSeconds | default 180 }}
+{{- $starvationSurface := $fb.starvationSurfaceSeconds | default 300 }}
+{{- $peerClusters := dig "networkPolicy" "crossRegionPeerClusters" (list) $topology }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "bp-postgres.instanceName" . }}-dr-failback
+  namespace: {{ include "bp-postgres.namespace" . }}
+  labels:
+    {{- include "bp-postgres.labels" . | nindent 4 }}
+    catalyst.openova.io/cnpg-pair: {{ include "bp-postgres.instanceName" . | quote }}
+    catalyst.openova.io/role: dr-failback
+---
+# #6148 WRITE-GUARD manifest — rendered here as inert ConfigMap DATA, applied
+# and deleted by the actor.
+#
+# WHY THE MANIFEST IS DATA AND NOT A TEMPLATE. The guard must exist only for
+# the duration of the peer-ahead hold, so its lifecycle is the actor's, not
+# helm's. Rendering it as a live template would put it under the bootstrap-kit
+# Kustomization's inventory and flux drift-correction would fight the actor over
+# it — the #5125-D1 shape this chart forbids everywhere else. As ConfigMap data
+# it stays version-controlled, render-testable and reviewable, while the OBJECT
+# the actor applies is owned by nobody but the actor and is therefore never
+# reverted and never pruned.
+#
+# WHY CiliumNetworkPolicy AND NOT NetworkPolicy. A k8s NetworkPolicy cannot
+# express deny — policies selecting the same Pods are additive allow-lists, so a
+# new one cannot subtract the consumer->5432 allow networkpolicy.yaml grants
+# (`- from: [{namespaceSelector: {}}]`, the #3577 rule). It would be created,
+# logged, and permit every write it claimed to stop. Cilium's ingressDeny takes
+# precedence over every allow, in this policy or any other.
+#
+# WHY enableDefaultDeny IS FALSE. A CNP that selects an endpoint normally flips
+# it to default-deny for that direction. This policy is purely subtractive: it
+# removes one path without disturbing the carve-outs in networkpolicy.yaml that
+# keep replication and the CNPG operator's status probe alive.
+#
+# WHO STAYS REACHABLE, AND WHY EACH ONE MUST. matchExpressions inside one
+# selector are ANDed, so the denied set is "endpoints that are neither a pair
+# Pod nor the failback Pod":
+#   - the pair's own Pods keep 5432 — that is the replication path region-A
+#     needs in order to re-clone from region-B once the demote lands
+#   - the failback Pod keeps 5432 — the signals loop reads the local timeline
+#     over it, and if that read fails `clear_hold "local timeline unreadable"`
+#     aborts the whole failback. A guard that blinds the decider is worse than
+#     no guard; that is the trap which ruled out CNPG instance fencing.
+#   - the CNPG operator is untouched — it probes 8000/9187, never 5432.
+# fromEndpoints (not ipBlock) is required for the cross-region case: an ipBlock
+# never matches a ClusterMesh remote Pod's identity, so an ipBlock guard would
+# silently miss the very peer traffic it reasons about.
+#
+# WHAT IT COSTS ON A *SHARED* ENGINE, STATED PLAINLY. bp-cnpg-pair's pair has no
+# in-cluster consumers; `shared-pg` has keycloak, gitea and harbor (16a), and
+# 16c/16d have grafana/powerdns and the Organization mesh. So the hold window
+# denies THEIR 5432 too, for up to peerAheadHoldSeconds. That is the correct
+# trade and not a regression in disguise: the guard goes up only once the
+# post-failover geometry is PROVEN (local writable + pinned sync standby absent
+# + peer writable on an equal-or-higher timeline), and from that moment every
+# commit region-A accepts is acknowledged to the consumer and then silently
+# discarded by the re-clone. Refusing a keycloak write for ~120s is strictly
+# better than accepting it, telling keycloak it is durable, and destroying it.
+# The guard is also reversible at zero cost: any fail-safe path that clears the
+# hold clock takes it straight back down.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "bp-postgres.instanceName" . }}-write-guard
+  namespace: {{ include "bp-postgres.namespace" . }}
+  labels:
+    {{- include "bp-postgres.labels" . | nindent 4 }}
+    catalyst.openova.io/cnpg-pair: {{ include "bp-postgres.instanceName" . | quote }}
+data:
+  guard.yaml: |
+    apiVersion: cilium.io/v2
+    kind: CiliumNetworkPolicy
+    metadata:
+      name: {{ include "bp-postgres.instanceName" . }}-write-guard
+      namespace: {{ include "bp-postgres.namespace" . }}
+      labels:
+        catalyst.openova.io/cnpg-pair: {{ include "bp-postgres.instanceName" . | quote }}
+        catalyst.openova.io/role: dr-failback-write-guard
+      annotations:
+        catalyst.openova.io/why: >-
+          Applied by dr-failback for the duration of the peer-ahead hold (#6148).
+          region-A is a writable primary on a timeline the peer has already
+          overtaken, so a write committed here is acknowledged and then silently
+          discarded by the re-clone. Removed on clear_hold.
+    spec:
+      endpointSelector:
+        matchLabels:
+          cnpg.io/cluster: {{ include "bp-postgres.instanceName" . }}
+      enableDefaultDeny:
+        ingress: false
+        egress: false
+      ingressDeny:
+        - fromEndpoints:
+            - matchExpressions:
+                - key: cnpg.io/cluster
+                  operator: NotIn
+                  values:
+                    - {{ include "bp-postgres.instanceName" . }}
+                    - {{ include "bp-postgres.replicaName" . }}
+                - key: catalyst.openova.io/role
+                  operator: NotIn
+                  values:
+                    - dr-failback
+          toPorts:
+            - ports:
+                - port: "5432"
+                  protocol: TCP
+---
+# Local-namespace surface: get + delete on EXACTLY the primary Cluster
+# CR (the bounded re-clone). No patch (live-CR patches are the #5125-D1
+# anti-pattern), no PVC verbs (owner-GC does the storage), no list.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "bp-postgres.instanceName" . }}-dr-failback
+  namespace: {{ include "bp-postgres.namespace" . }}
+  labels:
+    {{- include "bp-postgres.labels" . | nindent 4 }}
+    catalyst.openova.io/cnpg-pair: {{ include "bp-postgres.instanceName" . | quote }}
+rules:
+  - apiGroups: [postgresql.cnpg.io]
+    resources: [clusters]
+    verbs: [get, delete]
+    resourceNames: [{{ include "bp-postgres.instanceName" . }}]
+  # #6148 write-guard lifecycle. The guard is applied on peer-ahead detection
+  # and deleted on clear_hold, so the actor needs to own exactly one object.
+  # get/patch/delete are resourceNames-pinned to that one name.
+  #
+  # `create` is deliberately in its own rule WITHOUT resourceNames, because
+  # k8s RBAC ignores resourceNames on create — the object does not exist yet,
+  # so there is no name to authorize against. Pinning it there would read as a
+  # constraint while enforcing nothing, so the split states the real scope
+  # instead of implying a narrower one. The residual power is "create some
+  # CiliumNetworkPolicy in this one namespace", which is strictly less than the
+  # `delete` on the Cluster CR this same Role already grants.
+  - apiGroups: [cilium.io]
+    resources: [ciliumnetworkpolicies]
+    verbs: [get, patch, delete]
+    resourceNames: [{{ include "bp-postgres.instanceName" . }}-write-guard]
+  - apiGroups: [cilium.io]
+    resources: [ciliumnetworkpolicies]
+    verbs: [create]
+  # #5245 0.2.20 preserve_pki: strip the controller ownerReferences from
+  # the CNPG-issued PKI Secrets before the bounded Cluster-CR delete so
+  # the CA lineage survives (hw278: the delete GC'd -ca/-replication/
+  # -server, CNPG re-issued a FRESH CA, and region-B's one-shot synced
+  # clientCASecret copy could never trust the re-cloned cluster's new
+  # client leaf). get+patch only, resourceNames-pinned to the three
+  # Secrets — no list, no read of any other Secret.
+  - apiGroups: [""]
+    resources: [secrets]
+    verbs: [get, patch]
+    resourceNames:
+      - {{ include "bp-postgres.instanceName" . }}-ca
+      - {{ include "bp-postgres.instanceName" . }}-replication
+      - {{ include "bp-postgres.instanceName" . }}-server
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "bp-postgres.instanceName" . }}-dr-failback
+  namespace: {{ include "bp-postgres.namespace" . }}
+  labels:
+    {{- include "bp-postgres.labels" . | nindent 4 }}
+    catalyst.openova.io/cnpg-pair: {{ include "bp-postgres.instanceName" . | quote }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "bp-postgres.instanceName" . }}-dr-failback
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "bp-postgres.instanceName" . }}-dr-failback
+    namespace: {{ include "bp-postgres.namespace" . }}
+---
+# flux-system surface: the HR (annotations + reconcile nudges) and the
+# Kustomization (the durable per-instance DEMOTED substitute) —
+# both resourceNames-pinned, get+patch only.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "bp-postgres.instanceName" . }}-dr-failback
+  namespace: {{ $hrNamespace }}
+  labels:
+    {{- include "bp-postgres.labels" . | nindent 4 }}
+    catalyst.openova.io/cnpg-pair: {{ include "bp-postgres.instanceName" . | quote }}
+rules:
+  - apiGroups: [helm.toolkit.fluxcd.io]
+    resources: [helmreleases]
+    verbs: [get, patch]
+    resourceNames: [{{ $hrName }}]
+  - apiGroups: [kustomize.toolkit.fluxcd.io]
+    resources: [kustomizations]
+    verbs: [get, patch]
+    resourceNames: [{{ $ksName }}]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "bp-postgres.instanceName" . }}-dr-failback
+  namespace: {{ $hrNamespace }}
+  labels:
+    {{- include "bp-postgres.labels" . | nindent 4 }}
+    catalyst.openova.io/cnpg-pair: {{ include "bp-postgres.instanceName" . | quote }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "bp-postgres.instanceName" . }}-dr-failback
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "bp-postgres.instanceName" . }}-dr-failback
+    namespace: {{ include "bp-postgres.namespace" . }}
+---
+# Egress allow-list (one CNP, #4428 idiom): apiserver (kubectl) +
+# kube-dns + the local primary cluster's 5432 (signals psql) + the
+# peer replica cluster's 5432 across the ClusterMesh (the peer probe —
+# same #4846 identity-scoped shape as the dr-promoter's region-A leg).
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: {{ include "bp-postgres.instanceName" . }}-dr-failback-egress
+  namespace: {{ include "bp-postgres.namespace" . }}
+  labels:
+    {{- include "bp-postgres.labels" . | nindent 4 }}
+    catalyst.openova.io/cnpg-pair: {{ include "bp-postgres.instanceName" . | quote }}
+spec:
+  endpointSelector:
+    matchLabels:
+      catalyst.openova.io/role: dr-failback
+      catalyst.openova.io/cnpg-pair: {{ include "bp-postgres.instanceName" . }}
+  egress:
+    - toEntities:
+        - kube-apiserver
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+            k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+    - toEndpoints:
+        - matchLabels:
+            cnpg.io/cluster: {{ include "bp-postgres.instanceName" . }}
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP
+    # Peer probe path — region-B's replica Cluster Pods over the mesh.
+    # Cross-region ClusterMesh endpoints carry their OWN pod identity;
+    # a plain toEndpoints is implicitly ANDed with the LOCAL cluster
+    # (#4846), so admit the peer cluster(s) explicitly.
+    - toEndpoints:
+        - matchLabels:
+            cnpg.io/cluster: {{ include "bp-postgres.replicaName" . }}
+          matchExpressions:
+            - key: io.cilium.k8s.policy.cluster
+              operator: In
+              values:
+                {{- range $peerClusters }}
+                - {{ . | quote }}
+                {{- end }}
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "bp-postgres.instanceName" . }}-dr-failback
+  namespace: {{ include "bp-postgres.namespace" . }}
+  labels:
+    {{- include "bp-postgres.labels" . | nindent 4 }}
+    catalyst.openova.io/cnpg-pair: {{ include "bp-postgres.instanceName" . | quote }}
+    catalyst.openova.io/role: dr-failback
+  annotations:
+    catalyst.openova.io/blueprint: bp-postgres
+spec:
+  replicas: 1
+  # Single actor; never two failback loops at once (#5157 shape).
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: bp-postgres
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      catalyst.openova.io/role: dr-failback
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: bp-postgres
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        catalyst.openova.io/role: dr-failback
+        catalyst.openova.io/cnpg-pair: {{ include "bp-postgres.instanceName" . | quote }}
+        # kyverno cilium-l7-mtls (Enforce) — required on the Pod
+        # template or the Deployment is DENIED at admission (#3238).
+        policy.cilium.io/enforced: "true"
+    spec:
+      # The actor runs in the primary region — the half being rejoined.
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: openova.io/region
+                    operator: In
+                    values: [{{ include "bp-postgres.primaryRegion" . | quote }}]
+      serviceAccountName: {{ include "bp-postgres.instanceName" . }}-dr-failback
+      automountServiceAccountToken: true
+      securityContext:
+        runAsNonRoot: true
+        fsGroup: 26
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        # ── signals — post-failover-geometry detector ─────────────────
+        # psql (streaming_replica client cert — this cluster's own
+        # `-primary-replication`, the #5133 auth pattern) against the
+        # LOCAL `-rw` plus the PEER probe over `-replica-mesh`. The
+        # peer psql presents the SAME local cert: region-B accepts it
+        # because its client CA is pinned to the shared `-primary-ca`
+        # (replica-cluster.yaml #5245). Timelines via IDENTIFY_SYSTEM
+        # on replication-protocol connections (pg_hba `hostssl
+        # replication streaming_replica all cert` — no pg_control /
+        # pg_read_all_stats privileges involved, #5239 lesson).
+        - name: signals
+          image: {{ include "bp-postgres.imageRef" . | quote }}
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -eu
+              LOCAL_CONN="host={{ include "bp-postgres.instanceName" . }}-rw port=5432 dbname=postgres user=streaming_replica sslmode=require sslcert=/tls/client/tls.crt sslkey=/tls/client/tls.key"
+              PEER_CONN="host=${PEER_MESH_HOST} port=5432 dbname=postgres user=streaming_replica sslmode=require sslcert=/tls/client/tls.crt sslkey=/tls/client/tls.key"
+              # Replication-protocol conninfo for IDENTIFY_SYSTEM (the
+              # timeline read every streaming_replica can perform).
+              LOCAL_REPL="host={{ include "bp-postgres.instanceName" . }}-rw port=5432 dbname=postgres user=streaming_replica sslmode=require sslcert=/tls/client/tls.crt sslkey=/tls/client/tls.key replication=true"
+              PEER_REPL="host=${PEER_MESH_HOST} port=5432 dbname=postgres user=streaming_replica sslmode=require sslcert=/tls/client/tls.crt sslkey=/tls/client/tls.key replication=true"
+              # LOCAL state ladder — mirrors the dr-promoter's #5239-readable
+              # signals: 'primary' (writable), 'streaming' (standby with a live
+              # walreceiver row + a set receive-LSN), 'receiving' (row, no WAL
+              # yet), 'noreceiver' (standby, no stream), 'unknown' (probe
+              # failed — fail-safe).
+              LQ="SELECT CASE
+                WHEN NOT pg_is_in_recovery() THEN 'primary'
+                WHEN EXISTS (SELECT 1 FROM pg_stat_wal_receiver) AND pg_last_wal_receive_lsn() IS NOT NULL THEN 'streaming'
+                WHEN EXISTS (SELECT 1 FROM pg_stat_wal_receiver) THEN 'receiving'
+                ELSE 'noreceiver'
+              END"
+              # Pinned sync standby present? The walsender rows run AS
+              # streaming_replica, so this probe role sees its own rows in
+              # full (no #5239 NULLing for same-user rows) — and row
+              # ABSENCE, the signal that matters, is visible to everyone.
+              SQ="SELECT CASE WHEN EXISTS (SELECT 1 FROM pg_stat_replication WHERE application_name = '{{ include "bp-postgres.replicaName" . }}') THEN 'present' ELSE 'absent' END"
+              # IDENTIFY_SYSTEM row: systemid | timeline | xlogpos | dbname
+              tl_of() {
+                psql "$1" -tAXc "IDENTIFY_SYSTEM" 2>/dev/null | head -1 | cut -d'|' -f2
+              }
+              is_int() { case "$1" in ''|*[!0-9]*) return 1 ;; *) return 0 ;; esac; }
+              STARTED=$(date -u +%s)
+              echo "[dr-failback/signals] loop started (interval=${INTERVAL_SECONDS}s startupGrace=${STARTUP_GRACE_SECONDS}s peerMeshHost=${PEER_MESH_HOST})"
+              clear_hold() {
+                if [ -f /shared/peer-ahead-since ]; then
+                  echo "$(date -u +"%FT%TZ") [dr-failback/signals] $1 — peer-ahead hold clock cleared"
+                fi
+                rm -f /shared/peer-ahead-since
+              }
+              clear_wedge() { rm -f /shared/wedge-since; }
+              # #5388 — starvation clock: accrues ONLY while the
+              # post-failover geometry candidate (local primary, sync
+              # standby absent) persists with the peer probe failing for
+              # an observability-dead reason. Every other path clears it.
+              starve_clear() { rm -f /shared/peer-starved-since; }
+              # peer_report <key> <message> — #5245 FAIL-LOUD probe
+              # diagnostics (chart 0.2.19). hw277: the loop sat 57 min
+              # after 'loop started' with ZERO output while the peer
+              # probe failed every tick (TL2==TL2 under the then-strict
+              # -gt gate) — a silent wedge indistinguishable from an
+              # NXDOMAIN from outside. Every probe REASON now logs on
+              # its transition and re-logs every 30 ticks (~5 min at
+              # the 10s interval) while a non-ok reason persists.
+              peer_report() {
+                _k="$1"; _m="$2"
+                _prev=$(cat /shared/peer-probe-reason 2>/dev/null || echo "")
+                if [ "${_k}" != "${_prev}" ]; then
+                  echo "${_k}" > /shared/peer-probe-reason
+                  echo 0 > /shared/peer-probe-ticks
+                  echo "$(date -u +"%FT%TZ") [dr-failback/signals] peer probe: ${_m}"
+                elif [ "${_k}" != "ok" ]; then
+                  _n=$(($(cat /shared/peer-probe-ticks 2>/dev/null || echo 0) + 1))
+                  if [ "${_n}" -ge 30 ]; then
+                    _n=0
+                    echo "$(date -u +"%FT%TZ") [dr-failback/signals] peer probe STILL: ${_m}"
+                  fi
+                  echo "${_n}" > /shared/peer-probe-ticks
+                fi
+              }
+              # probe_peer_writable — peer RESOLVABLE + REACHABLE +
+              # WRITABLE. The first three rungs of the probe ladder,
+              # split out (0.2.20, #5245 hw278) so the post-demote
+              # escalations can keep a LIVE writable-peer proof while
+              # the LOCAL cluster is psql-dark (mid-demote restarts, a
+              # bootstrap-looping re-clone) — once the demotion is
+              # durably rendered the authority question is settled and
+              # what a destructive step still needs is a fresh writable
+              # peer, not a re-run of the TL arithmetic. Touches
+              # /shared/peer-writable-fresh on success. Failure reasons
+              # stay fail-loud via peer_report; success reporting is
+              # the CALLER's job (probe_peer_ahead reports 'ok' with
+              # the TL numbers; probe_peer_writable_report reports the
+              # dark-window transition) so alternating call sites never
+              # spam per-tick transitions.
+              probe_peer_writable() {
+                # DNS first, separately from reachability: a structural
+                # NXDOMAIN (missing local -replica-mesh stub Service /
+                # broken kube-dns) must surface BY NAME, immediately
+                # (#5245). getent-less images fall through to
+                # pg_isready, which still covers reachability.
+                if command -v getent >/dev/null 2>&1 && ! getent hosts "${PEER_MESH_HOST}" >/dev/null 2>&1; then
+                  peer_report nxdomain "peer host ${PEER_MESH_HOST} NOT RESOLVABLE from this pod (NXDOMAIN) — the like-named local -replica-mesh stub Service (peer-mesh-service.yaml) or kube-dns is missing/broken; failback cannot observe the peer (#5245)"
+                  return 1
+                fi
+                if ! pg_isready -h "${PEER_MESH_HOST}" -p 5432 -t "${PROBE_TIMEOUT}" -q; then
+                  peer_report unreachable "peer ${PEER_MESH_HOST} resolves but is UNREACHABLE (pg_isready failed — region-B down, mesh partition, or CNP block)"
+                  return 1
+                fi
+                _rec=$(psql "${PEER_CONN}" -tAXc "SELECT pg_is_in_recovery()" 2>/dev/null || echo "err")
+                if [ "${_rec}" != "f" ]; then
+                  peer_report in-recovery "peer ${PEER_MESH_HOST} reachable but NOT WRITABLE (in_recovery=${_rec}) — region-B not promoted (healthy pair / pre-promote window): no failback"
+                  return 1
+                fi
+                : > /shared/peer-writable-fresh
+                return 0
+              }
+              # probe_peer_writable_report — standalone form for ticks
+              # where the TL arithmetic cannot run (local psql dark):
+              # logs the writable-proof transition once, never per-tick.
+              probe_peer_writable_report() {
+                if probe_peer_writable; then
+                  _prev=$(cat /shared/peer-probe-reason 2>/dev/null || echo "")
+                  case "${_prev}" in
+                    ok|writable-ok) : ;;
+                    *) peer_report writable-ok "peer ${PEER_MESH_HOST} WRITABLE (in_recovery=f) — peer-writable proof held while the local cluster is psql-dark (#5245 hw278)" ;;
+                  esac
+                fi
+              }
+              # probe_peer_ahead <tl_local> — probe_peer_writable + TL
+              # equal-or-higher (>= — see the DETECT rationale: the
+              # hw277 TL2==TL2 deadlock; the sync fence, not the TL
+              # number, is the authority proof). On success touches the
+              # freshness marker the actor re-checks before EVERY
+              # destructive step. Any failure → non-zero (caller
+              # clears) with its reason fail-loud via peer_report.
+              probe_peer_ahead() {
+                _tl_local="$1"
+                probe_peer_writable || return 1
+                _tl_peer=$(tl_of "${PEER_REPL}")
+                if ! is_int "${_tl_peer}"; then
+                  peer_report tl-unreadable "peer ${PEER_MESH_HOST} writable but its timeline is unreadable over the replication protocol — fail-safe"
+                  return 1
+                fi
+                if ! [ "${_tl_peer}" -ge "${_tl_local}" ]; then
+                  peer_report tl-behind "SPLIT-BRAIN with peer TL BEHIND local (peer TL=${_tl_peer} < local TL=${_tl_local}): both sides writable but the recovered region out-promoted the survivor — automatic failback REFUSES this geometry (fail-safe); sovereign-admin action per RUNBOOKS §6.1 (#5245)"
+                  return 1
+                fi
+                peer_report ok "peer ${PEER_MESH_HOST} WRITABLE on TL=${_tl_peer} >= local TL=${_tl_local} — peer-ahead proof available (#5245)"
+                echo "${_tl_peer}" > /shared/tl-peer
+                : > /shared/peer-ahead-fresh
+                return 0
+              }
+              while true; do
+                : > /shared/signals-alive
+                STATE=$(psql "${LOCAL_CONN}" -tAXc "${LQ}" 2>/dev/null || echo "unknown")
+                NOW=$(date -u +%s)
+                echo "${STATE}" > /shared/local-state
+                if [ "$((NOW - STARTED))" -lt "${STARTUP_GRACE_SECONDS}" ]; then
+                  clear_hold "startup grace ($((NOW - STARTED))s<${STARTUP_GRACE_SECONDS}s, state=${STATE})"
+                  clear_wedge
+                  starve_clear
+                  sleep "${INTERVAL_SECONDS}"; continue
+                fi
+                case "${STATE}" in
+                  primary)
+                    clear_wedge
+                    SYNC=$(psql "${LOCAL_CONN}" -tAXc "${SQ}" 2>/dev/null || echo "err")
+                    if [ "${SYNC}" != "absent" ]; then
+                      # Standby streaming from us (or probe failed) — the pair
+                      # is healthy (or unknowable): fail-safe, no failback.
+                      clear_hold "local primary with sync standby ${SYNC}"
+                      starve_clear
+                      sleep "${INTERVAL_SECONDS}"; continue
+                    fi
+                    TL_LOCAL=$(tl_of "${LOCAL_REPL}")
+                    if ! is_int "${TL_LOCAL}"; then
+                      clear_hold "local timeline unreadable — fail-safe"
+                      starve_clear
+                      sleep "${INTERVAL_SECONDS}"; continue
+                    fi
+                    echo "${TL_LOCAL}" > /shared/tl-local
+                    if probe_peer_ahead "${TL_LOCAL}"; then
+                      starve_clear
+                      if [ ! -f /shared/peer-ahead-since ]; then
+                        echo "${NOW}" > /shared/peer-ahead-since
+                        echo "$(date -u +"%FT%TZ") [dr-failback/signals] POST-FAILOVER GEOMETRY: local writable TL=${TL_LOCAL}, sync standby ABSENT, peer WRITABLE on TL=$(cat /shared/tl-peer) (>= local) — peer-ahead hold clock started (#5245)"
+                      fi
+                    else
+                      clear_hold "peer not provably writable+equal-or-ahead (reason in the fail-loud peer-probe line above)"
+                      # #5388 — this is the hw290 leg-6 shape: local primary,
+                      # sync standby gone, and the peer UNOBSERVABLE
+                      # (nxdomain / unreachable / tl-unreadable — e.g. the
+                      # rebooted region's cross-region routes not yet healed,
+                      # #5339). Accrue the starvation clock so the actor can
+                      # surface it on the HR; an observable-but-ineligible
+                      # peer (in-recovery / tl-behind) clears instead — those
+                      # geometries are diagnosed by their own reasons.
+                      case "$(cat /shared/peer-probe-reason 2>/dev/null || echo '')" in
+                        nxdomain|unreachable|tl-unreadable)
+                          [ -f /shared/peer-starved-since ] || echo "${NOW}" > /shared/peer-starved-since ;;
+                        *) starve_clear ;;
+                      esac
+                    fi
+                    ;;
+                  streaming)
+                    # Demoted + streaming from region-B — the DATA-PLANE
+                    # signal only. A divergent in-place-demoted standby on its
+                    # own TL-fork also reads 'streaming' (walreceiver row + a
+                    # set receive-LSN) at a coincidentally-equal LSN; the ACTOR
+                    # makes the convergence call by ALSO checking CNPG's
+                    # ConsistentSystemID verdict (#5331). Keep the
+                    # peer-WRITABLE proof fresh here so that, if the actor
+                    # finds this 'streaming' is actually the divergent case
+                    # (ConsistentSystemID=False), its re-clone escalation has a
+                    # <60s-fresh writable-peer proof to act on — this arm never
+                    # refreshed it before, so the divergence escalation would
+                    # starve for a fresh proof and wedge. Harmless for a
+                    # genuinely-converged replica: the actor exits at CONVERGED
+                    # and never consumes the proof.
+                    clear_hold "local standby streaming (data-plane signal; actor verifies ConsistentSystemID)"
+                    clear_wedge
+                    starve_clear
+                    : > /shared/converged-streaming
+                    probe_peer_writable_report
+                    ;;
+                  receiving|noreceiver)
+                    # A local standby that is NOT streaming. If the peer is
+                    # provably writable+ahead this is the in-place-demote
+                    # wedge candidate (stale TL-N PGDATA that cannot follow) —
+                    # accrue the wedge clock for the actor's escalation.
+                    clear_hold "local standby state=${STATE}"
+                    starve_clear
+                    rm -f /shared/converged-streaming
+                    TL_LOCAL=$(tl_of "${LOCAL_REPL}")
+                    if is_int "${TL_LOCAL}" && probe_peer_ahead "${TL_LOCAL}"; then
+                      if [ ! -f /shared/wedge-since ]; then
+                        echo "${NOW}" > /shared/wedge-since
+                        echo "$(date -u +"%FT%TZ") [dr-failback/signals] local standby cannot stream (state=${STATE}) while peer is writable+equal-or-ahead — wedge clock started (#5245 escalation)"
+                      fi
+                    else
+                      # 0.2.20 (#5245 hw278): a standby whose own TL is
+                      # unreadable still needs the writable-peer proof
+                      # kept fresh for the divergence escalation.
+                      is_int "${TL_LOCAL}" || probe_peer_writable_report
+                      clear_wedge
+                    fi
+                    ;;
+                  unknown|*)
+                    # Local probe failed — mid-re-clone (no endpoints) or an
+                    # unhealthy local cluster. Fail-safe: no evidence accrues.
+                    # 0.2.20 (#5245 hw278): STILL probe the peer's
+                    # writability — the divergence escalation and the
+                    # post-re-clone watch need a fresh peer proof precisely
+                    # while the local cluster is psql-dark (the demoted
+                    # standby restarts through the in-place switch; a
+                    # bootstrap-looping re-clone has no endpoints at all).
+                    clear_hold "local state unknown (probe failed — fail-safe)"
+                    clear_wedge
+                    starve_clear
+                    rm -f /shared/converged-streaming
+                    probe_peer_writable_report
+                    ;;
+                esac
+                sleep "${INTERVAL_SECONDS}"
+              done
+          env:
+            - name: PGCONNECT_TIMEOUT
+              value: "5"
+            - name: PEER_MESH_HOST
+              value: {{ include "bp-postgres.peerReplicationServiceName" . | quote }}
+            - name: PROBE_TIMEOUT
+              value: {{ $probeTimeout | quote }}
+            - name: STARTUP_GRACE_SECONDS
+              value: {{ $startupGrace | quote }}
+            - name: INTERVAL_SECONDS
+              value: {{ $interval | quote }}
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - "test -f /shared/signals-alive && test -z \"$(find /shared/signals-alive -mmin +1)\""
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            exec:
+              command: ["test", "-f", "/shared/signals-alive"]
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 64Mi
+          securityContext:
+            runAsUser: 26   # postgres in upstream cnpg image
+            runAsGroup: 26
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          volumeMounts:
+            - name: shared
+              mountPath: /shared
+            - name: tmp
+              mountPath: /tmp
+            - name: replication-cert
+              mountPath: /tls/client
+              readOnly: true
+        # ── actor — demote (substitute) + bounded re-clone ────────────
+        # Every write carries --field-manager=dr-failback (survives the
+        # kustomize kubectl-manager cleanup — the #5245 root cause).
+        # Each tick runs in a subshell; every step is guarded by
+        # live-observed state, so the loop is idempotent and resumes
+        # from any crash point.
+        - name: actor
+          image: {{ printf "%s:%s" $krepo $ktag | quote }}
+          imagePullPolicy: {{ $kpull | quote }}
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              FM="--field-manager=dr-failback"
+              echo "[dr-failback/actor] loop started (hold=${HOLD_SECONDS}s wedgeHold=${WEDGE_HOLD_SECONDS}s divergenceGrace=${DIVERGENCE_GRACE_SECONDS}s interval=${INTERVAL_SECONDS}s hr=${HR_NAMESPACE}/${HR_NAME} kustomization=${KS_NAMESPACE}/${KS_NAME})"
+              # nudge <kind> <ns> <name> <marker> — rate-limited flux
+              # reconcile request (reconcile.fluxcd.io/requestedAt).
+              nudge() {
+                if [ ! -f "/shared/$4" ] || [ -n "$(find "/shared/$4" -mmin +1)" ]; then
+                  kubectl -n "$2" annotate "$1" "$3" "reconcile.fluxcd.io/requestedAt=$(date -u +%s)" --overwrite ${FM} >/dev/null 2>&1 || true
+                  : > "/shared/$4"
+                fi
+              }
+              # peer_fresh — the signals container re-verified the peer
+              # writable+ahead within the last 60s (it re-probes every
+              # tick, ~10s). Required before EVERY destructive step (a
+              # stale proof is no proof). POSIX find only (-mmin integer:
+              # busybox-safe).
+              peer_fresh() {
+                [ -f /shared/peer-ahead-fresh ] && [ -z "$(find /shared/peer-ahead-fresh -mmin +1 2>/dev/null)" ]
+              }
+              # peer_fresh_writable — the signals container verified the
+              # peer WRITABLE within the last 60s (0.2.20, #5245 hw278).
+              # The divergence escalation runs while the LOCAL cluster is
+              # psql-dark, so the full TL-arithmetic proof (peer_fresh)
+              # may be structurally unavailable — but the demotion is
+              # already durably rendered by then, so a live writable peer
+              # is the guard that still matters before destruction.
+              peer_fresh_writable() {
+                [ -f /shared/peer-writable-fresh ] && [ -z "$(find /shared/peer-writable-fresh -mmin +1 2>/dev/null)" ]
+              }
+              # preserve_pki — strip the controller ownerReferences from
+              # the CNPG-issued PKI Secrets so the bounded Cluster-CR
+              # delete does NOT garbage-collect the CA lineage (0.2.20,
+              # #5245 hw278: the delete GC'd -ca/-replication/-server,
+              # CNPG re-issued a FRESH CA on re-create, and region-B's
+              # one-shot post-mesh-flip synced clientCASecret copy could
+              # never trust the re-cloned cluster's new client leaf —
+              # auth dead even after the sslRootCert fix). CNPG adopts
+              # the surviving Secrets on re-create (BYO path). A failed
+              # strip ABORTS the delete for this tick — deleting anyway
+              # would reproduce the trust break.
+              preserve_pki() {
+                _rc=0
+                for _s in "${PRIMARY_CLUSTER}-ca" "${PRIMARY_CLUSTER}-replication" "${PRIMARY_CLUSTER}-server"; do
+                  if kubectl -n "${NAMESPACE}" get secret "${_s}" >/dev/null 2>&1; then
+                    if ! kubectl -n "${NAMESPACE}" patch secret "${_s}" --type merge ${FM} -p '{"metadata":{"ownerReferences":[]}}' >/dev/null 2>&1; then
+                      echo "$(date -u +"%FT%TZ") [dr-failback/actor] PKI-PRESERVE FAILED on Secret ${_s} — NOT deleting the Cluster this tick (#5245 hw278: a delete now would GC the CA and orphan region-B's synced client-CA trust); retrying next tick"
+                      _rc=1
+                    fi
+                  fi
+                done
+                return ${_rc}
+              }
+              # ts_lt <a> <b> — RFC3339-UTC lexicographic a < b (POSIX;
+              # no `[ \< ]` bashism).
+              ts_lt() {
+                [ "$1" != "$2" ] && [ "$(printf '%s\n%s\n' "$1" "$2" | sort | head -1)" = "$1" ]
+              }
+              # ── #6148 write-guard ────────────────────────────────────
+              # region-A returns from a region-kill as a writable stale-timeline
+              # primary while the peer is already writable and AHEAD. Every write
+              # committed in that window is acknowledged to the client and then
+              # silently discarded by the re-clone — and on THIS chart the
+              # clients are keycloak, gitea, harbor, grafana, powerdns and the
+              # Organization mesh. The 120s hold is legitimate — it guards the
+              # DEMOTE decision against a flap, and a demote/re-promote cycle
+              # bumps the timeline, which is the same class of damage. So the
+              # hold stays and the window gets a guard that is reversible at
+              # zero cost.
+              #
+              # Both helpers are idempotent and cheap: /shared/guard-state
+              # keeps them from re-issuing an API call every tick. They are
+              # deliberately NON-FATAL — a guard that cannot be applied must
+              # never stall the failback, because converging region-A is what
+              # ends the exposure. The failure is reported loudly instead.
+              GUARD_STATE=/shared/guard-state
+              guard_on() {
+                [ "$(cat "${GUARD_STATE}" 2>/dev/null || echo)" = "on" ] && return 0
+                if kubectl -n "${NAMESPACE}" apply ${FM} -f /guard/guard.yaml >/dev/null 2>&1; then
+                  echo "on" > "${GUARD_STATE}"
+                  echo "$(date -u +"%FT%TZ") [dr-failback/actor] WRITE-GUARD ON: region-A is a writable primary on TL=$(cat /shared/tl-local 2>/dev/null || echo '?') that the peer has overtaken on TL=$(cat /shared/tl-peer 2>/dev/null || echo '?') — denying consumer ingress to :5432 for the duration of the hold; replication and this actor's own timeline probe stay open (#6148)"
+                else
+                  echo "$(date -u +"%FT%TZ") [dr-failback/actor] WARN: WRITE-GUARD could not be applied (RBAC/CRD absent?) — the hold window is UNGUARDED and a region-A-local consumer can still commit a write that the re-clone will discard; failback continues (#6148)"
+                fi
+              }
+              guard_off() {
+                [ -f "${GUARD_STATE}" ] || return 0
+                kubectl -n "${NAMESPACE}" delete ciliumnetworkpolicy \
+                  "{{ include "bp-postgres.instanceName" . }}-write-guard" \
+                  --ignore-not-found >/dev/null 2>&1 || true
+                rm -f "${GUARD_STATE}"
+                echo "$(date -u +"%FT%TZ") [dr-failback/actor] WRITE-GUARD OFF — the peer-ahead hold is no longer active, consumer ingress to :5432 restored (#6148)"
+              }
+              while true; do
+                : > /shared/actor-alive
+                # Unconditional, and BEFORE the per-tick subshell: the guard is
+                # tied to the hold clock itself, not to any one geometry branch.
+                # The signals loop clears /shared/peer-ahead-since on every
+                # fail-safe path it has, so pinning the guard to that single
+                # file means every existing abort already unwinds it and no new
+                # control flow can forget to.
+                [ -f /shared/peer-ahead-since ] || guard_off
+                (
+                  set -eu
+                  SUB=$(kubectl -n "${KS_NAMESPACE}" get kustomization "${KS_NAME}" -o jsonpath="{.spec.postBuild.substitute.${DEMOTED_SUB_KEY}}" 2>/dev/null || echo "")
+                  VALS_DEMOTED=$(kubectl -n "${HR_NAMESPACE}" get helmrelease "${HR_NAME}" -o jsonpath='{.spec.values.topology.demoted}' 2>/dev/null || echo "")
+                  # 0.2.20 (#5245 hw278): also read the ConsistentSystemID
+                  # condition (CNPG's own cannot-consistently-follow-the-
+                  # source signal — live shape on hw278:
+                  # status=False reason=NotFound) + the phase, for the
+                  # divergence escalation and the post-re-clone watch.
+                  CR_JSON=$(kubectl -n "${NAMESPACE}" get clusters.postgresql.cnpg.io "${PRIMARY_CLUSTER}" -o jsonpath="{.spec.replica.enabled}|{.metadata.creationTimestamp}|{.metadata.deletionTimestamp}|{.status.conditions[?(@.type=='ConsistentSystemID')].status}|{.status.conditions[?(@.type=='ConsistentSystemID')].reason}|{.status.phase}" 2>/dev/null || echo "__absent__")
+                  STARTED_AT=$(kubectl -n "${HR_NAMESPACE}" get helmrelease "${HR_NAME}" -o jsonpath='{.metadata.annotations.catalyst\.openova\.io/dr-failback-started-at}' 2>/dev/null || echo "")
+                  # 0.2.21 (#5331): parse the CR fields up-front — the
+                  # CONVERGED verification gate below needs CNPG's own
+                  # ConsistentSystemID verdict, not just the psql streaming
+                  # signal. When the CR is absent (mid-re-clone) every field
+                  # is empty and the gate correctly declines to converge.
+                  CR_REPLICA=$(echo "${CR_JSON}" | cut -d'|' -f1)
+                  CR_CREATED=$(echo "${CR_JSON}" | cut -d'|' -f2)
+                  CR_DELETING=$(echo "${CR_JSON}" | cut -d'|' -f3)
+                  CR_SYSID_OK=$(echo "${CR_JSON}" | cut -d'|' -f4)
+                  CR_SYSID_REASON=$(echo "${CR_JSON}" | cut -d'|' -f5)
+                  CR_PHASE=$(echo "${CR_JSON}" | cut -d'|' -f6)
+
+                  # ── CONVERGED — record once, then idle ────────────────
+                  # #5331 (hw285 P0 data-loss trap): gate on VERIFIED data
+                  # convergence, NEVER on the bare local 'streaming' signal.
+                  # region-A must be BOTH (a) streaming from region-B (the
+                  # data-plane signal /shared/converged-streaming) AND (b)
+                  # reporting CNPG's ConsistentSystemID=True — CNPG's own
+                  # positive attestation that region-A's PGDATA / system
+                  # lineage is CONSISTENT with the source it streams from.
+                  # A divergent in-place-demoted standby on its OWN TL-fork
+                  # also reads 'streaming' (a walreceiver row + a set
+                  # receive-LSN) at a COINCIDENTALLY-EQUAL LSN, yet holds
+                  # ConsistentSystemID=False and is missing region-B's
+                  # post-failover writes. On hw285 the 0.2.20 gate
+                  # (converged-streaming + demoted only) declared such a
+                  # standby CONVERGED 10s into the 180s divergence grace,
+                  # with NO re-clone — a data-loss trap on switchback.
+                  # ConsistentSystemID=True CANNOT hold on a divergent line,
+                  # so it is the load-bearing positive proof; LSN-equality is
+                  # NOT (equal LSNs are exactly the false signal). The
+                  # divergence path below (D2a) re-clones region-A from
+                  # region-B, after which a genuine pg_basebackup replica
+                  # reports ConsistentSystemID=True and converges here.
+                  if [ -f /shared/converged-streaming ] && [ "${VALS_DEMOTED}" = "true" ] && [ "${CR_SYSID_OK}" = "True" ] && [ ! -f /shared/converged-recorded ]; then
+                    if kubectl -n "${HR_NAMESPACE}" patch helmrelease "${HR_NAME}" --type merge ${FM} -p "{\"metadata\":{\"annotations\":{\"catalyst.openova.io/dr-failback-converged-at\":\"$(date -u +"%FT%TZ")\"}}}" >/dev/null 2>&1; then
+                      : > /shared/converged-recorded
+                      echo "$(date -u +"%FT%TZ") [dr-failback/actor] CONVERGED: region-A streaming from region-B AND CNPG reports ConsistentSystemID=True (verified consistent lineage — not a divergent equal-LSN standby) — recorded dr-failback-converged-at on HR ${HR_NAMESPACE}/${HR_NAME}. Cross-region replication restored, roles swapped; the controlled switchback (demote region-B, restore region-A primary) is the sovereign-admin's RUNBOOKS §6.1 action (#5245 #5331)"
+                    fi
+                    exit 0
+                  fi
+
+                  # ── D0: DECIDE — flip the durable demotion substitute ─
+                  if [ "${SUB}" != "true" ]; then
+                    # ── #5388 STARVATION SURFACING (0.2.23, hw290 G12 leg-6) ──
+                    # The post-failover geometry candidate (local writable
+                    # primary, sync standby ABSENT) has persisted while the
+                    # peer probe fails for an OBSERVABILITY-DEAD reason —
+                    # on hw290 the rebooted region's cross-region routes
+                    # were gone (#5339 shape) and this actor idled at D0
+                    # forever while the split-brain persisted, with the only
+                    # evidence in this pod's logs. Record the starvation on
+                    # the HR where an operator looks. Diagnostic only: a
+                    # 2-node actor cannot distinguish region-B-dead (serving
+                    # here is CORRECT) from region-B-unreachable (split-
+                    # brain), so it must never act on blindness — but it
+                    # must not be silent about it either. Re-records on
+                    # reason change; clears its marker when the probe
+                    # recovers so a later episode records afresh.
+                    if [ -f /shared/peer-starved-since ]; then
+                      _ss=$(cat /shared/peer-starved-since 2>/dev/null || echo "")
+                      _now=$(date -u +%s)
+                      _reason=$(cat /shared/peer-probe-reason 2>/dev/null || echo "unknown")
+                      if [ -n "${_ss}" ] && [ "$((_now - _ss))" -ge "${STARVATION_SURFACE_SECONDS}" ] && [ "$(cat /shared/starved-recorded 2>/dev/null || echo '')" != "${_reason}" ]; then
+                        if kubectl -n "${HR_NAMESPACE}" patch helmrelease "${HR_NAME}" --type merge ${FM} -p "{\"metadata\":{\"annotations\":{\"catalyst.openova.io/dr-failback-starved-at\":\"$(date -u +"%FT%TZ")\",\"catalyst.openova.io/dr-failback-starved-reason\":\"peer probe ${_reason} for >=${STARVATION_SURFACE_SECONDS}s while local is a writable primary with the sync standby absent — failback cannot observe the peer; if region-B was promoted this IS a live split-brain until the mesh/datapath heals (#5388 #5339)\"}}}" >/dev/null 2>&1; then
+                          echo "${_reason}" > /shared/starved-recorded
+                          echo "$(date -u +"%FT%TZ") [dr-failback/actor] STARVED: post-failover geometry candidate held $((_now - _ss))s with peer probe '${_reason}' — recorded dr-failback-starved-at on HR ${HR_NAMESPACE}/${HR_NAME}; failback is BLIND, not idle (#5388)"
+                        else
+                          echo "$(date -u +"%FT%TZ") [dr-failback/actor] WARN: could not record starvation on HR (RBAC/conflict?) — retrying next tick (#5388)"
+                        fi
+                      fi
+                    else
+                      rm -f /shared/starved-recorded
+                    fi
+                    [ -f /shared/peer-ahead-since ] || exit 0
+                    # #6148 — guard FIRST, then evaluate the hold. The exposure
+                    # starts the moment the geometry is known-divergent, which
+                    # is here, not ${HOLD_SECONDS} later at the demote.
+                    guard_on
+                    SINCE=$(cat /shared/peer-ahead-since)
+                    NOW=$(date -u +%s)
+                    HELD=$((NOW - SINCE))
+                    if [ "${HELD}" -lt "${HOLD_SECONDS}" ]; then
+                      echo "$(date -u +"%FT%TZ") [dr-failback/actor] peer writable+ahead held ${HELD}s < ${HOLD_SECONDS}s — waiting"
+                      exit 0
+                    fi
+                    peer_fresh || { echo "$(date -u +"%FT%TZ") [dr-failback/actor] hold expired but peer proof is stale — re-verifying next tick (fail-safe)"; exit 0; }
+                    echo "$(date -u +"%FT%TZ") [dr-failback/actor] DEMOTING region-A: peer writable on TL=$(cat /shared/tl-peer 2>/dev/null || echo '?') >= local TL=$(cat /shared/tl-local 2>/dev/null || echo '?') held ${HELD}s — patching Kustomization substitute ${DEMOTED_SUB_KEY}=true (durable source seam, #5245 #6149)"
+                    kubectl -n "${KS_NAMESPACE}" patch kustomization "${KS_NAME}" --type merge ${FM} -p "{\"spec\":{\"postBuild\":{\"substitute\":{\"${DEMOTED_SUB_KEY}\":\"true\"}}}}"
+                    kubectl -n "${HR_NAMESPACE}" patch helmrelease "${HR_NAME}" --type merge ${FM} -p "{\"metadata\":{\"annotations\":{\"catalyst.openova.io/dr-failback-started-at\":\"$(date -u +"%FT%TZ")\",\"catalyst.openova.io/dr-failback-reason\":\"region-A resumed stale TL$(cat /shared/tl-local 2>/dev/null || echo '?') primary while region-B is writable on TL$(cat /shared/tl-peer 2>/dev/null || echo '?'); demoting + re-cloning region-A onto region-B's line (#5245)\"}}}" >/dev/null 2>&1 || true
+                    nudge kustomization "${KS_NAMESPACE}" "${KS_NAME}" nudged-ks
+                    exit 0
+                  fi
+
+                  # ── D1: WAIT for kustomize to render the demotion ─────
+                  if [ "${VALS_DEMOTED}" != "true" ]; then
+                    echo "$(date -u +"%FT%TZ") [dr-failback/actor] substitute set but HR values not yet rendered (demoted='${VALS_DEMOTED}') — waiting for kustomize-controller"
+                    nudge kustomization "${KS_NAMESPACE}" "${KS_NAME}" nudged-ks
+                    exit 0
+                  fi
+
+                  # ── D1.5: EPISODE-MARKER self-heal (0.2.20, #5245 hw278) ─
+                  # dr-failback-started-at was written once, best-effort, in
+                  # the same D0 tick as the substitute patch. If that single
+                  # write was lost (patch failure, actor crash between the
+                  # two patches), ts_lt() below never passes and EVERY
+                  # escalation is structurally disabled — silently. Re-write
+                  # it loudly whenever the demotion is rendered but the
+                  # marker is absent. (A late marker is safe: it only makes
+                  # the pre-existing in-place-demoted CR read as
+                  # pre-episode, which it is.)
+                  if [ -z "${STARTED_AT}" ]; then
+                    STARTED_AT="$(date -u +"%FT%TZ")"
+                    echo "$(date -u +"%FT%TZ") [dr-failback/actor] dr-failback-started-at annotation MISSING while the demotion is rendered — self-healing the episode marker to ${STARTED_AT} (#5245 hw278: without it the divergence/wedge escalations are dead, silently)"
+                    kubectl -n "${HR_NAMESPACE}" patch helmrelease "${HR_NAME}" --type merge ${FM} -p "{\"metadata\":{\"annotations\":{\"catalyst.openova.io/dr-failback-started-at\":\"${STARTED_AT}\"}}}" >/dev/null 2>&1 || { echo "$(date -u +"%FT%TZ") [dr-failback/actor] episode-marker self-heal patch FAILED — retrying next tick"; exit 0; }
+                  fi
+
+                  # ── D2: RE-CLONE — the one bounded destructive act ────
+                  if [ "${CR_JSON}" = "__absent__" ]; then
+                    # Deleted (by us) or not yet re-created — nudge helm to
+                    # render the demoted shape promptly.
+                    nudge helmrelease "${HR_NAMESPACE}" "${HR_NAME}" nudged-hr
+                    exit 0
+                  fi
+                  # CR fields parsed up-front (before the CONVERGED gate, #5331).
+                  if [ -n "${CR_DELETING}" ]; then
+                    exit 0   # teardown in progress — wait
+                  fi
+                  if [ "${CR_REPLICA}" != "true" ]; then
+                    # Still the OLD primary shape with the stale timeline.
+                    peer_fresh || { echo "$(date -u +"%FT%TZ") [dr-failback/actor] demotion rendered but peer proof stale — NOT deleting (fail-safe)"; exit 0; }
+                    preserve_pki || exit 0
+                    echo "$(date -u +"%FT%TZ") [dr-failback/actor] RE-CLONING: deleting stale Cluster ${PRIMARY_CLUSTER} (old primary shape, TL=$(cat /shared/tl-local 2>/dev/null || echo '?')) — helm re-creates it as a pg_basebackup replica of region-B; PVCs are CNPG-owned and garbage-collect, PKI Secrets preserved (#5245)"
+                    kubectl -n "${NAMESPACE}" delete clusters.postgresql.cnpg.io "${PRIMARY_CLUSTER}" --wait=false
+                    kubectl -n "${HR_NAMESPACE}" patch helmrelease "${HR_NAME}" --type merge ${FM} -p "{\"metadata\":{\"annotations\":{\"catalyst.openova.io/dr-failback-recloned-at\":\"$(date -u +"%FT%TZ")\"}}}" >/dev/null 2>&1 || true
+                    exit 0
+                  fi
+                  # Demoted shape exists. A CR created BEFORE the failback
+                  # episode is an IN-PLACE demote keeping stale PGDATA — it
+                  # escalates to the bounded re-clone on EITHER detector
+                  # below. A CR created AFTER (a fresh clone) is NEVER
+                  # deleted — bounded destruction, at most one re-clone per
+                  # divergence detection.
+                  if [ -n "${STARTED_AT}" ] && ts_lt "${CR_CREATED}" "${STARTED_AT}"; then
+                    # ── D2a: DIVERGENCE escalation (0.2.20, #5245 hw278) ──
+                    # CNPG's own signal: ConsistentSystemID stays False on
+                    # the in-place-demoted CR. Unlike the wedge clock below
+                    # this needs NO contiguous psql observability — the
+                    # demoted standby restarts through the in-place switch
+                    # and every 'unknown' tick resets the wedge clock (how
+                    # hw278 crawled to its escalation). One clock, cleared
+                    # whenever the condition leaves False; the delete still
+                    # requires a fresh writable-peer proof.
+                    # #5331: ConsistentSystemID=False is CNPG's AUTHORITATIVE
+                    # divergence verdict and OVERRIDES a coincidental local
+                    # 'streaming' appearance. A divergent in-place-demoted
+                    # standby momentarily attaches to region-B at an equal LSN
+                    # (walreceiver row + set receive-LSN → local state
+                    # 'streaming' → /shared/converged-streaming) yet can never
+                    # follow region-B's line. The removed
+                    # `! -f /shared/converged-streaming` conjunct let that
+                    # false 'streaming' suppress the escalation AND reset the
+                    # divergence clock via the else-branch below — exactly how
+                    # hw285 skipped the re-clone. Gate on CNPG's verdict alone.
+                    if [ "${CR_SYSID_OK}" = "False" ]; then
+                      if [ ! -f /shared/diverged-since ]; then
+                        date -u +%s > /shared/diverged-since
+                        echo "$(date -u +"%FT%TZ") [dr-failback/actor] DIVERGENCE DETECTED: in-place-demoted Cluster (created ${CR_CREATED} < episode ${STARTED_AT}) reports ConsistentSystemID=False (reason=${CR_SYSID_REASON:-?}, phase='${CR_PHASE:-?}') — the stale-PGDATA line cannot consistently follow region-B; divergence clock started (grace ${DIVERGENCE_GRACE_SECONDS}s) (#5245 hw278)"
+                      fi
+                      DSINCE=$(cat /shared/diverged-since)
+                      NOW=$(date -u +%s)
+                      if [ "$((NOW - DSINCE))" -ge "${DIVERGENCE_GRACE_SECONDS}" ]; then
+                        if peer_fresh_writable; then
+                          preserve_pki || exit 0
+                          echo "$(date -u +"%FT%TZ") [dr-failback/actor] DIVERGENCE ESCALATION: ConsistentSystemID=False held $((NOW - DSINCE))s >= ${DIVERGENCE_GRACE_SECONDS}s on the pre-episode demoted Cluster with peer verified writable — deleting for a clean pg_basebackup re-clone (PKI preserved) (#5245 hw278)"
+                          kubectl -n "${NAMESPACE}" delete clusters.postgresql.cnpg.io "${PRIMARY_CLUSTER}" --wait=false
+                          rm -f /shared/diverged-since
+                          kubectl -n "${HR_NAMESPACE}" patch helmrelease "${HR_NAME}" --type merge ${FM} -p "{\"metadata\":{\"annotations\":{\"catalyst.openova.io/dr-failback-recloned-at\":\"$(date -u +"%FT%TZ")\"}}}" >/dev/null 2>&1 || true
+                          exit 0
+                        fi
+                        echo "$(date -u +"%FT%TZ") [dr-failback/actor] divergence grace expired but no fresh peer-writable proof — NOT deleting (fail-safe)"
+                        exit 0
+                      fi
+                    else
+                      rm -f /shared/diverged-since
+                    fi
+                    # ── D2b: WEDGE escalation (the psql-observed path) ──
+                    if [ -f /shared/wedge-since ]; then
+                      WSINCE=$(cat /shared/wedge-since)
+                      NOW=$(date -u +%s)
+                      if [ "$((NOW - WSINCE))" -ge "${WEDGE_HOLD_SECONDS}" ]; then
+                        peer_fresh || { echo "$(date -u +"%FT%TZ") [dr-failback/actor] wedge hold expired but peer proof stale — NOT deleting (fail-safe)"; exit 0; }
+                        preserve_pki || exit 0
+                        echo "$(date -u +"%FT%TZ") [dr-failback/actor] WEDGE ESCALATION: in-place-demoted Cluster (created ${CR_CREATED} < failback start ${STARTED_AT}) unable to stream $((NOW - WSINCE))s >= ${WEDGE_HOLD_SECONDS}s with peer writable+ahead — deleting for a clean re-clone (PKI preserved) (#5245)"
+                        kubectl -n "${NAMESPACE}" delete clusters.postgresql.cnpg.io "${PRIMARY_CLUSTER}" --wait=false
+                        kubectl -n "${HR_NAMESPACE}" patch helmrelease "${HR_NAME}" --type merge ${FM} -p "{\"metadata\":{\"annotations\":{\"catalyst.openova.io/dr-failback-recloned-at\":\"$(date -u +"%FT%TZ")\"}}}" >/dev/null 2>&1 || true
+                        exit 0
+                      fi
+                    fi
+                    # Pre-episode CR, clocks still accruing (or following
+                    # cleanly) — wait.
+                    exit 0
+                  fi
+                  # ── D3: POST-RE-CLONE convergence watch (0.2.20) ──────
+                  # The CR postdates the episode: the fresh clone. NEVER
+                  # deleted (bounded destruction). hw278: the fresh clone's
+                  # pgbasebackup Job FATAL-looped on x509 for 5+ hours with
+                  # the actor totally silent — a wedged re-clone must name
+                  # itself. Log the live phase + ConsistentSystemID every
+                  # 30 ticks (~5 min) until CONVERGED records. #5331: key the
+                  # heartbeat on converged-RECORDED, not converged-STREAMING —
+                  # a fresh clone that is streaming but not yet
+                  # ConsistentSystemID=True is NOT converged (the CONVERGED
+                  # gate requires both), and must keep naming itself rather
+                  # than go dark on the bare streaming signal.
+                  if [ ! -f /shared/converged-recorded ]; then
+                    _n=$(($(cat /shared/postclone-ticks 2>/dev/null || echo 0) + 1))
+                    if [ "${_n}" -ge 30 ]; then
+                      _n=0
+                      echo "$(date -u +"%FT%TZ") [dr-failback/actor] RE-CLONE NOT YET CONVERGED: Cluster phase='${CR_PHASE:-?}', ConsistentSystemID=${CR_SYSID_OK:-?}(${CR_SYSID_REASON:-?}), local state=$(cat /shared/local-state 2>/dev/null || echo '?') — streaming AND ConsistentSystemID=True not both observed yet; check the ${PRIMARY_CLUSTER}-1-pgbasebackup Job logs (hw278 wedge shape: x509 unknown-authority = a root cert pinned against the wrong CA; hw285 shape: ConsistentSystemID=False = a divergent line that never re-cloned) (#5245 #5331)"
+                    fi
+                    echo "${_n}" > /shared/postclone-ticks
+                  else
+                    rm -f /shared/postclone-ticks
+                  fi
+                  # Fresh clone converging (or converged) — the CONVERGED
+                  # block closes out on the streaming signal.
+                  exit 0
+                ) || echo "[dr-failback/actor] tick returned non-zero — retry in ${INTERVAL_SECONDS}s"
+                sleep "${INTERVAL_SECONDS}"
+              done
+          env:
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: HR_NAME
+              value: {{ $hrName | quote }}
+            - name: HR_NAMESPACE
+              value: {{ $hrNamespace | quote }}
+            - name: KS_NAME
+              value: {{ $ksName | quote }}
+            - name: KS_NAMESPACE
+              value: {{ $ksNamespace | quote }}
+            # #6149 - the PER-INSTANCE demotion substitute key on the shared
+            # bootstrap-kit Kustomization (shared-pg / -b / -c each own one).
+            - name: DEMOTED_SUB_KEY
+              value: {{ $demotedSubKey | quote }}
+            - name: HOLD_SECONDS
+              value: {{ $hold | quote }}
+            - name: WEDGE_HOLD_SECONDS
+              value: {{ $wedgeHold | quote }}
+            - name: DIVERGENCE_GRACE_SECONDS
+              value: {{ $divergenceGrace | quote }}
+            - name: STARVATION_SURFACE_SECONDS
+              value: {{ $starvationSurface | quote }}
+            - name: INTERVAL_SECONDS
+              value: {{ $interval | quote }}
+            - name: PRIMARY_CLUSTER
+              value: {{ include "bp-postgres.instanceName" . | quote }}
+            # kubectl writes its discovery/http cache under $HOME.
+            - name: HOME
+              value: /tmp
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - "test -f /shared/actor-alive && test -z \"$(find /shared/actor-alive -mmin +1)\""
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            exec:
+              command: ["test", "-f", "/shared/actor-alive"]
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 128Mi
+          securityContext:
+            runAsUser: 65534
+            runAsGroup: 65534
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          volumeMounts:
+            - name: shared
+              mountPath: /shared
+            - name: tmp
+              mountPath: /tmp
+            # #6148 — the write-guard manifest the actor applies during the
+            # peer-ahead hold. Read-only: the actor applies this file, it
+            # never authors one, so a bug cannot widen the guard's scope.
+            - name: write-guard
+              mountPath: /guard
+              readOnly: true
+      volumes:
+        - name: shared
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}
+        - name: write-guard
+          configMap:
+            name: {{ include "bp-postgres.instanceName" . }}-write-guard
+        # THIS primary cluster's own CNPG-issued streaming_replica client
+        # cert — 0440 root:26, the perms libpq requires for an sslkey
+        # (#5133). The SAME cert authenticates against region-B thanks to
+        # the shared client CA (replica-cluster.yaml #5245).
+        - name: replication-cert
+          secret:
+            secretName: {{ include "bp-postgres.instanceName" . }}-replication
+            defaultMode: 0440
+{{- end }}

--- a/platform/postgres/chart/templates/dr-promoter.yaml
+++ b/platform/postgres/chart/templates/dr-promoter.yaml
@@ -92,7 +92,7 @@ replication.mode=sync (see bp-postgres.autoPromoteActive) — async has no fence
 {{- $probeTimeout := $ap.livenessProbeTimeoutSeconds | default 5 }}
 {{- $renderWait := $ap.promoteRenderWaitSeconds | default 90 }}
 {{- $armSeconds := $ap.steadyStateArmSeconds | default 180 }}
-{{- $peerClusters := .Values.topology.networkPolicy.crossRegionPeerClusters | default list }}
+{{- $peerClusters := dig "networkPolicy" "crossRegionPeerClusters" (list) (.Values.topology | default dict) }}
 {{- /* #5178 — the region-A liveness gate is meaningful ONLY when the mesh egress to
        region-A can be wired: clusterMesh on AND at least one peer ClusterMesh name.
        Without it the actor observes but NEVER promotes (fail-safe), because it has no

--- a/platform/postgres/chart/templates/networkpolicy.yaml
+++ b/platform/postgres/chart/templates/networkpolicy.yaml
@@ -91,7 +91,7 @@ spec:
           protocol: TCP
         - port: {{ .Values.topology.networkPolicy.operatorMetricsPort }}
           protocol: TCP
-{{- if gt (len .Values.topology.networkPolicy.crossRegionPeerClusters) 0 }}
+{{- if gt (len (dig "networkPolicy" "crossRegionPeerClusters" (list) (.Values.topology | default dict))) 0 }}
 ---
 # CROSS-REGION DR (#4846): the REPLICA region's Pods (consumers + the replica
 # Cluster's pg_basebackup / WAL streaming) reach the primary's 5432 over Cilium
@@ -126,7 +126,7 @@ spec:
             - key: io.cilium.k8s.policy.cluster
               operator: In
               values:
-                {{- range .Values.topology.networkPolicy.crossRegionPeerClusters }}
+                {{- range (dig "networkPolicy" "crossRegionPeerClusters" (list) (.Values.topology | default dict)) }}
                 - {{ . | quote }}
                 {{- end }}
             # ANY-NAMESPACE (#4854 row 67 L2): a namespaced CNP's fromEndpoints
@@ -257,7 +257,7 @@ spec:
         - port: 5432
           protocol: TCP
 {{- end }}
-{{- if gt (len .Values.topology.networkPolicy.crossRegionPeerClusters) 0 }}
+{{- if gt (len (dig "networkPolicy" "crossRegionPeerClusters" (list) (.Values.topology | default dict))) 0 }}
 ---
 # CROSS-REGION DR (#4846): the PRIMARY region's Pods (the primary Cluster
 # streaming to this replica + consumers reading the replica's -mesh-rw) reach
@@ -283,7 +283,7 @@ spec:
             - key: io.cilium.k8s.policy.cluster
               operator: In
               values:
-                {{- range .Values.topology.networkPolicy.crossRegionPeerClusters }}
+                {{- range (dig "networkPolicy" "crossRegionPeerClusters" (list) (.Values.topology | default dict)) }}
                 - {{ . | quote }}
                 {{- end }}
             # ANY-NAMESPACE (#4854 row 67 L2): a namespaced CNP's fromEndpoints

--- a/platform/postgres/chart/templates/peer-mesh-service.yaml
+++ b/platform/postgres/chart/templates/peer-mesh-service.yaml
@@ -1,0 +1,56 @@
+{{- /*
+Primary-side ClusterMesh global Service stub for `<instance>-replica-mesh`
+(#6149) — the exact mirror of replica-mesh-service.yaml, and the exact port of
+bp-cnpg-pair's peer-mesh-service.yaml (#5245).
+
+Cilium ClusterMesh global services merge BY NAME+NAMESPACE: a Service
+participates only if an object with the same name + namespace exists in EVERY
+consuming cluster, each annotated `service.cilium.io/global`. The replica side's
+`<instance>-replica-mesh` Service is CNPG-managed on cluster-B (replica Cluster
+CR `spec.managed.services.additional`) — but cluster-A has no replica Cluster
+CR, so without this stub the name is NXDOMAIN on cluster-A and NEITHER the
+dr-failback peer probe NOR the demoted (rejoin) primary Cluster's
+externalCluster could resolve region-B's writable endpoint. The failback's own
+probe ladder reports that case BY NAME (`peer host … NOT RESOLVABLE …
+(NXDOMAIN)`) precisely because a missing stub is the structural way this breaks.
+
+The selector (`cnpg.io/cluster: <instance>-replica`) matches ZERO Pods on
+cluster-A by construction, so every connection routes across the mesh to
+region-B's backends (the `affinity: local` hint falls through to remote when no
+local backend exists). No CNPG ownership collision: the local CNPG operator on
+cluster-A manages only the primary Cluster's Services, never this name.
+
+Rendered whenever the mesh + multi-region signal are on (NOT failback-gated, and
+NOT gated on the late cnpg-pair flip — same `meshGlobalServices` seam as
+replica-mesh-service.yaml, #4460): the stub is a passive DNS anchor with zero
+backends, so having it present from day 0 means the failback path needs no
+render-ordering dance when peers are wired later. A true single-region prov
+leaves `topology.replica.region` empty → meshGlobalServices false → this file
+renders nothing (byte-identical singleton).
+*/ -}}
+{{- if and (ne (toString .Values.enabled) "false") (eq (include "bp-postgres.meshGlobalServices" .) "true") (eq (include "bp-postgres.side" .) "primary") }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "bp-postgres.peerReplicationServiceName" . }}
+  namespace: {{ include "bp-postgres.namespace" . }}
+  labels:
+    {{- include "bp-postgres.labels" . | nindent 4 }}
+    catalyst.openova.io/cnpg-pair: {{ include "bp-postgres.instanceName" . | quote }}
+    catalyst.openova.io/role: failback-source
+  annotations:
+    service.cilium.io/global: "true"
+    service.cilium.io/affinity: {{ .Values.topology.clusterMesh.affinity | quote }}
+    catalyst.openova.io/blueprint: bp-postgres
+spec:
+  type: ClusterIP
+  selector:
+    # CNPG selector shape for the REPLICA Cluster — matches zero Pods on the
+    # primary cluster by construction.
+    cnpg.io/cluster: {{ include "bp-postgres.replicaName" . }}
+  ports:
+    - name: postgres
+      port: 5432
+      targetPort: 5432
+      protocol: TCP
+{{- end }}

--- a/platform/postgres/chart/templates/replica-cluster.yaml
+++ b/platform/postgres/chart/templates/replica-cluster.yaml
@@ -65,6 +65,37 @@ spec:
   resources:
     {{- toYaml .Values.instance.resources | nindent 4 }}
 
+  # ── Shared client CA (#6149, the bp-cnpg-pair #5245 shape) ────────
+  # Pin THIS cluster's CLIENT CA to the primary instance's CA Secret —
+  # already synced cluster-A → cluster-B at the post-mesh flip
+  # (catalyst-api handler/clustermesh.go copies `<instance>-ca` and
+  # `<instance>-replication`, with ca.crt + ca.key). CNPG then issues this
+  # cluster's own `<instance>-replica-replication` streaming_replica leaf
+  # FROM that CA (cluster_pki.go: a BYO clientCASecret carrying ca.key
+  # generates the replication leaf when replicationTLSSecret is unset), so
+  # every local consumer (failover-readiness + the dr-promoter signals)
+  # keeps mounting `<instance>-replica-replication` unchanged — AND
+  # region-A's own `<instance>-replication` cert (same CA) now
+  # authenticates HERE too.
+  #
+  # That reverse-direction auth is the whole precondition of the #6149
+  # failback: after this side is promoted, the demoted region-A streams
+  # FROM this cluster presenting the only client cert cluster-A natively
+  # holds. Without this pin the failback's peer probe and the rejoin
+  # basebackup are both rejected and the pair stays dual-writable — the
+  # hw293 end state.
+  #
+  # Server certs are untouched. NOTE (#5245 hw278 live-proof): sslmode
+  # =require skips server-chain verification ONLY when no sslRootCert is
+  # supplied; libpq/pgx upgrade `require` to verify-ca semantics the moment
+  # a root cert IS provided. The FORWARD stream below carries
+  # sslRootCert=`<instance>-ca` and verifies fine (that CA signs region-A's
+  # server leafs); the REVERSE stream (cluster.yaml demoted shape) carries
+  # NO root cert, because this cluster's server chain is signed by its own
+  # `<instance>-replica-ca`, which cluster-A does not hold.
+  certificates:
+    clientCASecret: {{ include "bp-postgres.instanceName" . }}-ca
+
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
@@ -153,4 +184,45 @@ spec:
       wal_level: "logical"
 
   enableSuperuserAccess: {{ .Values.instance.enableSuperuserAccess | default false }}
+
+  # ── Reverse-direction replication Service (#6149) ─────────────────
+  # Publish THIS cluster's writable endpoint across the mesh as
+  # `<instance>-replica-mesh` — the exact mirror of the primary side's
+  # `<instance>-mesh` (cluster.yaml managed additional Service,
+  # selectorType rw, Cilium-global). Pre-promote this tracks the
+  # designated primary (a standby — no consumers); POST-PROMOTE it is the
+  # writable survivor that region-A's failback rides: the dr-failback
+  # actor's peer probe and the demoted region-A's externalCluster both
+  # resolve this name (the side=primary local stub in
+  # peer-mesh-service.yaml completes the by-name global-service merge).
+  # CNPG re-points `rw` at whatever instance is current, so the alias
+  # tracks promotion/demotion with no chart change (#3740 idiom).
+  #
+  # selectorType MUST be `rw`, never `r` (#5473): `r` matches every
+  # instance, so a standby could serve as the failback source and region-A
+  # would re-clone from a non-writable line.
+  {{- if ne (toString (dig "clusterMesh" "enabled" true (.Values.topology | default dict))) "false" }}
+  managed:
+    services:
+      additional:
+        - selectorType: rw
+          serviceTemplate:
+            metadata:
+              name: {{ include "bp-postgres.peerReplicationServiceName" . }}
+              labels:
+                {{- include "bp-postgres.labels" . | nindent 16 }}
+                catalyst.openova.io/cnpg-pair: {{ include "bp-postgres.instanceName" . | quote }}
+                catalyst.openova.io/role: failback-source
+              annotations:
+                service.cilium.io/global: "true"
+                service.cilium.io/affinity: {{ .Values.topology.clusterMesh.affinity | quote }}
+                catalyst.openova.io/blueprint: bp-postgres
+            spec:
+              type: ClusterIP
+              ports:
+                - name: postgres
+                  port: 5432
+                  targetPort: 5432
+                  protocol: TCP
+  {{- end }}
 {{- end }}

--- a/platform/postgres/chart/tests/postgres-render.sh
+++ b/platform/postgres/chart/tests/postgres-render.sh
@@ -484,6 +484,14 @@ topology:
   replica: { region: hz-hel-rtz-prod }
   networkPolicy:
     crossRegionPeerClusters: [hw228-me-east-b]
+  # Isolate this case to the #4846 crossregion admission. The DR actors are
+  # default-ON and each carries its OWN egress CiliumNetworkPolicy (the #5623
+  # dr-promoter on the replica side, the #6149 dr-failback on this one), which
+  # are asserted separately in Cases 20a-20c / 21a-21h. Both gates must move
+  # TOGETHER: since #6149 the chart FAILS THE RENDER when exactly one of them is
+  # disabled, because a promoter without a failback is the hw293 hazard.
+  autoPromote: { enabled: false }
+  failback: { enabled: false }
 databases:
   - name: registry
     owner: harbor
@@ -526,8 +534,11 @@ topology:
   # Isolate this case to the #4846 crossregion admission — the #5623 dr-promoter
   # (default-ON) carries its OWN dr-promoter-egress CiliumNetworkPolicy, asserted
   # separately in Cases 20a-20c below; disabling it here keeps the "exactly 1 CNP"
-  # crossregion-dr assertion focused.
+  # crossregion-dr assertion focused. Since #6149 the two DR gates must move
+  # TOGETHER — disabling exactly one FAILS the render, because a promoter without
+  # a failback is the hw293 dual-writable hazard.
   autoPromote: { enabled: false }
+  failback: { enabled: false }
 # Same isolation, same reason (#6114): the replica-hub sentinel is default-ON on
 # the replica side and carries its OWN -egress CiliumNetworkPolicy (it must
 # reach the kube-apiserver through the shared-data default-deny). Its CNP is
@@ -1309,7 +1320,7 @@ grep -q 'already diverged' "$TMP/promoter.yaml" \
 grep -q 'resourceNames: \[bp-postgres-shared\]' "$TMP/promoter.yaml" \
   || fail "#5623 dr-promoter HR Role must be resourceNames-pinned to bp-postgres-shared"
 if grep -q 'kustomizations' "$TMP/promoter.yaml"; then
-  fail "#5623 dr-promoter must NOT grant kustomizations verbs (the #5245 durable-substitute handoff is a follow-up, not ported)"; fi
+  fail "#5623 dr-promoter must NOT grant kustomizations verbs — the durable-substitute seam belongs to the region-A dr-failback (#6149), and the promoter drives promotion through the HR values + suspend latch alone"; fi
 # 11. dr-promoter-egress CNP admits the kube-apiserver entity (kubectl egress).
 grep -q 'kube-apiserver' "$TMP/promoter.yaml" \
   || fail "#5623 dr-promoter-egress CNP missing the kube-apiserver entity — kubectl egress would be default-denied"
@@ -1330,7 +1341,12 @@ helm template shared-pg . -f "$TMP/promoter.values.yaml" --set topology.replicat
   --namespace shared-data --api-versions postgresql.cnpg.io/v1 > "$TMP/prom-async.yaml" 2>&1 || fail "#5623 async render errored"
 if grep -q 'role: dr-promoter' "$TMP/prom-async.yaml"; then
   fail "#5623 replication.mode=async must render ZERO dr-promoter resources (no sync-rep data fence)"; fi
-helm template shared-pg . -f "$TMP/promoter.values.yaml" --set topology.autoPromote.enabled=false \
+# #6149: the two DR gates move TOGETHER. Disabling exactly one FAILS the render
+# (a promoter without a failback is the hw293 dual-writable hazard), so the
+# operator-off case sets both — and Case 21f asserts the one-sided form is
+# refused.
+helm template shared-pg . -f "$TMP/promoter.values.yaml" \
+  --set topology.autoPromote.enabled=false --set topology.failback.enabled=false \
   --namespace shared-data --api-versions postgresql.cnpg.io/v1 > "$TMP/prom-off.yaml" 2>&1 || fail "#5623 autoPromote-off render errored"
 if grep -qE 'role: dr-promoter|role: failover-readiness-probe|shared-pg-probe-egress' "$TMP/prom-off.yaml"; then
   fail "#5623 autoPromote.enabled=false must render ZERO dr-promoter/probe resources"; fi
@@ -1338,8 +1354,21 @@ if grep -qE 'role: dr-promoter|role: failover-readiness-probe|shared-pg-probe-eg
   fail "#5623 singleton render leaked dr-promoter/probe resources (active-hot-standby replica only)"; fi
 echo "  PASS (no promoter/probe on primary / async / autoPromote-off / singleton)"
 
-# ── Case 20c: #5623 — fail-safe observe-only WITHOUT a cross-region liveness path ─
-echo "[render] Case 20c: #5623 fail-safe — no peer clusters => observe-only (PRIMARY_LIVENESS_ENABLED=false, no region-A egress rule)"
+# ── Case 20c: #6149 — NO cross-region probe path => NEITHER DR actor renders ──
+# SUPERSEDES the 0.2.18 shape of this case, which asserted the promoter still
+# rendered without peers as an "observe-only fail-safe" that would auto-arm once
+# the mesh was wired. That promoter could never promote: #5178's
+# PRIMARY_LIVENESS_ENABLED is exactly `clusterMesh AND peers`, so with no peers it
+# was a Deployment that consumed a Pod slot, reported Ready, and was structurally
+# incapable of the one thing it existed to do — indistinguishable from a working
+# one until a region was killed.
+#
+# #6149 makes the promoter and the failback ride ONE side-independent gate
+# (bp-postgres.drPairCapable) so the pair cannot be half-rendered. The failback
+# has ALWAYS required a peer — without a positive peer-writable proof it has no
+# safe action at all — so sharing the gate means the promoter requires one too.
+# An actor that cannot act is now honestly ABSENT rather than silently inert.
+echo "[render] Case 20c: #6149 no peer clusters => ZERO DR actors on BOTH sides (the gate is shared)"
 cat > "$TMP/promoter-nopeer.values.yaml" <<'YAML'
 instance: { name: shared-pg, namespace: shared-data }
 topology:
@@ -1350,14 +1379,16 @@ topology:
   replica: { region: hz-hel-rtz-prod }
 YAML
 helm template shared-pg . -f "$TMP/promoter-nopeer.values.yaml" --namespace shared-data \
-  --api-versions postgresql.cnpg.io/v1 > "$TMP/promoter-nopeer.yaml" 2>&1 || fail "#5623 no-peer render errored"
-grep -q 'role: dr-promoter' "$TMP/promoter-nopeer.yaml" \
-  || fail "#5623 the promoter still renders without peers (observe-only), so it can auto-arm once the mesh is wired"
-awk '/name: PRIMARY_LIVENESS_ENABLED/{getline; if ($0 ~ /"false"/) f=1} END{exit f?0:1}' "$TMP/promoter-nopeer.yaml" \
-  || fail "#5623 no-peer render must set PRIMARY_LIVENESS_ENABLED=false (fail-safe observe-only)"
+  --api-versions postgresql.cnpg.io/v1 > "$TMP/promoter-nopeer.yaml" 2>&1 || fail "#6149 no-peer replica render errored"
+if grep -q 'role: dr-promoter' "$TMP/promoter-nopeer.yaml"; then
+  fail "#6149 no-peer replica render still emits a dr-promoter — with no peer identity it can never positively prove region-A is gone (#5178), so it is inert, and its failback counterpart cannot render at all"; fi
 if grep -q 'io.cilium.k8s.policy.cluster' "$TMP/promoter-nopeer.yaml"; then
-  fail "#5623 no-peer render must NOT emit the region-A liveness egress rule (nothing proves region-A gone)"; fi
-echo "  PASS (observe-only fail-safe: PRIMARY_LIVENESS_ENABLED=false, no region-A egress rule)"
+  fail "#6149 no-peer render must NOT emit the region-A liveness egress rule (nothing proves region-A gone)"; fi
+helm template shared-pg . -f "$TMP/promoter-nopeer.values.yaml" --set topology.side=primary \
+  --namespace shared-data --api-versions postgresql.cnpg.io/v1 > "$TMP/failback-nopeer.yaml" 2>&1 || fail "#6149 no-peer primary render errored"
+if grep -q 'role: dr-failback' "$TMP/failback-nopeer.yaml"; then
+  fail "#6149 no-peer primary render still emits a dr-failback — without a peer probe it has no safe action"; fi
+echo "  PASS (no peers => no dr-promoter on the replica side AND no dr-failback on the primary side)"
 
 # ── Case 20d: #5623 — the promoted VALUE drives replica.enabled (both directions) ─
 echo "[render] Case 20d: #5623 replica.enabled follows topology.promoted (default replica, promoted->primary)"
@@ -1545,3 +1576,292 @@ sh -n "$TMP/sentinel-script.sh" \
   || fail "#6114 the sentinel loop is not valid POSIX sh — it would CrashLoopBackOff on the Alpine-based image"
 
 echo "  PASS (sentinel on replica + pre-flip; reap guards completed/age/positive-evidence; watch-list names hub AND role Secrets; readiness cannot wedge Helm wait; absent on primary CONTROL; opt-out clean; admission label + UID + HOME + POSIX-sh parse pinned)"
+# ─────────────────────────────────────────────────────────────────────────────
+# Cases 21a-21f: #6149 — the region-A dr-failback and the PAIRING INVARIANT.
+#
+# hw293 G12 (2026-08-11, dep a0077ba47e3720e5): all four DR pairs promoted and
+# exactly ONE could come back. Census after region A returned — 4 dr-promoters in
+# region B, 1 dr-failback in region A (bp-cnpg-pair's). `shared-pg` (keycloak's
+# database) and `shared-pg-b` were left DUAL-WRITABLE on divergent timelines,
+# both sides pg_is_in_recovery()=false with different row counts of the same
+# table and nothing scheduled to reconcile them.
+#
+# The catalog-wide census assertion (promoters == failbacks across every pair,
+# both sides, with a vacuity control) is
+# tests/e2e/bootstrap-kit/dr_pair_symmetry_6149_test.go and
+# scripts/check-dr-pairs-declare-promotion.sh Phase 3. What follows is this
+# chart's own contract: the actor renders where it must, is able to act when it
+# does, and renders nowhere else.
+# ─────────────────────────────────────────────────────────────────────────────
+echo "[render] Case 21a: #6149 dr-failback — side=primary, #5157 Deployment shape, durable demote seam"
+cat > "$TMP/failback.values.yaml" <<'YAML'
+instance: { name: shared-pg, namespace: shared-data }
+topology:
+  mode: active-hot-standby
+  side: primary
+  instances: 3
+  primary: { region: hz-fsn-rtz-prod }
+  replica: { region: hz-hel-rtz-prod }
+  networkPolicy:
+    crossRegionPeerClusters: [hw228-me-east-b]
+databases:
+  - name: keycloak
+    owner: keycloak
+    reflect: { secretName: keycloak-database-secret, namespaces: [keycloak] }
+YAML
+helm template shared-pg . -f "$TMP/failback.values.yaml" --namespace shared-data \
+  --api-versions postgresql.cnpg.io/v1 > "$TMP/failback.yaml" 2>&1 || fail "#6149 failback render errored"
+# 1. It is a Deployment, not a CronJob (#5157 — a CronJob's scheduler is the
+#    regional control plane and does not reliably resume after recovery), and a
+#    SINGLE actor (Recreate; never two failback loops at once).
+awk '/^kind: Deployment$/{d=1} d&&/^  name: shared-pg-dr-failback$/{f=1} END{exit f?0:1}' "$TMP/failback.yaml" \
+  || fail "#6149 no shared-pg-dr-failback Deployment on the primary side"
+if grep -q 'kind: CronJob' "$TMP/failback.yaml"; then fail "#6149 the failback must be a Deployment, not a CronJob (#5157)"; fi
+grep -q 'type: Recreate' "$TMP/failback.yaml" || fail "#6149 failback Deployment must use strategy Recreate (single actor)"
+# 2. It runs in REGION A — the half being rejoined.
+grep -q 'values: \["hz-fsn-rtz-prod"\]' "$TMP/failback.yaml" \
+  || fail "#6149 failback must pin nodeAffinity to the PRIMARY region (it acts on cluster-A)"
+# 3. #5125-D1 — the demote rides the DURABLE source seam (Kustomization
+#    substitute -> HR values), never a live Cluster-CR patch, which flux
+#    drift-correction reverts mid-outage (hw256 G12). Assert on the VALUES.
+for env_pair in "KS_NAME|bootstrap-kit" "KS_NAMESPACE|flux-system" "HR_NAME|bp-postgres-shared" "DEMOTED_SUB_KEY|SOVEREIGN_SHARED_PG_DEMOTED"; do
+  k="${env_pair%%|*}"; v="${env_pair#*|}"
+  awk -v k="$k" -v v="$v" '$0 ~ ("name: " k "$"){getline; if ($0 ~ ("\"" v "\"")) f=1} END{exit f?0:1}' "$TMP/failback.yaml" \
+    || fail "#6149 failback actor env $k != \"$v\" — without it there is no durable demote seam"
+done
+# 4. RBAC is resourceNames-pinned and carries NO blanket verbs. The one
+#    destructive verb it holds is `delete` on exactly this instance's Cluster CR.
+grep -q 'resourceNames: \[shared-pg\]' "$TMP/failback.yaml" \
+  || fail "#6149 failback Cluster Role must be resourceNames-pinned to shared-pg"
+grep -q 'verbs: \[get, delete\]' "$TMP/failback.yaml" \
+  || fail "#6149 failback Cluster Role must hold get+delete only (no patch — live-CR patches are the #5125-D1 anti-pattern)"
+if grep -qE 'resources: \[persistentvolumeclaims\]' "$TMP/failback.yaml"; then
+  fail "#6149 failback must NOT hold PVC verbs — storage is reclaimed by CNPG owner-GC"; fi
+# 5. Egress CNP: apiserver + kube-dns + the LOCAL cluster + the PEER cluster by
+#    ClusterMesh identity (a plain toEndpoints is implicitly local-only, #4846).
+grep -q 'shared-pg-dr-failback-egress' "$TMP/failback.yaml" || fail "#6149 missing the dr-failback egress CiliumNetworkPolicy"
+grep -q 'kube-apiserver' "$TMP/failback.yaml" || fail "#6149 failback egress CNP missing the kube-apiserver entity"
+grep -q '"hw228-me-east-b"' "$TMP/failback.yaml" || fail "#6149 failback egress CNP missing the peer cluster identity (the peer probe would be denied)"
+# 6. NO NodePort — ever.
+if grep -q 'NodePort' "$TMP/failback.yaml"; then fail "#6149 render leaked a NodePort (ABSOLUTELY FORBIDDEN)"; fi
+echo "  PASS (dr-failback Deployment/Recreate on region A; durable Kustomization+HR demote seam; pinned RBAC, get+delete only, no PVC verbs; peer-identity egress CNP)"
+
+echo "[render] Case 21b: #6149 the reverse-direction -replica-mesh alias exists on BOTH sides"
+# Cilium merges global services BY NAME+NAMESPACE. Without a same-named object on
+# cluster-A the failback's peer probe and the rejoin stream both NXDOMAIN — the
+# probe ladder reports that case by name precisely because it is the structural
+# way this breaks.
+grep -q 'name: shared-pg-replica-mesh' "$TMP/failback.yaml" \
+  || fail "#6149 primary side missing the -replica-mesh stub Service (peer host would be NXDOMAIN on cluster-A)"
+grep -q 'cnpg.io/cluster: shared-pg-replica' "$TMP/failback.yaml" \
+  || fail "#6149 -replica-mesh stub must select the REPLICA Cluster (zero local backends on cluster-A -> traffic crosses the mesh)"
+helm template shared-pg . -f "$TMP/failback.values.yaml" --set topology.side=replica \
+  --namespace shared-data --api-versions postgresql.cnpg.io/v1 > "$TMP/failback-replica.yaml" 2>&1 || fail "#6149 replica render errored"
+grep -q 'name: shared-pg-replica-mesh' "$TMP/failback-replica.yaml" \
+  || fail "#6149 replica side must publish -replica-mesh via the replica Cluster's managed.services"
+awk '/name: shared-pg-replica-mesh/{found=1} /selectorType: rw/{rw=1} END{exit (found&&rw)?0:1}' "$TMP/failback-replica.yaml" \
+  || fail "#6149 -replica-mesh must be selectorType rw (#5473: r matches every instance, so a STANDBY could serve as the failback source)"
+# The shared client CA is what lets region-A's own cert authenticate against
+# region-B — the precondition of the whole reverse direction.
+grep -q 'clientCASecret: shared-pg-ca' "$TMP/failback-replica.yaml" \
+  || fail "#6149 replica Cluster must pin clientCASecret to the shared shared-pg-ca, else region-A's rejoin stream is rejected"
+echo "  PASS (-replica-mesh published rw on the replica side + stubbed on the primary side; shared client CA pinned)"
+
+echo "[render] Case 21c: #6149 topology.demoted renders the REJOIN shape (replica of region-B)"
+helm template shared-pg . -f "$TMP/failback.values.yaml" --set topology.demoted=true \
+  --namespace shared-data --api-versions postgresql.cnpg.io/v1 > "$TMP/failback-demoted.yaml" 2>&1 || fail "#6149 demoted render errored"
+awk '/^kind: Cluster$/{c=1} c&&/^  name: shared-pg$/{r=1} r&&/^    enabled: /{print; exit}' "$TMP/failback-demoted.yaml" | grep -q 'enabled: true' \
+  || fail "#6149 topology.demoted=true must render replica.enabled: true on the primary Cluster (the region-A rejoin)"
+grep -q 'pg_basebackup:' "$TMP/failback-demoted.yaml" \
+  || fail "#6149 the demoted shape must bootstrap by pg_basebackup — a TL-N line cannot follow a TL-M source, so the stale timeline has to be discarded"
+grep -q 'host: shared-pg-replica-mesh' "$TMP/failback-demoted.yaml" \
+  || fail "#6149 the rejoin externalCluster must dial the reverse-direction -replica-mesh alias"
+# #5245 hw278: libpq/pgx upgrade sslmode=require to verify-ca semantics the moment
+# a root cert is supplied, and region-B's server chain is signed by a CA cluster-A
+# does not hold. Pinning one here FATAL-loops the re-clone on x509 for hours.
+if awk '/name: shared-pg-replica$/{e=1} e&&/sslRootCert:/{f=1} END{exit f?0:1}' "$TMP/failback-demoted.yaml"; then
+  fail "#6149 the rejoin externalCluster must carry NO sslRootCert (#5245 hw278 x509 unknown-authority FATAL-loop)"; fi
+# A standby carries no sync fence and can never reconcile CREATE/ALTER ROLE.
+if grep -q 'dataDurability: required' "$TMP/failback-demoted.yaml"; then
+  fail "#6149 the demoted shape must omit the synchronous block (a standby has no sync standby of its own)"; fi
+if grep -qE '^    roles:$' "$TMP/failback-demoted.yaml"; then
+  fail "#6149 the demoted shape must omit managed.roles — a read-only standby can never reconcile them"; fi
+if grep -q '^kind: Database$' "$TMP/failback-demoted.yaml"; then
+  fail "#6149 the demoted shape must omit Database CRs — CREATE DATABASE against a standby can never succeed"; fi
+# The mesh aliases stay: the switchback needs those names to keep resolving.
+grep -q 'name: shared-pg-mesh-rw' "$TMP/failback-demoted.yaml" \
+  || fail "#6149 the demoted shape dropped the -mesh-rw consumer alias"
+echo "  PASS (rejoin: replica.enabled + pg_basebackup off -replica-mesh, no sslRootCert, no sync fence, no managed roles, no Database CRs, mesh aliases intact)"
+
+echo "[render] Case 21d: #6149 dr-failback absent for replica / async / singleton"
+if grep -q 'role: dr-failback' "$TMP/failback-replica.yaml"; then
+  fail "#6149 side=replica must render ZERO dr-failback resources (the actor belongs on cluster-A, the half being rejoined)"; fi
+helm template shared-pg . -f "$TMP/failback.values.yaml" --set topology.replication.mode=async \
+  --namespace shared-data --api-versions postgresql.cnpg.io/v1 > "$TMP/failback-async.yaml" 2>&1 || fail "#6149 async render errored"
+if grep -q 'role: dr-failback' "$TMP/failback-async.yaml"; then
+  fail "#6149 replication.mode=async must render ZERO dr-failback resources — without the sync fence, 'region-B's line contains every acknowledged commit' is not true, so an automatic re-clone could DISCARD acked data"; fi
+helm template shared-pg . --set instance.name=shared-pg --namespace shared-data \
+  --api-versions postgresql.cnpg.io/v1 > "$TMP/failback-singleton.yaml" 2>&1 || fail "#6149 singleton render errored"
+if grep -qE 'role: dr-failback|shared-pg-replica-mesh' "$TMP/failback-singleton.yaml"; then
+  fail "#6149 a single-region singleton must be byte-identical — no failback, no reverse-direction alias"; fi
+echo "  PASS (no failback on replica / async / singleton; singleton leaks no -replica-mesh)"
+
+echo "[render] Case 21e: #6149 both DR actors render TOGETHER on their own sides"
+grep -q 'role: dr-failback' "$TMP/failback.yaml" || fail "#6149 primary side must render the dr-failback"
+grep -q 'role: dr-promoter' "$TMP/failback-replica.yaml" || fail "#6149 replica side must render the dr-promoter"
+if grep -q 'role: dr-promoter' "$TMP/failback.yaml"; then fail "#6149 the promoter must NOT render on the primary side"; fi
+echo "  PASS (exactly one dr-failback on side=primary, exactly one dr-promoter on side=replica — 1:1)"
+
+echo "[render] Case 21f: #6149 THE PAIRING INVARIANT — disabling exactly one half FAILS the render"
+# The structural preconditions are shared (bp-postgres.drPairCapable), so the only
+# remaining way to express the hw293 geometry by hand is a one-sided operator
+# gate. Both directions are refused: promoter-without-failback is the hazard
+# itself; failback-without-promoter is an actor armed to demote and re-clone
+# region A on a peer-ahead proof only a hand-promotion could produce.
+for one_sided in topology.failback.enabled topology.autoPromote.enabled; do
+  if helm template shared-pg . -f "$TMP/failback.values.yaml" --set "${one_sided}=false" \
+    --namespace shared-data --api-versions postgresql.cnpg.io/v1 > "$TMP/failback-asym.yaml" 2>&1; then
+    fail "#6149 the chart ACCEPTED ${one_sided}=false — a pair that can be promoted must be able to fail back; this configuration is what left hw293's shared-pg dual-writable"
+  fi
+  grep -q 'DR PAIRING INVARIANT VIOLATED' "$TMP/failback-asym.yaml" \
+    || fail "#6149 ${one_sided}=false failed, but not with the pairing-invariant error — the operator cannot tell which two keys disagree"
+  grep -q 'topology.autoPromote.enabled' "$TMP/failback-asym.yaml" \
+    || fail "#6149 the invariant error must name topology.autoPromote.enabled"
+  grep -q 'topology.failback.enabled' "$TMP/failback-asym.yaml" \
+    || fail "#6149 the invariant error must name topology.failback.enabled"
+done
+# Both off together is a legitimate (if unusual) operator choice: no DR chain at
+# all, symmetric. It must render cleanly with ZERO actors — otherwise the guard
+# is just "always red", which proves nothing.
+helm template shared-pg . -f "$TMP/failback.values.yaml" \
+  --set topology.failback.enabled=false --set topology.autoPromote.enabled=false \
+  --namespace shared-data --api-versions postgresql.cnpg.io/v1 > "$TMP/failback-bothoff.yaml" 2>&1 \
+  || fail "#6149 both-off render errored — symmetric OFF is a valid configuration, the invariant is about ASYMMETRY"
+if grep -qE 'role: dr-failback|role: dr-promoter' "$TMP/failback-bothoff.yaml"; then
+  fail "#6149 both-off render still emitted a DR actor"; fi
+echo "  PASS (one-sided gate REFUSED in both directions naming both keys; symmetric OFF renders cleanly with zero actors)"
+
+# ── Case 21g: #6148 peer-ahead write-guard ───────────────────────────────────
+#
+# region-A returns from a region-kill as a writable primary on a timeline the
+# peer has already overtaken, and stays writable for the WHOLE peer-ahead hold.
+# Every commit it accepts in that window is acknowledged to a consumer and then
+# discarded by the re-clone — and on THIS chart the consumers are keycloak,
+# gitea, harbor, grafana, powerdns and the Organization mesh, not a dedicated DR
+# pair with no clients. bp-cnpg-pair closed that window in #6148 (PR #6219); the
+# #6149 port must not re-open it here.
+#
+# These assertions pin the FOUR properties that make it a real guard rather than
+# an object that merely exists. Each one has a specific way of being wrong that
+# renders cleanly and reads correct, which is why each is asserted on the parsed
+# object rather than by grepping for a token.
+echo "[render] Case 21g: #6148 peer-ahead write-guard (deny is real · decider stays reachable · unwinds on every abort)"
+python3 - "$TMP/failback.yaml" <<'PYEOF' || { echo "FAIL: #6148 write-guard assertions failed." >&2; exit 1; }
+import sys, yaml
+docs=[d for d in yaml.safe_load_all(open(sys.argv[1])) if d]
+
+dep=[d for d in docs if d.get('kind')=='Deployment' and 'dr-failback' in d['metadata']['name']][0]
+act=[c for c in dep['spec']['template']['spec']['containers'] if c['name']=='actor'][0]['args'][0]
+
+cms=[d for d in docs if d.get('kind')=='ConfigMap' and d['metadata']['name'].endswith('-write-guard')]
+assert len(cms)==1, f"#6148: exactly one write-guard ConfigMap expected, got {len(cms)}"
+guard=yaml.safe_load(cms[0]['data']['guard.yaml'])
+
+# (a) The guard must DENY. A k8s NetworkPolicy cannot express deny — policies
+#     selecting the same Pods are additive allow-lists — so a guard authored as
+#     a NetworkPolicy would be created, logged, and permit every write it
+#     claimed to stop. That failure mode is REACHABLE here: this chart's own
+#     networkpolicy.yaml grants `- from: [{namespaceSelector: {}}]` on 5432
+#     (#3577), and nothing a NetworkPolicy can say subtracts it.
+assert guard['kind']=='CiliumNetworkPolicy', \
+    f"#6148: the guard must be a CiliumNetworkPolicy — a k8s NetworkPolicy cannot deny, got {guard['kind']}"
+deny=guard['spec'].get('ingressDeny')
+assert deny, "#6148: the guard must carry ingressDeny — an allow-only policy subtracts nothing"
+ports=[p['port'] for r in deny for tp in r.get('toPorts',[]) for p in tp.get('ports',[])]
+assert '5432' in ports, f"#6148: the guard must deny the postgres port, got {ports}"
+
+# (b) It must be purely SUBTRACTIVE. A CNP selecting an endpoint normally flips
+#     it to default-deny for that direction, which would take out the
+#     replication and CNPG-operator-status carve-outs in networkpolicy.yaml.
+edd=guard['spec'].get('enableDefaultDeny')
+assert edd=={'ingress': False, 'egress': False}, \
+    f"#6148: the guard must not flip the primary to default-deny, got {edd}"
+
+# (c) The DECIDER must stay reachable. The signals loop reads the local timeline
+#     over 5432; if that read fails, clear_hold "local timeline unreadable"
+#     aborts the failback outright. A guard that blinds the decider is worse
+#     than no guard — this is exactly what ruled out CNPG instance fencing.
+exempt=set()
+for r in deny:
+    for fe in r.get('fromEndpoints',[]):
+        for me in fe.get('matchExpressions',[]):
+            assert me['operator']=='NotIn', f"#6148: exemptions must be NotIn, got {me['operator']}"
+            exempt.add(me['key'])
+            exempt.update(me['values'])
+assert 'dr-failback' in exempt, \
+    "#6148: the failback Pod must be exempt or its own timeline probe trips clear_hold and aborts the failback"
+assert 'cnpg.io/cluster' in exempt, \
+    "#6148: the pair's own Pods must be exempt or the re-clone cannot stream from the peer"
+# fromEndpoints, never ipBlock: an ipBlock never matches a ClusterMesh remote
+# Pod identity, so an ipBlock guard silently misses the peer traffic it reasons about.
+assert not any(r.get('fromCIDR') or r.get('fromCIDRSet') for r in deny), \
+    "#6148: the guard must select by endpoint identity, not CIDR (ipBlock never matches a ClusterMesh remote Pod)"
+
+# (d) It must go UP at detection and come DOWN on every abort. The guard is
+#     keyed to /shared/peer-ahead-since, the same file every fail-safe path in
+#     the signals loop already clears, so no new control flow can forget it.
+k=act.find('peer-ahead-since ] || exit 0')
+assert k!=-1, "#6148: the D0 peer-ahead early-exit must still exist"
+assert 'guard_on' in act[k:k+400], \
+    "#6148: guard_on must fire at DETECTION (right after the D0 early-exit), not at demote time"
+assert '[ -f /shared/peer-ahead-since ] || guard_off' in act, \
+    "#6148: guard_off must run unconditionally per tick whenever the hold is not active"
+assert act.find('[ -f /shared/peer-ahead-since ] || guard_off') < act.find('while true') + 400, \
+    "#6148: the guard_off sweep must sit in the outer loop, not inside one geometry branch"
+
+# (e) It must be NON-FATAL. Converging region-A is what ends the exposure, so a
+#     guard that cannot be applied must report loudly and let the failback run.
+i=act.find('guard_on() {'); j=act.find('guard_off() {')
+assert i!=-1 and j!=-1 and i<j, "#6148: both guard helpers must be defined, guard_on first"
+body=act[i:j]
+assert 'exit 1' not in body and 'return 1' not in body, \
+    "#6148: guard_on must never fail the tick — stalling the failback prolongs the very window the guard exists to shorten"
+assert 'WARN' in body, "#6148: a guard that could not be applied must say so loudly"
+
+# (f) The actor must be able to take its own guard DOWN, and must not be able to
+#     create anything else. `create` cannot be resourceNames-pinned (k8s RBAC has
+#     no name to match before the object exists), so it is bounded by RESOURCE.
+roles=[d for d in docs if d.get('kind')=='Role' and 'dr-failback' in d['metadata']['name']]
+assert len(roles)==2, f"#6148: expected 2 dr-failback Roles (local ns + flux-system), got {len(roles)}"
+cnp_delete=[r for role in roles for r in role.get('rules',[])
+            if r.get('resources')==['ciliumnetworkpolicies'] and 'delete' in r.get('verbs',[])]
+assert cnp_delete, "#6148: the actor must hold delete on its own guard or a failed episode leaves :5432 denied after the reason has passed"
+assert all(r.get('resourceNames') for r in cnp_delete), "#6148: the guard delete rule must be resourceNames-pinned"
+for role in roles:
+    for r in role.get('rules',[]):
+        verbs=set(r.get('verbs',[])); res=r.get('resources',[])
+        assert 'persistentvolumeclaims' not in res, "#6148/#6149: dr-failback must never hold PVC verbs"
+        if 'create' in verbs:
+            assert res==['ciliumnetworkpolicies'], \
+                f"#6148: create verb only on the write-guard resource, got {res}"
+        if 'delete' in verbs:
+            assert res in (['clusters'], ['ciliumnetworkpolicies']), \
+                f"#6148/#6149: delete verb only on the Cluster CR or the write-guard, got {res}"
+
+# (g) The guard manifest must be MOUNTED read-only from the ConfigMap: the actor
+#     applies this file, it never authors one, so a bug cannot widen its scope.
+mounts=[m for c in dep['spec']['template']['spec']['containers'] if c['name']=='actor'
+        for m in c.get('volumeMounts',[]) if m['mountPath']=='/guard']
+assert mounts and mounts[0].get('readOnly') is True, \
+    "#6148: /guard must be mounted read-only into the actor"
+vols=[v for v in dep['spec']['template']['spec']['volumes'] if v['name']=='write-guard']
+assert vols and vols[0].get('configMap',{}).get('name','').endswith('-write-guard'), \
+    "#6148: the write-guard volume must come from the rendered ConfigMap"
+PYEOF
+# The guard is part of the DR chain, so it must be absent everywhere the chain
+# is — otherwise a singleton or a replica half carries a deny-5432 manifest.
+for absent in "$TMP/failback-replica.yaml" "$TMP/failback-singleton.yaml" "$TMP/failback-bothoff.yaml"; do
+  if grep -q 'shared-pg-write-guard' "$absent"; then
+    fail "#6148 the write-guard leaked into a render with no dr-failback ($absent)"; fi
+done
+echo "  PASS (#6148 ingressDeny on 5432 · purely subtractive · failback Pod and replication exempt · endpoint-identity not CIDR · armed at detection, swept on every abort · non-fatal · RBAC bounded · absent with the chain)"

--- a/platform/postgres/chart/values.yaml
+++ b/platform/postgres/chart/values.yaml
@@ -251,6 +251,100 @@ topology:
       tag: "1.30.0"
       pullPolicy: IfNotPresent
 
+  # ── DEMOTED (rejoin) seam (#6149) ─────────────────────────────────────
+  # When true the active-hot-standby PRIMARY half renders as a REPLICA CLUSTER
+  # of region-B — the region-A rejoin after a region-kill promote. The
+  # dr-failback actor drives this through the DURABLE SOURCE SEAM (it patches
+  # the bootstrap-kit Kustomization's per-instance demotion substitute, which
+  # kustomize renders onto this key), NEVER a live `kubectl patch` of the
+  # Cluster CR — flux drift-correction reverts that mid-outage (#5125-D1,
+  # hw256 G12). Flipping it back to false is the sovereign-admin's controlled
+  # switchback (RUNBOOKS §6.1), after region-B has been demoted in turn.
+  demoted: false
+
+  # ── Region-A AUTOMATIC DR FAILBACK (#6149) ────────────────────────────
+  # THE SYMMETRIC HALF OF autoPromote, and not optional relative to it.
+  #
+  # On the hw293 G12 region-kill (2026-08-11, dep a0077ba47e3720e5) all four
+  # DR pairs promoted — and exactly ONE of them, bp-cnpg-pair, could come
+  # back. `shared-pg` and `shared-pg-b` were left DUAL-WRITABLE on divergent
+  # timelines: both sides `pg_is_in_recovery()=false`, different row counts of
+  # the same table, neither following the other, and nothing scheduled to ever
+  # reconcile them. `shared-pg` carries keycloak. A split-brained identity
+  # store fails OPEN and SILENT, which is strictly worse than #5623's
+  # read-only outage — that one failed closed and was obvious.
+  #
+  # So: a pair that can be PROMOTED must be able to FAIL BACK. Both actors
+  # ride ONE structural gate (bp-postgres.drPairCapable — active-hot-standby +
+  # sync + clusterMesh + peers), and setting exactly one of the two `enabled`
+  # keys FAILS THE RENDER naming both (bp-postgres.assertDRPairSymmetry).
+  # There is no supported configuration in which only one of them exists.
+  #
+  # The actor is a region-A-local Deployment (Deployment NOT CronJob — #5157)
+  # that detects the post-failover geometry (local writable + pinned sync
+  # standby ABSENT + peer WRITABLE on an equal-or-higher timeline over
+  # `-replica-mesh`), holds peerAheadHoldSeconds, demotes through the durable
+  # substitute seam, and re-clones region-A onto region-B's line exactly once.
+  # Same chain proven live on bp-cnpg-pair in the hw293 walk that measured
+  # this defect.
+  failback:
+    enabled: true
+    intervalSeconds: 10
+    # The peer-ahead evidence must hold CONTINUOUSLY this long before the
+    # actor flips the demotion substitute. A transient mesh blip or a replica
+    # restart clears the clock. #6148 records what this window still leaves
+    # open: the stale region-A line is UNFENCED and accepts writes for its
+    # duration.
+    peerAheadHoldSeconds: 120
+    # A freshly-(re)started signals container must never act on a
+    # half-observed geometry.
+    startupGraceSeconds: 300
+    # pg_isready timeout for the peer probe.
+    livenessProbeTimeoutSeconds: 5
+    # How long an in-place-demoted standby (a Cluster CR that CNPG demoted in
+    # place, keeping its stale TL-n PGDATA) may sit unable to stream from a
+    # writable+ahead peer before the actor escalates to the re-clone. A fresh
+    # clone created AFTER the failback started is NEVER deleted (bounded
+    # destruction: at most one re-clone per failback episode).
+    wedgeHoldSeconds: 600
+    # How long the in-place-demoted Cluster's ConsistentSystemID condition
+    # (CNPG's own cannot-consistently-follow-the-source signal) must stay
+    # False before the actor escalates to the re-clone. Unlike the wedge clock
+    # this detector needs NO contiguous psql observability — the demoted
+    # standby restarts through the in-place switch and every 'unknown' tick
+    # resets the 600s wedge clock (#5245 hw278).
+    divergenceGraceSeconds: 180
+    # How long the post-failover geometry candidate may persist with the peer
+    # probe failing for an OBSERVABILITY-DEAD reason (nxdomain / unreachable /
+    # tl-unreadable) before the actor surfaces the starvation on the HR. A
+    # 2-node actor cannot distinguish region-B-dead (serving here is CORRECT)
+    # from region-B-unreachable (split-brain), so it must never act on
+    # blindness — but it must not be silent about it either (#5388).
+    starvationSurfaceSeconds: 300
+    # The flux HelmRelease this instance's demotion renders onto
+    # (spec.values.topology.demoted). Per-instance, same as autoPromote.hr.
+    hr:
+      name: bp-postgres-shared
+      namespace: flux-system
+    # The flux Kustomization carrying the DURABLE demotion substitute. This is
+    # the bootstrap-kit Kustomization cloud-init applies.
+    kustomization:
+      name: bootstrap-kit
+      namespace: flux-system
+    # PER-INSTANCE demotion substitute key. bp-cnpg-pair hard-codes
+    # SOVEREIGN_CNPG_PAIR_DEMOTED because there is exactly one pair; this
+    # chart is installed THREE times against the SAME bootstrap-kit
+    # Kustomization, so a shared key would demote all three the moment any one
+    # of them failed back. Slots 16a/16c/16d stamp their own
+    # (SOVEREIGN_SHARED_PG{,_B,_C}_DEMOTED).
+    demotedSubstituteKey: SOVEREIGN_SHARED_PG_DEMOTED
+    # kubectl-bearing image for the actor container — same harbor-proxy-pull-
+    # compliant prefix as autoPromote.kubectlImage.
+    kubectlImage:
+      repository: harbor.openova.io/proxy-dockerhub/alpine/k8s
+      tag: "1.30.0"
+      pullPolicy: IfNotPresent
+
   # ── Cilium ClusterMesh — the canonical inter-region replication transport
   # (ADR-0001 §9). The primary's `-mesh` global Service publishes its read
   # endpoint across the mesh; the replica's externalCluster dials it. OFF

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-13T09:30:53.174Z",
+  "generatedAt": "2026-08-13T10:13:50.324Z",
   "blueprints": [
     {
       "id": "bp-agenity",
@@ -4083,7 +4083,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "listed",
-      "version": "0.2.20",
+      "version": "0.2.23",
       "section": "pts-4-1-data-services",
       "depends": [
         "bp-cnpg",

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -4218,7 +4218,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "listed",
-    "version": "0.2.22",
+    "version": "0.2.23",
     "section": "pts-4-1-data-services",
     "depends": [
       "bp-cnpg",

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -4218,7 +4218,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "listed",
-    "version": "0.2.20",
+    "version": "0.2.22",
     "section": "pts-4-1-data-services",
     "depends": [
       "bp-cnpg",

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3899,7 +3899,16 @@ name: bp-catalyst-platform
 #   The seed pin is the delivery half: without this bump a pinned Sovereign
 #   resolves 1.5.9 and never sees the fix. This chart's own templates are
 #   unchanged.
-version: 1.4.1436
+# 1.4.1437 — #6149 (Refs #6148): catalog-seed advances bp-postgres 0.2.20 -> 0.2.23,
+#   the release that gives the three shared-pg DR pairs a region-A dr-failback.
+#   hw293's census was 4 dr-promoters against 1 dr-failback, which left shared-pg
+#   and shared-pg-b permanently DUAL-WRITABLE on divergent timelines with keycloak
+#   on one of them. 0.2.23 also carries the #6148 write-guard, so the 120s
+#   peer-ahead hold no longer accepts consumer writes it is about to discard. The
+#   seed pin is the delivery half: without this republish a pinned Sovereign
+#   resolves 0.2.20 and never sees the failback. This chart's own templates are
+#   unchanged apart from the seed entry.
+version: 1.4.1437
 # 1.4.1229 — #5389: catalog-seed bp-newapi declares its `ui` endpoint
 #   (newapi.<fqdn>, ssoEnabled, launchDefault, ssoInitPath "/") instead of
 #   `endpoints: []`. The empty list made userUIGatePasses fail closed, which
@@ -4054,7 +4063,7 @@ version: 1.4.1436
 # scripts/check-chart-version-forward.sh (#5743) fails unless the two match —
 # main was carrying a pre-existing 1.4.1330/1.4.1329 split, so this bump heals
 # it in the same commit, exactly as the documented self-heal contract does.
-appVersion: 1.4.1436
+appVersion: 1.4.1437
 # 1.4.239 — Wave 3 / Issue #2140 (2026-05-23): Huawei provider
 # implementation lands behind the Wave 2 CloudProvider interface.
 # Adds the OpenTofu module at infra/providers/huawei/ (VPC + Subnet +

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5809,11 +5809,11 @@ spec:
   # CNPG never recreates (a Job pod template is immutable, so #6016's spec repair
   # could not heal the generation-1 Pod) and reports the cross-mesh consumer-hub
   # sync's absence loudly instead of leaving 14 Secrets silently missing.
-  # 0.2.22 (#6149): region-A AUTOMATIC DR FAILBACK — ported bp-cnpg-pair dr-failback
+  # 0.2.23 (#6149, Refs #6148): region-A AUTOMATIC DR FAILBACK — ported bp-cnpg-pair dr-failback
   # + the `-replica-mesh` reverse alias + the topology.demoted rejoin shape, AND the
   # pairing invariant that renders promoter and failback off ONE gate. hw293 shipped
   # 4 promoters against 1 failback and left shared-pg/-b permanently dual-writable.
-  version: "0.2.22"
+  version: "0.2.23"
   visibility: listed
   # Shareability + Contexts (#3370) — seeded verbatim from
   # platform/postgres/blueprint.yaml (lockstep-guarded). One instance
@@ -5937,11 +5937,11 @@ spec:
     # + topology.promoted seam) on the active-hot-standby replica half.
     # 0.2.20 (#6114): replica-side hub sentinel (stale-initdb reap + loud hub-sync
     # absence); readiness never gates on the synced state so it cannot wedge Helm wait.
-    # 0.2.22 (#6149): region-A automatic DR FAILBACK (dr-failback + the
+    # 0.2.23 (#6149, Refs #6148): region-A automatic DR FAILBACK (dr-failback + the
     # `-replica-mesh` reverse alias + the topology.demoted rejoin shape) AND the
     # pairing invariant — promoter and failback now ride ONE gate, so a pair that
     # can be promoted can always fail back. hw293 left shared-pg/-b dual-writable.
-    version: "0.2.22"
+    version: "0.2.23"
   # Seeded verbatim from platform/postgres/blueprint.yaml spec.topology.
   # singleton = single-instance Cluster; active-hot-standby = sync
   # replication across regions (ADR-0004 Pillar-3 zero-tx-loss) via the

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5809,7 +5809,11 @@ spec:
   # CNPG never recreates (a Job pod template is immutable, so #6016's spec repair
   # could not heal the generation-1 Pod) and reports the cross-mesh consumer-hub
   # sync's absence loudly instead of leaving 14 Secrets silently missing.
-  version: "0.2.20"
+  # 0.2.22 (#6149): region-A AUTOMATIC DR FAILBACK — ported bp-cnpg-pair dr-failback
+  # + the `-replica-mesh` reverse alias + the topology.demoted rejoin shape, AND the
+  # pairing invariant that renders promoter and failback off ONE gate. hw293 shipped
+  # 4 promoters against 1 failback and left shared-pg/-b permanently dual-writable.
+  version: "0.2.22"
   visibility: listed
   # Shareability + Contexts (#3370) — seeded verbatim from
   # platform/postgres/blueprint.yaml (lockstep-guarded). One instance
@@ -5933,7 +5937,11 @@ spec:
     # + topology.promoted seam) on the active-hot-standby replica half.
     # 0.2.20 (#6114): replica-side hub sentinel (stale-initdb reap + loud hub-sync
     # absence); readiness never gates on the synced state so it cannot wedge Helm wait.
-    version: "0.2.20"
+    # 0.2.22 (#6149): region-A automatic DR FAILBACK (dr-failback + the
+    # `-replica-mesh` reverse alias + the topology.demoted rejoin shape) AND the
+    # pairing invariant — promoter and failback now ride ONE gate, so a pair that
+    # can be promoted can always fail back. hw293 left shared-pg/-b dual-writable.
+    version: "0.2.22"
   # Seeded verbatim from platform/postgres/blueprint.yaml spec.topology.
   # singleton = single-instance Cluster; active-hot-standby = sync
   # replication across regions (ADR-0004 Pillar-3 zero-tx-loss) via the

--- a/scripts/check-dr-pairs-declare-promotion.sh
+++ b/scripts/check-dr-pairs-declare-promotion.sh
@@ -156,8 +156,14 @@ REGISTRY="
 platform/cnpg-pair/chart/templates/replica-cluster.yaml|platform/cnpg-pair/chart|dr-promoter
 platform/cnpg-pair/chart/templates/primary-cluster.yaml|platform/cnpg-pair/chart|dr-promoter
 platform/postgres/chart/templates/replica-cluster.yaml|platform/postgres/chart|dr-promoter
+platform/postgres/chart/templates/cluster.yaml|platform/postgres/chart|dr-promoter
 platform/wordpress-tenant/chart/templates/cnpg-cluster.yaml|platform/wordpress-tenant/chart|manual
 "
+# platform/postgres/chart/templates/cluster.yaml joined the registry with #6149:
+# in the DEMOTED (rejoin) shape the primary half renders as a pg_basebackup
+# replica of region-B, so it is a standby-half renderer by the same structural
+# signature the detector uses — exactly as bp-cnpg-pair's primary-cluster.yaml
+# has been since #5245.
 
 echo "══ Phase 1 — registry completeness ══"
 
@@ -447,9 +453,131 @@ else
   fail "bp-wordpress-tenant singleton render errored — the #5623 declaration must not affect non-DR installs"
 fi
 
+# ─────────────────────────────────────────────────────────────────────────────
+echo
+echo "══ Phase 3 — the PAIRING INVARIANT (#6149) ══"
+#
+# This phase exists because Phase 2 was GREEN on the tree that produced hw293.
+# It proved every pair can PROMOTE and said nothing about coming back, so
+# `bp-postgres` shipped four promoters against one failback and the G12 walk of
+# 2026-08-11 left `shared-pg` (keycloak's database) and `shared-pg-b`
+# permanently DUAL-WRITABLE on divergent timelines — both sides
+# pg_is_in_recovery()=false, different row counts of the same table, nothing
+# scheduled to reconcile them. A promoter without a failback is not a partial
+# feature; it is a data-integrity hazard, and #5623 made the failure mode worse
+# rather than better by shipping one alone.
+#
+# So the assertion is on the PAIR COUNT — promoters == failbacks — never on
+# either alone. The two halves render in SEPARATE helm invocations
+# (side=primary on cluster-A, side=replica on cluster-B), so both are rendered
+# here and the census is taken across the catalog exactly as it was taken live.
+#
+# The exhaustive form of this check (per-pair census, the operator-gate
+# symmetry, the vacuity control, the registry-rot detector) is
+# tests/e2e/bootstrap-kit/dr_pair_symmetry_6149_test.go. This phase is the
+# same claim in the gate whose promoter-only framing let the defect through.
+
+# failback_deployments <file> — rendered Deployments carrying the
+# `catalyst.openova.io/role: dr-failback` LABEL VALUE. Parsed as YAML, so a
+# comment or a name substring can never satisfy it (#5639).
+failback_deployments() {
+  python3 - "$1" <<'PYEOF'
+import sys, yaml
+try:
+    docs = [d for d in yaml.safe_load_all(open(sys.argv[1])) if d]
+except Exception as e:
+    print(f"__PARSE_ERROR__ {e}")
+    sys.exit(0)
+for d in docs:
+    if d.get('kind') == 'Deployment':
+        md = d.get('metadata') or {}
+        if (md.get('labels') or {}).get('catalyst.openova.io/role') == 'dr-failback':
+            print(md.get('name', ''))
+PYEOF
+}
+
+total_promoters=0
+total_failbacks=0
+
+# count_pair <label> <promoter-side render> <failback-side render>
+count_pair() {
+  local label="$1" pfile="$2" ffile="$3"
+  local p f np nf
+  p="$(promoter_deployments "$pfile")"
+  f="$(failback_deployments "$ffile")"
+  np=$([ -n "$p" ] && echo "$p" | wc -l || echo 0)
+  nf=$([ -n "$f" ] && echo "$f" | wc -l || echo 0)
+  total_promoters=$((total_promoters + np))
+  total_failbacks=$((total_failbacks + nf))
+  if [ "$np" -eq "$nf" ] && [ "$np" -gt 0 ]; then
+    pass "$label: promoters=$np failbacks=$nf — a pair that can be promoted can fail back"
+  else
+    fail "$label: PAIR ASYMMETRY — promoters=$np failbacks=$nf.
+        This is the #6149 geometry: region B promotes on a region kill and
+        region A returns as a SECOND writable primary on a divergent timeline
+        with nothing scheduled to reconcile them. Measured live on hw293
+        2026-08-11 — shared-pg and shared-pg-b, both left dual-writable."
+  fi
+}
+
+# bp-cnpg-pair — THE CONTROL. It shares the suspect property (a CNPG DR pair
+# rendering a region-B promoter) and already carried a failback before #6149, so
+# it must stay green and unchanged. A red control means this phase cannot tell a
+# real green from a vacuous one.
+if helm template dr platform/cnpg-pair/chart \
+  --set cnpgPair.enabled=true \
+  --set cnpgPair.side=primary \
+  --set cnpgPair.primary.region="$A" \
+  --set cnpgPair.replica.region="$B" \
+  --set cnpgPair.image.tag=16.3-23 \
+  --set 'cnpgPair.networkPolicy.crossRegionPeerClusters={peer-mesh}' \
+  --api-versions postgresql.cnpg.io/v1 > "$TMP/cnpg-pair-primary.yaml" 2>"$TMP/cnpg-pair-primary.err"; then
+  count_pair "bp-cnpg-pair (CONTROL)" "$TMP/cnpg-pair-replica.yaml" "$TMP/cnpg-pair-primary.yaml"
+else
+  fail "bp-cnpg-pair side=primary render errored: $(tail -2 "$TMP/cnpg-pair-primary.err")"
+fi
+
+# bp-postgres — the three shared-pg instances. shared-pg carries keycloak.
+if helm template shared-pg platform/postgres/chart -f "$TMP/pg-replica.values.yaml" \
+  --set topology.side=primary \
+  --namespace shared-data --api-versions postgresql.cnpg.io/v1 \
+  > "$TMP/pg-primary.yaml" 2>"$TMP/pg-primary.err"; then
+  count_pair "bp-postgres (shared-pg)" "$TMP/pg-replica.yaml" "$TMP/pg-primary.yaml"
+else
+  fail "bp-postgres side=primary render errored: $(tail -2 "$TMP/pg-primary.err")"
+fi
+
+# The aggregate census — the exact number the hw293 walk produced (4 vs 1).
+if [ "$total_promoters" -eq "$total_failbacks" ] && [ "$total_promoters" -gt 0 ]; then
+  pass "catalog census: dr-promoter=$total_promoters dr-failback=$total_failbacks"
+else
+  fail "CATALOG CENSUS ASYMMETRY — dr-promoter=$total_promoters dr-failback=$total_failbacks.
+        hw293 measured 4 and 1, and that asymmetry IS the whole explanation of
+        its two permanently dual-writable databases."
+fi
+
+# Operator-gate symmetry: disabling exactly ONE half must FAIL THE RENDER. The
+# structural preconditions are shared (bp-postgres.drPairCapable), so this is
+# the only remaining way to express the hazard by hand — in both directions.
+for pair in "topology.failback.enabled|promoter without a failback (the #6149 hazard)" \
+            "topology.autoPromote.enabled|failback without a promoter (the inverse trap)"; do
+  key="${pair%%|*}"; why="${pair#*|}"
+  if helm template shared-pg platform/postgres/chart -f "$TMP/pg-replica.values.yaml" \
+    --set "${key}=false" \
+    --namespace shared-data --api-versions postgresql.cnpg.io/v1 \
+    > /dev/null 2>"$TMP/pg-asym.err"; then
+    fail "bp-postgres accepted ${key}=false — $why. The chart must fail closed."
+  elif grep -q 'DR PAIRING INVARIANT VIOLATED' "$TMP/pg-asym.err"; then
+    pass "bp-postgres: ${key}=false fails closed naming both keys ($why)"
+  else
+    fail "bp-postgres: ${key}=false failed, but not with the pairing-invariant error —
+        got: $(tail -2 "$TMP/pg-asym.err")"
+  fi
+done
+
 echo
 if [ "$fails" -ne 0 ]; then
-  echo "══ $fails failure(s) — a DR pair in this catalog cannot promote its standby ══"
+  echo "══ $fails failure(s) — a DR pair in this catalog cannot promote its standby, or cannot come back ══"
   exit 1
 fi
-echo "══ OK — every DR pair declares a promotion mechanism and renders it ══"
+echo "══ OK — every DR pair declares a promotion mechanism, renders it, and can fail back ══"

--- a/scripts/check-region-selector-fail-closed.sh
+++ b/scripts/check-region-selector-fail-closed.sh
@@ -90,6 +90,7 @@ fail() {
 REGISTRY="
 platform/postgres/chart/templates/cluster.yaml|platform/postgres/chart|bp-postgres.primaryRegion
 platform/postgres/chart/templates/replica-cluster.yaml|platform/postgres/chart|bp-postgres.replicaRegion
+platform/postgres/chart/templates/dr-failback.yaml|platform/postgres/chart|bp-postgres.primaryRegion (#6149 — failbackActive requires drPairCapable+side=primary, so cluster.yaml co-renders; the Deployment nodeAffinity pins bp-postgres.primaryRegion directly)
 platform/postgres/chart/templates/dr-promoter.yaml|platform/postgres/chart|bp-postgres.replicaRegion (#5623 — autoPromoteActive requires renderReplicaHalf, so replica-cluster.yaml co-renders; the Deployment nodeAffinity pins bp-postgres.replicaRegion directly)
 platform/postgres/chart/templates/failover-readiness.yaml|platform/postgres/chart|bp-postgres.replicaRegion (#5623 — same autoPromoteActive gate; the Deployment nodeAffinity pins bp-postgres.replicaRegion directly)
 platform/cnpg-pair/chart/templates/primary-cluster.yaml|platform/cnpg-pair/chart|cnpg-pair.validateRegions

--- a/tests/e2e/bootstrap-kit/dr_pair_symmetry_6149_test.go
+++ b/tests/e2e/bootstrap-kit/dr_pair_symmetry_6149_test.go
@@ -1,0 +1,648 @@
+// #6149 — THE DR PAIRING INVARIANT: a pair that can be PROMOTED must be able to
+// FAIL BACK, and neither half may render without the other.
+//
+// THE DEFECT THIS EXISTS TO PREVENT
+// ---------------------------------
+// hw293 G12 region-kill, 2026-08-11, dep a0077ba47e3720e5. The deployment census
+// taken after region A returned and cnpg-pair had fully converged:
+//
+//	dr-promoter deployments in region B : 4   <- all four pairs
+//	dr-failback deployments in region A : 1   <- bp-cnpg-pair ONLY
+//
+// The single failback belonged to the single pair that converged. `shared-pg` and
+// `shared-pg-b` were left permanently DUAL-WRITABLE on divergent timelines — both
+// sides pg_is_in_recovery()=false, different row counts of the SAME table, neither
+// following the other, and nothing anywhere scheduled to reconcile them.
+// `shared-pg` carries keycloak, the authoritative identity store.
+//
+// #5623 added the promoter to bp-postgres and thereby converted "does not fail
+// over" into "fails over and never comes back" — strictly worse, because a
+// split-brain accepting writes on both sides silently diverges rather than simply
+// being unavailable. A promoter without a failback is not a partial feature; it is
+// a data-integrity hazard.
+//
+// WHY THE ASSERTIONS LOOK LIKE THIS
+// ---------------------------------
+//  1. The assertion is on the PAIR COUNT — promoters == failbacks — never on
+//     either alone. An assertion that only checks "the failback renders" passes on
+//     a tree where the promoter quietly stopped rendering, and an assertion that
+//     only checks the promoter is exactly the guard that was green for every one
+//     of the months bp-postgres had no failback. The ASYMMETRY is the defect, so
+//     the asymmetry is what has to go red.
+//  2. Both sides are rendered. The two halves render in SEPARATE helm invocations
+//     (side=primary on cluster-A, side=replica on cluster-B), so a test that
+//     renders one side cannot see the census that mattered live.
+//  3. Deployments are identified by their rendered `catalyst.openova.io/role`
+//     LABEL VALUE, parsed as YAML — not by grepping the name, which passes on a
+//     comment (#5639: assert on the value, never on the key).
+//  4. bp-cnpg-pair is the CONTROL: it shares the suspect property (it is a CNPG DR
+//     pair rendering a promoter) and it already carried a failback before this
+//     change. It must stay green, unchanged. If the whole suite could pass on an
+//     empty render, the control would go red too.
+//  5. Vacuity: TestDRPairSymmetry_ComparatorGoesRedOnAsymmetry feeds the SAME
+//     comparator a deliberately asymmetric census and requires it to report a
+//     violation. A comparator observed only passing is not yet known to be a
+//     comparator.
+//  6. The registry cannot rot: every chart template in the catalog that emits a
+//     CNPG `bootstrap.pg_basebackup` stanza (the structural signature of a standby
+//     half) must be covered by a case here or declared promoter-less.
+//
+// Run: go test ./tests/e2e/bootstrap-kit/ -run 'DRPair' -count=1 -v
+// (-count=1 always: a cached green is indistinguishable from a real one.)
+//
+// Refs #6149 #5623 #5245 #6148
+package bootstrapkit
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	drRoleLabel    = "catalyst.openova.io/role"
+	drRolePromoter = "dr-promoter"
+	drRoleFailback = "dr-failback"
+
+	drRegionA = "hz-fsn-rtz-prod"
+	drRegionB = "hz-hel-rtz-prod"
+)
+
+// drCensus is the rendered-actor tally for ONE DR pair — the exact shape of the
+// live census taken on hw293.
+type drCensus struct {
+	pair      string
+	promoters []string // Deployment names carrying role=dr-promoter (region-B side)
+	failbacks []string // Deployment names carrying role=dr-failback (region-A side)
+}
+
+func (c drCensus) symmetric() bool { return len(c.promoters) == len(c.failbacks) }
+
+func (c drCensus) String() string {
+	return fmt.Sprintf("%s: promoters=%d %v failbacks=%d %v",
+		c.pair, len(c.promoters), c.promoters, len(c.failbacks), c.failbacks)
+}
+
+// violations returns a human-readable reason per asymmetric pair, plus the
+// aggregate census line. THIS is the comparator under test — the vacuity case
+// feeds it a hand-built asymmetric census and requires a non-empty result.
+func drViolations(census []drCensus) []string {
+	var out []string
+	totalP, totalF := 0, 0
+	for _, c := range census {
+		totalP += len(c.promoters)
+		totalF += len(c.failbacks)
+		if !c.symmetric() {
+			out = append(out, fmt.Sprintf(
+				"PAIR ASYMMETRY — %s. A pair that can be PROMOTED must be able to FAIL BACK; "+
+					"this is the #6149 geometry, in which region B promotes on a kill and region A "+
+					"returns as a second writable primary on a divergent timeline with nothing "+
+					"scheduled to reconcile them.", c))
+		}
+	}
+	if totalP != totalF {
+		out = append(out, fmt.Sprintf(
+			"CATALOG CENSUS ASYMMETRY — dr-promoter deployments=%d, dr-failback deployments=%d. "+
+				"hw293 measured 4 and 1; the whole explanation of that walk's permanently "+
+				"dual-writable shared-pg/shared-pg-b was that promote was implemented for four "+
+				"pairs and failback for one.", totalP, totalF))
+	}
+	return out
+}
+
+// drHelm renders a chart and returns the parsed docs. A render ERROR is returned,
+// not fataled, so the negative cases can assert on it.
+func drHelm(t *testing.T, chartDir string, args ...string) ([]map[string]any, string, error) {
+	t.Helper()
+
+	helmBin := os.Getenv("HELM_BIN")
+	if helmBin == "" {
+		helmBin = "helm"
+	}
+	if _, err := exec.LookPath(helmBin); err != nil {
+		t.Skipf("helm not on PATH (%v)", err)
+	}
+
+	root := repoRoot(t)
+	full := append([]string{"template", "dr", filepath.Join(root, chartDir)}, args...)
+	full = append(full, "--api-versions", "postgresql.cnpg.io/v1")
+
+	cmd := exec.Command(helmBin, full...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, string(out), err
+	}
+
+	var docs []map[string]any
+	dec := yaml.NewDecoder(strings.NewReader(string(out)))
+	for {
+		var doc map[string]any
+		if derr := dec.Decode(&doc); derr != nil {
+			break
+		}
+		if doc != nil {
+			docs = append(docs, doc)
+		}
+	}
+	return docs, string(out), nil
+}
+
+// drActors returns the names of Deployments whose rendered
+// `catalyst.openova.io/role` label VALUE equals want. Parsed as YAML off the
+// object, so a comment or a name substring can never satisfy it.
+func drActors(docs []map[string]any, want string) []string {
+	var names []string
+	for _, d := range docs {
+		if k, _ := d["kind"].(string); k != "Deployment" {
+			continue
+		}
+		md, _ := d["metadata"].(map[string]any)
+		if md == nil {
+			continue
+		}
+		labels, _ := md["labels"].(map[string]any)
+		if labels == nil {
+			continue
+		}
+		if v, _ := labels[drRoleLabel].(string); v == want {
+			n, _ := md["name"].(string)
+			names = append(names, n)
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
+// drPairCase is one DR pair and the two per-side renders that make up its census.
+type drPairCase struct {
+	pair string
+	// chart dir, relative to the repo root
+	chart string
+	// helm args for the REGION-A (primary) half — where a failback belongs
+	primaryArgs []string
+	// helm args for the REGION-B (replica) half — where a promoter belongs
+	replicaArgs []string
+	// control marks the pair that already carried a failback before #6149. It
+	// must stay green and unchanged; if it goes red the suite is broken, not the
+	// tree under test.
+	control bool
+}
+
+// bpPostgresArgs builds the shared-pg value set for one instance name + side.
+func bpPostgresArgs(instance, side string, extra ...string) []string {
+	a := []string{
+		"--namespace", "shared-data",
+		"--set", "enabled=true",
+		"--set", "instance.name=" + instance,
+		"--set", "instance.namespace=shared-data",
+		"--set", "topology.mode=active-hot-standby",
+		"--set", "topology.side=" + side,
+		"--set", "topology.primary.region=" + drRegionA,
+		"--set", "topology.replica.region=" + drRegionB,
+		"--set", "topology.networkPolicy.crossRegionPeerClusters={peer-mesh}",
+		"--set", "databases[0].name=keycloak",
+		"--set", "databases[0].owner=keycloak",
+	}
+	return append(a, extra...)
+}
+
+func cnpgPairArgs(side string, extra ...string) []string {
+	a := []string{
+		"--set", "cnpgPair.enabled=true",
+		"--set", "cnpgPair.side=" + side,
+		"--set", "cnpgPair.primary.region=" + drRegionA,
+		"--set", "cnpgPair.replica.region=" + drRegionB,
+		"--set", "cnpgPair.image.tag=16.3-23",
+		"--set", "cnpgPair.networkPolicy.crossRegionPeerClusters={peer-mesh}",
+	}
+	return append(a, extra...)
+}
+
+// drPairs is the catalog of DR pairs whose census this guard takes. Kept honest
+// by TestDRPairSymmetry_RegistryCoversEveryStandbyHalf below.
+func drPairs() []drPairCase {
+	return []drPairCase{
+		{
+			// THE CONTROL. Shares the suspect property (a CNPG DR pair that
+			// renders a region-B promoter) and already shipped the failback
+			// before #6149. Untouched by this change; it must stay green.
+			pair:        "bp-cnpg-pair",
+			chart:       "platform/cnpg-pair/chart",
+			primaryArgs: cnpgPairArgs("primary"),
+			replicaArgs: cnpgPairArgs("replica"),
+			control:     true,
+		},
+		{
+			// hw293: promoted, then returned WRITABLE on TL=3 alongside a
+			// WRITABLE region B on TL=3 with different row counts. Carries
+			// keycloak.
+			pair:        "bp-postgres/shared-pg",
+			chart:       "platform/postgres/chart",
+			primaryArgs: bpPostgresArgs("shared-pg", "primary"),
+			replicaArgs: bpPostgresArgs("shared-pg", "replica"),
+		},
+		{
+			// hw293: promoted, then returned WRITABLE on TL=2 against a WRITABLE
+			// region B on TL=3. The `secondary` side alias is exercised here
+			// because that is the literal value cloud-init stamps.
+			pair:  "bp-postgres/shared-pg-b",
+			chart: "platform/postgres/chart",
+			primaryArgs: bpPostgresArgs("shared-pg-b", "primary",
+				"--set", "topology.failback.hr.name=bp-postgres-shared-b",
+				"--set", "topology.failback.demotedSubstituteKey=SOVEREIGN_SHARED_PG_B_DEMOTED"),
+			replicaArgs: bpPostgresArgs("shared-pg-b", "secondary",
+				"--set", "topology.autoPromote.hr.name=bp-postgres-shared-b"),
+		},
+		{
+			// hw293: did NOT promote (its promoter correctly refused — #5220,
+			// unarmed at T0), so there was never a second timeline. Included so
+			// the census covers the pair that looked healthy for the wrong
+			// reason.
+			pair:  "bp-postgres/shared-pg-c",
+			chart: "platform/postgres/chart",
+			primaryArgs: bpPostgresArgs("shared-pg-c", "primary",
+				"--set", "topology.failback.hr.name=bp-postgres-shared-c",
+				"--set", "topology.failback.demotedSubstituteKey=SOVEREIGN_SHARED_PG_C_DEMOTED"),
+			replicaArgs: bpPostgresArgs("shared-pg-c", "secondary",
+				"--set", "topology.autoPromote.hr.name=bp-postgres-shared-c"),
+		},
+	}
+}
+
+// TestDRPairSymmetry_EveryPromotablePairCanFailBack is the primary assertion:
+// the rendered PAIR COUNT, per pair AND in aggregate.
+//
+// BEFORE this fix it reports exactly the hw293 census — 4 promoters, 1 failback —
+// and fails on three pairs. AFTER, 4 and 4.
+func TestDRPairSymmetry_EveryPromotablePairCanFailBack(t *testing.T) {
+	var census []drCensus
+
+	for _, c := range drPairs() {
+		primaryDocs, primaryOut, err := drHelm(t, c.chart, c.primaryArgs...)
+		if err != nil {
+			t.Fatalf("%s: region-A (primary) render failed: %v\n%s", c.pair, err, tailLines(primaryOut, 6))
+		}
+		replicaDocs, replicaOut, err := drHelm(t, c.chart, c.replicaArgs...)
+		if err != nil {
+			t.Fatalf("%s: region-B (replica) render failed: %v\n%s", c.pair, err, tailLines(replicaOut, 6))
+		}
+
+		cc := drCensus{
+			pair: c.pair,
+			// The promoter is a region-B actor and the failback a region-A one,
+			// so each is counted on the side that would actually run it. Counting
+			// both sides for both roles would let a misplaced actor pass.
+			promoters: drActors(replicaDocs, drRolePromoter),
+			failbacks: drActors(primaryDocs, drRoleFailback),
+		}
+		census = append(census, cc)
+		t.Logf("census %s", cc)
+
+		if c.control {
+			// The control must keep BOTH actors. It shares the suspect property,
+			// so if this pair ever goes red the suite itself is broken (bad helm,
+			// bad label, empty render) and no green elsewhere can be trusted.
+			if len(cc.failbacks) == 0 {
+				t.Errorf("CONTROL %s lost its dr-failback — this pair carried one before #6149 and "+
+					"must be unchanged by it. A red control means the guard cannot distinguish a "+
+					"real green from a vacuous one.", c.pair)
+			}
+			if len(cc.promoters) == 0 {
+				t.Errorf("CONTROL %s lost its dr-promoter — see above.", c.pair)
+			}
+		}
+	}
+
+	if len(census) == 0 {
+		t.Fatal("ZERO pairs rendered — the guard is vacuous. Fix the case table before trusting a green run.")
+	}
+
+	for _, v := range drViolations(census) {
+		t.Error(v)
+	}
+}
+
+// TestDRPairSymmetry_ComparatorGoesRedOnAsymmetry — THE VACUITY CHECK.
+//
+// Feed the comparator a deliberately asymmetric census (the literal hw293 shape:
+// four promoters, one failback) and require it to report violations. Without this,
+// a comparator that returned nil unconditionally would make every other assertion
+// in this file pass forever.
+func TestDRPairSymmetry_ComparatorGoesRedOnAsymmetry(t *testing.T) {
+	hw293 := []drCensus{
+		{pair: "bp-cnpg-pair", promoters: []string{"cnpg-pair-dr-promoter"}, failbacks: []string{"cnpg-pair-dr-failback"}},
+		{pair: "shared-pg", promoters: []string{"shared-pg-dr-promoter"}},
+		{pair: "shared-pg-b", promoters: []string{"shared-pg-b-dr-promoter"}},
+		{pair: "shared-pg-c", promoters: []string{"shared-pg-c-dr-promoter"}},
+	}
+	v := drViolations(hw293)
+	if len(v) == 0 {
+		t.Fatal("VACUOUS COMPARATOR: the literal hw293 census (4 promoters, 1 failback — the census that " +
+			"accompanied two permanently dual-writable databases) was reported as SYMMETRIC. Every other " +
+			"assertion in this file is worthless until this is fixed.")
+	}
+	if len(v) != 4 { // three asymmetric pairs + the aggregate line
+		t.Errorf("expected 3 per-pair violations + 1 aggregate, got %d:\n%s", len(v), strings.Join(v, "\n"))
+	}
+
+	// And the inverse: a symmetric census must produce NO violations, so the
+	// comparator is not simply always-red.
+	balanced := []drCensus{
+		{pair: "a", promoters: []string{"p"}, failbacks: []string{"f"}},
+		{pair: "b", promoters: []string{"p"}, failbacks: []string{"f"}},
+	}
+	if v := drViolations(balanced); len(v) != 0 {
+		t.Errorf("comparator is always-red: a balanced census produced %v", v)
+	}
+}
+
+// TestDRPairSymmetry_OperatorCannotDisableOneHalf — the producer-side invariant.
+//
+// drPairCapable makes the STRUCTURAL preconditions common to both actors, so the
+// only remaining way to express the hw293 geometry is to switch exactly one of the
+// two `enabled` gates off by hand. That must FAIL THE RENDER, naming both keys —
+// in BOTH directions.
+func TestDRPairSymmetry_OperatorCannotDisableOneHalf(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{
+			// The #6149 hazard itself: promote on, fail back off.
+			name: "failback disabled while the promoter still renders",
+			args: bpPostgresArgs("shared-pg", "replica", "--set", "topology.failback.enabled=false"),
+		},
+		{
+			// The inverse trap: an actor armed to demote and re-clone region A on
+			// a peer-ahead proof that only a hand-promotion could ever produce.
+			name: "promoter disabled while the failback still renders",
+			args: bpPostgresArgs("shared-pg", "primary", "--set", "topology.autoPromote.enabled=false"),
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, out, err := drHelm(t, "platform/postgres/chart", tc.args...)
+			if err == nil {
+				t.Fatalf("render SUCCEEDED with one DR half disabled. The chart must fail closed: "+
+					"this is the configuration that produced hw293's permanently dual-writable "+
+					"shared-pg.\nrendered:\n%s", tailLines(out, 10))
+			}
+			if !strings.Contains(out, "DR PAIRING INVARIANT VIOLATED") {
+				t.Fatalf("render failed, but not with the pairing-invariant error — the operator gets "+
+					"no idea which two keys disagree.\ngot:\n%s", tailLines(out, 10))
+			}
+			for _, key := range []string{"topology.autoPromote.enabled", "topology.failback.enabled"} {
+				if !strings.Contains(out, key) {
+					t.Errorf("the failure message does not name %q; an invariant the operator cannot "+
+						"locate is not enforceable", key)
+				}
+			}
+		})
+	}
+}
+
+// TestDRPairSymmetry_NoDRChainRendersNeitherHalf — the negative twin.
+//
+// Every configuration that is NOT DR-capable must render ZERO of BOTH actors. A
+// blanket "everything renders" cannot satisfy the symmetry assertion above, and a
+// promoter that renders where it can never promote is the silently-inert shape
+// #6149 replaced with an honestly-absent one.
+func TestDRPairSymmetry_NoDRChainRendersNeitherHalf(t *testing.T) {
+	cases := []struct {
+		name string
+		why  string
+		args []string
+	}{
+		{
+			name: "async replication",
+			why:  "async has no synchronous data fence — an automatic promote could fork committed data, and the failback's 'region-B's line contains every acked commit' premise does not hold",
+			args: []string{"--set", "topology.replication.mode=async"},
+		},
+		{
+			name: "no peer ClusterMesh names",
+			why:  "with no peer identity there is no cross-region probe path: the promoter could never positively prove region A is gone (#5178) and the failback could not observe the peer at all",
+			args: []string{"--set", "topology.networkPolicy.crossRegionPeerClusters=null"},
+		},
+		{
+			name: "clusterMesh disabled",
+			why:  "same as above — the mesh IS the probe path",
+			args: []string{"--set", "topology.clusterMesh.enabled=false"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, side := range []string{"primary", "replica"} {
+				docs, out, err := drHelm(t, "platform/postgres/chart", bpPostgresArgs("shared-pg", side, tc.args...)...)
+				if err != nil {
+					t.Fatalf("side=%s render errored (expected a clean render with no DR actors): %v\n%s",
+						side, err, tailLines(out, 6))
+				}
+				if got := drActors(docs, drRolePromoter); len(got) != 0 {
+					t.Errorf("side=%s rendered a dr-promoter under %q — %s; got %v", side, tc.name, tc.why, got)
+				}
+				if got := drActors(docs, drRoleFailback); len(got) != 0 {
+					t.Errorf("side=%s rendered a dr-failback under %q — %s; got %v", side, tc.name, tc.why, got)
+				}
+			}
+		})
+	}
+}
+
+// TestDRPairSymmetry_SingletonRendersNoDRActors — non-regression for the
+// overwhelming majority of installs. A single-region prov must be untouched.
+func TestDRPairSymmetry_SingletonRendersNoDRActors(t *testing.T) {
+	docs, out, err := drHelm(t, "platform/postgres/chart",
+		"--namespace", "shared-data",
+		"--set", "enabled=true",
+		"--set", "instance.name=shared-pg",
+		"--set", "instance.namespace=shared-data",
+		"--set", "databases[0].name=keycloak",
+		"--set", "databases[0].owner=keycloak",
+	)
+	if err != nil {
+		t.Fatalf("singleton render errored — the #6149 invariant must not affect non-DR installs: %v\n%s",
+			err, tailLines(out, 6))
+	}
+	if got := drActors(docs, drRolePromoter); len(got) != 0 {
+		t.Errorf("singleton rendered a dr-promoter: %v", got)
+	}
+	if got := drActors(docs, drRoleFailback); len(got) != 0 {
+		t.Errorf("singleton rendered a dr-failback: %v", got)
+	}
+	if strings.Contains(out, "-replica-mesh") {
+		t.Errorf("singleton leaked the reverse-direction `-replica-mesh` alias — a single-region " +
+			"install has no peer region and must stay byte-identical")
+	}
+}
+
+// TestDRPairSymmetry_FailbackDrivesTheDurableSeam — the failback is only worth
+// counting if it can actually act. Assert on the rendered VALUES that make it
+// able to demote, not on the Deployment's existence (#5639).
+func TestDRPairSymmetry_FailbackDrivesTheDurableSeam(t *testing.T) {
+	// Per-instance demotion substitute keys. Three bp-postgres installs share ONE
+	// bootstrap-kit Kustomization, so a SHARED key would demote and re-clone all
+	// three the moment any single one of them failed back.
+	seen := map[string]string{}
+
+	for _, c := range drPairs() {
+		if !strings.HasPrefix(c.pair, "bp-postgres/") {
+			continue
+		}
+		docs, out, err := drHelm(t, c.chart, c.primaryArgs...)
+		if err != nil {
+			t.Fatalf("%s: primary render failed: %v\n%s", c.pair, err, tailLines(out, 6))
+		}
+		env := drActorEnv(docs, drRoleFailback, "actor")
+		if len(env) == 0 {
+			t.Fatalf("%s: no dr-failback actor container env rendered", c.pair)
+		}
+
+		// #5125-D1 — the demote must ride a DURABLE source seam. A live Cluster-CR
+		// patch is reverted by flux drift-correction mid-outage (hw256 G12).
+		for _, k := range []string{"KS_NAME", "KS_NAMESPACE", "HR_NAME", "DEMOTED_SUB_KEY"} {
+			if strings.TrimSpace(env[k]) == "" {
+				t.Errorf("%s: dr-failback actor has no %s — it has no durable demote seam", c.pair, k)
+			}
+		}
+		key := env["DEMOTED_SUB_KEY"]
+		if prev, dup := seen[key]; dup {
+			t.Errorf("%s and %s SHARE the demotion substitute key %q. They are installed against the "+
+				"SAME bootstrap-kit Kustomization, so one pair failing back would demote and re-clone "+
+				"the other(s) too.", prev, c.pair, key)
+		}
+		seen[key] = c.pair
+
+		// #5245 — the peer-ahead hold must be a positive number of seconds; a zero
+		// hold demotes on the first flap.
+		if h := strings.TrimSpace(env["HOLD_SECONDS"]); h == "" || h == "0" {
+			t.Errorf("%s: dr-failback HOLD_SECONDS=%q — a zero/absent peer-ahead hold demotes region A "+
+				"on a transient mesh blip", c.pair, h)
+		}
+	}
+	if len(seen) < 3 {
+		t.Errorf("expected 3 distinct bp-postgres demotion substitute keys, got %d: %v", len(seen), seen)
+	}
+}
+
+// TestDRPairSymmetry_RegistryCoversEveryStandbyHalf keeps drPairs() honest: any
+// chart template in the catalog that emits a CNPG `bootstrap.pg_basebackup`
+// stanza renders one half of a pair, and the other half is somewhere it can be
+// lost. A new one must be either covered here or explicitly declared
+// promoter-less.
+func TestDRPairSymmetry_RegistryCoversEveryStandbyHalf(t *testing.T) {
+	root := repoRoot(t)
+
+	// Charts that render a CNPG standby half but ship NO promoter at all, and
+	// therefore have nothing to be symmetric WITH. bp-wordpress-tenant declares
+	// `manual` promotion and fails closed without that declaration
+	// (scripts/check-dr-pairs-declare-promotion.sh owns that contract).
+	promoterless := map[string]string{
+		"platform/wordpress-tenant/chart": "declares promotion.mechanism=manual and renders no DR actor",
+	}
+
+	covered := map[string]bool{}
+	for _, c := range drPairs() {
+		covered[c.chart] = true
+	}
+
+	var found []string
+	for _, dir := range []string{"platform", "products"} {
+		walkErr := filepath.Walk(filepath.Join(root, dir), func(path string, info os.FileInfo, err error) error {
+			if err != nil || info.IsDir() {
+				return nil
+			}
+			if ext := filepath.Ext(path); ext != ".yaml" && ext != ".tpl" {
+				return nil
+			}
+			b, rerr := os.ReadFile(path)
+			if rerr != nil {
+				return nil
+			}
+			for _, line := range strings.Split(string(b), "\n") {
+				if strings.HasPrefix(strings.TrimSpace(line), "pg_basebackup:") {
+					rel, _ := filepath.Rel(root, path)
+					found = append(found, rel)
+					return nil
+				}
+			}
+			return nil
+		})
+		if walkErr != nil {
+			t.Fatalf("walk %s: %v", dir, walkErr)
+		}
+	}
+
+	if len(found) == 0 {
+		t.Fatal("detector matched ZERO templates — the pg_basebackup signature changed and this " +
+			"registry check is now vacuous. Fix the detector before trusting a green run.")
+	}
+	sort.Strings(found)
+	t.Logf("standby-half renderers: %v", found)
+
+	for _, f := range found {
+		chart := f
+		if i := strings.Index(f, "/templates/"); i > 0 {
+			chart = f[:i]
+		}
+		if covered[chart] || promoterless[chart] != "" {
+			continue
+		}
+		t.Errorf("UNCOVERED DR pair: %s (chart %s). It renders a CNPG standby half, so something "+
+			"promotes it on a region kill — and whatever promotes it must also be able to bring the "+
+			"other side back (#6149). Add a drPairCase, or declare it promoter-less.", f, chart)
+	}
+}
+
+// drActorEnv returns the rendered env map of the named container inside the
+// Deployment carrying role=want. Values only — a `valueFrom` entry is skipped so
+// a present-but-empty key can never read as satisfied (#5639).
+func drActorEnv(docs []map[string]any, wantRole, container string) map[string]string {
+	out := map[string]string{}
+	for _, d := range docs {
+		if k, _ := d["kind"].(string); k != "Deployment" {
+			continue
+		}
+		md, _ := d["metadata"].(map[string]any)
+		labels, _ := md["labels"].(map[string]any)
+		if labels == nil {
+			continue
+		}
+		if v, _ := labels[drRoleLabel].(string); v != wantRole {
+			continue
+		}
+		spec, _ := d["spec"].(map[string]any)
+		tmpl, _ := spec["template"].(map[string]any)
+		pspec, _ := tmpl["spec"].(map[string]any)
+		ctrs, _ := pspec["containers"].([]any)
+		for _, ci := range ctrs {
+			c, _ := ci.(map[string]any)
+			if n, _ := c["name"].(string); n != container {
+				continue
+			}
+			envs, _ := c["env"].([]any)
+			for _, ei := range envs {
+				e, _ := ei.(map[string]any)
+				n, _ := e["name"].(string)
+				v, ok := e["value"].(string)
+				if n != "" && ok {
+					out[n] = v
+				}
+			}
+		}
+	}
+	return out
+}
+
+func tailLines(s string, n int) string {
+	lines := strings.Split(strings.TrimRight(s, "\n"), "\n")
+	if len(lines) > n {
+		lines = lines[len(lines)-n:]
+	}
+	return strings.Join(lines, "\n")
+}


### PR DESCRIPTION
Refs #6149 · Refs #6148 · Refs #5623 · Refs #5245 · Supersedes #6175

## What this is, and what is not mine

**PR #6175 already ported `dr-failback` into `bp-postgres`.** It is open, green, and two days idle (branch 358 commits behind `main`, parked with a "DO NOT MERGE" note about hw294's provisioning). I found it by the version-claim enumeration below rather than by assuming the port did not exist, and I did not re-derive it.

This branch is **#6175's two commits rebased onto current `main`**, plus the one thing #6175 explicitly deferred. Its own header said so, verbatim:

> Fencing region A during the hold is NOT implemented in this actor and is deliberately not bolted on here. […] The correct place for a fence-on-DETECT is a separate, non-destructive step that gates the local read-write Service endpoint […] That reasoning is recorded on #6148.

That step now exists: **PR #6219 shipped it for `bp-cnpg-pair`**, and it meets #6175's own criteria — separate, non-destructive, applied at POST-FAILOVER GEOMETRY time, lifted when the hold clears. Shipping the port here without it would put the identical gap into three more pairs.

## Why the guard matters more here than it did on bp-cnpg-pair

For the whole `peerAheadHoldSeconds` window, region A is a writable primary on a line the peer has already overtaken, so every commit it accepts is acknowledged to a client and then discarded by the re-clone.

`bp-cnpg-pair`'s pair has no in-cluster clients. These do:

| instance | slot | consumers whose writes the hold would swallow |
|---|---|---|
| `shared-pg` | 16a | keycloak, gitea, harbor |
| `shared-pg-b` | 16c | grafana, powerdns, powerdns-admin |
| `shared-pg-c` | 16d | the Organization mesh, newapi, openova-flow |

Refusing a keycloak write for ~120s is strictly better than accepting it, reporting it durable, and destroying it. The hold itself is not shortened — it guards the demote decision against a flap, and a demote/re-promote cycle bumps the timeline, which is the same class of damage.

## The write-guard — every property is load-bearing

Applied on peer-ahead **DETECTION** (not at demote time; the exposure starts when the geometry is known-divergent), removed by `guard_off`, which runs unconditionally on every tick where `/shared/peer-ahead-since` is absent — the same file every fail-safe path in the signals loop already clears, so no future control flow can forget to unwind it.

- **`ingressDeny` on a CiliumNetworkPolicy, never a k8s NetworkPolicy.** k8s policies are additive allow-lists. This chart's own `networkpolicy.yaml` grants `- from: [{namespaceSelector: {}}]` on 5432 (#3577) and nothing a NetworkPolicy can say subtracts it — a NetworkPolicy guard would be created, logged, and permit every write it claimed to stop.
- **`enableDefaultDeny: {ingress: false, egress: false}`** — purely subtractive, so it cannot take out the replication and CNPG-operator-status carve-outs.
- **The failback Pod stays exempt** (`matchExpressions` `NotIn`, ANDed with the pair's own Pods). The signals loop reads the LOCAL timeline over 5432; blind that read and `clear_hold "local timeline unreadable"` aborts the whole failback. That trap is exactly what ruled out CNPG instance fencing.
- **`fromEndpoints`, never `ipBlock`** — an ipBlock never matches a ClusterMesh remote Pod identity, so an ipBlock guard silently misses the peer traffic it reasons about.
- **The manifest is ConfigMap DATA applied by the actor**, not a live template: its lifecycle is the actor's, so keeping it out of the Kustomization inventory leaves flux drift-correction nothing to revert (#5125-D1).
- **`guard_on` is NON-FATAL.** Converging region A is what ENDS the exposure, so a guard that cannot be applied warns loudly and lets the failback run.

RBAC adds `ciliumnetworkpolicies` `get/patch/delete` resourceNames-pinned to that one object, plus `create` in **its own rule** — k8s RBAC ignores `resourceNames` on create, so pinning it there would read as a constraint while enforcing nothing.

## Naming map used for the port (from #6175, verified against the render)

| bp-cnpg-pair | bp-postgres |
|---|---|
| `.Values.cnpgPair.*` | `.Values.topology.*` |
| `cnpg-pair.fullname` | `bp-postgres.instanceName` (the CR keeps the instance name so `<instance>-rw` is unchanged) |
| `cnpg-pair.primaryName` | `bp-postgres.instanceName` |
| `cnpg-pair.replicaName` | `bp-postgres.replicaName` (`<instance>-replica`) |
| `cnpg-pair.replicationServiceName` | `bp-postgres.replicationServiceName` (`<instance>-mesh`) |
| `cnpg-pair.peerReplicationServiceName` | `bp-postgres.peerReplicationServiceName` (`<instance>-replica-mesh`) |
| `cnpg-pair.isPrimarySide` / `isReplicaSide` | `bp-postgres.side` + the shared `bp-postgres.drPairCapable` gate |
| `cnpg-pair.failbackActive` | `bp-postgres.failbackActive` |
| `cnpg-pair.labels` / `imageRef` | `bp-postgres.labels` / `bp-postgres.imageRef` |
| `SOVEREIGN_CNPG_PAIR_DEMOTED` (hard-coded) | `topology.failback.demotedSubstituteKey`, **per instance** — three installs share ONE bootstrap-kit Kustomization, so a shared key would demote all three the moment any one failed back |

## Deliberately NOT ported from bp-cnpg-pair

- **The dr-promoter's TL-ahead re-promote leg.** It is a `bp-cnpg-pair` dr-promoter behaviour, not a failback one, and this chart's promoter (#5623) is a faithful port of the 0.2.17 promoter that predates it. Porting it belongs with a promoter change, on its own evidence.
- **`cnpg-pair.validateRegions`'s distinct-region `fail`.** `bp-postgres` already fails closed on an unresolvable region through `bp-postgres.primaryRegion` / `replicaRegion` (#5639), which is the stronger guard; adding a second, differently-worded refusal would give two error texts for one condition.
- **The `-primary` / `-replica` CR name suffixes.** `bp-postgres`'s primary CR must keep the bare instance name or every consumer's `<instance>-rw` host breaks. The port keeps bp-postgres's names throughout.

## Mutant table — Case 21g is not vacuous

Each mutant **renders cleanly** (a mutant that breaks the render proves nothing) and turns the case **red**. Unmutated baseline: render `rc=0`, suite `rc=0`.

| mutant | `helm template` rc | suite rc | assertion that caught it |
|---|---|---|---|
| `enableDefaultDeny.ingress` `false` → `true` | 0 | 1 | `the guard must not flip the primary to default-deny, got {'ingress': True, …}` |
| failback-Pod exemption removed | 0 | 1 | `the failback Pod must be exempt or its own timeline probe trips clear_hold` |
| `guard_on` call removed | 0 | 1 | `guard_on must fire at DETECTION (right after the D0 early-exit)` |
| per-tick `guard_off` sweep removed | 0 | 1 | `guard_off must run unconditionally per tick whenever the hold is not active` |
| `CiliumNetworkPolicy` → k8s `NetworkPolicy` | 0 | 1 | `the guard must be a CiliumNetworkPolicy — a k8s NetworkPolicy cannot deny` |

Restored: render `rc=0`, suite `rc=0`.

## Gates run

| gate | result |
|---|---|
| `bash platform/postgres/chart/tests/postgres-render.sh` (full suite, Cases 1 → 21g) | rc=0 |
| `go test ./tests/e2e/bootstrap-kit/ -run DRPair -count=1` | ok |
| `scripts/check-dr-pairs-declare-promotion.sh` | rc=0 |
| `scripts/check-region-selector-fail-closed.sh` | rc=0 |
| `scripts/check-catalog-seed-lockstep.sh` | rc=0 |
| `scripts/check-catalog-seed-source-coverage.py` | rc=0 |
| `scripts/check-umbrella-republish-gate.py` | PASS — 160 pins / 80 Blueprints, umbrella at 1.4.1437 |
| `scripts/check-no-banned-words.sh --commit-messages origin/main..HEAD` | OK |
| `scripts/check-chart-version-forward.sh` (both charts) | forward, consistent |
| POSIX parse of both rendered container scripts (`sh -n`) | ok |

## RUNBOOKS §6.1

#6175's RUNBOOKS change is carried: the G12 reverse-leg assertion is now the **census** (`dr-promoter` count in region B == `dr-failback` count in region A), because hw293's 4-to-1 census read green from a region-B-only sample while two pairs sat dual-writable.

Its #6148 note is **rewritten rather than carried verbatim** — it said region A is UNFENCED for the whole hold, which was true when #6175 was written and is not true now. The note now names the two things a walker must sample (the guard EXISTS during the hold; it is GONE after convergence, since a stuck guard leaves `:5432` denied) and the `WARN: WRITE-GUARD could not be applied` line that means the episode ran with the window open.

## Version claim — enumerated, not guessed

Every one of the 60 open PR heads was read for both `Chart.yaml`s:

- **bp-postgres**: highest open claim **0.2.22** (PR #6175, superseded here); `main` at 0.2.20. GHCR's newest published tag is **0.2.20**, so 0.2.21/0.2.22/0.2.23 are all unpublished and no pin is hollow.
- **bp-catalyst-platform**: highest open claim **1.4.1423**; `main` at 1.4.1436.

Taken: **bp-postgres 0.2.23**, **bp-catalyst-platform 1.4.1437** — forward of `main` and of every open head in any merge order, so this does not have to be re-serialised if #6175 lands first.

Five lockstep sites moved together: `chart/Chart.yaml`, `blueprint.yaml`, slots 16a/16c/16d, the catalog-seed pin (`scripts/sync-catalog-seed-pin.py bp-postgres 0.2.23`), and the regenerated catalog (`build-catalog.mjs`). The umbrella republish (#5734) moved `products/catalyst/chart/Chart.yaml` **and** its slot-13 pin in the same commit.

## What is still owed

**A live region-kill.** Everything here is render-level and unit-level. The claim that these three pairs now rejoin, and that the guard goes up and comes down at the right moments, is proven on the next 2-region G12 walk — not by this PR merging.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HvMZTDx7W6EPZMmjyXmYh1
