### PR TITLE
fix(bp-guacamole): nothing had ever written a Guacamole connection — ship the producer (UAT row 115)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1392,7 +1392,10 @@ spec:
       # 1.4.1437 — #6149 (Refs #6148): catalog-seed advances bp-postgres 0.2.20 ->
       #   0.2.23 (region-A dr-failback for the three shared-pg DR pairs + the
       #   #6148 peer-ahead write-guard). Lockstep w/ products/catalyst/chart/Chart.yaml.
-      version: 1.4.1439
+      # 1.4.1440 — #5991 (UAT row 115): catalog-seed advances bp-guacamole
+      #   0.2.37 -> 0.2.38, the release that writes a Guacamole connection at
+      #   all. Lockstep w/ products/catalyst/chart/Chart.yaml.
+      version: 1.4.1440
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/clusters/_template/bootstrap-kit/52-bp-guacamole.yaml
+++ b/clusters/_template/bootstrap-kit/52-bp-guacamole.yaml
@@ -198,7 +198,15 @@ spec:
       # dead cached GUAC_AUTH token → 403 PERMISSION_DENIED on every
       # session API call → bare "An error has occurred" page (UAT rows
       # 35/115 on hw292). Session lifetime now matches the gate cookie.
-      version: 0.2.37
+      #
+      # 0.2.38 (#5991 / UAT row 115): the connection PRODUCER. Nothing had
+      # ever inserted into `guacamole_connection`, so a signed-in
+      # sovereign-admin landed on an empty ALL CONNECTIONS list. The seed
+      # Job now writes the declared set (default: one ssh target on this
+      # Sovereign's own node, address from the downward API) and the
+      # per-minute enroll CronJob re-converges it. Credentials come from an
+      # optional Secret, never from values.
+      version: 0.2.38
       sourceRef:
         kind: HelmRepository
         name: bp-guacamole

--- a/platform/guacamole/README.md
+++ b/platform/guacamole/README.md
@@ -134,35 +134,74 @@ spec:
 
 ---
 
-## Connection definitions — DESIGN, NOT BUILT
+## Connection definitions — seeded by the chart (0.2.38)
 
-> **Status (2026-08-10, UAT row 115).** Nothing in this repository creates a
-> Guacamole connection. `guacamole_connection` is created empty by the Apache
-> schema DDL (`chart/files/postgresql/001-create-schema.sql:109`) and stays at
-> zero rows, so a signed-in sovereign-admin lands on an empty connections list.
->
-> The `GuacamoleConnection` CRD and the `relay-controller` that this section
-> previously described as reconciling it **do not exist** — no Go type, no CRD
-> manifest, no reconciler, no chart template; the only occurrences of either
-> name in the repo were the two sentences this note replaces. Documenting an
-> absent producer as a shipped one is how a missing component reads as a
-> configuration problem, so the design sketch is kept below explicitly labelled
-> as a sketch.
->
-> What DOES exist today, in `chart/templates/jdbc-schema-seed-job.yaml`, is the
-> identity + permission half: the `<adminGroup>` USER_GROUP (`:155-164`) and its
-> `ADMINISTER` + five `CREATE_*` system permissions (`:166-181`), plus the
-> per-minute admin-enroll CronJob (`:116-125`). That grants the *right* to
-> create connections; it creates none.
->
-> A seeded kubectl-shell connection additionally needs a wire fix, not just an
-> INSERT: `bp-k8s-ws-proxy` rejects any WebSocket upgrade without
-> `X-Catalyst-Timestamp` + `X-Catalyst-HMAC`
-> (`core/cmd/k8s-ws-proxy/DESIGN.md:32-37`, 401 at `:79`), and guacd's
-> `kubernetes` protocol handler cannot emit them — so a naively seeded row would
-> fail on click rather than open a shell.
+**Status (2026-08-13, UAT row 115 / #5991).** The chart now ships a connection
+**producer**. Until 0.2.38 nothing in this repository ever inserted into
+`guacamole_connection` — the table is created empty by the Apache schema DDL
+(`chart/files/postgresql/001-create-schema.sql:109`), the `GuacamoleConnection`
+CRD and `relay-controller` this section once described were never written, and
+catalyst-api's `GuacamoleClient` interface has no production implementation
+(`SetGuacamoleClient` has no non-test caller). So a signed-in sovereign-admin
+reached Guacamole successfully and landed on an empty connections list. The
+`<adminGroup>` USER_GROUP with `ADMINISTER` + five `CREATE_*` system permissions
+was already seeded — that is the *right* to create a connection, and it created
+none.
 
-Design sketch (target state — **not** reconciled by anything today):
+**What produces the rows.** `seed_connections()` in
+`chart/templates/jdbc-schema-seed-job.yaml`, alongside the existing identity
+seed. It runs from `seed.sh` on install/upgrade and again from `promote.sh` on
+the per-minute admin-enroll CronJob, so the set **converges**: a restored or
+rebuilt database returns to the declared set on its own. Writes are idempotent —
+the connection INSERT is `NOT EXISTS`-guarded (the schema's
+`UNIQUE (connection_name, parent_id)` does *not* dedupe root-level connections,
+because `parent_id` is NULL there and Postgres treats NULLs as distinct) and
+parameters converge via `ON CONFLICT … DO UPDATE`. Each connection also gets a
+`READ` grant for the admin USER_GROUP, so it renders for a member who is not a
+system admin.
+
+**The declared set** lives in `.Values.guacamole.database.connections`. The
+default is one target — `sovereign-node`, protocol `ssh`, port 22, user `root`.
+Its hostname is this Sovereign's own node address, taken from the seeder Pod's
+**downward API** (`status.hostIP`): no node list is baked into a public chart and
+the seeder needs no cluster read. Declare nothing and the producer's body
+renders empty — zero rows, never a fabricated one, which matters on a table that
+carries credentials.
+
+**Credentials never come from values or the chart.** A target names an *optional*
+Secret (`credentialSecretName`); the seeder mounts it read-only at
+`/conn-cred/<connection-name>` and reads `username` / `password` / `private-key`
+/ `passphrase` at run time. Setting a credential-shaped parameter under
+`parameters` fails the helm render on purpose — this repo is public and those
+values land in a ConfigMap.
+
+**Honest limits, so the next reader does not re-derive them.**
+
+- The Sovereign's node sshd is key-only (`PasswordAuthentication no`,
+  `PermitRootLogin prohibit-password` —
+  `infra/providers/_shared/cloudinit-control-plane.tftpl:118-136`), and the node
+  SSH private key is deliberately **not** in the cluster. With no
+  `credentialSecretName`, Guacamole opens the connection and prompts; point it at
+  a Secret holding `private-key` and the session authenticates. Who holds that
+  key is a Sovereign decision, not a platform one.
+- A **kubectl-shell** connection is not seeded, and not for want of an INSERT.
+  guacd's `kubernetes` protocol authenticates to the kube-apiserver by mTLS
+  client certificate only, and nothing in-cluster can mint an apiserver-trusted
+  client cert without granting the seeder CSR **approve** rights on the
+  `kubernetes.io/kube-apiserver-client` signer — which is not scopeable by CN and
+  is therefore cluster-admin-equivalent escalation. The other wire is no better:
+  `bp-k8s-ws-proxy` rejects any WebSocket upgrade without `X-Catalyst-Timestamp`
+  + `X-Catalyst-HMAC` (`core/cmd/k8s-ws-proxy/DESIGN.md:32-37`, 401 at `:79`) and
+  guacd cannot emit them. The browser shell into a Pod stays the console's
+  `/shells/issue` → k8s-ws-proxy → xterm.js path, which already works.
+
+Tests: `chart/tests/connection-seed-render.sh` (render + the empty-set control +
+the credential guard) and `chart/tests/connection-seed-sql.sh`, which executes
+the shipped `seed.sh`/`common.sh` against a throwaway Postgres and reads the
+tables back.
+
+Design sketch (a CRD-shaped future, **not** reconciled by anything today — the
+shipped model is the values-driven set above):
 
 ```yaml
 apiVersion: catalyst.openova.io/v1alpha1
@@ -185,10 +224,12 @@ spec:
     maxDurationMinutes: 60
 ```
 
-The intended model is that a controller reconciles `GuacamoleConnection` into
-Guacamole's PostgreSQL backend (managed by CNPG), the Catalyst console exposes a
-"Connections" tab, and sovereign-admin / org-admin grant connection access via
-Keycloak group membership. None of those three parts is built.
+That sketch's model is a controller reconciling `GuacamoleConnection` into
+Guacamole's PostgreSQL backend, a "Connections" tab in the Catalyst console, and
+JIT approval — **none of those three is built**. What 0.2.38 ships instead is the
+declarative values-driven set described above, written by the seed Job, which
+covers the "the list must not be empty for a sovereign-admin" contract without a
+CRD, a controller, or a console surface.
 
 ---
 

--- a/platform/guacamole/blueprint.yaml
+++ b/platform/guacamole/blueprint.yaml
@@ -7,7 +7,7 @@ metadata:
     catalyst.openova.io/category: platform
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.2.37
+  version: 0.2.38
   card:
     title: Apache Guacamole
     summary: Clientless HTML5 remote-desktop gateway. Browser-based RDP / VNC / SSH and kubectl-exec into Pods, with Keycloak SSO and full session recording to SeaweedFS. One Guacamole per Sovereign per ADR-0001 §11.

