### PR TITLE
fix(catalyst): a flaky post-reclaim quota re-read false-failed a re-prov after a wipe (UAT row 228)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/provisioner/provisioner.go
+++ b/products/catalyst/bootstrap/api/internal/provisioner/provisioner.go
@@ -2044,26 +2044,39 @@ func (p *Provisioner) Provision(ctx context.Context, req Request, events chan<- 
 	// apply, which is the canonical authority. We never block on quota
 	// uncertainty — only on quota *known to be insufficient after a
 	// reclaim attempt*.
+	//
+	// #6225 (UAT row 228) — that last sentence is now enforced by
+	// vpcPreflightRefuses instead of being restated inline. It previously
+	// held for the FIRST read only: the post-reclaim re-read was an
+	// assign-on-success with no else, so a flaky re-read left the STALE
+	// pre-reclaim numbers in place and the refusal fired on them, killing
+	// a re-prov whose orphaned catalyst-* VPCs had just been reclaimed
+	// successfully. Same uncertainty as a flaky first read, opposite
+	// verdict. The decision now lives in vpc_quota_preflight.go where it
+	// is unit-testable without an HCS project.
 	if req.Provider == "huawei" && len(req.Regions) > 0 && VPCQuotaHook != nil {
 		needed := len(req.Regions)
 		region := strings.TrimSpace(req.HuaweiRegion)
 		if region == "" {
 			region = "me-east-215"
 		}
-		used, limit, qerr := VPCQuotaHook(ctx, req.HuaweiAccessKey, req.HuaweiSecretKey, req.HuaweiProjectID, region)
-		if qerr != nil {
-			emit("tofu-init", "warn", fmt.Sprintf("HCS VPC quota check skipped (transient API error): %v", qerr))
+		var first, after quotaReading
+		reclaimAttempted := false
+		first.used, first.limit, first.err = VPCQuotaHook(ctx, req.HuaweiAccessKey, req.HuaweiSecretKey, req.HuaweiProjectID, region)
+		if !first.known() {
+			emit("tofu-init", "warn", fmt.Sprintf("HCS VPC quota check skipped (transient API error): %v", first.err))
 		} else {
-			emit("tofu-init", "info", fmt.Sprintf("HCS VPC quota: used %d / %d, requesting %d", used, limit, needed))
-			if used+needed > limit && VPCReclaimHook != nil {
+			emit("tofu-init", "info", fmt.Sprintf("HCS VPC quota: used %d / %d, requesting %d", first.used, first.limit, needed))
+			if !first.fits(needed) && VPCReclaimHook != nil {
 				// #4614: protect EVERY live deployment, not just THIS
 				// prov's own prefix. SweepOrphanVPCs reaps any catalyst-*
 				// VPC whose 8-char prefix is NOT in `protect`; seeding it
 				// with only this prov's prefix made the reclaim treat a
 				// live production Sovereign sharing the project as an
 				// orphan and DELETE its VPC (the 2026-06-28 incident).
+				reclaimAttempted = true
 				protect := reclaimProtectSet(req.DeploymentID)
-				emit("tofu-init", "info", fmt.Sprintf("HCS VPC quota over budget (%d/%d, need %d) — reclaiming orphaned catalyst VPCs before failing", used, limit, needed))
+				emit("tofu-init", "info", fmt.Sprintf("HCS VPC quota over budget (%d/%d, need %d) — reclaiming orphaned catalyst VPCs before failing", first.used, first.limit, needed))
 				reclaimed, rerr := VPCReclaimHook(ctx, req.HuaweiAccessKey, req.HuaweiSecretKey, req.HuaweiProjectID, region, protect, func(msg string) {
 					emit("tofu-init", "info", "vpc-reclaim: "+msg)
 				})
@@ -2072,15 +2085,20 @@ func (p *Provisioner) Provision(ctx context.Context, req Request, events chan<- 
 				} else {
 					emit("tofu-init", "info", fmt.Sprintf("HCS orphan-VPC reclaim freed %d VPC(s); re-reading quota", reclaimed))
 				}
-				// Re-read the quota after reclaim. A failed re-read falls
-				// through (best-effort — tofu apply remains authority).
-				if u2, l2, q2 := VPCQuotaHook(ctx, req.HuaweiAccessKey, req.HuaweiSecretKey, req.HuaweiProjectID, region); q2 == nil {
-					used, limit = u2, l2
-					emit("tofu-init", "info", fmt.Sprintf("HCS VPC quota after reclaim: used %d / %d, requesting %d", used, limit, needed))
+				// Re-read the quota after the reclaim. #6225: a FAILED
+				// re-read genuinely falls through now — the project is not
+				// known to be insufficient, so the prov proceeds and tofu
+				// apply arbitrates, exactly as a failed first read does.
+				after.used, after.limit, after.err = VPCQuotaHook(ctx, req.HuaweiAccessKey, req.HuaweiSecretKey, req.HuaweiProjectID, region)
+				if after.known() {
+					emit("tofu-init", "info", fmt.Sprintf("HCS VPC quota after reclaim: used %d / %d, requesting %d", after.used, after.limit, needed))
+				} else {
+					emit("tofu-init", "warn", fmt.Sprintf("HCS VPC quota re-read after reclaim failed (%v) — reclaimed %d VPC(s); proceeding to tofu apply, which is the canonical authority on project capacity", after.err, reclaimed))
 				}
 			}
-			if used+needed > limit {
-				return nil, fmt.Errorf("HCS VPC quota exhausted: project at %d/%d after orphan reclaim, this prov requests %d more — a concurrent Sovereign genuinely occupies the project; wipe one before retrying", used, limit, needed)
+			if vpcPreflightRefuses(needed, first, reclaimAttempted, after) {
+				eff := effectiveReading(first, reclaimAttempted, after)
+				return nil, fmt.Errorf("HCS VPC quota exhausted: project at %d/%d after orphan reclaim, this prov requests %d more — a concurrent Sovereign genuinely occupies the project; wipe one before retrying", eff.used, eff.limit, needed)
 			}
 		}
 	}

--- a/products/catalyst/bootstrap/api/internal/provisioner/vpc_quota_preflight.go
+++ b/products/catalyst/bootstrap/api/internal/provisioner/vpc_quota_preflight.go
@@ -1,0 +1,126 @@
+package provisioner
+
+// The HCS VPC-quota pre-flight decision (#6225, UAT row 228).
+//
+// WHY THIS IS A SEPARATE, PURE FUNCTION
+// ─────────────────────────────────────
+// The decision used to live inline inside Provision — a ~1000-line
+// function that needs a live HCS project, a tofu workdir and a running
+// mothership to reach. That is why the defect below shipped and survived:
+// there was no seam at which "does the pre-flight refuse?" could be asked
+// without provisioning a Sovereign. `quotaReading` + vpcPreflightRefuses
+// are that seam; Provision now only gathers the readings and reports the
+// verdict.
+//
+// THE CONTRACT (stated at the call site since #4431, honoured here)
+// ─────────────────────────────────────────────────────────────────
+// The pre-flight is BEST-EFFORT. `tofu apply` is the canonical authority
+// on whether the project has room; the pre-flight exists only to turn a
+// KNOWN-hopeless prov into a fast, legible refusal instead of a failure
+// ~3 minutes into apply with CP + EIPs + SGs already allocated. So it
+// blocks ONLY on quota known to be insufficient — never on quota
+// uncertainty.
+//
+// THE DEFECT THIS FIXES (#6225)
+// ─────────────────────────────
+// The FIRST quota read honoured that contract: a transient API error
+// skipped the gate and let the prov proceed. The RE-READ taken after the
+// orphan reclaim did not. It was written as an assign-on-success with no
+// else branch, so a flaky re-read left the STALE, PRE-RECLAIM used/limit
+// in place and the refusal then fired on those stale numbers — killing a
+// prov whose orphaned catalyst-* VPCs had just been deleted successfully,
+// under a message blaming "a concurrent Sovereign". Same uncertainty as a
+// flaky first read, opposite verdict.
+//
+// That is UAT row 228's false-fail: a re-prov AFTER a wipe dying on the
+// leftovers of the wiped predecessor even though the reclaim worked.
+//
+// WHAT IS DELIBERATELY *NOT* CHANGED
+// ──────────────────────────────────
+// A SUCCESSFUL post-reclaim re-read that still shows the project over cap
+// must still REFUSE. That is the genuine-conflict case: a concurrent
+// Sovereign really does occupy the project, its VPCs are correctly
+// protected from the reclaim by reclaimProtectSet, and there is no room.
+// Widening the gate to wave that through would convert a false-fail into
+// a false-pass — the prov would sink ~3 minutes into apply before HCS
+// refused the VPC create anyway. A false-pass here is strictly worse than
+// the bug being fixed, so the refusal path is preserved exactly and is
+// pinned by its own control test.
+
+// quotaReading is one observation of the HCS per-project VPC quota.
+//
+// `err != nil` means the observation FAILED and carries no usable
+// numbers — used/limit must not be read in that state. This is the
+// distinction the inline code lost: it had no way to represent "we asked
+// and did not find out", so a failed re-read was indistinguishable from
+// the previous successful one.
+type quotaReading struct {
+	used  int
+	limit int
+	err   error
+}
+
+// known reports whether this reading carries usable numbers.
+func (q quotaReading) known() bool { return q.err == nil }
+
+// fits reports whether `needed` additional VPCs sit within the observed
+// cap. Only meaningful when known() is true.
+//
+// The comparison is `used+needed <= limit`, so an exact fit (a 2-region
+// prov into a project at 3/5) is admitted — the pre-flight refuses only
+// what genuinely cannot fit, never what merely fills the project.
+func (q quotaReading) fits(needed int) bool { return q.used+needed <= q.limit }
+
+// vpcPreflightRefuses is the whole pre-flight verdict: true = REFUSE the
+// prov before tofu init, false = proceed and let tofu apply arbitrate.
+//
+// Parameters:
+//   - needed: VPCs this prov will create (one per region).
+//   - first: the pre-reclaim quota observation.
+//   - reclaimAttempted: whether the in-band orphan-VPC reclaim actually
+//     ran. False when the project already fit, or when no VPCReclaimHook
+//     is registered (e.g. a non-huawei build or CI).
+//   - after: the post-reclaim observation. Read ONLY when
+//     reclaimAttempted is true, and the caller assigns it in the same
+//     branch that sets that flag.
+//
+// The four exits, in order:
+//
+//  1. first unknown          → PROCEED. A transient quota-API error must
+//     never wedge the create path (#4431).
+//  2. first fits             → PROCEED. Nothing to reclaim, nothing to
+//     refuse.
+//  3. no reclaim attempted   → REFUSE. Known-over with no reclaim path
+//     available; this is the pre-#4431 behaviour and stays intact.
+//  4. after unknown          → PROCEED (#6225). A reclaim ran and we
+//     could not re-measure. The project is NOT known to be
+//     insufficient, so the contract forbids blocking here.
+//     Symmetric with exit 1.
+//  5. otherwise              → refuse iff the post-reclaim reading still
+//     does not fit. The genuine-conflict control.
+func vpcPreflightRefuses(needed int, first quotaReading, reclaimAttempted bool, after quotaReading) bool {
+	if !first.known() {
+		return false
+	}
+	if first.fits(needed) {
+		return false
+	}
+	if !reclaimAttempted {
+		return true
+	}
+	if !after.known() {
+		return false
+	}
+	return !after.fits(needed)
+}
+
+// effectiveReading returns the reading the operator-facing refusal
+// message should quote: the post-reclaim one when a reclaim ran and
+// re-measured, else the original. Keeps the error text describing the
+// state that actually drove the refusal.
+func effectiveReading(first quotaReading, reclaimAttempted bool, after quotaReading) quotaReading {
+	if reclaimAttempted && after.known() {
+		return after
+	}
+	return first
+}

--- a/products/catalyst/bootstrap/api/internal/provisioner/vpc_quota_preflight_6225_test.go
+++ b/products/catalyst/bootstrap/api/internal/provisioner/vpc_quota_preflight_6225_test.go
@@ -1,0 +1,174 @@
+package provisioner
+
+import (
+	"errors"
+	"testing"
+)
+
+// errQuotaAPI stands in for the transient HCS quota-API failures the
+// pre-flight is documented to tolerate: a 5xx from
+// GET /v1/{project}/quotas?type=vpc, or a response with no `type: vpc`
+// resource in it (both produce a non-nil error from Provider.VPCQuota,
+// internal/providers/huawei/provider.go:2395-2424).
+var errQuotaAPI = errors.New("VPC quota GET: status 503")
+
+// ─────────────────────────────────────────────────────────────────────
+// THE DEFECT (#6225, UAT row 228)
+// ─────────────────────────────────────────────────────────────────────
+
+// TestVPCPreflight_ProceedsWhenPostReclaimQuotaUnknown is the row-228
+// regression, and the one case that was RED before the fix.
+//
+// The scenario is precisely the row's clause — a re-prov immediately
+// after a wipe:
+//
+//	project at 5/5 (the Kom4DC me-east-215 cap), of which the wiped
+//	predecessor's orphaned catalyst-* VPCs are the occupants; the
+//	2-region prov needs 2; the in-band reclaim RUNS AND SUCCEEDS; the
+//	quota re-read taken straight afterwards flakes.
+//
+// The reclaim worked. The project is NOT known to be insufficient — it
+// is un-measured. The documented contract (provisioner.go:2042-2046, "we
+// never block on quota uncertainty") says proceed and let tofu apply
+// arbitrate, which is exactly what a flaky FIRST read already did.
+//
+// Before the fix the re-read was an assign-on-success with no else, so
+// the stale PRE-reclaim 5/5 survived into the refusal and the prov died
+// with "a concurrent Sovereign genuinely occupies the project" — on a
+// project whose orphans had just been deleted. That is the false-fail
+// row 228 forbids.
+func TestVPCPreflight_ProceedsWhenPostReclaimQuotaUnknown(t *testing.T) {
+	first := quotaReading{used: 5, limit: 5}
+	after := quotaReading{err: errQuotaAPI}
+
+	if vpcPreflightRefuses(2, first, true, after) {
+		t.Fatal("pre-flight REFUSED a re-prov whose orphan reclaim succeeded but whose " +
+			"post-reclaim quota re-read flaked — the project is un-measured, not known-full. " +
+			"This is the UAT row 228 false-fail: the wiped predecessor's orphans were " +
+			"reclaimed and the prov was killed on the stale pre-reclaim reading anyway")
+	}
+}
+
+// TestVPCPreflight_FirstAndReReadUncertaintyAgree pins the SYMMETRY that
+// the defect broke. A failed first read and a failed post-reclaim
+// re-read are the same epistemic state — "we asked and did not find
+// out" — and must produce the same verdict. Before the fix they
+// produced opposite ones, which is what made the bug so easy to miss:
+// the tolerant path was right there, three lines above the intolerant
+// one.
+func TestVPCPreflight_FirstAndReReadUncertaintyAgree(t *testing.T) {
+	unknownFirst := vpcPreflightRefuses(2, quotaReading{err: errQuotaAPI}, false, quotaReading{})
+	unknownAfter := vpcPreflightRefuses(2, quotaReading{used: 5, limit: 5}, true, quotaReading{err: errQuotaAPI})
+
+	if unknownFirst != unknownAfter {
+		t.Fatalf("uncertainty must yield the same verdict wherever it occurs: "+
+			"failed FIRST read refuses=%v, failed POST-RECLAIM re-read refuses=%v", unknownFirst, unknownAfter)
+	}
+	if unknownFirst {
+		t.Fatal("neither uncertain reading may block the prov (provisioner.go:2042-2046)")
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// THE CONTROLS — without these, the fix above is indistinguishable from
+// a pre-flight that waves everything through, which would turn a
+// false-fail into a strictly worse false-pass.
+// ─────────────────────────────────────────────────────────────────────
+
+// TestVPCPreflight_StillRefusesGenuineConflict is THE control.
+//
+// A genuinely-conflicting VPC that is NOT an orphan: a concurrent live
+// Sovereign shares the HCS project, so reclaimProtectSet correctly
+// protects its VPCs from the reclaim (#4614 — the 2026-06-28 incident
+// where an under-seeded protect-set cascade-deleted 12 production
+// nodes). The reclaim therefore frees nothing, and the post-reclaim
+// re-read SUCCEEDS and still reports the project full.
+//
+// That state IS "known to be insufficient" and must still REFUSE. If
+// this case ever passes the gate, the fix has widened the pre-flight
+// rather than corrected it: the prov would proceed, sink ~3 minutes into
+// tofu apply with CP + EIPs + SGs allocated, and HCS would refuse the
+// VPC create anyway.
+func TestVPCPreflight_StillRefusesGenuineConflict(t *testing.T) {
+	first := quotaReading{used: 5, limit: 5}
+	after := quotaReading{used: 5, limit: 5} // reclaim freed nothing; re-read SUCCEEDED
+
+	if !vpcPreflightRefuses(2, first, true, after) {
+		t.Fatal("pre-flight ADMITTED a prov into a project a live concurrent Sovereign " +
+			"genuinely fills (post-reclaim re-read succeeded and still reads 5/5). " +
+			"Known-insufficient must refuse — admitting it converts row 228's false-fail " +
+			"into a false-pass that dies ~3min into tofu apply instead")
+	}
+}
+
+// TestVPCPreflight_RefusesWhenNoReclaimPathExists keeps the pre-#4431
+// baseline. With no VPCReclaimHook registered there is nothing that
+// could free room, so a known-over project must refuse immediately.
+// Pairs with the control above so "reclaimAttempted" cannot be turned
+// into a blanket escape hatch.
+func TestVPCPreflight_RefusesWhenNoReclaimPathExists(t *testing.T) {
+	if !vpcPreflightRefuses(2, quotaReading{used: 4, limit: 5}, false, quotaReading{}) {
+		t.Fatal("known-over project with NO reclaim path available must refuse")
+	}
+}
+
+// TestVPCPreflight_ProceedsWhenReclaimFreedRoom is the happy path row
+// 228 describes when the re-read works: the wiped predecessor's orphans
+// are reclaimed, the re-read succeeds, the project now fits, the prov
+// proceeds. Proves the fix did not make the gate unconditionally
+// refuse-on-reclaim either.
+func TestVPCPreflight_ProceedsWhenReclaimFreedRoom(t *testing.T) {
+	first := quotaReading{used: 5, limit: 5}
+	after := quotaReading{used: 1, limit: 5} // 4 orphaned catalyst-* VPCs reclaimed
+
+	if vpcPreflightRefuses(2, first, true, after) {
+		t.Fatal("pre-flight refused after the reclaim measurably freed room (5/5 -> 1/5, need 2)")
+	}
+}
+
+// TestVPCPreflight_ProceedsWhenProjectAlreadyFits guards the ordinary
+// prov: a project with room is admitted and no reclaim is even
+// attempted. This is the case that must NOT regress into "sweep on every
+// prov".
+func TestVPCPreflight_ProceedsWhenProjectAlreadyFits(t *testing.T) {
+	if vpcPreflightRefuses(2, quotaReading{used: 1, limit: 5}, false, quotaReading{}) {
+		t.Fatal("pre-flight refused a prov that fits comfortably (1/5, need 2)")
+	}
+}
+
+// TestVPCPreflight_ExactFitAdmitted pins the boundary. A 2-region prov
+// into a project at 3/5 lands exactly on the cap. The comparison is
+// used+needed <= limit, so it is admitted: the pre-flight refuses what
+// cannot fit, never what merely fills the project. An off-by-one here
+// would false-fail every prov that exactly consumes its quota — the same
+// class of defect as row 228, one slot earlier.
+func TestVPCPreflight_ExactFitAdmitted(t *testing.T) {
+	if vpcPreflightRefuses(2, quotaReading{used: 3, limit: 5}, false, quotaReading{}) {
+		t.Fatal("exact fit (3/5 + 2 = 5) must be admitted, not refused")
+	}
+	// One more than an exact fit must still refuse — proves the boundary
+	// test above is not passing because the predicate is inert.
+	if !vpcPreflightRefuses(3, quotaReading{used: 3, limit: 5}, false, quotaReading{}) {
+		t.Fatal("3/5 + 3 = 6 exceeds the cap and must refuse")
+	}
+}
+
+// TestEffectiveReading_QuotesTheReadingThatDroveTheRefusal checks the
+// operator-facing message quotes the right numbers: the post-reclaim
+// reading when one was successfully taken, else the original. A refusal
+// that printed stale pre-reclaim numbers is what made the original
+// defect read as "the project is full" when it was not.
+func TestEffectiveReading_QuotesTheReadingThatDroveTheRefusal(t *testing.T) {
+	first := quotaReading{used: 5, limit: 5}
+	after := quotaReading{used: 4, limit: 5}
+
+	if got := effectiveReading(first, true, after); got.used != 4 {
+		t.Errorf("after a successful re-read the message must quote it: used=%d, want 4", got.used)
+	}
+	if got := effectiveReading(first, true, quotaReading{err: errQuotaAPI}); got.used != 5 {
+		t.Errorf("with no usable re-read the message falls back to the first reading: used=%d, want 5", got.used)
+	}
+	if got := effectiveReading(first, false, quotaReading{}); got.used != 5 {
+		t.Errorf("with no reclaim attempted the message quotes the first reading: used=%d, want 5", got.used)
+	}
+}


### PR DESCRIPTION
UAT **row 228** — *"A re-prov AFTER a wipe does NOT false-fail on orphaned `catalyst-*` VPCs — the orphan-VPC janitor sweeps them."*

## Which of the three defect classes it actually was

**CLASSIFICATION.** The other two were checked against the code, not assumed, and both are ruled out.

### Not ORDERING — the reclaim already runs first

The in-band orphan-VPC reclaim is wired ahead of everything it must precede:

| what | where | ordering |
|---|---|---|
| VPC-quota pre-flight + in-band reclaim | `internal/provisioner/provisioner.go:2047` | runs first |
| `tofu init` | `internal/provisioner/provisioner.go:2089` | 42 lines later |
| background janitor's VPC sweep | `internal/handler/janitor.go:325` | step 5 of the pass |

The in-band reclaim also passes `destructive=true` unconditionally (`internal/providers/huawei/provider.go:104-106`), so it is **not** gated by the `#4466` log-only default that governs the background janitor.

### Not SELECTOR — the predicate matches the real names

`isReclaimableOrphanVPC` (`internal/providers/huawei/provider.go:2129-2146`) requires the `catalyst-` prefix, hard-protects anything containing `bastion`, and skips any name embedding a live deployment's 8-char prefix.

That prefix genuinely is in the rendered name — checked against the IaC rather than the Go comment that asserts it. `infra/providers/huawei/main.tf:167` builds `name_prefix` from the fqdn slug plus `substr(var.deployment_id, 0, 8)`, and `:182` appends `-<region>-vpc`. The live janitor lines already banked on this env (UAT rows R1/G4/G5/M1) show exactly that shape.

### The actual defect — an unknown post-reclaim quota state classified as fatal

`provisioner.go:2042-2046` states the contract:

> The check is BEST-EFFORT: any quota-API failure … falls through to tofu apply, which is the canonical authority. **We never block on quota uncertainty** — only on quota *known to be insufficient after a reclaim attempt*.

The **first** read honours it — `:2054-2055`, a transient error warns and skips the gate entirely.

The **post-reclaim re-read did not.** It was written as assign-on-success with no `else`:

```go
// Re-read the quota after reclaim. A failed re-read falls
// through (best-effort — tofu apply remains authority).
if u2, l2, q2 := VPCQuotaHook(ctx, ...); q2 == nil {
    used, limit = u2, l2
}
```

On a failed re-read, `used`/`limit` kept their **stale pre-reclaim** values, and `:2082` refused on those stale numbers. The comment at `:2075-2076` claims a fall-through the code three lines below does not perform.

Same uncertainty, opposite verdicts: a flaky **first** read lets the prov through, a flaky **re-read** kills it.

The operator-visible result is precisely the false-fail this row forbids, under a message naming the wrong cause:

> `HCS VPC quota exhausted: project at 5/5 after orphan reclaim, this prov requests 2 more — a concurrent Sovereign genuinely occupies the project; wipe one before retrying`

…emitted on a project whose orphaned `catalyst-*` VPCs were successfully deleted microseconds earlier. The `reclaimed` count (`:2073`) was logged and then ignored by the decision entirely.

**Why it survived:** the decision was inline in the ~1000-line `Provision`, reachable only with a live HCS project, a tofu workdir and a running mothership. `grep -rn "vpcPreflight\|quota exhausted" --include=*_test.go` returned **zero** hits.

## The fix

`internal/provisioner/vpc_quota_preflight.go` extracts the verdict into a pure `vpcPreflightRefuses` over a `quotaReading` that can represent *"we asked and did not find out"* — the state the inline code had no way to express, which is the root of the bug. A reclaim that ran but could not be re-measured now falls through to `tofu apply`, symmetric with the first-read path. `Provision` gathers readings and reports the verdict.

## What is deliberately NOT widened — the control

**A successful post-reclaim re-read that still shows the project over cap must still REFUSE.** That is the genuine-conflict case: a concurrent live Sovereign really does occupy the project, and its VPCs are correctly protected from the reclaim by `reclaimProtectSet` (#4614 — the 2026-06-28 incident where an under-seeded protect-set cascade-deleted 12 production nodes).

`TestVPCPreflight_StillRefusesGenuineConflict` pins exactly that: a **non-orphan** conflicting VPC, re-read succeeded, still 5/5 → must refuse. Without it this change would convert a false-fail into a **false-pass** — the prov would proceed and sink ~3 min into apply with CP + EIPs + SGs allocated before HCS refused the VPC create anyway. That is strictly worse than the bug being fixed.

`TestVPCPreflight_ExactFitAdmitted` additionally pins the boundary in **both** directions (3/5 + 2 admitted, 3/5 + 3 refused), so the predicate cannot pass by being inert.

## Mutant table — both mutants COMPILE

| # | mutant | `go build` rc | `go test` rc | result |
|---|---|---|---|---|
| 1 | revert the fix — unknown re-read falls back to the stale `first` reading (the exact pre-fix semantics) | **0** | **1** | RED on exactly the 2 defect tests: `ProceedsWhenPostReclaimQuotaUnknown`, `FirstAndReReadUncertaintyAgree` |
| — | restored | 0 | **0** | GREEN |
| 2 | vacuity check — predicate admits everything (`if true { return false }`) | **0** | **1** | RED on the 3 controls: `StillRefusesGenuineConflict`, `RefusesWhenNoReclaimPathExists`, `ExactFitAdmitted` |
| — | restored | 0 | **0** | GREEN |

Mutant 2 is what proves the controls are load-bearing: a pre-flight that waves everything through — the false-pass this fix must not become — **cannot** satisfy this test file.

## Tests

`go build ./...` and `go vet ./...` clean. Suites at rc=0: `internal/provisioner`, `internal/providers/huawei`, `internal/handler` (297s, full).

`bash scripts/check-no-banned-words.sh --commit-messages origin/main..HEAD` → `OK`, rc=0.

## No live proof taken

Everything here is source-side. **No live cluster or cloud API was written to, no VPC was deleted, and the bastion was not touched.** The pre-flight's behaviour on a real HCS quota flake is argued from the code path, not measured.

Row 228 flips only on a live wipe-then-re-prov cycle, so **`docs/ledger/UAT.md` is deliberately not stamped** by this PR.

## Residual gap this does not close

The clause's second half — *"the janitor log shows the orphaned `catalyst-*` VPC(s) swept"* — still depends on the **background** janitor being armed. PR #6137 made `CATALYST_JANITOR_DESTRUCTIVE` reachable through the chart, but it defaults to log-only (`would-reap`), so that half remains operator-configuration, not code. The **prov does not false-fail** half is what this PR addresses, and it is the half that gates throughput.

Refs #6225
Refs #4431
Refs #6114

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HvMZTDx7W6EPZMmjyXmYh1
