### PR TITLE
fix(openova-mcp): row 213 sibling sweep — list_organizations dropped the caller's OWN Org row

### DIFF
--- a/products/openova-mcp/internal/tools/catalogue.go
+++ b/products/openova-mcp/internal/tools/catalogue.go
@@ -168,6 +168,21 @@ func handleListOrganizations(ctx context.Context, id *identity.Identity, api *ca
 	items := resp.Items
 	// Org scoping: an Org-context caller sees only their own Organization.
 	// A sovereign-admin sees the full list.
+	//
+	// WHY A CLIENT-SIDE FILTER SURVIVES HERE when #5516 removed it from the
+	// applications path. The two seams are not alike. /api/v1/org/applications
+	// is STRUCTURALLY own-org — it has no way to name another Organization —
+	// so a filter on it can only subtract. /api/v1/organizations is the
+	// Sovereign-WIDE directory: it returns every Org to an operator, and is
+	// confined to the caller's own row only by catalyst-api's
+	// confineOrgResponsesToSlug (#6081, UAT row 218), which reaches an MCP
+	// caller through orgScopeForRequest's CLAIMS fallback — the MCP presents
+	// no Org console host, so the host half of that predicate does not fire.
+	// This filter is the second lock on a directory whose first lock depends
+	// on a claims path, and it costs nothing.
+	//
+	// It is only worth keeping while it can actually match, which is the bug
+	// fixed alongside this comment — see orgIdentityKeys.
 	if id.Context == identity.ContextOrganization {
 		items = filterOrgs(items, id.OrgID)
 	}
@@ -577,10 +592,42 @@ func filterOrgs(items []map[string]any, orgID string) []map[string]any {
 	return out
 }
 
-// orgMatches reports whether an org record's slug/id/name matches orgID.
+// orgIdentityKeys are the response fields that CARRY an Organization's
+// identity, in the shape GET /api/v1/organizations actually emits.
+//
+// `subdomain` is the live one and it was missing: the endpoint marshals
+// orgTenantResponse (organization_provisioning.go), whose Org slug is tagged
+// `json:"subdomain"` — there is no `slug`, `id`, `name`, `org_id` or
+// `organization` key anywhere in that payload. So the previous key list
+// matched NOTHING, filterOrgs dropped the caller's own row, and
+// list_organizations answered every Org-scoped caller with an empty
+// directory reported as success. That is the #5516 failure mode verbatim
+// ("a client-side filter … would drop EVERY row and report an empty estate
+// as success"), which the note at the foot of this file records for the
+// applications path — it survived here because this endpoint's payload was
+// never sampled. Pinned by TestListOrganizations… in org_scope_213_test.go,
+// which builds its fixture from the real JSON tags.
+//
+// `console_host` is deliberately ABSENT. It is `console.<slug>.<zone>`, so
+// under the leading-label comparison below its first label is the literal
+// "console" for every Organization on the Sovereign — matching on it would
+// make one Org's row match another's. An identity key must be the identity,
+// not a string that contains it.
+var orgIdentityKeys = []string{"subdomain", "slug", "id", "org_tenant_id", "name", "org_id", "organization"}
+
+// orgMatches reports whether an org record names the caller's Organization.
+//
+// It delegates to orgRefMatches — the SAME slug-vs-FQDN equivalence
+// create_application enforces — rather than re-deriving one. The two sides
+// previously disagreed: this function did an exact case-fold compare while
+// resolveCreateTargetOrg accepted "hw178" and "hw178.omani.works" as one
+// Org, so a token scoped to the FQDN could create in the Org it could not
+// see listed. orgRefMatches also rejects an empty ref on either side, which
+// the old compare did not — `EqualFold("", "")` is true, so a record with a
+// blank identity field matched a caller with no Org scope at all.
 func orgMatches(rec map[string]any, orgID string) bool {
-	for _, k := range []string{"slug", "id", "name", "org_id", "organization"} {
-		if v, ok := rec[k].(string); ok && strings.EqualFold(strings.TrimSpace(v), orgID) {
+	for _, k := range orgIdentityKeys {
+		if v, ok := rec[k].(string); ok && orgRefMatches(v, orgID) {
 			return true
 		}
 	}

--- a/products/openova-mcp/internal/tools/org_scope_213_test.go
+++ b/products/openova-mcp/internal/tools/org_scope_213_test.go
@@ -1,0 +1,205 @@
+// org_scope_213_test.go — the SIBLING half of UAT row 213 / #6122.
+//
+// Row 213's clause is about get_application, and that tool is pinned at the
+// wire by cmd/openova-mcp/cross_org_denial_shape_213_test.go. The clause
+// generalises, though: no Org-scoped tool may answer with another
+// Organization's data. list_organizations is the one remaining Org-context
+// tool whose scoping is NOT decided by seam choice — it reads the
+// Sovereign-WIDE directory GET /api/v1/organizations and then filters. So it
+// is the one that needs its own guard, and it is where the defect was.
+//
+// WHAT THE DEFECT WAS. filterOrgs keyed on "slug"/"id"/"name"/"org_id"/
+// "organization". The endpoint marshals orgTenantResponse, whose Org slug is
+// tagged `json:"subdomain"` and which carries NONE of those five keys. Every
+// row therefore failed the match and the caller's OWN Organization was
+// dropped — an empty directory returned as success, the exact #5516 failure
+// mode. It was invisible because no test had ever fed this handler the JSON
+// the endpoint really emits.
+//
+// SO THE FIXTURES BELOW ARE BUILT FROM THE REAL JSON TAGS
+// (products/catalyst/bootstrap/api/internal/handler/organization_provisioning.go,
+// type orgTenantResponse). A fixture invented from the field NAMES instead of
+// the TAGS would have passed against the broken filter and pinned nothing —
+// that is precisely how the defect survived.
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/openova-io/openova/products/openova-mcp/internal/catalystapi"
+	"github.com/openova-io/openova/products/openova-mcp/internal/identity"
+)
+
+// directoryBody is what GET /api/v1/organizations puts on the wire. Two
+// Organizations, byte-shaped like orgTenantResponse.
+//
+// It carries BOTH Orgs on purpose. catalyst-api confines an Org-scoped
+// caller server-side, so in production the second row would normally be gone
+// already; serving it here is what lets these tests measure the MCP's OWN
+// filter instead of measuring the stub. A test fed a pre-confined body
+// cannot tell a working filter from no filter at all.
+const directoryBody = `{"items":[
+ {"org_tenant_id":"11111111-aaaa","state":"ready","subdomain":"hw293walkone",
+  "domain_mode":"pool","admin_email":"walker@hw293walkone","company_name":"Walk One Ltd",
+  "otech_fqdn":"hw293.omani.works","tenant_namespace":"org-11111111",
+  "console_host":"console.hw293walkone.omani.homes"},
+ {"org_tenant_id":"22222222-bbbb","state":"ready","subdomain":"hw293walktwo",
+  "domain_mode":"pool","admin_email":"other@hw293walktwo","company_name":"Walk Two Ltd",
+  "otech_fqdn":"hw293.omani.works","tenant_namespace":"org-22222222",
+  "console_host":"console.hw293walktwo.omani.homes"}
+]}`
+
+// directoryAPI wires a client whose backend always serves directoryBody.
+func directoryAPI(t *testing.T) *catalystapi.Client {
+	t.Helper()
+	return catalystapi.New("https://console.hw293walkone.omani.homes").
+		WithTenantHost("console.hw293walkone.omani.homes").
+		WithHTTPClient(&http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			return jsonResp(200, directoryBody), nil
+		})})
+}
+
+// orgCaller is the identity the seed-reconciler mints per Org
+// (sovereign_mcp_bearer_seed.go): context=organization, tier=admin, org_id =
+// the Org slug, and NO deployment_id. Reuses the package's existing
+// orgIdentityNoDeployment so this file cannot drift from the shape every
+// other Org-context test asserts against.
+func orgCaller(orgID string) *identity.Identity {
+	return orgIdentityNoDeployment(orgID, identity.TierAdmin)
+}
+
+// callListOrganizations invokes the handler and returns the rows it produced.
+func callListOrganizations(t *testing.T, id *identity.Identity) []map[string]any {
+	t.Helper()
+	out, err := handleListOrganizations(context.Background(), id, directoryAPI(t), nil)
+	if err != nil {
+		t.Fatalf("list_organizations returned an error: %v", err)
+	}
+	m, ok := out.(map[string]any)
+	if !ok {
+		t.Fatalf("list_organizations returned %T, want map", out)
+	}
+	items, ok := m["items"].([]map[string]any)
+	if !ok {
+		t.Fatalf("list_organizations items is %T, want []map[string]any", m["items"])
+	}
+	return items
+}
+
+// subdomainsOf renders the rows as their Org slugs for readable failures.
+func subdomainsOf(items []map[string]any) []string {
+	out := make([]string, 0, len(items))
+	for _, it := range items {
+		s, _ := it["subdomain"].(string)
+		out = append(out, s)
+	}
+	return out
+}
+
+// TestListOrganizationsOrgContextReturnsOwnRow is the DEFECT test: before the
+// fix this returned zero rows, because no key in the real payload was one the
+// filter looked at. An empty list is the most dangerous possible failure here
+// — it is indistinguishable from "you have no Organizations" and it is
+// returned as SUCCESS, so nothing upstream ever raises.
+func TestListOrganizationsOrgContextReturnsOwnRow(t *testing.T) {
+	items := callListOrganizations(t, orgCaller("hw293walkone"))
+
+	if len(items) != 1 {
+		t.Fatalf("own-Org caller must see exactly their own row, got %d: %v",
+			len(items), subdomainsOf(items))
+	}
+	if got, _ := items[0]["subdomain"].(string); got != "hw293walkone" {
+		t.Fatalf("own-Org caller saw the wrong Organization: %q", got)
+	}
+}
+
+// TestListOrganizationsOrgContextDropsTheOtherOrg is the CONTROL, and it
+// shares the suspect property with the test above: same handler, same
+// backend body, same tool, same code path — only the Organization differs.
+//
+// Without it, the test above also passes for a filter that has been deleted
+// outright (both rows returned includes the own row). With it, the pair can
+// only pass for a filter that keeps exactly the caller's Organization.
+func TestListOrganizationsOrgContextDropsTheOtherOrg(t *testing.T) {
+	items := callListOrganizations(t, orgCaller("hw293walkone"))
+
+	for _, it := range items {
+		if s, _ := it["subdomain"].(string); s == "hw293walktwo" {
+			t.Fatalf("list_organizations leaked another Organization's row: %v", subdomainsOf(items))
+		}
+	}
+	// The other Org's identifying detail must not ride along in ANY field of
+	// the surviving rows either — a leak by payload is still a leak.
+	blob, err := json.Marshal(items)
+	if err != nil {
+		t.Fatalf("marshal rows: %v", err)
+	}
+	for _, needle := range []string{"hw293walktwo", "22222222-bbbb", "other@hw293walktwo", "Walk Two Ltd"} {
+		if strings.Contains(string(blob), needle) {
+			t.Fatalf("list_organizations leaked %q from the other Organization: %s", needle, blob)
+		}
+	}
+}
+
+// TestListOrganizationsAcceptsFQDNScopedToken pins the slug-vs-FQDN
+// equivalence against the SAME rule create_application enforces. A token
+// scoped to "hw293walkone.omani.homes" is the same Organization as the row
+// whose subdomain is "hw293walkone" — resolveCreateTargetOrg has always
+// accepted that pair, so the directory must not deny what the create seam
+// would honour (the #6064 shape: a picker offering nothing the writer takes).
+func TestListOrganizationsAcceptsFQDNScopedToken(t *testing.T) {
+	items := callListOrganizations(t, orgCaller("hw293walkone.omani.homes"))
+
+	if len(items) != 1 {
+		t.Fatalf("an FQDN-scoped token must resolve to its own Org row, got %d: %v",
+			len(items), subdomainsOf(items))
+	}
+	if got, _ := items[0]["subdomain"].(string); got != "hw293walkone" {
+		t.Fatalf("FQDN-scoped token saw the wrong Organization: %q", got)
+	}
+}
+
+// TestListOrganizationsSovereignContextIsUnfiltered is the second control:
+// the fix must not have turned the filter into a blanket refusal. A
+// sovereign-admin legitimately reads every Organization, so the same body
+// must come back whole.
+func TestListOrganizationsSovereignContextIsUnfiltered(t *testing.T) {
+	items := callListOrganizations(t, sovereignIdentity("dep-1"))
+
+	if len(items) != 2 {
+		t.Fatalf("a sovereign-admin must see the whole directory, got %d: %v",
+			len(items), subdomainsOf(items))
+	}
+}
+
+// TestOrgMatchesRejectsEmptyRefs pins the edge the old exact-fold compare got
+// wrong: strings.EqualFold("", "") is TRUE, so a record carrying a blank
+// identity field matched a caller carrying no Org scope. Both sides must be
+// non-empty for a match.
+func TestOrgMatchesRejectsEmptyRefs(t *testing.T) {
+	if orgMatches(map[string]any{"subdomain": ""}, "") {
+		t.Fatal("a blank record field must not match a caller with no Org scope")
+	}
+	if orgMatches(map[string]any{"subdomain": "hw293walkone"}, "") {
+		t.Fatal("a caller with no Org scope must match nothing")
+	}
+}
+
+// TestOrgMatchesIgnoresConsoleHost pins the key deliberately LEFT OUT of
+// orgIdentityKeys. console_host is `console.<slug>.<zone>`, so its leading
+// label is "console" for every Organization on the Sovereign; admitting it
+// would make one Org's row match another's under the leading-label
+// comparison. This is the guard on the fix itself.
+func TestOrgMatchesIgnoresConsoleHost(t *testing.T) {
+	other := map[string]any{"console_host": "console.hw293walktwo.omani.homes"}
+	if orgMatches(other, "console") {
+		t.Fatal("console_host must never be an identity key — every Org shares its first label")
+	}
+	if orgMatches(other, "hw293walkone") {
+		t.Fatal("another Organization's row matched on console_host")
+	}
+}