--- a/platform/guacamole/chart/Chart.yaml
+++ b/platform/guacamole/chart/Chart.yaml
@@ -301,7 +301,58 @@ name: bp-guacamole
 # chart/tests/crossregion-render.sh (Case 3 fails against the pre-fix chart —
 # role=secondary there still renders 2 Deployments + 1 CNPG Cluster).
 # Refs #5358.
-version: 0.2.37
+#
+# 0.2.38 (#5991 / UAT row 115, 2026-08-13): the CONNECTION PRODUCER. Until this
+# version nothing in the repository ever inserted into `guacamole_connection` —
+# the Apache schema creates it empty (files/postgresql/001-create-schema.sql:109),
+# the `GuacamoleConnection` CRD + `relay-controller` the README described were
+# never written, and catalyst-api's `GuacamoleClient` interface has no production
+# implementation (`SetGuacamoleClient` has no non-test caller). A signed-in
+# sovereign-admin therefore reached Guacamole successfully and landed on an EMPTY
+# ALL CONNECTIONS list. The `<adminGroup>` USER_GROUP with ADMINISTER + five
+# CREATE_* system permissions, seeded since 0.2.9, is the RIGHT to create a
+# connection — it creates none, which is exactly what row 115's vacuity guard
+# says is a FAIL.
+#   - seed_connections() in templates/jdbc-schema-seed-job.yaml writes the
+#     declared set. Called from seed.sh (install/upgrade) AND promote.sh (the
+#     per-minute enroll CronJob), so the set CONVERGES after a restore or rebuild
+#     rather than being written once.
+#   - Idempotent by construction: the connection INSERT is NOT EXISTS-guarded
+#     because UNIQUE (connection_name, parent_id) does NOT dedupe root-level
+#     connections — parent_id is NULL and Postgres treats NULLs as distinct, so a
+#     bare INSERT would add one duplicate per minute. Parameters converge with
+#     ON CONFLICT … DO UPDATE. Each connection carries a READ grant for the admin
+#     USER_GROUP so it renders for a member who is not a system admin.
+#   - Default declared set: ONE target, `sovereign-node` (ssh :22, user root),
+#     whose hostname comes from the seeder Pod's downward API (status.hostIP) —
+#     no node list baked into a public chart, no cluster read, no new RBAC.
+#     Declare nothing (connections.enabled=false, or nodeShell.enabled=false with
+#     an empty `extra`) and the producer's body renders EMPTY: zero rows, never a
+#     fabricated one.
+#   - Credentials NEVER come from values or this chart. A target names an
+#     OPTIONAL Secret (credentialSecretName), mounted read-only at
+#     /conn-cred/<name>; username/password/private-key/passphrase are read at run
+#     time. A credential-shaped parameter in values FAILS the render — the repo
+#     is public and those values land in a ConfigMap.
+#   - NOT seeded, deliberately: a kubectl-shell connection. guacd's `kubernetes`
+#     protocol authenticates by mTLS client certificate only, and minting an
+#     apiserver-trusted client cert in-cluster needs CSR `approve` on the
+#     kubernetes.io/kube-apiserver-client signer, which is not scopeable by CN
+#     and is cluster-admin-equivalent escalation; bp-k8s-ws-proxy's HMAC upgrade
+#     contract (core/cmd/k8s-ws-proxy/DESIGN.md:32-37) is unspeakable by guacd.
+#     The browser shell into a Pod remains the console's /shells/issue path.
+#   - New guards: chart/tests/connection-seed-render.sh (producer renders, the
+#     empty-set CONTROL writes nothing, credentials in values are refused) and
+#     chart/tests/connection-seed-sql.sh, which runs the SHIPPED seed.sh +
+#     common.sh against a throwaway Postgres and reads the tables back — it is
+#     what proves the second run adds no duplicate.
+#   - CRED / SCRIPTS_DIR / SCHEMA_DIR / CONN_CRED_DIR in the seed scripts gained
+#     `${VAR:-<pod path>}` defaults so the test harness can execute the shipped
+#     script rather than a copy. Pod behaviour is unchanged.
+# Lockstep: 52-bp-guacamole.yaml pin + blueprint.yaml + catalog-seed
+# source.version → 0.2.38.
+# Refs #5991.
+version: 0.2.38
 appVersion: "1.5.5"
 description: |
   Catalyst-authored Blueprint chart for Apache Guacamole — a clientless

--- a/platform/guacamole/chart/templates/jdbc-schema-seed-job.yaml
+++ b/platform/guacamole/chart/templates/jdbc-schema-seed-job.yaml
@@ -61,6 +61,86 @@ postgresql.cnpg.io CRD absent.
    name-match did not reach the owner live on hw133 — #3475). */ -}}
 {{- $cronName := printf "%s-admin-enroll" (include "bp-guacamole.fullname" .) | trunc 63 | trimSuffix "-" -}}
 {{- $promoteSchedule := $db.promoteSchedule | default "* * * * *" -}}
+{{- /* #5991 / UAT row 115 (2026-08-13) — the CONNECTION PRODUCER.
+
+   Everything above this line seeds IDENTITY: the <adminGroup> USER_GROUP, its
+   ADMINISTER + CREATE_* system permissions, and the per-minute enrollment of
+   each SSO-auto-created USER into that group. That is the RIGHT to create a
+   connection; it created none, and `guacamole_connection` — created empty by
+   the vendored Apache schema (files/postgresql/001-create-schema.sql:109) —
+   stayed at zero rows on every Sovereign. A signed-in sovereign-admin
+   therefore reached Guacamole successfully and landed on an empty ALL
+   CONNECTIONS list. No producer existed anywhere in the repo (the
+   `GuacamoleConnection` CRD + `relay-controller` the README used to describe
+   were never written; catalyst-api's `GuacamoleClient` interface has no
+   production implementation and `SetGuacamoleClient` no non-test caller).
+
+   The target set is DECLARED in .Values.guacamole.database.connections and
+   rendered into seed_connections() below, one block per target. An empty
+   declared set renders an EMPTY body — this producer writes zero rows rather
+   than invent one, which matters more than usual on a table that carries
+   credentials.
+
+   Credentials NEVER come from values, this template, or the ConfigMap (public
+   repo): each target may name an OPTIONAL Secret, mounted read-only at
+   /conn-cred/<connection-name>, whose keys are read at run time. The
+   render-time guard below FAILS the template if a credential-shaped parameter
+   is set from values instead. */ -}}
+{{- $conn := $db.connections | default dict -}}
+{{- /* `default true X` is UNSAFE for a bool: sprig treats false as empty and
+   hands back the default, so `enabled: false` would arm the producer anyway.
+   hasKey is the only correct off-switch here. */ -}}
+{{- $connEnabled := true -}}
+{{- if hasKey $conn "enabled" }}{{- $connEnabled = $conn.enabled -}}{{- end -}}
+{{- $targets := list -}}
+{{- if $connEnabled -}}
+{{- $ns := $conn.nodeShell | default dict -}}
+{{- $nsEnabled := true -}}
+{{- if hasKey $ns "enabled" }}{{- $nsEnabled = $ns.enabled -}}{{- end -}}
+{{- if $nsEnabled -}}
+{{- $targets = append $targets (dict
+      "name" ($ns.name | default "sovereign-node")
+      "protocol" ($ns.protocol | default "ssh")
+      "hostnameFromNodeIP" true
+      "params" (dict "port" (toString ($ns.port | default 22)) "username" ($ns.username | default "root"))
+      "credentialSecretName" ($ns.credentialSecretName | default "")) -}}
+{{- end -}}
+{{- range $e := ($conn.extra | default list) -}}
+{{- $targets = append $targets (dict
+      "name" (required "bp-guacamole: every guacamole.database.connections.extra entry needs a name" $e.name)
+      "protocol" (required "bp-guacamole: every guacamole.database.connections.extra entry needs a protocol" $e.protocol)
+      "hostnameFromNodeIP" false
+      "params" ($e.parameters | default dict)
+      "credentialSecretName" ($e.credentialSecretName | default "")) -}}
+{{- end -}}
+{{- end -}}
+{{- /* Render-time guards. Each one has a live failure mode: a credential in
+   values would be committed to a public repo, and a quote in a name or value
+   would break out of the single-quoted shell word the target block renders. */ -}}
+{{- $credentialParams := list "password" "passphrase" "private-key" "client-key" "client-cert" "secret" "token" "auth-token" -}}
+{{- range $t := $targets -}}
+{{- if not (regexMatch "^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$" $t.name) -}}
+{{- fail (printf "bp-guacamole: connection name %q is not [A-Za-z0-9._-]{1,64} — the name is rendered into a shell word and a Secret mount path" $t.name) -}}
+{{- end -}}
+{{- /* A connection with no hostname is a broken row, and a broken row is
+   exactly what row 115's vacuity guard is written against. The nodeShell
+   target gets its hostname at run time from the downward API; every other
+   target must declare one. */ -}}
+{{- if and (not $t.hostnameFromNodeIP) (not (get $t.params "hostname")) -}}
+{{- fail (printf "bp-guacamole: connection %q declares no `hostname` parameter — a connection with nowhere to dial is not a connection" $t.name) -}}
+{{- end -}}
+{{- range $k, $v := $t.params -}}
+{{- if has $k $credentialParams -}}
+{{- fail (printf "bp-guacamole: connection %q sets credential parameter %q from values. Credentials must come from a Secret named by credentialSecretName and read at run time — never from values, this chart, or a ConfigMap (this repo is public)." $t.name $k) -}}
+{{- end -}}
+{{- if not (regexMatch "^[A-Za-z0-9._-]+$" $k) -}}
+{{- fail (printf "bp-guacamole: connection %q parameter name %q is not [A-Za-z0-9._-]+" $t.name $k) -}}
+{{- end -}}
+{{- if contains "'" (toString $v) -}}
+{{- fail (printf "bp-guacamole: connection %q parameter %q value contains a single quote, which would break the rendered shell word" $t.name $k) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -80,7 +160,10 @@ data:
     # admin-enroll function (#3374). Sourced by seed.sh (one-shot) + promote.sh
     # (per-minute CronJob).
     set -eu
-    CRED=/cnpg
+    # /cnpg in the Pod (the CNPG -app Secret projection). Overridable so the
+    # chart's own test harness can run THIS script — not a copy of it —
+    # against a throwaway Postgres (tests/connection-seed-sql.sh).
+    CRED="${CRED:-/cnpg}"
     PGHOST="$(cat "${CRED}/host")"
     PGPORT="$(cat "${CRED}/port" 2>/dev/null || echo 5432)"
     PGDATABASE="$(cat "${CRED}/dbname")"
@@ -130,8 +213,115 @@ data:
       cnt="$(printf '%s' "$n" | grep -c . || true)"
       echo "[jdbc-seed] enrolled ${cnt} user(s) into ${ADMIN_GROUP}"
     }
+    # ── connection producer (#5991 / UAT row 115) ──────────────────────────
+    # ensure_connection <name> <protocol>: create the connection if absent and
+    # grant the admin USER_GROUP READ on it (what makes it render in ALL
+    # CONNECTIONS for a member who is not a system admin).
+    #
+    # The absence guard is NOT EXISTS rather than ON CONFLICT because the
+    # schema's UNIQUE (connection_name, parent_id) does NOT dedupe root-level
+    # connections: parent_id is NULL there and Postgres treats NULLs as
+    # distinct, so a bare INSERT adds one duplicate per run — and this runs
+    # every minute from promote.sh.
+    #
+    # Every value crosses into SQL as a psql :'var' literal, never string
+    # concatenation, so a hostname or key containing a quote cannot terminate
+    # the statement.
+    ensure_connection() {
+      cname="$1"; cproto="$2"
+      $PSQL -v cname="$cname" -v cproto="$cproto" -v agroup="$ADMIN_GROUP" <<'SQL'
+    INSERT INTO guacamole_connection (connection_name, protocol)
+    SELECT :'cname', :'cproto'
+    WHERE NOT EXISTS (
+      SELECT 1 FROM guacamole_connection
+      WHERE connection_name = :'cname' AND parent_id IS NULL
+    );
+    UPDATE guacamole_connection SET protocol = :'cproto'
+    WHERE connection_name = :'cname' AND parent_id IS NULL AND protocol <> :'cproto';
+    INSERT INTO guacamole_connection_permission (entity_id, connection_id, permission)
+    SELECT e.entity_id, c.connection_id, 'READ'::guacamole_object_permission_type
+    FROM guacamole_entity e
+    JOIN guacamole_connection c
+      ON c.connection_name = :'cname' AND c.parent_id IS NULL
+    WHERE e.name = :'agroup' AND e.type = 'USER_GROUP'
+      AND NOT EXISTS (
+        SELECT 1 FROM guacamole_connection_permission p
+        WHERE p.entity_id = e.entity_id AND p.connection_id = c.connection_id
+          AND p.permission = 'READ'
+      );
+    SQL
+    }
+    # set_connection_parameter <name> <param> <value>: converge one parameter.
+    # Empty value writes nothing — an empty hostname is a broken connection,
+    # not a connection.
+    set_connection_parameter() {
+      cname="$1"; pname="$2"; pvalue="$3"
+      if [ -z "$pvalue" ]; then
+        echo "[jdbc-seed] ${cname}: parameter ${pname} has no value — not written"
+        return 0
+      fi
+      $PSQL -v cname="$cname" -v pname="$pname" -v pvalue="$pvalue" <<'SQL'
+    INSERT INTO guacamole_connection_parameter (connection_id, parameter_name, parameter_value)
+    SELECT c.connection_id, :'pname', :'pvalue'
+    FROM guacamole_connection c
+    WHERE c.connection_name = :'cname' AND c.parent_id IS NULL
+    ON CONFLICT (connection_id, parameter_name)
+    DO UPDATE SET parameter_value = EXCLUDED.parameter_value;
+    SQL
+    }
+    # load_connection_credentials <name> <dir>: credential material is read
+    # HERE, at run time, from a Secret mounted read-only — it is never in
+    # values, in this chart, or in the ConfigMap. The mount is optional, so an
+    # absent Secret leaves the connection credential-free (guacd then prompts
+    # the signed-in sovereign-admin) instead of failing the seed.
+    load_connection_credentials() {
+      cname="$1"; dir="$2"
+      [ -n "$dir" ] || return 0
+      if [ ! -d "$dir" ]; then
+        echo "[jdbc-seed] ${cname}: credential Secret not mounted — connection left credential-free"
+        return 0
+      fi
+      for key in username password private-key passphrase; do
+        [ -f "${dir}/${key}" ] || continue
+        set_connection_parameter "$cname" "$key" "$(cat "${dir}/${key}")"
+        echo "[jdbc-seed] ${cname}: ${key} sourced from the mounted Secret"
+      done
+    }
+    # seed_connections: converge the DECLARED set. The per-target blocks are
+    # rendered from .Values.guacamole.database.connections — declare nothing
+    # and this function's body is empty, which is deliberate: zero rows beats
+    # a fabricated one on a table that holds credentials.
+    seed_connections() {
+      if ! $PSQL -c "SELECT to_regclass('public.guacamole_connection');" 2>/dev/null | grep -q '^guacamole_connection$'; then
+        echo "[jdbc-seed] schema not yet present — connection seeding deferred"; return 0
+      fi
+{{- range $t := $targets }}
+      # ── target: {{ $t.name }} ({{ $t.protocol }}) ──
+  {{- if $t.hostnameFromNodeIP }}
+      # Hostname is this Sovereign's own node, learned from the downward API
+      # (status.hostIP) — no cluster read, no node list baked into the chart.
+      if [ -z "${NODE_IP:-}" ]; then
+        echo "[jdbc-seed] {{ $t.name }}: NODE_IP empty — connection NOT written (a target is never invented)"
+      else
+        ensure_connection '{{ $t.name }}' '{{ $t.protocol }}'
+        set_connection_parameter '{{ $t.name }}' 'hostname' "${NODE_IP}"
+    {{- range $k, $v := $t.params }}
+        set_connection_parameter '{{ $t.name }}' '{{ $k }}' '{{ toString $v }}'
+    {{- end }}
+        load_connection_credentials '{{ $t.name }}' "{{ if $t.credentialSecretName }}${CONN_CRED_DIR:-/conn-cred}/{{ $t.name }}{{ end }}"
+      fi
+  {{- else }}
+      ensure_connection '{{ $t.name }}' '{{ $t.protocol }}'
+    {{- range $k, $v := $t.params }}
+      set_connection_parameter '{{ $t.name }}' '{{ $k }}' '{{ toString $v }}'
+    {{- end }}
+      load_connection_credentials '{{ $t.name }}' "{{ if $t.credentialSecretName }}${CONN_CRED_DIR:-/conn-cred}/{{ $t.name }}{{ end }}"
+  {{- end }}
+{{- end }}
+      echo "[jdbc-seed] guacamole_connection holds $($PSQL -c 'SELECT count(*) FROM guacamole_connection;') row(s)"
+    }
   seed.sh: |
-    . /scripts/common.sh
+    . "${SCRIPTS_DIR:-/scripts}/common.sh"
     echo "[jdbc-seed] target=${PGHOST}:${PGPORT}/${PGDATABASE} user=${PGUSER}"
     wait_for_db
 
@@ -142,7 +332,7 @@ data:
       echo "[jdbc-seed] schema already present — skipping 001-create-schema.sql"
     else
       echo "[jdbc-seed] applying 001-create-schema.sql"
-      $PSQL -f /schema/001-create-schema.sql
+      $PSQL -f "${SCHEMA_DIR:-/schema}/001-create-schema.sql"
       echo "[jdbc-seed] schema applied"
     fi
 
@@ -186,11 +376,17 @@ data:
     #     (catch-up for owners who logged in before this seed ran). The
     #     per-minute admin-enroll CronJob covers first-login users going forward.
     enroll_admins
+
+    # (4) Converge the declared connection set (#5991 / UAT row 115). Runs
+    #     AFTER enrollment so a fault here can never cost the owner their
+    #     admin grant, and again every minute from promote.sh.
+    seed_connections
     echo "[jdbc-seed] done."
   promote.sh: |
-    . /scripts/common.sh
+    . "${SCRIPTS_DIR:-/scripts}/common.sh"
     wait_for_db
     enroll_admins
+    seed_connections
   # Verbatim Apache Guacamole 1.5.5 PostgreSQL schema, vendored into the chart
   # (files/postgresql/001-create-schema.sql) and pinned to
   # .Values.guacamole.webapp.image.tag. Loaded here so the seed container needs
@@ -247,6 +443,18 @@ spec:
           image: {{ $pgImage | quote }}
           imagePullPolicy: IfNotPresent
           command: ["/bin/sh", "/scripts/seed.sh"]
+          # #5991: the node-shell connection's hostname. The downward API is
+          # the whole node-address mechanism — no cluster read, no RBAC, and
+          # nothing about the Sovereign's addresses baked into a public chart.
+          env:
+            - name: NODE_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
@@ -265,6 +473,13 @@ spec:
               readOnly: true
             - name: tmp
               mountPath: /tmp
+            {{- range $i, $t := $targets }}
+            {{- if $t.credentialSecretName }}
+            - name: conn-cred-{{ $i }}
+              mountPath: {{ printf "/conn-cred/%s" $t.name | quote }}
+              readOnly: true
+            {{- end }}
+            {{- end }}
           resources:
             {{- toYaml ($sj.resources | default (dict "requests" (dict "cpu" "10m" "memory" "64Mi") "limits" (dict "cpu" "200m" "memory" "128Mi"))) | nindent 12 }}
       volumes:
@@ -279,6 +494,16 @@ spec:
           emptyDir:
             medium: Memory
             sizeLimit: 8Mi
+        {{- range $i, $t := $targets }}
+        {{- if $t.credentialSecretName }}
+        # #5991: connection credential for {{ $t.name }} — optional, so the
+        # connection is still produced (credential-free) when it is absent.
+        - name: conn-cred-{{ $i }}
+          secret:
+            secretName: {{ $t.credentialSecretName | quote }}
+            optional: true
+        {{- end }}
+        {{- end }}
 ---
 {{- /* #3374 (2026-06-14): per-minute admin-enroll CronJob. Binds every
    SSO-auto-created JDBC USER into <adminGroup> membership so the owner's FIRST
@@ -340,6 +565,19 @@ spec:
               image: {{ $pgImage | quote }}
               imagePullPolicy: IfNotPresent
               command: ["/bin/sh", "/scripts/promote.sh"]
+              # #5991: same downward-API node address as the seed Job — this
+              # CronJob is the CONVERGING leg of the connection producer, so a
+              # restored or rebuilt database returns to the declared set on its
+              # own within one minute.
+              env:
+                - name: NODE_IP
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: status.hostIP
+                - name: NODE_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: spec.nodeName
               securityContext:
                 allowPrivilegeEscalation: false
                 readOnlyRootFilesystem: true
@@ -354,6 +592,13 @@ spec:
                   readOnly: true
                 - name: tmp
                   mountPath: /tmp
+                {{- range $i, $t := $targets }}
+                {{- if $t.credentialSecretName }}
+                - name: conn-cred-{{ $i }}
+                  mountPath: {{ printf "/conn-cred/%s" $t.name | quote }}
+                  readOnly: true
+                {{- end }}
+                {{- end }}
               resources:
                 requests:
                   cpu: 10m
@@ -373,4 +618,12 @@ spec:
               emptyDir:
                 medium: Memory
                 sizeLimit: 8Mi
+            {{- range $i, $t := $targets }}
+            {{- if $t.credentialSecretName }}
+            - name: conn-cred-{{ $i }}
+              secret:
+                secretName: {{ $t.credentialSecretName | quote }}
+                optional: true
+            {{- end }}
+            {{- end }}
 {{- end }}

--- a/platform/guacamole/chart/tests/connection-seed-render.sh
+++ b/platform/guacamole/chart/tests/connection-seed-render.sh
@@ -1,0 +1,265 @@
+#!/usr/bin/env bash
+# connection-seed-render — the chart must SHIP a connection producer, and it
+# must produce nothing when nothing is declared.
+#
+# WHY THIS FILE EXISTS (#5991 / UAT row 115). `guacamole_connection` is created
+# empty by the vendored Apache schema and, until 0.2.38, no writer existed
+# anywhere in the repository — not a CRD, not a controller, not a chart hook,
+# not the catalyst-api `GuacamoleClient` (interface only, no production
+# implementation). A signed-in sovereign-admin reached Guacamole successfully
+# and landed on an empty ALL CONNECTIONS list. The four sibling test scripts
+# all passed throughout, because none of them asserted anything about a
+# connection: deleting seed_connections() left the suite green.
+#
+# The load-bearing pair here is:
+#   * the producer renders a real target, and
+#   * the CONTROL — an empty declared set renders ZERO connection writes.
+# Without the control, this file would also pass for a producer that invents a
+# row, which on a table that holds credentials is worse than the empty list
+# row 115 is about.
+set -euo pipefail
+
+CHART_DIR="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+TMP="$(mktemp -d)"
+trap 'rm -rf "${TMP}"' EXIT
+fails=0
+pass() { printf '  ok   — %s\n' "$1"; }
+fail() { printf '  FAIL — %s\n' "$1"; fails=$((fails + 1)); }
+
+cd "${CHART_DIR}"
+if [[ ! -d charts ]] || [[ -z "$(ls -A charts 2>/dev/null)" ]]; then
+  helm dependency update >/dev/null 2>&1 || {
+    echo "[connection-seed] SKIPPED — helm dependency update failed (no network);"
+    echo "[connection-seed] NOTHING WAS ASSERTED. Re-run after \`helm dep build\`."
+    exit 0
+  }
+fi
+
+# --api-versions is REQUIRED: the seed Job + enroll CronJob are gated on
+# `.Capabilities.APIVersions.Has "postgresql.cnpg.io/v1"`, and without it the
+# render is silently empty and every assertion below "fails" for a reason that
+# has nothing to do with the chart. The vacuity check at the end catches that.
+render() { # render <outfile> [extra --set args…]
+  local out="$1"; shift
+  helm template bp-guacamole . \
+    --api-versions postgresql.cnpg.io/v1 \
+    --set guacamole.enabled=true \
+    --set guacamole.httproute.hostname=guacamole.test \
+    --set guacamole.oidc.issuer=https://kc.test/realms/c \
+    "$@" >"${out}" 2>"${out}.err"
+}
+
+# scripts <render> <key> — the ConfigMap value, parsed as YAML so a comment
+# elsewhere in the render can never satisfy an assertion.
+scripts() {
+  python3 - "$1" "$2" <<'PY'
+import sys, yaml
+docs = [d for d in yaml.safe_load_all(open(sys.argv[1])) if d]
+for d in docs:
+    if d.get("kind") == "ConfigMap" and d.get("metadata", {}).get("name", "").endswith("-jdbc-seed-scripts"):
+        sys.stdout.write((d.get("data") or {}).get(sys.argv[2], ""))
+        break
+PY
+}
+
+# body <script-file> <function> — just the named shell function's body, so
+# "the producer emits no writes" cannot be satisfied by a call in a comment or
+# in a different function.
+body() {
+  python3 - "$1" "$2" <<'PY'
+import re, sys
+text = open(sys.argv[1]).read()
+m = re.search(r"^%s\(\) \{\n(.*?)^\}" % re.escape(sys.argv[2]), text, re.S | re.M)
+sys.stdout.write(m.group(1) if m else "")
+PY
+}
+
+echo "[connection-seed] 1/6 — default render ships a producer"
+render "${TMP}/default.yaml" || { echo "helm template failed:"; cat "${TMP}/default.yaml.err"; exit 1; }
+scripts "${TMP}/default.yaml" common.sh >"${TMP}/common.sh"
+scripts "${TMP}/default.yaml" seed.sh >"${TMP}/seed.sh"
+scripts "${TMP}/default.yaml" promote.sh >"${TMP}/promote.sh"
+common="$(cat "${TMP}/common.sh")"
+seed="$(cat "${TMP}/seed.sh")"
+promote="$(cat "${TMP}/promote.sh")"
+
+for fn in ensure_connection set_connection_parameter load_connection_credentials seed_connections; do
+  if printf '%s' "${common}" | grep -q "^${fn}() {"; then
+    pass "common.sh defines ${fn}()"
+  else
+    fail "common.sh does not define ${fn}() — the producer is missing"
+  fi
+done
+
+# Both legs: the one-shot seed writes the set, the per-minute CronJob converges
+# it. Losing either leg is the #5598 shape (one leg deleted, suite still green).
+if printf '%s' "${seed}" | grep -qx 'seed_connections'; then
+  pass "seed.sh calls seed_connections (install/upgrade leg)"
+else
+  fail "seed.sh never calls seed_connections"
+fi
+if printf '%s' "${promote}" | grep -qx 'seed_connections'; then
+  pass "promote.sh calls seed_connections (per-minute converging leg)"
+else
+  fail "promote.sh never calls seed_connections — the set would never re-converge"
+fi
+
+echo "[connection-seed] 2/6 — the produced connection is a real, named target"
+seed_body="$(body "${TMP}/common.sh" seed_connections)"
+if printf '%s' "${seed_body}" | grep -q "ensure_connection 'sovereign-node' 'ssh'"; then
+  pass "seed_connections() creates the sovereign-node ssh connection (asserted on the VALUES)"
+else
+  fail "seed_connections() has no sovereign-node/ssh target"
+fi
+# The hostname must come from the downward API at run time — a hardcoded
+# address in a public chart would be both wrong and a leak.
+if printf '%s' "${seed_body}" | grep -q 'set_connection_parameter .sovereign-node. .hostname. "\${NODE_IP}"'; then
+  pass "hostname is \${NODE_IP} (downward API), not a baked address"
+else
+  fail "hostname is not sourced from \${NODE_IP}"
+fi
+if printf '%s' "${seed_body}" | grep -q "NODE_IP:-" && printf '%s' "${seed_body}" | grep -q 'NOT written'; then
+  pass "an empty NODE_IP writes no connection (runtime half of the control)"
+else
+  fail "no runtime guard on an empty NODE_IP — the producer could write a hostname-less row"
+fi
+
+echo "[connection-seed] 3/6 — idempotent and permission-granting SQL"
+if printf '%s' "${common}" | grep -A4 'INSERT INTO guacamole_connection (connection_name, protocol)' | grep -q 'WHERE NOT EXISTS'; then
+  pass "the connection INSERT is guarded by NOT EXISTS (re-run adds no duplicate)"
+else
+  fail "the connection INSERT has no NOT EXISTS guard — UNIQUE(connection_name, parent_id) does NOT dedupe when parent_id IS NULL"
+fi
+if printf '%s' "${common}" | grep -A6 'INSERT INTO guacamole_connection_parameter' | grep -q 'ON CONFLICT'; then
+  pass "parameter writes converge via ON CONFLICT DO UPDATE"
+else
+  fail "parameter writes are not idempotent"
+fi
+if printf '%s' "${common}" | grep -q "INSERT INTO guacamole_connection_permission"; then
+  pass "the admin USER_GROUP is granted READ on the connection"
+else
+  fail "no connection_permission grant — a non-admin group member would not see the connection"
+fi
+
+echo "[connection-seed] 4/6 — CONTROL: an empty declared set writes nothing"
+render "${TMP}/empty.yaml" \
+  --set guacamole.database.connections.nodeShell.enabled=false \
+  --set-json 'guacamole.database.connections.extra=[]' \
+  || { echo "helm template failed:"; cat "${TMP}/empty.yaml.err"; exit 1; }
+scripts "${TMP}/empty.yaml" common.sh >"${TMP}/empty-common.sh"
+empty_common="$(cat "${TMP}/empty-common.sh")"
+if [[ -z "${empty_common}" ]]; then
+  fail "CONTROL rendered no seed ConfigMap at all — the control asserts nothing"
+else
+  empty_body="$(body "${TMP}/empty-common.sh" seed_connections)"
+  n="$(printf '%s\n' "${empty_body}" | grep -c 'ensure_connection ' || true)"
+  if [[ "${n}" == "0" ]]; then
+    pass "no declared target ⇒ ZERO connection writes (not one fabricated row)"
+  else
+    fail "CONTROL: ${n} connection write(s) rendered from an empty declared set"
+  fi
+  if printf '%s' "${empty_common}" | grep -q '^seed_connections() {'; then
+    pass "CONTROL is non-vacuous: seed_connections() still renders, it just writes nothing"
+  else
+    fail "CONTROL: seed_connections() absent, so the zero-writes result proves nothing"
+  fi
+fi
+
+echo "[connection-seed] 5/6 — credentials cannot be declared in values"
+if render "${TMP}/cred.yaml" \
+     --set 'guacamole.database.connections.extra[0].name=legacy' \
+     --set 'guacamole.database.connections.extra[0].protocol=rdp' \
+     --set 'guacamole.database.connections.extra[0].parameters.hostname=10.0.0.9' \
+     --set 'guacamole.database.connections.extra[0].parameters.password=hunter2'; then
+  fail "a password in values rendered successfully — it would ship in a ConfigMap, in a PUBLIC repo"
+else
+  if grep -q 'credential parameter' "${TMP}/cred.yaml.err"; then
+    pass "a credential parameter in values FAILS the render, naming the parameter"
+  else
+    fail "render failed but not with the credential guard message: $(head -2 "${TMP}/cred.yaml.err")"
+  fi
+fi
+if render "${TMP}/quote.yaml" \
+     --set 'guacamole.database.connections.nodeShell.name=bad'"'"'name'; then
+  fail "a quote in a connection name rendered — it breaks out of the rendered shell word"
+else
+  pass "a quote in a connection name FAILS the render"
+fi
+# A declared target with nowhere to dial is a broken row, which is what the
+# row-115 vacuity guard is aimed at.
+if render "${TMP}/nohost.yaml" \
+     --set 'guacamole.database.connections.extra[0].name=nowhere' \
+     --set 'guacamole.database.connections.extra[0].protocol=ssh'; then
+  fail "a connection with no hostname rendered — it would seed a row that cannot dial"
+else
+  pass "a declared target with no hostname FAILS the render"
+fi
+# …and the same entry WITH a hostname must render, so the guard above is not
+# just rejecting every extra entry.
+if render "${TMP}/withhost.yaml" \
+     --set 'guacamole.database.connections.extra[0].name=nowhere' \
+     --set 'guacamole.database.connections.extra[0].protocol=ssh' \
+     --set 'guacamole.database.connections.extra[0].parameters.hostname=10.0.0.9'; then
+  scripts "${TMP}/withhost.yaml" common.sh >"${TMP}/withhost-common.sh"
+  if body "${TMP}/withhost-common.sh" seed_connections | grep -q "ensure_connection 'nowhere' 'ssh'"; then
+    pass "an extra target WITH a hostname renders its own connection"
+  else
+    fail "the extra target did not render a connection write"
+  fi
+else
+  fail "a valid extra target failed to render: $(head -2 "${TMP}/withhost.yaml.err")"
+fi
+
+echo "[connection-seed] 6/6 — credential Secret is mounted, optional, on both legs"
+render "${TMP}/secret.yaml" \
+  --set guacamole.database.connections.nodeShell.credentialSecretName=guac-node-key \
+  || { echo "helm template failed:"; cat "${TMP}/secret.yaml.err"; exit 1; }
+mounts="$(python3 - "${TMP}/secret.yaml" <<'PY'
+import sys, yaml
+out = []
+for d in (x for x in yaml.safe_load_all(open(sys.argv[1])) if x):
+    kind = d.get("kind")
+    if kind == "Job":
+        spec = d["spec"]["template"]["spec"]
+    elif kind == "CronJob":
+        spec = d["spec"]["jobTemplate"]["spec"]["template"]["spec"]
+    else:
+        continue
+    for v in spec.get("volumes", []):
+        sec = v.get("secret") or {}
+        if sec.get("secretName") == "guac-node-key":
+            out.append(f"{kind}:volume:optional={sec.get('optional')}")
+    for c in spec.get("containers", []):
+        for m in c.get("volumeMounts", []):
+            if m.get("mountPath") == "/conn-cred/sovereign-node":
+                out.append(f"{kind}:mount:readOnly={m.get('readOnly')}")
+        for e in c.get("env", []) or []:
+            fp = ((e.get("valueFrom") or {}).get("fieldRef") or {}).get("fieldPath")
+            if e.get("name") == "NODE_IP":
+                out.append(f"{kind}:NODE_IP={fp}")
+print("\n".join(out))
+PY
+)"
+for want in "Job:volume:optional=True" "CronJob:volume:optional=True" \
+            "Job:mount:readOnly=True" "CronJob:mount:readOnly=True" \
+            "Job:NODE_IP=status.hostIP" "CronJob:NODE_IP=status.hostIP"; do
+  if printf '%s\n' "${mounts}" | grep -qx -- "${want}"; then
+    pass "${want}"
+  else
+    fail "missing: ${want} (got: $(printf '%s' "${mounts}" | tr '\n' ' '))"
+  fi
+done
+
+# Vacuity check — every assertion above reads the seed ConfigMap, so prove the
+# default render actually contained the seed Job it belongs to.
+if grep -q 'catalyst.openova.io/component: jdbc-seed' "${TMP}/default.yaml"; then
+  pass "vacuity: the default render did contain the jdbc-seed Job"
+else
+  fail "vacuity: no jdbc-seed Job in the default render — assertions above were empty-string comparisons"
+fi
+
+if [[ "${fails}" -gt 0 ]]; then
+  echo "[connection-seed] ${fails} assertion(s) FAILED"
+  exit 1
+fi
+echo "[connection-seed] all assertions passed"

--- a/platform/guacamole/chart/tests/connection-seed-sql.sh
+++ b/platform/guacamole/chart/tests/connection-seed-sql.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+# connection-seed-sql — run the SHIPPED seed script against a real Postgres.
+#
+# WHY THIS FILE EXISTS (#5991 / UAT row 115). tests/connection-seed-render.sh
+# asserts the producer is rendered; it cannot tell you whether the SQL it
+# renders actually inserts a row, inserts exactly one row on a second run, or
+# grants the permission that makes the row visible. Row 115 is a claim about
+# what is IN the database, so the strongest available test executes the real
+# chart artifact — the seed.sh + common.sh that ship in the ConfigMap, not a
+# copy of them — against a throwaway Postgres, and reads the tables back.
+#
+# The two questions it settles, which no render assertion can:
+#   * re-running writes no duplicate (the per-minute CronJob runs it ~1440×/day,
+#     and UNIQUE(connection_name, parent_id) does NOT dedupe when parent_id IS
+#     NULL, so this is a real failure mode, not a hypothetical one), and
+#   * an empty declared set leaves the table EMPTY while the same script still
+#     seeds the admin group — a control that a fabricating producer fails.
+#
+# Database: uses $PGHOST/$PGPORT/$PGUSER/$PGPASSWORD if exported, else starts
+# an ephemeral postgres via podman/docker. With neither, it SKIPS LOUDLY —
+# nothing is asserted, and the render test remains the CI gate.
+set -euo pipefail
+
+CHART_DIR="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+TMP="$(mktemp -d)"
+CTR=""
+cleanup() {
+  [[ -n "${CTR}" ]] && ${RUNTIME:-true} rm -f "${CTR}" >/dev/null 2>&1 || true
+  rm -rf "${TMP}"
+}
+trap cleanup EXIT
+fails=0
+pass() { printf '  ok   — %s\n' "$1"; }
+fail() { printf '  FAIL — %s\n' "$1"; fails=$((fails + 1)); }
+
+cd "${CHART_DIR}"
+command -v psql >/dev/null 2>&1 || {
+  echo "[connection-seed-sql] SKIPPED — no psql client; NOTHING WAS ASSERTED."
+  exit 0
+}
+if [[ ! -d charts ]] || [[ -z "$(ls -A charts 2>/dev/null)" ]]; then
+  helm dependency update >/dev/null 2>&1 || {
+    echo "[connection-seed-sql] SKIPPED — helm dependency update failed (no network);"
+    echo "[connection-seed-sql] NOTHING WAS ASSERTED."
+    exit 0
+  }
+fi
+
+# ── a database ────────────────────────────────────────────────────────────
+PGPORT="${PGPORT:-}"
+if [[ -n "${PGHOST:-}" && -n "${PGUSER:-}" && -n "${PGPASSWORD:-}" ]]; then
+  echo "[connection-seed-sql] using the exported PG* connection"
+  ADMIN_DB="${PGDATABASE:-postgres}"
+else
+  RUNTIME=""
+  for r in podman docker; do
+    if command -v "$r" >/dev/null 2>&1 && "$r" info >/dev/null 2>&1; then RUNTIME="$r"; break; fi
+  done
+  if [[ -z "${RUNTIME}" ]]; then
+    echo "[connection-seed-sql] SKIPPED — no PG* env and no usable podman/docker;"
+    echo "[connection-seed-sql] NOTHING WAS ASSERTED. Export PGHOST/PGPORT/PGUSER/PGPASSWORD to run it."
+    exit 0
+  fi
+  PGPORT="$(python3 -c 'import socket;s=socket.socket();s.bind(("127.0.0.1",0));print(s.getsockname()[1]);s.close()')"
+  export PGHOST=127.0.0.1 PGUSER=guacamole PGPASSWORD=seedtest
+  ADMIN_DB=postgres
+  CTR="$("${RUNTIME}" run --rm -d \
+    -e POSTGRES_PASSWORD="${PGPASSWORD}" -e POSTGRES_USER="${PGUSER}" \
+    -p "127.0.0.1:${PGPORT}:5432" docker.io/library/postgres:16-alpine 2>/dev/null | tail -1)"
+  [[ -n "${CTR}" ]] || { echo "[connection-seed-sql] SKIPPED — could not start postgres; NOTHING WAS ASSERTED."; exit 0; }
+  echo "[connection-seed-sql] ephemeral postgres on 127.0.0.1:${PGPORT}"
+fi
+export PGPORT PGHOST PGUSER PGPASSWORD
+q() { psql -qtA -d "$1" -c "$2" | tr -d ' '; }
+for _ in $(seq 1 30); do q "${ADMIN_DB}" "SELECT 1" >/dev/null 2>&1 && break; sleep 2; done
+q "${ADMIN_DB}" "SELECT 1" >/dev/null || { echo "[connection-seed-sql] SKIPPED — database never became reachable; NOTHING WAS ASSERTED."; exit 0; }
+
+# ── the shipped scripts, straight out of the rendered ConfigMap ───────────
+extract() { # extract <outdir> [--set …]
+  local dir="$1"; shift
+  mkdir -p "${dir}"
+  helm template bp-guacamole . \
+    --api-versions postgresql.cnpg.io/v1 \
+    --set guacamole.enabled=true \
+    --set guacamole.httproute.hostname=guacamole.test \
+    --set guacamole.oidc.issuer=https://kc.test/realms/c \
+    "$@" >"${dir}/render.yaml"
+  python3 - "${dir}" <<'PY'
+import os, sys, yaml
+d = sys.argv[1]
+for doc in (x for x in yaml.safe_load_all(open(os.path.join(d, "render.yaml"))) if x):
+    if doc.get("kind") == "ConfigMap" and doc.get("metadata", {}).get("name", "").endswith("-jdbc-seed-scripts"):
+        for k, v in (doc.get("data") or {}).items():
+            open(os.path.join(d, k), "w").write(v)
+        break
+else:
+    sys.exit("no jdbc-seed scripts ConfigMap rendered")
+PY
+}
+creds() { # creds <dir> <dbname>
+  mkdir -p "$1"
+  printf '%s' "${PGHOST}"      >"$1/host"
+  printf '%s' "${PGPORT:-5432}">"$1/port"
+  printf '%s' "$2"             >"$1/dbname"
+  printf '%s' "${PGUSER}"      >"$1/user"
+  printf '%s' "${PGPASSWORD}"  >"$1/password"
+}
+run_seed() { # run_seed <scriptdir> <creddir>
+  CRED="$2" SCRIPTS_DIR="$1" SCHEMA_DIR="$1" NODE_IP="10.9.8.7" NODE_NAME="cp-1" \
+    sh "$1/seed.sh" >>"${TMP}/seed.log" 2>&1
+}
+
+echo "[connection-seed-sql] 1/4 — the producer writes a real connection"
+extract "${TMP}/armed"
+q "${ADMIN_DB}" "DROP DATABASE IF EXISTS guac_armed" >/dev/null
+q "${ADMIN_DB}" "CREATE DATABASE guac_armed" >/dev/null
+creds "${TMP}/cred-armed" guac_armed
+run_seed "${TMP}/armed" "${TMP}/cred-armed" || { echo "seed.sh failed:"; tail -30 "${TMP}/seed.log"; exit 1; }
+
+n="$(q guac_armed "SELECT count(*) FROM guacamole_connection")"
+[[ "${n}" == "1" ]] && pass "guacamole_connection holds 1 row (was 0 on every Sovereign)" \
+                    || fail "guacamole_connection holds ${n} rows, want 1"
+got="$(q guac_armed "SELECT connection_name || '/' || protocol FROM guacamole_connection")"
+[[ "${got}" == "sovereign-node/ssh" ]] && pass "the row is sovereign-node/ssh" \
+                                       || fail "row is ${got}, want sovereign-node/ssh"
+host="$(q guac_armed "SELECT parameter_value FROM guacamole_connection_parameter WHERE parameter_name='hostname'")"
+[[ "${host}" == "10.9.8.7" ]] && pass "hostname parameter carries the downward-API node IP" \
+                              || fail "hostname is '${host}', want 10.9.8.7 (the NODE_IP the Pod was given)"
+params="$(q guac_armed "SELECT string_agg(parameter_name || '=' || parameter_value, ',' ORDER BY parameter_name) FROM guacamole_connection_parameter")"
+[[ "${params}" == "hostname=10.9.8.7,port=22,username=root" ]] \
+  && pass "parameters are exactly hostname/port/username" \
+  || fail "parameters are '${params}'"
+perm="$(q guac_armed "SELECT e.name || ':' || p.permission FROM guacamole_connection_permission p JOIN guacamole_entity e USING (entity_id)")"
+[[ "${perm}" == "sovereign-admins:READ" ]] && pass "the admin USER_GROUP holds READ on the connection" \
+                                           || fail "connection permission is '${perm}', want sovereign-admins:READ"
+# No credential Secret was mounted, so nothing credential-shaped may exist.
+leaked="$(q guac_armed "SELECT count(*) FROM guacamole_connection_parameter WHERE parameter_name IN ('password','private-key','passphrase')")"
+[[ "${leaked}" == "0" ]] && pass "no credential parameter written when no Secret is mounted" \
+                         || fail "${leaked} credential parameter(s) written from a chart with no Secret"
+
+echo "[connection-seed-sql] 2/4 — re-running converges instead of duplicating"
+run_seed "${TMP}/armed" "${TMP}/cred-armed" || { echo "second seed.sh failed:"; tail -30 "${TMP}/seed.log"; exit 1; }
+n2="$(q guac_armed "SELECT count(*) FROM guacamole_connection")"
+p2="$(q guac_armed "SELECT count(*) FROM guacamole_connection_parameter")"
+r2="$(q guac_armed "SELECT count(*) FROM guacamole_connection_permission")"
+[[ "${n2}" == "1" && "${p2}" == "3" && "${r2}" == "1" ]] \
+  && pass "second run: 1 connection / 3 parameters / 1 permission (no duplicates)" \
+  || fail "second run drifted: connections=${n2} parameters=${p2} permissions=${r2}"
+
+echo "[connection-seed-sql] 3/4 — CONTROL: an empty declared set writes NO connection"
+extract "${TMP}/empty" \
+  --set guacamole.database.connections.nodeShell.enabled=false \
+  --set-json 'guacamole.database.connections.extra=[]'
+q "${ADMIN_DB}" "DROP DATABASE IF EXISTS guac_empty" >/dev/null
+q "${ADMIN_DB}" "CREATE DATABASE guac_empty" >/dev/null
+creds "${TMP}/cred-empty" guac_empty
+run_seed "${TMP}/empty" "${TMP}/cred-empty" || { echo "control seed.sh failed:"; tail -30 "${TMP}/seed.log"; exit 1; }
+cn="$(q guac_empty "SELECT count(*) FROM guacamole_connection")"
+[[ "${cn}" == "0" ]] && pass "no declared target ⇒ 0 connection rows (nothing invented)" \
+                     || fail "CONTROL: ${cn} connection row(s) appeared from an empty declared set"
+# Non-vacuous: the SAME script ran and did its identity work in this database.
+gn="$(q guac_empty "SELECT count(*) FROM guacamole_user_group")"
+[[ "${gn}" == "1" ]] && pass "CONTROL is non-vacuous: the same run seeded the admin USER_GROUP" \
+                     || fail "CONTROL: admin USER_GROUP count is ${gn} — the script did not really run"
+
+echo "[connection-seed-sql] 4/4 — credentials come from the Secret, never from the chart"
+extract "${TMP}/cred" --set guacamole.database.connections.nodeShell.credentialSecretName=guac-node-key
+mkdir -p "${TMP}/mounted/sovereign-node"
+printf '%s' '-----BEGIN OPENSSH PRIVATE KEY-----
+TEST-ONLY-NOT-A-REAL-KEY
+-----END OPENSSH PRIVATE KEY-----' >"${TMP}/mounted/sovereign-node/private-key"
+q "${ADMIN_DB}" "DROP DATABASE IF EXISTS guac_cred" >/dev/null
+q "${ADMIN_DB}" "CREATE DATABASE guac_cred" >/dev/null
+creds "${TMP}/cred-cred" guac_cred
+CRED="${TMP}/cred-cred" SCRIPTS_DIR="${TMP}/cred" SCHEMA_DIR="${TMP}/cred" \
+  CONN_CRED_DIR="${TMP}/mounted" NODE_IP="10.9.8.7" NODE_NAME="cp-1" \
+  sh "${TMP}/cred/seed.sh" >>"${TMP}/seed.log" 2>&1 || { echo "credential seed.sh failed:"; tail -30 "${TMP}/seed.log"; exit 1; }
+kn="$(q guac_cred "SELECT count(*) FROM guacamole_connection_parameter WHERE parameter_name='private-key'")"
+[[ "${kn}" == "1" ]] && pass "the mounted Secret's private-key reached the connection" \
+                     || fail "private-key parameter count is ${kn}, want 1"
+if grep -q 'TEST-ONLY-NOT-A-REAL-KEY' "${TMP}/cred/render.yaml"; then
+  fail "the key material appears in the rendered manifests — a chart must never carry it"
+else
+  pass "the rendered manifests carry the Secret NAME only, never the material"
+fi
+
+if [[ "${fails}" -gt 0 ]]; then
+  echo "[connection-seed-sql] ${fails} assertion(s) FAILED"
+  exit 1
+fi
+echo "[connection-seed-sql] all assertions passed"

--- a/platform/guacamole/chart/values.yaml
+++ b/platform/guacamole/chart/values.yaml
@@ -376,6 +376,58 @@ guacamole:
     # (operators only), so enrolling SSO users as admin matches the chart's
     # intent (same model as bp-newapi's promote CronJob). Idempotent.
     promoteSchedule: "* * * * *"
+    # ── Connection producer (#5991 / UAT row 115, 2026-08-13) ──────
+    # Everything above seeds IDENTITY — the <adminGroup> USER_GROUP and its
+    # ADMINISTER + CREATE_* system permissions. That is the RIGHT to create a
+    # connection; until this block existed, nothing in the repository ever
+    # inserted one, so `guacamole_connection` sat at zero rows on every
+    # Sovereign and a signed-in sovereign-admin landed on an empty ALL
+    # CONNECTIONS list. seed_connections() in the schema-seed ConfigMap is the
+    # producer; the per-minute enroll CronJob re-runs it, so the declared set
+    # converges rather than being written once.
+    #
+    # CREDENTIALS ARE NEVER DECLARED HERE. This repo is public and these
+    # values land in a ConfigMap. A target names an OPTIONAL Secret
+    # (`credentialSecretName`); the seeder mounts it read-only at
+    # /conn-cred/<connection-name> and reads the keys `username`, `password`,
+    # `private-key`, `passphrase` at run time. Setting any credential-shaped
+    # parameter under `parameters` FAILS the helm render on purpose.
+    connections:
+      # Master switch. OFF means the producer's body renders empty and writes
+      # zero rows — never a fabricated row.
+      enabled: true
+      # The default target, and the only one the chart can name on its own: a
+      # node of this Sovereign. Its address comes from the seeder Pod's own
+      # downward API (status.hostIP), so no node list is baked into the chart
+      # and the seeder needs no cluster read.
+      #
+      # HONEST LIMIT: the Sovereign's node sshd is key-only
+      # (`PasswordAuthentication no`, `PermitRootLogin prohibit-password` —
+      # infra/providers/_shared/cloudinit-control-plane.tftpl), and the node
+      # SSH private key is deliberately NOT in the cluster. Leave
+      # credentialSecretName empty and Guacamole opens the connection and
+      # prompts; point it at a Secret holding `private-key` (+ `passphrase`)
+      # and the session authenticates. Which operator holds that key is a
+      # Sovereign decision, not a platform one.
+      nodeShell:
+        enabled: true
+        name: sovereign-node
+        protocol: ssh
+        port: 22
+        username: root
+        credentialSecretName: ""
+      # Additional connections declared by the per-Sovereign overlay. Each
+      # entry: {name, protocol, parameters: {…}, credentialSecretName}. The
+      # `parameters` map is guacd's own parameter set (hostname, port, …) and
+      # must carry NO credential — see the render guard above.
+      #   extra:
+      #     - name: legacy-erp
+      #       protocol: rdp
+      #       parameters:
+      #         hostname: "10.42.7.12"
+      #         port: "3389"
+      #       credentialSecretName: guacamole-legacy-erp
+      extra: []
     # Image for the schema-seed Job's psql container (same CNPG postgres image
     # as the cluster — has psql). The schema SQL itself is copied out of the
     # guacamole webapp image by an initContainer.

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-13T10:13:50.324Z",
+  "generatedAt": "2026-08-13T12:17:11.398Z",
   "blueprints": [
     {
       "id": "bp-agenity",
@@ -1817,7 +1817,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "listed",
-      "version": "0.2.37",
+      "version": "0.2.38",
       "section": "pts-3-1-networking-and-service-mesh",
       "depends": [
         "bp-keycloak",

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -1952,7 +1952,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "listed",
-    "version": "0.2.37",
+    "version": "0.2.38",
     "section": "pts-3-1-networking-and-service-mesh",
     "depends": [
       "bp-keycloak",

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3908,7 +3908,16 @@ name: bp-catalyst-platform
 #   seed pin is the delivery half: without this republish a pinned Sovereign
 #   resolves 0.2.20 and never sees the failback. This chart's own templates are
 #   unchanged apart from the seed entry.
-version: 1.4.1439
+# 1.4.1440 — #5991 (UAT row 115): catalog-seed advances bp-guacamole 0.2.37 ->
+#   0.2.38, the release that finally WRITES a Guacamole connection. Nothing in
+#   the repository had ever inserted into `guacamole_connection`, so a signed-in
+#   sovereign-admin reached Guacamole and landed on an empty ALL CONNECTIONS
+#   list — the identity half (admin USER_GROUP + CREATE_* permissions) was the
+#   right to create a connection, not a connection. The seed pin is the delivery
+#   half: without this republish a pinned Sovereign resolves 0.2.37 and the list
+#   stays empty. This chart's own templates are unchanged apart from the seed
+#   entry.
+version: 1.4.1440
 # 1.4.1229 — #5389: catalog-seed bp-newapi declares its `ui` endpoint
 #   (newapi.<fqdn>, ssoEnabled, launchDefault, ssoInitPath "/") instead of
 #   `endpoints: []`. The empty list made userUIGatePasses fail closed, which

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -1740,7 +1740,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.2.37"
+  version: "0.2.38"
   visibility: listed
   card:
     title: "Apache Guacamole"
@@ -1768,7 +1768,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-guacamole
-    version: "0.2.37"
+    version: "0.2.38"
   topology:
     supported:
     - active-hot-standby


### PR DESCRIPTION
## The defect class is MISSING PRODUCER, and this ships the producer

UAT row 115 asserts `guacamole_connection` holds at least one row and the ALL
CONNECTIONS list renders it, with an explicit vacuity guard: *"the admin group's
`CREATE_*` system permissions are the RIGHT to create a connection, not a
connection — a permission-only check is a FAIL."*

### Every writer found: there were none

Searched repo-wide before writing a line, not in one tree:

| Candidate | Verdict |
|---|---|
| `INSERT INTO guacamole_connection` anywhere in the repo | **zero matches** (the only occurrence of the table name outside `docs/ledger/` is the DDL that creates it, `platform/guacamole/chart/files/postgresql/001-create-schema.sql:109`) |
| `GuacamoleConnection` CRD + `relay-controller` | never written — no Go type, no CRD manifest, no reconciler, no template. `platform/guacamole/README.md` was corrected on 2026-08-10 to say so |
| catalyst-api `GuacamoleClient` (`products/catalyst/bootstrap/api/internal/handler/k8s_exec.go:166`) | interface only. `SetGuacamoleClient` has **no non-test caller** — `cmd/api/main.go` never binds it, so `h.guacamoleClient()` is nil in every deployed catalyst-api and only the in-memory fallback branch runs. Even wired, it mints per-click sessions, not the standing list |
| quickconnect / json-auth extensions | not wired, so no non-DB path populates the list either |
| `chart/templates/jdbc-schema-seed-job.yaml` | writes `guacamole_entity`, `guacamole_user_group`, `guacamole_system_permission`, `guacamole_user_group_member` — the identity half. Exactly the shape row 115's vacuity guard names as a FAIL |

So the reader is fine and SSO is fine; nothing ever wrote a row. The earlier
session prior is confirmed.

### The producer

`seed_connections()` in the schema-seed ConfigMap, beside the identity seed that
already works. Called from `seed.sh` (install/upgrade) **and** `promote.sh` (the
per-minute admin-enroll CronJob), so the set converges after a restore or a
rebuild rather than being written once.

Idempotence is not decoration here — `promote.sh` runs ~1440×/day:

- the connection INSERT is `NOT EXISTS`-guarded, because the schema's
  `UNIQUE (connection_name, parent_id)` does **not** dedupe root-level
  connections (`parent_id` is NULL and Postgres treats NULLs as distinct), so a
  bare INSERT would add one duplicate per minute;
- parameters converge with `ON CONFLICT … DO UPDATE`;
- every value crosses into SQL as a psql `:'var'` literal, never concatenation.

Each connection also gets a `READ` grant for the admin USER_GROUP, so it renders
for a member who is not a system admin.

### The connection set, and why

**Default: one target — `sovereign-node`, ssh :22, user `root`, hostname from the
seeder Pod's downward API (`status.hostIP`).**

The brief named the Sovereign's own nodes as the obvious candidate and the chart
agrees. The downward API is the whole address mechanism: no node list baked into
a public chart, no cluster read, no new RBAC. Operators can declare more targets
under `guacamole.database.connections.extra`.

Two candidates were considered and rejected on the merits, recorded so the next
reader does not re-derive them:

- **kubectl-shell into a Pod.** guacd's `kubernetes` protocol authenticates to
  the kube-apiserver by **mTLS client certificate only** (no bearer token in
  1.5.5). Minting an apiserver-trusted client cert in-cluster means granting the
  seeder CSR `approve` on the `kubernetes.io/kube-apiserver-client` signer —
  which is **not scopeable by CN**, so it is cluster-admin-equivalent escalation
  shipped default-on in a public chart. Refused. The other wire is no better:
  `bp-k8s-ws-proxy` rejects any upgrade without `X-Catalyst-Timestamp` +
  `X-Catalyst-HMAC` (`core/cmd/k8s-ws-proxy/DESIGN.md:32-37`) and guacd cannot
  emit them. The browser shell into a Pod stays the console's `/shells/issue`
  path, which already works.
- **A target whose credentials the platform holds.** There is none, by design.

**Honest limit, stated plainly:** the node sshd is key-only
(`PasswordAuthentication no`, `PermitRootLogin prohibit-password` —
`infra/providers/_shared/cloudinit-control-plane.tftpl:118-136`) and the node SSH
private key is deliberately not in the cluster. With no `credentialSecretName`
the connection opens and Guacamole prompts; point it at a Secret holding
`private-key` and the session authenticates. Who holds that key is a Sovereign
decision, not a platform one — which is why the chart cannot and should not
carry it.

### How credentials are sourced

Never from values, this chart, or the ConfigMap — this repo is public and those
values land in a ConfigMap. A target names an **optional** Secret
(`credentialSecretName`); the seeder mounts it read-only at
`/conn-cred/<connection-name>` and reads `username` / `password` / `private-key`
/ `passphrase` at run time. `optional: true` means an absent Secret leaves the
connection credential-free instead of failing the seed.

Two render-time guards, both with live failure modes: a credential-shaped
parameter in values **fails the render**, and so does a target with no
`hostname` (a row that cannot dial is not a connection).

### Tests, and the mutant table

`chart/tests/connection-seed-render.sh` — render assertions plus the empty-set
control and the credential guard. `chart/tests/connection-seed-sql.sh` — starts a
throwaway Postgres and executes the **shipped** `seed.sh` + `common.sh` (not a
copy: the scripts gained `${VAR:-<pod path>}` defaults for `CRED` /
`SCRIPTS_DIR` / `SCHEMA_DIR` / `CONN_CRED_DIR`, pod behaviour unchanged), then
reads the tables back. Both are auto-discovered by the `chart/tests/*.sh` gate in
`blueprint-release.yaml`.

Baseline: render `rc=0` (23 assertions), sql `rc=0` (11 assertions). Every mutant
below still **renders cleanly** (`renders_rc=0`) — none is a compile break.

| # | Mutant | render rc | sql rc | Caught by |
|---|---|---|---|---|
| M1 | producer exists but `seed_connections` is never called (merged-but-unwired shape) | **1** | **1** | "seed.sh never calls seed_connections"; DB reads 0 rows |
| M2 | drop the `NOT EXISTS` guard from the connection INSERT | **1** | **1** | "no NOT EXISTS guard"; second run drifted: **connections=2** |
| M3 | delete the `guacamole_connection_permission` grant | **1** | **1** | "no connection_permission grant"; permission reads `''` |
| M4 | restore `default true $ns.enabled` as the off-switch | **1** | **1** | **both controls**: 1 write rendered / 1 row appeared from an empty declared set |
| M5 | delete the downward-API env from the CronJob (converging leg only) | **1** | 0 | render only — correctly, since the SQL suite executes `seed.sh`, not the CronJob's `promote.sh` |

M4 is not hypothetical: the empty-set control caught it **while this change was
being written**. `default true false` returns `true` in sprig, so
`nodeShell.enabled=false` armed the producer anyway. The fix is `hasKey`.

### The empty-set control

Both suites carry it, and both are non-vacuous:

- render: `nodeShell.enabled=false` + `extra: []` ⇒ **zero** `ensure_connection`
  calls, while `seed_connections()` still renders (so the zero is a real result,
  not an absent function);
- sql: the same run against a fresh database leaves `guacamole_connection` at
  **0 rows** while still seeding the admin USER_GROUP — proving the script ran.

Without it this PR would also pass for a producer that invents a row, which on a
credentials-bearing table is worse than the empty list row 115 is about.

### No live proof was taken

This is source plus a local database harness. Nothing was applied, patched, or
written to any cluster; every cluster interaction in this session was read-only,
and there is no NodePort anywhere in the change (`git diff` carries no port
literal in 30000-32767). **Row 115 flips only on a walk against a Sovereign
actually running >= 0.2.38** — the catalog-seed + slot-13 pins here are the
delivery half, not the proof.

### Lockstep

`platform/guacamole/chart/Chart.yaml` 0.2.38 · `blueprint.yaml` ·
`clusters/_template/bootstrap-kit/52-bp-guacamole.yaml` · catalog-seed pin (via
`scripts/sync-catalog-seed-pin.py`) · `products/catalyst/chart/Chart.yaml`
1.4.1440 + its slot-13 pin in the same commit (#5734 gate) · regenerated
`build-catalog.mjs` outputs. Versions taken by enumerating all open PR heads: no
open PR claims bp-guacamole 0.2.38 (highest claimed catalyst version on any open
head is 1.4.1423). This branch first took 1.4.1439 and had to be rebased: main's
deploy bot published that version while this was in flight, so the catalyst
release here is **1.4.1440** — the collision was caught by a `CONFLICTING`
mergeable state, not by a guard.

Guards run green: `check-catalog-seed-lockstep.sh`,
`check-bootstrap-kit-pin-sync.sh`, `check-chart-version-bumped.sh`,
`check-guards-are-wired.sh`, `check-no-banned-words.sh`, `helm lint`, and the
four pre-existing bp-guacamole chart suites (render, crossregion, httproute,
admin-enroll, g117-sso-secret) — all rc=0.

Refs #5991

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HvMZTDx7W6EPZMmjyXmYh1