### PR DESCRIPTION
## What this is

UAT row 213 (epic `mcp`) asserts:

> MCP cross-Org `get_application` is REFUSED as **not found** — `-32000`, and the message names only the calling Org.

I went to fix that and found **it is already implemented and already pinned at the wire**. So this PR does two things: it *proves* the existing guard is not vacuous (mutation table below), and it ships the one real defect the sibling sweep turned up.

---

## Part 1 — row 213's own clause: already held, now proven non-vacuous

`handleGetApplication` (`products/openova-mcp/internal/tools/catalogue.go`) routes an Org-context caller to the own-org seam `GET /api/v1/org/applications`, which catalyst-api confines to the caller's namespace server-side. A foreign name is simply absent, and the refusal is:

```go
fmt.Errorf("application %q not found in organization %q", in.Name, id.OrgID)
```

`id.OrgID` is the **caller's own** Org, so the message cannot name the other one. `toolError` maps a plain error to **-32000**. The write half (`resolveCreateTargetOrg`) returns `ErrForbidden` → **-32003 / 403**, deliberately a different shape (ADR-0013: deny-by-**lookup** vs deny-by-**assertion**).

`cmd/openova-mcp/cross_org_denial_shape_213_test.go` already pins this at the wire, with an own-Org success as the control. **I added no code here.** What was missing was evidence the guard can fail, so I mutation-checked it (M1–M3 below).

## Part 2 — the sibling sweep, and the defect it found

Every Org-context tool, and what actually scopes it:

| Tool | Org-context scoping | Verdict |
|---|---|---|
| `get_application` | own-org seam `/api/v1/org/applications`, confined server-side | holds — row 213's clause |
| `list_applications` | same seam via `listApplicationsForCaller` | holds |
| `list_environments` | same seam via `listApplicationsForCaller` | holds |
| `create_application` | `resolveCreateTargetOrg` → `ErrForbidden` | holds — cross-Org 403 |
| `list_blueprints` | `/api/v1/catalog` — Sovereign-wide catalog, not Org data | not applicable |
| `whoami` | echoes the caller's own resolved identity | not applicable |
| **`list_organizations`** | Sovereign-wide `/api/v1/organizations` + **client-side filter** | **defective — fixed here** |

There is no `get_organization` / `get_environment` / `get_blueprint` tool, so `get_application` is the only per-resource getter in the catalogue.

### The hole

`list_organizations` is the only Org-context tool whose scoping is not decided by seam choice. It reads the Sovereign-wide directory and filters client-side with `orgMatches`, which keyed on `slug` / `id` / `name` / `org_id` / `organization`.

That endpoint marshals `orgTenantResponse` (`products/catalyst/bootstrap/api/internal/handler/organization_provisioning.go:492`), whose Org slug is tagged **`json:"subdomain"`** — and which carries **none of those five keys**. So every row failed the match and the caller's **own** Organization was dropped.

Measured before the fix, feeding the handler the real payload: **1 row in, 0 rows out.** An empty Organization directory, returned as `isError: false` success — nothing upstream ever raises on it.

This is the `#5516` failure mode verbatim, which `catalogue.go`'s own closing note already records for the applications path ("would drop EVERY row and report an empty estate as success"). It survived here because no test had ever fed this handler the JSON the endpoint really emits.

**Direction of the failure: fail-CLOSED.** No Organization's data ever leaked; the tool was blind, not leaky. I am not claiming a tenancy breach, and row 213's isolation property was never violated by it.

### The fix

1. Add `subdomain` to the identity keys.
2. Compare with the file's **own** `orgRefMatches` instead of a second hand-rolled predicate. The two had diverged: `orgMatches` did an exact case-fold compare, while `resolveCreateTargetOrg` treats `hw178` and `hw178.omani.works` as one Org — so a token scoped to the FQDN could create in an Org it could not see listed (the #6064 shape: a picker offering nothing the writer honours). `orgRefMatches` also rejects an empty ref on either side, which the old compare did not: `EqualFold("", "")` is **true**, so a record with a blank identity field matched a caller carrying no Org scope at all.
3. `console_host` is deliberately **excluded**. It is `console.<slug>.<zone>`, so under the leading-label comparison its first label is the literal `console` for *every* Organization on the Sovereign — admitting it would make one Org's row match another's. A test pins the exclusion.

The client-side filter **stays** here rather than being deleted as it was on the applications path. `/api/v1/org/applications` is structurally own-org; `/api/v1/organizations` is the Sovereign-wide directory, confined to the caller's row only by catalyst-api's `confineOrgResponsesToSlug` (#6081), which reaches an MCP caller through `orgScopeForRequest`'s **claims** fallback — the MCP presents no Org console host, so the host half of that predicate never fires. Keeping a filter that works is the second lock on a directory whose first lock runs through a claims path.

---

## Tests

`products/openova-mcp/internal/tools/org_scope_213_test.go`. Fixtures are built from the **real JSON tags**, not the Go field names — a fixture invented from the field names would have passed against the broken filter and pinned nothing. That is exactly how the defect survived.

The fixture body carries **both** Organizations on purpose. catalyst-api would normally have confined the second row away server-side; serving it here is what lets the tests measure the MCP's own filter rather than measuring the stub. A test fed a pre-confined body cannot tell a working filter from no filter at all.

Two controls that share the suspect property:

- **`…DropsTheOtherOrg`** — same handler, same backend body, same tool, same code path, **only the Organization differs**. Without it, the "returns own row" test also passes for a filter deleted outright. It also asserts the other Org's uuid / admin email / company name appear nowhere in the surviving rows, since a leak by payload is still a leak.
- **`…SovereignContextIsUnfiltered`** — a sovereign-admin must still see the whole directory, so the fix cannot be a blanket refusal.

## Mutation table

Every mutant compiles. `rc` is `go test`'s own exit code, captured directly (not through a pipe).

| # | Mutant | Target | rc | Detected by |
|---|---|---|---|---|
| — | baseline, unmutated | both suites | **0** | — |
| M1 | wrap the not-found in `ErrForbidden` (→ -32003/403) | `get_application` | **1** | `CrossOrgGetIsNotFoundNot403`, `TheTwoShapesAreDifferentOnPurpose` |
| M2 | invert the context guard → Org falls to the deployment-addressed seam | `get_application` | **1** | `CrossOrgGetIsNotFoundNot403` **and the own-Org control** |
| M3 | Org branch falls through to the Sovereign-wide getter (the real leak) | `get_application` | **1** | `CrossOrgGetIsNotFoundNot403` — "a cross-Org name must not resolve" |
| M4 | drop `subdomain` from the identity keys (the pre-fix state) | `list_organizations` | **1** | `ReturnsOwnRow` (got 0 rows), `AcceptsFQDNScopedToken` |
| M5 | revert the predicate to exact case-fold | `list_organizations` | **1** | `AcceptsFQDNScopedToken`, `OrgMatchesRejectsEmptyRefs` |
| M6 | delete the filter entirely | `list_organizations` | **1** | **`DropsTheOtherOrg`** (leaked `hw293walktwo`), `ReturnsOwnRow` |
| M7 | admit `console_host` as an identity key | `orgMatches` | **1** | `OrgMatchesIgnoresConsoleHost` |

M3 and M6 are the tenancy mutants: each makes the code actually return another Organization's data, and each is caught.

`go build ./...`, `go vet ./...`, `go test ./...` across `products/openova-mcp` — all rc=0.
`bash scripts/check-no-banned-words.sh --commit-messages origin/main..HEAD` — rc=0.

## No live proof taken

This is a **source + unit-test change only**. I ran nothing against a live cluster and took no screenshot or wire capture. Row 213 stays ❌ and flips only on a live walk with **two** Organizations, which the current environment does not have (hw295 has one Org, and the per-Org MCP bearer is minted into OpenBao rather than a k8s Secret). `docs/ledger/UAT.md` is untouched.

Refs #6122
Refs #3988

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HvMZTDx7W6EPZMmjyXmYh1
