### PR TITLE
fix(catalyst): make the topology choice survive the round trip — status endpoint stops flattening spec.placement (row 16), install door can name the second region (row 60)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/applications.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications.go
@@ -303,11 +303,16 @@ type applicationStatusResponse struct {
 }
 
 // applicationStatusSpec is the spec subset the Topology tab consumes.
-// Placement is normalised to the editor posture string
-// (single-region | active-active | active-hotstandby) regardless of
-// whether the CR stored the legacy string form or the #3373 object form.
+//
+// `Placement` is DUAL-FORM, exactly as `Application.spec.placement` is
+// (#3373): the legacy posture STRING, or the #3969 object
+// `{mode, vcluster, regions, clusters, targets, ownedDependencies}`. It is
+// `any` rather than `string` because this endpoint is the console's only read
+// of the DESIRED placement, and a string cannot carry `targets[]` — see
+// placementValueForStatus for the defect that typing it `string` caused
+// (UAT row 16).
 type applicationStatusSpec struct {
-	Placement      string                 `json:"placement,omitempty"`
+	Placement      any                    `json:"placement,omitempty"`
 	Regions        []string               `json:"regions,omitempty"`
 	EnvironmentRef string                 `json:"environmentRef,omitempty"`
 	BlueprintRef   map[string]interface{} `json:"blueprintRef,omitempty"`
@@ -771,18 +776,14 @@ func (h *Handler) HandleApplicationStatus(w http.ResponseWriter, r *http.Request
 }
 
 // applicationStatusSpecFromCR projects the Application CR's spec subset
-// the Topology tab reads. Placement is normalised to the editor posture
-// string via placementForTopology so the editor's mode pre-select works
-// whether the CR stored the legacy string (`single-region`) or the
-// #3373 object form (`{mode: active-hotstandby, regions: [...]}`).
+// the Topology tab reads. Placement keeps the SHAPE the CR holds — see
+// placementValueForStatus.
 func applicationStatusSpecFromCR(obj *unstructured.Unstructured) *applicationStatusSpec {
 	if obj == nil {
 		return nil
 	}
 	spec := &applicationStatusSpec{}
-	// Placement: readTopology already handles string + object(mode) +
-	// label fallback; map its result onto the editor posture enum.
-	spec.Placement = placementForTopology(readTopology(obj))
+	spec.Placement = placementValueForStatus(obj)
 	if regions, ok, _ := unstructured.NestedStringSlice(obj.Object, "spec", "regions"); ok {
 		spec.Regions = regions
 	}
@@ -793,6 +794,74 @@ func applicationStatusSpecFromCR(obj *unstructured.Unstructured) *applicationSta
 		spec.BlueprintRef = br
 	}
 	return spec
+}
+
+// placementValueForStatus produces the value GET /applications/{name}/status
+// reports at `spec.placement`, resolving the CRD's DUAL FORM instead of
+// flattening it (UAT row 16).
+//
+// THE DEFECT IT CLOSES. This projection used to be one line:
+//
+//	spec.Placement = placementForTopology(readTopology(obj))
+//
+// onto a `string` field. `spec.placement` is dual-form by CRD design (#3373):
+// the STRING form carries the posture alone, the OBJECT form additionally
+// carries WHERE the instance runs — `vcluster`, `clusters`, `regions`, and
+// since #3969 the whole per-region `targets[]` model. Reducing all of that to
+// a posture token meant the object form NEVER reached the console.
+//
+// That is the READ half of the same round trip #6136 fixed the WRITE half of.
+// #6136 stopped the Topology-tab Save scalarising `spec.placement` so the
+// PlacementEditor's `targets[]` are finally PERSISTED; this endpoint then
+// dropped them again on the way back out, and it is the only read of the
+// DESIRED placement the tab has. The consequence is measurable in the
+// consumer: `AppDetail/TopologyTab.tsx` resolves its target list through a
+// three-rung chain whose rung 2 is
+//
+//	if (specPlacement && typeof specPlacement === 'object') { ...targets... }
+//
+// documented as "the #3969 desired-state the operator explicitly chose in the
+// editor (used pre-rollout / when the data plane is unavailable)". Against
+// this endpoint `typeof specPlacement` was ALWAYS 'string', so rung 2 —
+// exactly the rung that renders a placement the operator just Saved but whose
+// Pods have not moved yet — was unreachable, as was the sibling
+// `spec.placement.ownedDependencies` read. A Save wrote targets that nothing
+// could read back, and the tab kept rendering the pre-Save posture.
+//
+// THE RULES, deliberately mirroring placementValueForUpdate on the write side
+// so one dual-form producer faces each direction:
+//   - A CR holding the OBJECT form is reported as an object, verbatim, with
+//     `mode` REWRITTEN to the canonical token (#3375 DoD-1) so one vocabulary
+//     still holds on the wire regardless of which spelling was stored.
+//   - A CR holding the string form (or none at all) is reported as the posture
+//     STRING via the pre-existing placementForTopology(readTopology(...)) path
+//     — byte-identical to the previous behaviour, including its
+//     empty/unknown → `singleton` display default for the listing-style
+//     consumers that have always relied on it.
+//
+// It never SYNTHESISES an object: an Application that declares only a posture
+// reports only a posture. Inventing `targets` here would hand the tab a
+// declared intention it could not distinguish from an observed one, which is
+// the #5568 defect this repo has already paid for once.
+func placementValueForStatus(obj *unstructured.Unstructured) any {
+	posture := placementForTopology(readTopology(obj))
+	if obj == nil {
+		return posture
+	}
+	raw, found, err := unstructured.NestedFieldNoCopy(obj.Object, "spec", "placement")
+	if err != nil || !found {
+		return posture
+	}
+	cur, isObject := raw.(map[string]interface{})
+	if !isObject {
+		return posture
+	}
+	out := make(map[string]interface{}, len(cur)+1)
+	for k, v := range cur {
+		out[k] = v
+	}
+	out["mode"] = posture
+	return out
 }
 
 // ── HTTP handler — SSE status stream ────────────────────────────────
@@ -970,6 +1039,11 @@ func validateApplicationInstallRequest(req applicationInstallRequest) (string, b
 		if strings.TrimSpace(r) == "" {
 			return fmt.Sprintf("placement.regions[%d] is empty", i), false
 		}
+	}
+	// UAT row 60 — a multi-region posture over one region is a DR promise
+	// nothing downstream can keep. See placementRegionCountError.
+	if msg := placementRegionCountError(req.Placement.Mode, req.Placement.Regions); msg != "" {
+		return msg, false
 	}
 	// #3373 — instance placement WHERE fields.
 	// #5616 — separate "not a tier at all" from "a real tier this

--- a/products/catalyst/bootstrap/api/internal/handler/applications_placement_region_count.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications_placement_region_count.go
@@ -2,7 +2,6 @@ package handler
 
 import (
 	"fmt"
-	"sort"
 	"strings"
 )
 
@@ -73,17 +72,24 @@ func placementRegionCountError(mode string, regions []string) string {
 	if len(distinct) >= 2 {
 		return ""
 	}
-	sort.Strings(distinct)
 	named := "none"
 	if len(distinct) == 1 {
 		named = fmt.Sprintf("%q", distinct[0])
 	}
+	// State the consequence per CLASS. active-active has no standby by design —
+	// its problem is that one region makes it a singleton under another name —
+	// so a shared "has no standby" sentence would be wrong for it, and an error
+	// an operator can tell is wrong is one they learn to skip.
+	consequence := "regions[0] is the primary and regions[1..] are the standbys, so a " +
+		"single-region " + canon + " has no standby to fail over to and no Continuum is created for it"
+	if canon == "active-active" {
+		consequence = "active-active means every region serves traffic, so over one region it is a " +
+			"singleton under another name"
+	}
 	return fmt.Sprintf(
-		"placement.mode %q needs at least 2 DISTINCT regions and got %d (%s) — "+
-			"regions[0] is the primary and regions[1..] are the standbys, so a single-region "+
-			"%s has no standby to fail over to and no Continuum is created for it. "+
+		"placement.mode %q needs at least 2 DISTINCT regions and got %d (%s) — %s. "+
 			"Name a second region, or use placement.mode singleton for a one-region install",
-		canon, len(distinct), named, canon)
+		canon, len(distinct), named, consequence)
 }
 
 // placementModeRequiresMultipleRegions reports whether a canonical topology

--- a/products/catalyst/bootstrap/api/internal/handler/applications_placement_region_count.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications_placement_region_count.go
@@ -1,0 +1,104 @@
+package handler
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// placementRegionCountError enforces the one rule that separates a DR promise
+// from a DR posture: a multi-region topology must name more than one region
+// (UAT row 60).
+//
+// THE DEFECT IT CLOSES. Both write doors — POST /applications
+// (validateApplicationInstallRequest) and PUT /applications/{name}
+// (validateApplicationUpdateRequest) — checked only `len(regions) >= 1`, for
+// EVERY mode. So `{"mode":"active-hot-standby","regions":["me-east-215-a"]}`
+// was accepted, persisted, and reported back as a hot-standby Application.
+// Nothing downstream can make that true:
+//
+//   - placement.Resolve (core/controllers/internal/placement/placement.go:251)
+//     puts regions[0] Primary and iterates regions[1..] for the standbys, so a
+//     one-region list yields ZERO standby regions;
+//   - buildContinuumPlan (core/controllers/application/internal/controller/
+//     continuum.go:165) then returns (zero, false) precisely because
+//     `len(standbys) == 0`, so NO Continuum CR is minted — and the Continuum CR
+//     is what the per-app Topology tab arms its Switchover against;
+//   - applications_preview.go marks a region standby only when `i > 0`, so the
+//     rendered manifest set is a single primary.
+//
+// The result was a DR promise that reported success at every layer: HTTP 201,
+// `phase: Ready`, `spec.placement.mode: active-hot-standby` — over one region,
+// with `status.perCluster[0].role: singleton` sitting next to it and no
+// standby anywhere (#6033, measured on hw293). Refs #6033.
+//
+// So the rule fails CLOSED here, where it can still be named, rather than
+// resolving into a silent single-region install. This is NOT a new rule — it
+// is an unenforced one. Both surfaces that already ask an operator for a
+// multi-region placement enforce it in the browser and always have:
+// `core/marketplace/src/components/BCPStep.svelte:230` ("Primary and replica
+// regions must differ — pick two distinct regions to enable
+// active-hot-standby") and
+// `products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/InstancesSection.tsx`
+// ("#3599 validation — multi-region modes need ≥2 regions"). The doors behind
+// them did not, so any caller that skipped those forms — including the
+// console's own POST /applications install page — could write the shape the
+// forms refuse.
+//
+// DISTINCT regions, not entry count: `["a","a"]` is one place. The update
+// door reaches this rule through applicationUpdateRequestNormalize, which
+// folds the #3969 `targets[]` onto mode+regions via
+// regionsFromPlacementTargets — and that helper DEDUPES, so a PlacementEditor
+// Apply carrying a Primary and a Standby that name the same region arrives
+// here as active-hot-standby over one region. Counting entries would let it
+// through.
+//
+// Returns "" when the placement is acceptable, so callers read it as
+// `if msg := placementRegionCountError(...); msg != "" { reject }`.
+func placementRegionCountError(mode string, regions []string) string {
+	canon := canonicalizeTopology(mode)
+	if !placementModeRequiresMultipleRegions(canon) {
+		return ""
+	}
+	seen := make(map[string]bool, len(regions))
+	distinct := make([]string, 0, len(regions))
+	for _, r := range regions {
+		r = strings.TrimSpace(r)
+		if r == "" || seen[r] {
+			continue
+		}
+		seen[r] = true
+		distinct = append(distinct, r)
+	}
+	if len(distinct) >= 2 {
+		return ""
+	}
+	sort.Strings(distinct)
+	named := "none"
+	if len(distinct) == 1 {
+		named = fmt.Sprintf("%q", distinct[0])
+	}
+	return fmt.Sprintf(
+		"placement.mode %q needs at least 2 DISTINCT regions and got %d (%s) — "+
+			"regions[0] is the primary and regions[1..] are the standbys, so a single-region "+
+			"%s has no standby to fail over to and no Continuum is created for it. "+
+			"Name a second region, or use placement.mode singleton for a one-region install",
+		canon, len(distinct), named, canon)
+}
+
+// placementModeRequiresMultipleRegions reports whether a canonical topology
+// mode is a MULTI-REGION posture. Mirrors the frontend's MULTI_REGION_MODES
+// (products/catalyst/bootstrap/ui/src/widgets/topology/modes.ts) — the same
+// three classes, on the canonical vocabulary (#3375 DoD-1).
+//
+// `singleton` is deliberately absent: it is the one-region posture, and
+// placement.Resolve hard-errors on a singleton carrying more than one region
+// entry, so nothing here needs to second-guess it.
+func placementModeRequiresMultipleRegions(canonicalMode string) bool {
+	switch canonicalMode {
+	case "active-active", "active-hot-standby", "active-passive":
+		return true
+	default:
+		return false
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/applications_placement_region_count_row60_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications_placement_region_count_row60_test.go
@@ -1,0 +1,236 @@
+package handler
+
+// UAT row 60 — "pick active-hot-standby → Provision → that app's Topology tab
+// shows a 2-region pair (region-a primary + region-b replica + armed
+// Switchover)".
+//
+// THE DEFECT. Both write doors validated `len(placement.regions) >= 1` for
+// EVERY mode, so `{"mode":"active-hot-standby","regions":["one-region"]}` was
+// accepted, persisted and reported back as a hot-standby Application. Nothing
+// downstream can make that true — placement.Resolve puts regions[0] Primary
+// and iterates regions[1..] for the standbys, so a one-region list yields zero
+// standbys, and buildContinuumPlan then skips CR production precisely because
+// `len(standbys) == 0`. No Continuum means nothing for the Topology tab's
+// Switchover to arm against. Refs #6033.
+//
+// The failure was SILENT at every layer an operator can see: HTTP 201,
+// `phase: Ready`, `spec.placement.mode: active-hot-standby` — with
+// `status.perCluster[0].role: singleton` sitting next to it.
+//
+// These tests assert the RULE, both directions, on both doors. The negative
+// cases matter as much as the positive ones: a gate that refuses everything
+// would satisfy the "1 region is rejected" half on its own.
+
+import (
+	"strings"
+	"testing"
+
+	bpv1 "github.com/openova-io/openova/core/controllers/pkg/apis/blueprint/v1alpha1"
+)
+
+func row60InstallRequest(mode string, regions []string) applicationInstallRequest {
+	return applicationInstallRequest{
+		BlueprintRef:    applicationBlueprintRef{Name: "bp-postgres", Version: "1.2.3"},
+		Name:            "ahs-pg",
+		OrganizationRef: "acme",
+		EnvironmentRef:  "acme-prod",
+		Placement:       applicationPlacement{Mode: mode, Regions: regions},
+	}
+}
+
+// TestInstallDoor_Row60_MultiRegionModeNeedsTwoRegions is the RED test for the
+// create door — the one row 60's walk goes through.
+func TestInstallDoor_Row60_MultiRegionModeNeedsTwoRegions(t *testing.T) {
+	cases := []struct {
+		name       string
+		mode       string
+		regions    []string
+		wantReject bool
+		why        string
+	}{
+		{
+			name:       "active-hot-standby over ONE region is refused",
+			mode:       "active-hot-standby",
+			regions:    []string{"me-east-215-a"},
+			wantReject: true,
+			why:        "there is no second region for the standby, so no Continuum is minted and Switchover can never arm",
+		},
+		{
+			name:       "active-passive over ONE region is refused",
+			mode:       "active-passive",
+			regions:    []string{"me-east-215-a"},
+			wantReject: true,
+			why:        "active-passive shares the primary+standby fan-out plan",
+		},
+		{
+			name:       "active-active over ONE region is refused",
+			mode:       "active-active",
+			regions:    []string{"me-east-215-a"},
+			wantReject: true,
+			why:        "a single-region active-active is a singleton wearing another name",
+		},
+		{
+			name:       "the LEGACY spelling is refused too",
+			mode:       "active-hotstandby",
+			regions:    []string{"me-east-215-a"},
+			wantReject: true,
+			why:        "the rule canonicalises first, so it cannot be side-stepped by spelling",
+		},
+		{
+			name:       "TWO ENTRIES naming the SAME region is refused",
+			mode:       "active-hot-standby",
+			regions:    []string{"me-east-215-a", "me-east-215-a"},
+			wantReject: true,
+			why:        "two entries for one place is still one place; the rule counts DISTINCT regions",
+		},
+		// ── CONTROLS: what must keep working ──
+		{
+			name:       "CONTROL active-hot-standby over TWO DISTINCT regions is accepted",
+			mode:       "active-hot-standby",
+			regions:    []string{"me-east-215-a", "me-east-215-b"},
+			wantReject: false,
+			why:        "this is the shape row 60 needs to succeed; a gate that refused it would be worse than the defect",
+		},
+		{
+			name:       "CONTROL singleton over ONE region is accepted",
+			mode:       "singleton",
+			regions:    []string{"me-east-215-a"},
+			wantReject: false,
+			why:        "singleton IS the one-region posture — the rule must discriminate by mode, not refuse every short list",
+		},
+		{
+			name:       "CONTROL active-active over THREE regions is accepted",
+			mode:       "active-active",
+			regions:    []string{"me-east-215-a", "me-east-215-b", "me-east-215-c"},
+			wantReject: false,
+			why:        "the rule is a floor, not an equality",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			msg, ok := validateApplicationInstallRequest(row60InstallRequest(tc.mode, tc.regions))
+			if tc.wantReject && ok {
+				t.Fatalf("install door ACCEPTED %s over %v — %s", tc.mode, tc.regions, tc.why)
+			}
+			if !tc.wantReject && !ok {
+				t.Fatalf("install door REJECTED %s over %v (%s) — %s", tc.mode, tc.regions, msg, tc.why)
+			}
+			if tc.wantReject {
+				// The message must NAME the problem and the remedy, or the
+				// operator sees a 400 they cannot act on.
+				if !strings.Contains(msg, "2 DISTINCT regions") {
+					t.Errorf("rejection message does not name the rule: %q", msg)
+				}
+				if !strings.Contains(msg, "singleton") {
+					t.Errorf("rejection message offers no remedy: %q", msg)
+				}
+			}
+		})
+	}
+}
+
+// TestUpdateDoor_Row60_SameRuleFromTheSameHelper covers the CHANGE door (row
+// 16's Save), which reaches the rule by a different route: the console's
+// PlacementEditor sends targets[] with no mode/regions, and
+// applicationUpdateRequestNormalize folds them onto mode+regions via
+// regionsFromPlacementTargets — which DEDUPES. So a Primary and a Standby that
+// name the SAME region arrive at the validator as active-hot-standby over ONE
+// region.
+//
+// That is not hypothetical: PlacementEditor.addTarget picks the new target's
+// region as `availableRegions.find(unused) ?? availableRegions[1] ??
+// availableRegions[0]`, so on a Sovereign reporting a single region the
+// fallback lands on the SAME region as the primary, and both the editor's own
+// validatePlacement and this door used to accept it.
+func TestUpdateDoor_Row60_SameRuleFromTheSameHelper(t *testing.T) {
+	// The exact editor body: targets only, no mode, no regions.
+	sameRegion := applicationUpdateRequestNormalize(applicationUpdateRequest{
+		Placement: &applicationPlacement{Targets: []bpv1.PlacementTarget{
+			{Region: "me-east-215-a", Cluster: "c-a", VCluster: "host", Role: bpv1.DataRolePrimary},
+			{Region: "me-east-215-a", Cluster: "c-a", VCluster: "host", Role: bpv1.DataRoleStandby, StandbyType: bpv1.StandbyHot},
+		}},
+	})
+
+	// VACUITY CHECK — prove the fold really did produce the dangerous shape
+	// (a multi-region posture over one region). Without this the rejection
+	// below could be for any reason at all.
+	if sameRegion.Placement.Mode != "active-hot-standby" {
+		t.Fatalf("VACUITY: fold produced mode %q, want active-hot-standby", sameRegion.Placement.Mode)
+	}
+	if len(sameRegion.Placement.Regions) != 1 {
+		t.Fatalf("VACUITY: fold produced regions %v, want exactly 1 (the dedupe is the point)",
+			sameRegion.Placement.Regions)
+	}
+
+	if msg, ok := validateApplicationUpdateRequest(sameRegion); ok {
+		t.Fatalf("update door ACCEPTED a hot-standby whose standby shares the primary's "+
+			"region — the Save would persist a DR posture with no standby (msg=%q)", msg)
+	}
+
+	// CONTROL — the same editor body across TWO regions must still be
+	// accepted, or the Topology-tab Save (row 16) breaks.
+	twoRegions := applicationUpdateRequestNormalize(applicationUpdateRequest{
+		Placement: &applicationPlacement{Targets: []bpv1.PlacementTarget{
+			{Region: "me-east-215-a", Cluster: "c-a", VCluster: "host", Role: bpv1.DataRolePrimary},
+			{Region: "me-east-215-b", Cluster: "c-b", VCluster: "host", Role: bpv1.DataRoleStandby, StandbyType: bpv1.StandbyHot},
+		}},
+	})
+	if msg, ok := validateApplicationUpdateRequest(twoRegions); !ok {
+		t.Fatalf("update door REJECTED the canonical 2-region hot-standby Save: %s", msg)
+	}
+
+	// CONTROL — a singleton edit over one region is untouched.
+	singleton := applicationUpdateRequestNormalize(applicationUpdateRequest{
+		Placement: &applicationPlacement{Targets: []bpv1.PlacementTarget{
+			{Region: "me-east-215-a", Cluster: "c-a", VCluster: "host", Role: bpv1.DataRolePrimary},
+		}},
+	})
+	if singleton.Placement.Mode != "singleton" {
+		t.Fatalf("VACUITY: control fold produced mode %q, want singleton", singleton.Placement.Mode)
+	}
+	if msg, ok := validateApplicationUpdateRequest(singleton); !ok {
+		t.Fatalf("update door REJECTED a singleton over one region: %s", msg)
+	}
+}
+
+// TestPlacementRegionCountError_IsAFunctionOfTheMode pins the discrimination
+// itself. `placementRegionCountError` returning "" for singleton is what makes
+// it a RULE rather than a blanket refusal, and the frontend mirror
+// (widgets/topology/modes MULTI_REGION_MODES) must agree with this set.
+func TestPlacementRegionCountError_IsAFunctionOfTheMode(t *testing.T) {
+	one := []string{"me-east-215-a"}
+	for _, mode := range []string{"active-active", "active-hot-standby", "active-passive"} {
+		if msg := placementRegionCountError(mode, one); msg == "" {
+			t.Errorf("mode %q over one region returned no error — it is a multi-region class", mode)
+		}
+		if !placementModeRequiresMultipleRegions(mode) {
+			t.Errorf("placementModeRequiresMultipleRegions(%q) = false, want true", mode)
+		}
+	}
+	if msg := placementRegionCountError("singleton", one); msg != "" {
+		t.Errorf("singleton over one region was refused: %q", msg)
+	}
+	if placementModeRequiresMultipleRegions("singleton") {
+		t.Errorf("placementModeRequiresMultipleRegions(singleton) = true, want false")
+	}
+	// An unknown mode is NOT this rule's business — the vocabulary check owns
+	// that verdict, and returning an error here would report the wrong cause.
+	if msg := placementRegionCountError("not-a-mode", one); msg != "" {
+		t.Errorf("unknown mode was refused by the REGION rule: %q", msg)
+	}
+
+	// DRIFT GATE — the partition is stated against the CANONICAL VOCABULARY
+	// itself (placement_vocabulary_drift_test.go's canonicalPlacementVocabulary),
+	// not against a second list typed here. A fifth canonical mode therefore
+	// cannot be added without a deliberate decision about which side of this
+	// line it falls on, and the frontend mirror asserts the identical partition
+	// (widgets/topology/placement-vocabulary.drift.test.tsx).
+	for _, mode := range canonicalPlacementVocabulary {
+		want := mode != "singleton"
+		if got := placementModeRequiresMultipleRegions(mode); got != want {
+			t.Errorf("placementModeRequiresMultipleRegions(%q) = %v, want %v — every "+
+				"canonical mode is either the one-region posture or a multi-region one",
+				mode, got, want)
+		}
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/applications_status_placement_readback_row16_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications_status_placement_readback_row16_test.go
@@ -1,0 +1,266 @@
+package handler
+
+// UAT row 16 — "change topology → Save PERSISTS".
+//
+// #6136 (PR #6142) fixed the WRITE half: a Topology-tab Save no longer
+// scalarises `spec.placement`, so the PlacementEditor's `targets[]` reach the
+// Application CR. This file covers the READ half, which was still dropping
+// them — the round trip is what the row asserts, and half of it is not it.
+//
+// THE DEFECT. GET /applications/{name}/status projected the CR's placement
+// through one line onto a `string` field:
+//
+//	spec.Placement = placementForTopology(readTopology(obj))
+//
+// `spec.placement` is dual-form by CRD design (#3373): a bare posture STRING,
+// or an OBJECT additionally carrying WHERE the instance runs — `vcluster`,
+// `clusters`, `regions`, and since #3969 the per-region `targets[]`. A string
+// cannot carry any of that, so the object form never reached the console.
+//
+// WHY THAT IS THE ROW. This endpoint is the ONLY read of the DESIRED
+// placement the Topology tab has. Its resolver
+// (`pages/sovereign/AppDetail/TopologyTab.tsx`) walks three rungs, and rung 2
+// is `if (specPlacement && typeof specPlacement === 'object') { ...targets }`,
+// documented as "the #3969 desired-state the operator explicitly chose in the
+// editor (used pre-rollout / when the data plane is unavailable)". Against
+// this endpoint `typeof specPlacement` was ALWAYS 'string', so rung 2 — the
+// one rung that renders a placement just Saved but whose Pods have not moved
+// yet — could never execute, and neither could the sibling
+// `spec.placement.ownedDependencies` read. The operator changed the topology,
+// the object accepted it, and the tab went on rendering the pre-Save posture.
+//
+// ASSERTIONS ARE ON THE WIRE, and on VALUES. The response is decoded as raw
+// JSON rather than into applicationStatusResponse, because the defect is a
+// SHAPE on the wire: a test that read a typed `string` field would have
+// compiled and passed against the very code that lost the data.
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	bpv1 "github.com/openova-io/openova/core/controllers/pkg/apis/blueprint/v1alpha1"
+)
+
+// registerApplicationRoundTripRoutes wires the PUT the editor Saves through
+// and the GET the tab reads back — the round trip in ONE router, because the
+// row is about the two agreeing, not about either in isolation.
+func registerApplicationRoundTripRoutes(r chi.Router, h *Handler) {
+	r.Put("/api/v1/sovereigns/{id}/applications/{name}", h.HandleApplicationUpdate)
+	r.Get("/api/v1/sovereigns/{id}/applications/{name}/status", h.HandleApplicationStatus)
+}
+
+// statusSpecPlacement pulls `spec.placement` off the RAW response body.
+func statusSpecPlacement(t *testing.T, body []byte) any {
+	t.Helper()
+	var envelope map[string]any
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		t.Fatalf("decode status body: %v; body=%s", err, string(body))
+	}
+	spec, ok := envelope["spec"].(map[string]any)
+	if !ok {
+		t.Fatalf("status response carries no `spec` object; body=%s", string(body))
+	}
+	return spec["placement"]
+}
+
+// TestApplicationStatus_Row16_EditorTargetsSurviveTheRoundTrip is the RED
+// test. It drives the ACTUAL PlacementEditor body — targets[] only, no
+// mode/regions, exactly what widgets/topology/PlacementEditor.tsx `apply()`
+// sends — through the PUT, then reads the tab's own endpoint back.
+//
+// Before the fix it failed at the shape assertion: `spec.placement` came back
+// the JSON string "active-hot-standby", so there was nowhere for `targets` to
+// be.
+func TestApplicationStatus_Row16_EditorTargetsSurviveTheRoundTrip(t *testing.T) {
+	cr := makeAppCR("acme", "ahs-app", "1.2.3", "singleton", []string{"me-east-215-a"})
+
+	// VACUITY CHECK — the seed must NOT already carry targets, or the test
+	// would pass on a fixture that was never changed by the PUT.
+	if _, ok, _ := unstructured.NestedSlice(cr.Object, "spec", "placement", "targets"); ok {
+		t.Fatalf("VACUITY: fixture must seed a CR with no placement targets")
+	}
+
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	factory, _ := fakeApplicationDynamicFactory(cr)
+	h.dynamicFactory = factory
+	h.SetCatalogClient(newFakeCatalog(sampleWordpressBlueprint()))
+	dep := installUserAccessDeployment(t, h, "dep-row16-roundtrip")
+
+	// The editor's body verbatim: targets only, ownedDependencies, no mode.
+	body := applicationUpdateRequest{
+		Placement: &applicationPlacement{
+			Targets: []bpv1.PlacementTarget{
+				{Region: "me-east-215-a", Cluster: "hw-me-east-215-a-rtz-prod", VCluster: "host", Role: bpv1.DataRolePrimary},
+				{Region: "me-east-215-b", Cluster: "hw-me-east-215-b-rtz-prod", VCluster: "host", Role: bpv1.DataRoleStandby, StandbyType: bpv1.StandbyHot},
+			},
+		},
+	}
+	put := callUserAccess(t, h, http.MethodPut,
+		"/api/v1/sovereigns/"+dep.ID+"/applications/ahs-app?namespace=acme", body,
+		registerApplicationRoundTripRoutes)
+	if put.Code != http.StatusOK {
+		t.Fatalf("PUT status: got %d want 200; body=%s", put.Code, put.Body.String())
+	}
+
+	get := callUserAccess(t, h, http.MethodGet,
+		"/api/v1/sovereigns/"+dep.ID+"/applications/ahs-app/status?namespace=acme", nil,
+		registerApplicationRoundTripRoutes)
+	if get.Code != http.StatusOK {
+		t.Fatalf("GET /status: got %d want 200; body=%s", get.Code, get.Body.String())
+	}
+
+	placement := statusSpecPlacement(t, get.Body.Bytes())
+	obj, isObject := placement.(map[string]any)
+	if !isObject {
+		t.Fatalf("spec.placement came back %T (%v) — the pre-fix failure. The Topology "+
+			"tab's rung-2 read is `typeof specPlacement === 'object'`, so a string means "+
+			"the targets the operator just Saved are unreadable", placement, placement)
+	}
+
+	// The posture is present AND canonical — one vocabulary on the wire.
+	if obj["mode"] != "active-hot-standby" {
+		t.Fatalf("spec.placement.mode = %v, want active-hot-standby (derived from the targets)", obj["mode"])
+	}
+
+	targets, ok := obj["targets"].([]any)
+	if !ok {
+		t.Fatalf("spec.placement.targets missing from the status response: %v", obj)
+	}
+	if len(targets) != 2 {
+		t.Fatalf("spec.placement.targets has %d entries, want 2", len(targets))
+	}
+
+	// Assert on the VALUES: which region got which role is the whole content
+	// of the operator's edit. A test that only counted targets would pass on a
+	// projection that returned two identical primaries (#6200's shape).
+	roleByRegion := map[string]string{}
+	standbyTypeByRegion := map[string]string{}
+	for _, raw := range targets {
+		tgt, isMap := raw.(map[string]any)
+		if !isMap {
+			t.Fatalf("target entry is %T, want an object: %v", raw, raw)
+		}
+		region, _ := tgt["region"].(string)
+		role, _ := tgt["role"].(string)
+		roleByRegion[region] = role
+		if st, present := tgt["standbyType"].(string); present {
+			standbyTypeByRegion[region] = st
+		}
+	}
+	if roleByRegion["me-east-215-a"] != string(bpv1.DataRolePrimary) {
+		t.Errorf("region me-east-215-a role = %q, want Primary", roleByRegion["me-east-215-a"])
+	}
+	if roleByRegion["me-east-215-b"] != string(bpv1.DataRoleStandby) {
+		t.Errorf("region me-east-215-b role = %q, want Standby", roleByRegion["me-east-215-b"])
+	}
+	if standbyTypeByRegion["me-east-215-b"] != string(bpv1.StandbyHot) {
+		t.Errorf("region me-east-215-b standbyType = %q, want Hot", standbyTypeByRegion["me-east-215-b"])
+	}
+}
+
+// TestApplicationStatus_Row16_Control_DifferentTopologyRoundTripsDifferently
+// is the CONTROL that discriminates. It runs the SAME endpoint over the SAME
+// fixture shape and changes ONLY the topology the operator picks — a
+// COLD standby, which is the active-passive class rather than
+// active-hot-standby.
+//
+// Without it the test above also passes for a projection that hardcodes the
+// hot-standby answer, which is exactly how a display-only defect hides: a
+// constant is indistinguishable from a correct read until a second value is
+// asked for.
+func TestApplicationStatus_Row16_Control_DifferentTopologyRoundTripsDifferently(t *testing.T) {
+	cr := makeAppCR("acme", "ap-app", "1.2.3", "singleton", []string{"me-east-215-a"})
+
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	factory, _ := fakeApplicationDynamicFactory(cr)
+	h.dynamicFactory = factory
+	h.SetCatalogClient(newFakeCatalog(sampleWordpressBlueprint()))
+	dep := installUserAccessDeployment(t, h, "dep-row16-control-cold")
+
+	body := applicationUpdateRequest{
+		Placement: &applicationPlacement{
+			Targets: []bpv1.PlacementTarget{
+				{Region: "me-east-215-a", Cluster: "hw-me-east-215-a-rtz-prod", VCluster: "host", Role: bpv1.DataRolePrimary},
+				{Region: "me-east-215-b", Cluster: "hw-me-east-215-b-rtz-prod", VCluster: "host", Role: bpv1.DataRoleStandby, StandbyType: bpv1.StandbyCold},
+			},
+		},
+	}
+	put := callUserAccess(t, h, http.MethodPut,
+		"/api/v1/sovereigns/"+dep.ID+"/applications/ap-app?namespace=acme", body,
+		registerApplicationRoundTripRoutes)
+	if put.Code != http.StatusOK {
+		t.Fatalf("PUT status: got %d want 200; body=%s", put.Code, put.Body.String())
+	}
+
+	get := callUserAccess(t, h, http.MethodGet,
+		"/api/v1/sovereigns/"+dep.ID+"/applications/ap-app/status?namespace=acme", nil,
+		registerApplicationRoundTripRoutes)
+	if get.Code != http.StatusOK {
+		t.Fatalf("GET /status: got %d want 200; body=%s", get.Code, get.Body.String())
+	}
+
+	obj, isObject := statusSpecPlacement(t, get.Body.Bytes()).(map[string]any)
+	if !isObject {
+		t.Fatalf("control: spec.placement is not an object")
+	}
+	// A DIFFERENT posture must round-trip DIFFERENTLY. If this reads
+	// active-hot-standby the projection is printing a constant.
+	if obj["mode"] != "active-passive" {
+		t.Fatalf("spec.placement.mode = %v, want active-passive — a Cold standby is the "+
+			"active-passive class, and reading active-hot-standby here would mean the "+
+			"projection prints a constant rather than the placement", obj["mode"])
+	}
+	targets, _ := obj["targets"].([]any)
+	if len(targets) != 2 {
+		t.Fatalf("control: targets has %d entries, want 2", len(targets))
+	}
+	for _, raw := range targets {
+		tgt, _ := raw.(map[string]any)
+		if tgt["role"] == string(bpv1.DataRoleStandby) && tgt["standbyType"] != string(bpv1.StandbyCold) {
+			t.Fatalf("control: standby standbyType = %v, want Cold", tgt["standbyType"])
+		}
+	}
+}
+
+// TestApplicationStatus_Row16_Control_StringPlacementStaysAString is the
+// SECOND control, sharing the suspect property from the other side: a CR that
+// declares ONLY a posture must still report only a posture. A "fix" that
+// promoted every placement to an object would hand the tab a `targets[]` the
+// operator never chose — a declared intention it could not tell apart from an
+// observed fact, which is #5568's defect — and would turn this red.
+func TestApplicationStatus_Row16_Control_StringPlacementStaysAString(t *testing.T) {
+	cr := makeAppCR("acme", "wp-str", "1.2.3", "single-region", []string{"me-east-215-a"})
+
+	// VACUITY CHECK — the control only means something if the seed is a string.
+	if _, ok, _ := unstructured.NestedMap(cr.Object, "spec", "placement"); ok {
+		t.Fatalf("VACUITY: control fixture must seed a STRING spec.placement, got a map")
+	}
+
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	factory, _ := fakeApplicationDynamicFactory(cr)
+	h.dynamicFactory = factory
+	dep := installUserAccessDeployment(t, h, "dep-row16-string-readback")
+
+	get := callUserAccess(t, h, http.MethodGet,
+		"/api/v1/sovereigns/"+dep.ID+"/applications/wp-str/status?namespace=acme", nil,
+		registerApplicationRoundTripRoutes)
+	if get.Code != http.StatusOK {
+		t.Fatalf("GET /status: got %d want 200; body=%s", get.Code, get.Body.String())
+	}
+
+	placement := statusSpecPlacement(t, get.Body.Bytes())
+	mode, isString := placement.(string)
+	if !isString {
+		t.Fatalf("spec.placement came back %T (%v) — a CR declaring only a posture must "+
+			"report only a posture; synthesising an object would invent a desired state",
+			placement, placement)
+	}
+	// The legacy spelling still folds to the canonical token on the wire.
+	if mode != "singleton" {
+		t.Fatalf("spec.placement = %q, want canonical singleton (legacy single-region folded)", mode)
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/applications_update.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications_update.go
@@ -1115,6 +1115,16 @@ func validateApplicationUpdateRequest(req applicationUpdateRequest) (string, boo
 				return fmt.Sprintf("placement.regions[%d] is empty", i), false
 			}
 		}
+		// UAT row 60 (and the change half, row 16) — the SAME rule the install
+		// door applies, from the SAME helper so there is not a second
+		// authority. This door reaches it through the targets[] fold in
+		// applicationUpdateRequestNormalize, whose regionsFromPlacementTargets
+		// DEDUPES: a PlacementEditor Apply whose Primary and Standby name the
+		// same region arrives here as active-hot-standby over ONE region, and
+		// would otherwise be persisted as a standby-less hot-standby.
+		if msg := placementRegionCountError(req.Placement.Mode, req.Placement.Regions); msg != "" {
+			return msg, false
+		}
 		// #5616 — the placement TIER was never validated on this door at
 		// all, on either the flat field or the #3969 per-target form. It
 		// is the door the shipped Topology-tab PlacementEditor uses, and

--- a/products/catalyst/bootstrap/api/internal/handler/placement_vocabulary_drift_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/placement_vocabulary_drift_test.go
@@ -96,13 +96,26 @@ func TestPlacementForTopology_EmitsOnlyCanonicalTokens(t *testing.T) {
 // The install + update + preview wire-validation MUST accept every
 // canonical class and the legacy aliases, and reject a genuine unknown.
 func TestApplicationWireValidation_AcceptsCanonicalVocabulary(t *testing.T) {
+	// This test pins the VOCABULARY, so its fixture must satisfy every OTHER
+	// rule of the validator — otherwise a rejection here reads as "the mode
+	// spelling was refused" when the real cause was elsewhere. UAT row 60 added
+	// one such rule: a multi-region posture needs ≥2 distinct regions
+	// (placementRegionCountError). The region list is therefore shaped from the
+	// SAME predicate the rule uses rather than a second hand-rolled list of
+	// which modes are multi-region — a copy here would silently stop matching
+	// the moment the vocabulary grows, which is the drift this file exists to
+	// catch.
 	base := func(mode string) applicationInstallRequest {
+		regions := []string{"hz-fsn-rtz-prod"}
+		if placementModeRequiresMultipleRegions(canonicalizeTopology(mode)) {
+			regions = append(regions, "hz-hel-rtz-prod")
+		}
 		return applicationInstallRequest{
 			BlueprintRef:    applicationBlueprintRef{Name: "bp-wp", Version: "1.0.0"},
 			Name:            "site",
 			OrganizationRef: "acme",
 			EnvironmentRef:  "acme-prod",
-			Placement:       applicationPlacement{Mode: mode, Regions: []string{"hz-fsn-rtz-prod"}},
+			Placement:       applicationPlacement{Mode: mode, Regions: regions},
 		}
 	}
 	accept := append([]string{}, canonicalPlacementVocabulary...)

--- a/products/catalyst/bootstrap/ui/src/lib/catalog.api.ts
+++ b/products/catalyst/bootstrap/ui/src/lib/catalog.api.ts
@@ -281,11 +281,21 @@ export interface ApplicationStatusResponse {
   /**
    * #3599 — the create-time placement projected from the Application
    * CR's spec so the Topology tab reflects it without waiting for the
-   * controller to populate status.placement. `placement` is the editor
-   * posture string (single-region | active-active | active-hotstandby).
+   * controller to populate status.placement.
+   *
+   * `placement` is DUAL-FORM, exactly as `Application.spec.placement` is
+   * (#3373): the posture STRING on its own, or the #3969 object
+   * `{mode, vcluster, regions, clusters, targets, ownedDependencies}`.
+   *
+   * This type said `string` while the endpoint really did flatten the
+   * object form to a posture token — so it was accurate, and the pair of
+   * them silently made the Topology tab's `spec.placement.targets` read
+   * (its rung 2, the DESIRED placement an operator just Saved) unreachable
+   * (UAT row 16). Both sides now carry the CR's real shape; consumers must
+   * branch on `typeof`, which TopologyTab already does.
    */
   spec?: {
-    placement?: string
+    placement?: string | Record<string, unknown>
     regions?: string[]
     environmentRef?: string
     blueprintRef?: { name?: string; version?: string }

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/InstancesSection.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/InstancesSection.tsx
@@ -29,7 +29,12 @@ import {
 import { listOrganizations, type OrgRow } from '@/lib/organizations.api'
 import { getHierarchicalInfrastructure } from '@/lib/infrastructure.types'
 import { useResolvedDeploymentId } from '@/shared/lib/useResolvedDeploymentId'
-import { ALL_MODES, canonicalizeMode, describeModeForComponent } from '@/widgets/topology/modes'
+import {
+  ALL_MODES,
+  MULTI_REGION_MODES as SHARED_MULTI_REGION_MODES,
+  canonicalizeMode,
+  describeModeForComponent,
+} from '@/widgets/topology/modes'
 import { BLUEPRINT_BY_ID, TOPOLOGY_BY_ID } from '@/shared/constants/catalog.generated'
 
 // #3599 / #3600 / #5616 — the tier namespaces the backend can RESOLVE:
@@ -48,10 +53,13 @@ const RESOLVABLE_TIER_NAMESPACES = ['mgmt', 'dmz', 'rtz'] as const
 
 /**
  * Modes that require ≥2 regions (the create-flow validation rule). ONE
- * canonical vocabulary (#3375 DoD-1) — active-passive is multi-region
- * too. Membership is tested on the canonical token (canonicalEditorMode).
+ * canonical vocabulary (#3375 DoD-1) — active-passive is multi-region too.
+ *
+ * The set MOVED to `@/widgets/topology/modes` (UAT row 60) because the install
+ * page needs the identical predicate and a second copy would drift. Imported
+ * rather than re-declared, and aliased so the call sites below read unchanged.
  */
-const MULTI_REGION_MODES = new Set(['active-active', 'active-hot-standby', 'active-passive'])
+const MULTI_REGION_MODES = SHARED_MULTI_REGION_MODES
 
 /**
  * InstancesSection — renders the per-Blueprint instances list (one row

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/SettingsTab.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/SettingsTab.tsx
@@ -51,7 +51,13 @@ interface ApplicationStatus {
 interface ApplicationSpec {
   blueprintRef?: { name?: string; version?: string }
   parameters?: Record<string, unknown>
-  placement?: string
+  // DUAL-FORM, like `Application.spec.placement` itself (#3373 / UAT row 16):
+  // the posture string, or the #3969 object carrying targets[]. This tab does
+  // not read the field — the declaration exists so the shared
+  // ApplicationStatusResponse assigns cleanly — but it must not narrow the
+  // wire contract, which is how the object form got flattened in the first
+  // place.
+  placement?: string | Record<string, unknown>
   regions?: string[]
   environmentRef?: string
 }

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.dualform-placement-row16.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.dualform-placement-row16.test.tsx
@@ -1,0 +1,217 @@
+/**
+ * TopologyTab.dualform-placement-row16.test.tsx — UAT row 16, the consumer half.
+ *
+ * THE ROW. "change topology → Save persists". #6136 made the Topology-tab Save
+ * PERSIST the PlacementEditor's `targets[]` onto `spec.placement`. The
+ * /status endpoint then flattened that object back down to a posture STRING on
+ * the way out, so the console never saw them — and this tab's rung-2 read is
+ *
+ *     if (specPlacement && typeof specPlacement === 'object') { ...targets }
+ *
+ * i.e. exactly the rung that renders a placement just Saved whose Pods have
+ * not moved yet. Against a string it can never execute.
+ *
+ * WHAT THESE TESTS ARE FOR. The server fix is asserted in Go
+ * (applications_status_placement_readback_row16_test.go). This file asserts the
+ * OTHER end of the same wire: that the shape the endpoint now sends is the
+ * shape that makes the operator's own choice appear, and that the shape it used
+ * to send does NOT. The pair is the causal claim — without the string case,
+ * "the object renders" would not establish that the flattening was the defect.
+ *
+ * It also guards the regression the server fix could have caused. Rung 3 (the
+ * legacy mode+regions projection) read the posture ONLY from the string form.
+ * Once `spec.placement` arrives as an object, an object-form CR carrying
+ * `{mode, regions}` and no `targets[]` — the shape the "+ New instance" dialog
+ * writes — would have reached rung 3 with an EMPTY mode and projected an
+ * active-active app as primary+standby. The dual-form read there is covered
+ * below, with active-active and active-hot-standby as each other's control.
+ */
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest'
+import { render, screen, cleanup, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+const getApplicationStatus = vi.fn()
+const getCatalogItem = vi.fn()
+const getApplicationPlacement = vi.fn()
+const getHierarchicalInfrastructure = vi.fn()
+const getContinuumReplicationStatus = vi.fn()
+
+vi.mock('@/lib/catalog.api', () => ({
+  getApplicationStatus: (...a: unknown[]) => getApplicationStatus(...a),
+  getCatalogItem: (...a: unknown[]) => getCatalogItem(...a),
+  getApplicationPlacement: (...a: unknown[]) => getApplicationPlacement(...a),
+}))
+
+vi.mock('@/lib/continuum.api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/continuum.api')>()
+  return {
+    ...actual,
+    getContinuumReplicationStatus: (...a: unknown[]) => getContinuumReplicationStatus(...a),
+  }
+})
+
+vi.mock('@/lib/infrastructure.types', () => ({
+  getHierarchicalInfrastructure: (...a: unknown[]) => getHierarchicalInfrastructure(...a),
+}))
+
+vi.mock('@/widgets/topology/PlacementEditor', () => ({
+  PlacementEditor: () => <div data-testid="stub-placement-editor" />,
+}))
+
+import { TopologyTab } from './TopologyTab'
+
+function withProviders(node: React.ReactNode) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return <QueryClientProvider client={qc}>{node}</QueryClientProvider>
+}
+
+const REGION_A = 'hw-me-east-215-a-rtz-prod'
+const REGION_B = 'hw-me-east-215-b-rtz-prod'
+
+/**
+ * What the endpoint sends NOW: the CR's own object form, carrying the
+ * `targets[]` the PlacementEditor Saved. Nothing has been observed yet — the
+ * runtime answers empty, which is the whole point (the Save has happened, the
+ * Pods have not moved).
+ */
+const OBJECT_FORM_WITH_SAVED_TARGETS = {
+  name: 'ahs-app',
+  namespace: 'acme',
+  spec: {
+    placement: {
+      mode: 'active-hot-standby',
+      targets: [
+        { region: REGION_A, cluster: REGION_A, vcluster: 'host', role: 'Primary' },
+        { region: REGION_B, cluster: REGION_B, vcluster: 'host', role: 'Standby', standbyType: 'Hot' },
+      ],
+    },
+    regions: [REGION_A, REGION_B],
+  },
+  status: {},
+}
+
+/**
+ * THE CONTROL that establishes causality: the SAME Application, the same
+ * everything, as the endpoint used to report it — `spec.placement` flattened
+ * to the posture token. Same declared posture, same regions; only the SHAPE
+ * differs.
+ */
+const FLATTENED_STRING_FORM = {
+  name: 'ahs-app',
+  namespace: 'acme',
+  spec: { placement: 'active-hot-standby', regions: [REGION_A, REGION_B] },
+  status: {},
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  // Rung 1 answers EMPTY — the Save happened, no runtime has caught up.
+  getApplicationPlacement.mockResolvedValue({ targets: [], derivedFromRuntime: true })
+  getCatalogItem.mockResolvedValue({ name: 'bp-postgres', placementCapability: 'active-hot-standby' })
+  getHierarchicalInfrastructure.mockResolvedValue({ regions: [] })
+  getContinuumReplicationStatus.mockResolvedValue({ source: 'pending' })
+})
+
+afterEach(() => cleanup())
+
+async function renderTab(name = 'ahs-app') {
+  render(withProviders(<TopologyTab sovereignId="dep-1" applicationName={name} namespace="acme" />))
+  // Anchor on the panel so no assertion below can pass on an unpainted page.
+  await waitFor(() => expect(screen.getByTestId('topology-tab-placement-panel')).toBeTruthy())
+}
+
+/** The rendered role of each target card, in order. */
+function renderedRoles(): string[] {
+  const roles: string[] = []
+  for (let i = 0; ; i++) {
+    const el = screen.queryByTestId(`topology-tab-target-card-${i}-role`)
+    if (!el) break
+    roles.push(el.textContent ?? '')
+  }
+  return roles
+}
+
+describe('row 16 — the DESIRED placement the operator Saved must survive the read-back', () => {
+  it('renders the SAVED per-target roles from the object form, before any runtime observation', async () => {
+    getApplicationStatus.mockResolvedValue(OBJECT_FORM_WITH_SAVED_TARGETS)
+    await renderTab()
+
+    const roles = await waitFor(() => {
+      const r = renderedRoles()
+      expect(r.length).toBe(2)
+      return r
+    })
+
+    // The operator's actual edit: region A primary, region B a HOT standby.
+    // Asserted on the values, not on the card count — a pair of primaries
+    // would satisfy a count-only check (#6200's shape).
+    expect(roles[0]).toContain('PRIMARY')
+    expect(roles[1]).toContain('STANDBY')
+    expect(roles[1]).toContain('Hot')
+
+    // And the panel is honest about WHERE it came from: this is the declared
+    // desired state, not an observation. The distinction is #5568's point and
+    // must survive this fix.
+    expect(screen.getByTestId('topology-tab-placement-source').textContent).toContain('declared')
+  })
+
+  it('CONTROL — the FLATTENED string the endpoint used to send cannot carry those roles', async () => {
+    getApplicationStatus.mockResolvedValue(FLATTENED_STRING_FORM)
+    await renderTab()
+
+    await waitFor(() => expect(renderedRoles().length).toBeGreaterThan(0))
+
+    // The posture still projects a pair through the legacy rung — so the tab
+    // does not look broken, which is exactly why this went unseen. What is
+    // GONE is the operator's own target list: the string carries no
+    // `targets[]`, so nothing here came from what they Saved. The Go test
+    // asserts the endpoint no longer sends this shape.
+    const placement = FLATTENED_STRING_FORM.spec.placement as unknown
+    expect(typeof placement).toBe('string')
+    expect((placement as Record<string, unknown>).targets).toBeUndefined()
+  })
+})
+
+describe('rung 3 keeps reading the posture once spec.placement arrives as an object', () => {
+  /** Object-form CR with a posture + regions but NO targets[] — the shape the
+   *  "+ New instance" dialog writes. */
+  const objectFormNoTargets = (mode: string) => ({
+    name: 'app-' + mode,
+    namespace: 'acme',
+    spec: { placement: { mode, vcluster: 'host', regions: [REGION_A, REGION_B] }, regions: [REGION_A, REGION_B] },
+    status: {},
+  })
+
+  it('active-active renders TWO PRIMARIES — not a fabricated standby', async () => {
+    getApplicationStatus.mockResolvedValue(objectFormNoTargets('active-active'))
+    getCatalogItem.mockResolvedValue({ name: 'bp-grafana', placementCapability: 'multi-primary' })
+    await renderTab('app-active-active')
+
+    const roles = await waitFor(() => {
+      const r = renderedRoles()
+      expect(r.length).toBe(2)
+      return r
+    })
+    expect(roles[0]).toContain('PRIMARY')
+    expect(roles[1]).toContain('PRIMARY')
+    expect(roles.join(' ')).not.toContain('STANDBY')
+    expect(screen.getByTestId('topology-tab-pattern').textContent).toContain('active-active')
+  })
+
+  it('CONTROL — active-hot-standby over the SAME object shape renders primary + standby', async () => {
+    getApplicationStatus.mockResolvedValue(objectFormNoTargets('active-hot-standby'))
+    await renderTab('app-active-hot-standby')
+
+    const roles = await waitFor(() => {
+      const r = renderedRoles()
+      expect(r.length).toBe(2)
+      return r
+    })
+    // A DIFFERENT declared posture over an IDENTICAL object shape must render
+    // differently, or the projection is ignoring the mode — which is precisely
+    // the state the dual-form read prevents.
+    expect(roles[0]).toContain('PRIMARY')
+    expect(roles[1]).toContain('STANDBY')
+    expect(screen.getByTestId('topology-tab-pattern').textContent).toContain('active-hot-standby')
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.tsx
@@ -363,12 +363,24 @@ export function TopologyTab({
     const statusRegions = (status.regions ?? []) as RegionStatus[]
     // status.placement is an OBJECT on a real (#3373/#3969) controller; only
     // a pre-#3969 controller wrote the legacy posture string here.
+    //
+    // UAT row 16 — read the OBJECT form's `mode` too. `spec.placement` is
+    // dual-form (#3373) and the /status endpoint now reports it in the shape
+    // the CR holds instead of flattening it to a posture token, which is what
+    // makes rung 2 above reachable at all. This rung must not lose the posture
+    // in exchange: an object-form CR that carries `{mode, regions}` but no
+    // `targets[]` — the shape the "+ New instance" dialog writes — reaches
+    // here, and reading only the string form would leave `mode` empty and
+    // project an ACTIVE-ACTIVE app as primary+standby. Same dual-form read as
+    // declaresStandby below.
     const mode =
       typeof specPlacement === 'string'
         ? specPlacement
-        : typeof status.placement === 'string'
-          ? status.placement
-          : ''
+        : specPlacement && typeof (specPlacement as Record<string, unknown>).mode === 'string'
+          ? ((specPlacement as Record<string, unknown>).mode as string)
+          : typeof status.placement === 'string'
+            ? status.placement
+            : ''
     const regions = Array.isArray(app?.spec?.regions) ? app!.spec!.regions! : statusRegions.map((r) => r.name)
     const legacy = targetsFromLegacy({ mode, regions, statusRegions })
     // Nothing anywhere — an empty list is neither observed nor declared, and

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/InstallPage.regions-row60.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/InstallPage.regions-row60.test.tsx
@@ -1,0 +1,206 @@
+/**
+ * InstallPage.regions-row60.test.tsx — UAT row 60.
+ *
+ * THE DEFECT. `composeInstallRequest` hardcoded the submitted placement as
+ *
+ *     placement: { mode: placementMode, regions: [region] }
+ *
+ * over a single `Region` input. So picking `active-hot-standby` in the picker
+ * submitted a ONE-region hot-standby, every time. The Application CR then
+ * declared a DR posture nothing downstream could back: placement.Resolve puts
+ * regions[0] Primary and iterates regions[1..] for the standbys, so a
+ * one-region list yields zero standbys, and buildContinuumPlan skips the
+ * Continuum CR precisely because `len(standbys) == 0` — leaving the Topology
+ * tab's Switchover with nothing to arm against. Refs #6033.
+ *
+ * WHY THE EXISTING TEST DID NOT CATCH IT. `InstallPage.placement.test.tsx`
+ * asserts that the picker OFFERS all four canonical modes and that one can be
+ * SELECTED. Both were true the whole time. Neither looks at the request the
+ * page actually sends, and the request was where the choice was being
+ * discarded — the picker could not fail.
+ *
+ * So this file asserts the REQUEST BODY, and includes the control that makes
+ * the assertion mean something: a DIFFERENT topology must submit a
+ * DIFFERENTLY-shaped regions[], or the test would also pass for a page that
+ * hardcodes two regions for everything.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, cleanup, fireEvent } from '@testing-library/react'
+
+vi.mock('@/shared/lib/useResolvedDeploymentId', () => ({
+  useResolvedDeploymentId: () => ({ deploymentId: 'dep-test' }),
+}))
+
+const grafanaCard = {
+  name: 'bp-grafana',
+  version: '1.0.6',
+  card: { title: 'Grafana', summary: 'Dashboards', description: 'Dashboards' },
+  source: 'gitea',
+}
+
+vi.mock('@/lib/useCatalog', () => ({
+  useCatalog: () => ({ data: [grafanaCard], isLoading: false, isError: false }),
+  useCatalogItemVersion: () => ({ data: { ...grafanaCard, raw: { spec: { configSchema: {} } } }, isLoading: false }),
+}))
+
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => () => Promise.resolve(undefined),
+}))
+
+// Capture the install body on the wire. This is the seam the defect lived in,
+// so it is the seam the test observes.
+const installApplication = vi.fn(async () => ({ name: 'grafana-prod' }))
+const previewApplication = vi.fn(async () => ({ blueprint: { name: 'bp-grafana', version: '1.0.6' }, manifests: [] }))
+vi.mock('@/lib/catalog.api', () => ({
+  installApplication: (...args: unknown[]) => installApplication(...(args as [])),
+  previewApplication: (...args: unknown[]) => previewApplication(...(args as [])),
+}))
+
+// The RJSF form is not under test; expose a bare submit button that calls the
+// page's own onSubmit with empty parameters.
+vi.mock('@/widgets/install/InstallForm', () => ({
+  InstallForm: ({
+    onSubmit,
+    onPreview,
+  }: {
+    onSubmit: (p: Record<string, unknown>) => void
+    onPreview: (p: Record<string, unknown>) => void
+  }) => (
+    <>
+      <button type="button" data-testid="stub-install-submit" onClick={() => onSubmit({})}>
+        submit
+      </button>
+      <button type="button" data-testid="stub-install-preview" onClick={() => onPreview({})}>
+        preview
+      </button>
+    </>
+  ),
+}))
+
+vi.mock('@/widgets/code/CodeView', () => ({ CodeView: () => null }))
+
+import { InstallPage } from './InstallPage'
+
+/** The `placement` object of the most recent installApplication call. */
+function submittedPlacement(): { mode: string; regions: string[] } {
+  const call = installApplication.mock.calls.at(-1) as unknown as [string, { placement: { mode: string; regions: string[] } }]
+  expect(call, 'installApplication was never called').toBeTruthy()
+  return call[1].placement
+}
+
+describe('InstallPage placement regions (UAT row 60)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+  afterEach(() => cleanup())
+
+  it('submits BOTH regions when the chosen topology places a standby', () => {
+    render(<InstallPage preselectedBlueprint="bp-grafana" />)
+
+    fireEvent.change(screen.getByTestId('install-page-placement'), {
+      target: { value: 'active-hot-standby' },
+    })
+    fireEvent.change(screen.getByTestId('install-page-region'), {
+      target: { value: 'me-east-215-a' },
+    })
+    // The control the page did not have. Its ABSENCE is the defect: there was
+    // nowhere to name the standby region, so there could never be one.
+    fireEvent.change(screen.getByTestId('install-page-standby-region'), {
+      target: { value: 'me-east-215-b' },
+    })
+
+    fireEvent.click(screen.getByTestId('stub-install-submit'))
+
+    const placement = submittedPlacement()
+    expect(placement.mode).toBe('active-hot-standby')
+    // regions[0] is the primary and regions[1..] the standbys — the ordering
+    // placement.Resolve reads, so the ORDER is asserted, not just membership.
+    expect(placement.regions).toEqual(['me-east-215-a', 'me-east-215-b'])
+  })
+
+  it('CONTROL — a singleton still submits exactly ONE region', () => {
+    render(<InstallPage preselectedBlueprint="bp-grafana" />)
+
+    fireEvent.change(screen.getByTestId('install-page-placement'), {
+      target: { value: 'singleton' },
+    })
+    fireEvent.change(screen.getByTestId('install-page-region'), {
+      target: { value: 'me-east-215-a' },
+    })
+    // The standby control must not even be rendered for a one-region posture.
+    expect(screen.queryByTestId('install-page-standby-region')).toBeNull()
+
+    fireEvent.click(screen.getByTestId('stub-install-submit'))
+
+    const placement = submittedPlacement()
+    expect(placement.mode).toBe('singleton')
+    expect(placement.regions).toEqual(['me-east-215-a'])
+  })
+
+  it('refuses to submit a multi-region posture with no second region, and says why', () => {
+    render(<InstallPage preselectedBlueprint="bp-grafana" />)
+
+    fireEvent.change(screen.getByTestId('install-page-placement'), {
+      target: { value: 'active-hot-standby' },
+    })
+    fireEvent.change(screen.getByTestId('install-page-region'), {
+      target: { value: 'me-east-215-a' },
+    })
+    // Standby left blank — the exact state the page used to submit happily.
+
+    expect(screen.getByTestId('install-page-placement-regions-validation').textContent)
+      .toContain('needs a second region')
+
+    fireEvent.click(screen.getByTestId('stub-install-submit'))
+    expect(installApplication).not.toHaveBeenCalled()
+    expect(screen.getByTestId('install-page-error').textContent).toContain('needs a second region')
+  })
+
+  it('refuses a standby region equal to the primary — two names for one place', () => {
+    render(<InstallPage preselectedBlueprint="bp-grafana" />)
+
+    fireEvent.change(screen.getByTestId('install-page-placement'), {
+      target: { value: 'active-passive' },
+    })
+    fireEvent.change(screen.getByTestId('install-page-region'), {
+      target: { value: 'me-east-215-a' },
+    })
+    fireEvent.change(screen.getByTestId('install-page-standby-region'), {
+      target: { value: 'me-east-215-a' },
+    })
+
+    expect(screen.getByTestId('install-page-placement-regions-validation').textContent)
+      .toContain('must differ')
+
+    fireEvent.click(screen.getByTestId('stub-install-submit'))
+    expect(installApplication).not.toHaveBeenCalled()
+  })
+
+  it('the PREVIEW door carries the same regions as the install door', () => {
+    render(<InstallPage preselectedBlueprint="bp-grafana" />)
+
+    fireEvent.change(screen.getByTestId('install-page-placement'), {
+      target: { value: 'active-active' },
+    })
+    fireEvent.change(screen.getByTestId('install-page-region'), {
+      target: { value: 'me-east-215-a' },
+    })
+    fireEvent.change(screen.getByTestId('install-page-standby-region'), {
+      target: { value: 'me-east-215-b' },
+    })
+
+    fireEvent.click(screen.getByTestId('stub-install-preview'))
+
+    const call = previewApplication.mock.calls.at(-1) as unknown as [
+      string,
+      { placement: { mode: string; regions: string[] } },
+    ]
+    expect(call, 'previewApplication was never called').toBeTruthy()
+    expect(call[1].placement.regions).toEqual(['me-east-215-a', 'me-east-215-b'])
+    // A preview that renders a different region set than the install would
+    // submit is a preview of something else.
+    fireEvent.click(screen.getByTestId('stub-install-submit'))
+    expect(submittedPlacement().regions).toEqual(call[1].placement.regions)
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/InstallPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/InstallPage.tsx
@@ -41,6 +41,7 @@ import {
 } from '@/lib/catalog.api'
 import { InstallForm } from '@/widgets/install/InstallForm'
 import { CodeView } from '@/widgets/code/CodeView'
+import { requiresMultipleRegions } from '@/widgets/topology/modes'
 
 interface InstallPageProps {
   /** Test seam — pre-selected Blueprint without going through the catalog grid. */
@@ -83,6 +84,17 @@ export function InstallPage({ preselectedBlueprint }: InstallPageProps = {}) {
   const [appName, setAppName] = useState<string>('')
   const [region, setRegion] = useState<string>('hz-fsn-rtz-prod')
   const [placementMode, setPlacementMode] = useState<string>('singleton')
+  // UAT row 60 — the SECOND region. A multi-region posture places a standby
+  // (active-hot-standby / active-passive) or a co-equal primary
+  // (active-active) in another region, and this page had nowhere to name it:
+  // composeInstallRequest hardcoded `regions: [region]`, so picking
+  // active-hot-standby submitted a ONE-region hot-standby. The Application CR
+  // then declared a DR posture the placement plan could not back —
+  // placement.Resolve yields zero standbys from a one-region list, so
+  // buildContinuumPlan mints no Continuum and there is nothing for the
+  // Topology tab's Switchover to arm against. HTTP 201 and phase Ready
+  // throughout (#6033).
+  const [secondaryRegion, setSecondaryRegion] = useState<string>('')
 
   // Reset the form scaffold when a new Blueprint is selected. Keeps the
   // "click another card" UX intuitive — the prior input doesn't survive
@@ -97,6 +109,44 @@ export function InstallPage({ preselectedBlueprint }: InstallPageProps = {}) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedCard?.name])
 
+  // UAT row 60 — does the CHOSEN mode need a second region? Answered by the
+  // shared predicate (widgets/topology/modes), never a list re-typed here: the
+  // create dialog and the catalyst-api both gate on that same set, and a
+  // fourth hand-rolled copy is how the three of them would stop agreeing.
+  const needsSecondRegion = requiresMultipleRegions(placementMode)
+
+  /**
+   * The regions[] this page submits. `regions[0]` is the primary and
+   * `regions[1..]` are the standbys — the ordering
+   * `core/controllers/internal/placement/placement.go` resolves, and the
+   * reason the second region is a distinct field rather than a count.
+   */
+  const placementRegions = useMemo(() => {
+    const primary = region.trim()
+    if (!needsSecondRegion) return [primary]
+    const secondary = secondaryRegion.trim()
+    return secondary ? [primary, secondary] : [primary]
+  }, [region, secondaryRegion, needsSecondRegion])
+
+  /**
+   * Refuse the submit the server would now refuse (and that it previously
+   * ACCEPTED, silently, producing a standby-less hot-standby). Same rule and
+   * same wording family as the funnel's BCP step and the create dialog.
+   * Returns null when the placement is submittable.
+   */
+  const placementRegionError = useMemo<string | null>(() => {
+    if (!needsSecondRegion) return null
+    const primary = region.trim()
+    const secondary = secondaryRegion.trim()
+    if (!secondary) {
+      return `${placementMode} needs a second region — name the standby region, or pick singleton for a one-region install.`
+    }
+    if (secondary === primary) {
+      return `Primary and standby regions must differ — ${placementMode} places the standby in another region.`
+    }
+    return null
+  }, [needsSecondRegion, region, secondaryRegion, placementMode])
+
   const composeInstallRequest = (parameters: Record<string, unknown>): ApplicationInstallRequest => ({
     blueprintRef: {
       name: selectedCard?.name ?? '',
@@ -106,12 +156,16 @@ export function InstallPage({ preselectedBlueprint }: InstallPageProps = {}) {
     organizationRef,
     environmentRef,
     parameters,
-    placement: { mode: placementMode, regions: [region] },
+    placement: { mode: placementMode, regions: placementRegions },
   })
 
   const handleSubmit = async (parameters: Record<string, unknown>) => {
     if (!deploymentId || !selectedCard) return
     setInstallError(null)
+    if (placementRegionError) {
+      setInstallError(placementRegionError)
+      return
+    }
     try {
       const resp = await installApplication(deploymentId, composeInstallRequest(parameters))
       setStatusName(resp.name)
@@ -123,6 +177,10 @@ export function InstallPage({ preselectedBlueprint }: InstallPageProps = {}) {
   const handlePreview = async (parameters: Record<string, unknown>) => {
     if (!deploymentId || !selectedCard) return
     setInstallError(null)
+    if (placementRegionError) {
+      setInstallError(placementRegionError)
+      return
+    }
     try {
       const resp = await previewApplication(deploymentId, composeInstallRequest(parameters))
       setPreviewState(resp)
@@ -392,7 +450,7 @@ export function InstallPage({ preselectedBlueprint }: InstallPageProps = {}) {
               />
             </label>
             <label className="flex flex-col text-xs text-[var(--color-text-dim)]">
-              Region
+              {needsSecondRegion ? 'Primary region' : 'Region'}
               <input
                 type="text"
                 className="mt-1 rounded-md border border-[var(--color-border)] bg-[var(--color-bg)] px-3 py-2 text-sm"
@@ -401,6 +459,22 @@ export function InstallPage({ preselectedBlueprint }: InstallPageProps = {}) {
                 onChange={(e) => setRegion(e.target.value)}
               />
             </label>
+            {/* UAT row 60 — the standby / second region, rendered ONLY for a
+                posture that places one. Absent for singleton so the
+                one-region flow is unchanged. */}
+            {needsSecondRegion ? (
+              <label className="flex flex-col text-xs text-[var(--color-text-dim)]">
+                {placementMode === 'active-active' ? 'Second region' : 'Standby region'}
+                <input
+                  type="text"
+                  className="mt-1 rounded-md border border-[var(--color-border)] bg-[var(--color-bg)] px-3 py-2 text-sm"
+                  data-testid="install-page-standby-region"
+                  value={secondaryRegion}
+                  onChange={(e) => setSecondaryRegion(e.target.value)}
+                  placeholder="e.g. hz-hel-rtz-prod"
+                />
+              </label>
+            ) : null}
             <label className="flex flex-col text-xs text-[var(--color-text-dim)]">
               Placement mode
               {/*
@@ -429,6 +503,18 @@ export function InstallPage({ preselectedBlueprint }: InstallPageProps = {}) {
               </select>
             </label>
           </div>
+
+          {/* UAT row 60 — say WHY the submit will be refused, before it is.
+              The catalyst-api enforces the same rule, so this is the local
+              half of one contract, not a second authority. */}
+          {placementRegionError ? (
+            <div
+              className="mb-3 rounded-md border border-yellow-500/40 bg-yellow-500/10 px-3 py-2 text-xs text-yellow-300"
+              data-testid="install-page-placement-regions-validation"
+            >
+              {placementRegionError}
+            </div>
+          ) : null}
 
           {/* Auto-form for Blueprint parameters. */}
           {versionQuery.isLoading ? (

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/InstallPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/InstallPage.tsx
@@ -138,11 +138,14 @@ export function InstallPage({ preselectedBlueprint }: InstallPageProps = {}) {
     if (!needsSecondRegion) return null
     const primary = region.trim()
     const secondary = secondaryRegion.trim()
+    // active-active places a co-equal primary, not a standby — naming it a
+    // "standby region" there would be copy the operator can tell is wrong.
+    const secondName = placementMode === 'active-active' ? 'second region' : 'standby region'
     if (!secondary) {
-      return `${placementMode} needs a second region — name the standby region, or pick singleton for a one-region install.`
+      return `${placementMode} needs a second region — name the ${secondName}, or pick singleton for a one-region install.`
     }
     if (secondary === primary) {
-      return `Primary and standby regions must differ — ${placementMode} places the standby in another region.`
+      return `The two regions must differ — ${placementMode} runs in a second region, and naming the same one twice is one place.`
     }
     return null
   }, [needsSecondRegion, region, secondaryRegion, placementMode])

--- a/products/catalyst/bootstrap/ui/src/widgets/topology/modes.ts
+++ b/products/catalyst/bootstrap/ui/src/widgets/topology/modes.ts
@@ -36,6 +36,36 @@ export const ALL_MODES = ['singleton', 'active-active', 'active-hot-standby', 'a
 export type TopologyMode = (typeof ALL_MODES)[number]
 
 /**
+ * MULTI_REGION_MODES — the classes that require ≥2 regions. `singleton` is
+ * the one-region posture; every other canonical class places a second region
+ * (a standby for active-hot-standby / active-passive, a co-equal primary for
+ * active-active).
+ *
+ * Lives here, in the vocabulary module, because THREE surfaces need the same
+ * predicate and a copy in each is how they drift: the create dialog
+ * (`NewInstanceDialog` in pages/sovereign/AppDetail/InstancesSection — where
+ * this set was defined and from where it moved), the install page
+ * (pages/sovereign/InstallPage), and the catalyst-api's Go mirror
+ * `placementModeRequiresMultipleRegions`. Membership is tested on the
+ * CANONICAL token, so callers must canonicalizeMode first — requiresMultipleRegions
+ * does that for them.
+ */
+export const MULTI_REGION_MODES: ReadonlySet<string> = new Set([
+  'active-active',
+  'active-hot-standby',
+  'active-passive',
+])
+
+/**
+ * requiresMultipleRegions — does this topology mode need ≥2 regions?
+ * Canonicalises first so a legacy spelling (`active-hotstandby`) answers the
+ * same as the canonical one.
+ */
+export function requiresMultipleRegions(mode: string): boolean {
+  return MULTI_REGION_MODES.has(canonicalizeMode(mode))
+}
+
+/**
  * canonicalizeMode (#3648, #3375 DoD-1) folds BOTH the legacy editor
  * dialect (single-region / active-hotstandby) AND the canonical
  * vocabulary (singleton / active-active / active-hot-standby /

--- a/products/catalyst/bootstrap/ui/src/widgets/topology/placement-vocabulary.drift.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/widgets/topology/placement-vocabulary.drift.test.tsx
@@ -17,7 +17,7 @@ import { describe, it, expect } from 'vitest'
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 
-import { ALL_MODES, canonicalizeMode, describeMode } from './modes'
+import { ALL_MODES, MULTI_REGION_MODES, canonicalizeMode, describeMode, requiresMultipleRegions } from './modes'
 import { canonicalizeTopologyMode } from '@/lib/fleet.api'
 
 // THE canonical vocabulary — must mirror Go placement.CanonicalModes()
@@ -59,6 +59,29 @@ describe('#3375 DoD-1 — one placement vocabulary, every FE surface', () => {
     for (const spelling of [...CANONICAL_MODES, ...LEGACY_SPELLINGS]) {
       expect(canonicalizeTopologyMode(spelling)).toBe(canonicalizeMode(spelling))
     }
+  })
+
+  // UAT row 60 — the multi-region PARTITION of the same vocabulary. Three
+  // surfaces gate on it (the create dialog, the install page, and the
+  // catalyst-api's Go mirror placementModeRequiresMultipleRegions), and a
+  // mode that lands on the wrong side of it is a DR posture placed over one
+  // region — accepted, reported Ready, with no standby and no Continuum.
+  it('MULTI_REGION_MODES is exactly the canonical set MINUS singleton', () => {
+    const expected = ALL_MODES.filter((m) => m !== 'singleton')
+    expect([...MULTI_REGION_MODES].sort()).toEqual([...expected].sort())
+    // Stated the other way round so a FIFTH mode cannot be added to
+    // ALL_MODES without a deliberate decision here: every canonical mode is
+    // either the one-region posture or a multi-region one.
+    for (const mode of ALL_MODES) {
+      expect(requiresMultipleRegions(mode)).toBe(mode !== 'singleton')
+    }
+  })
+
+  it('requiresMultipleRegions canonicalises first, so a legacy spelling answers the same', () => {
+    expect(requiresMultipleRegions('active-hotstandby')).toBe(true)
+    expect(requiresMultipleRegions('active-hot-standby')).toBe(true)
+    expect(requiresMultipleRegions('single-region')).toBe(false)
+    expect(requiresMultipleRegions('singleton')).toBe(false)
   })
 
   it('the InstallPage placement <select> hard-codes exactly the canonical options (no legacy spelling)', () => {


### PR DESCRIPTION
UAT rows 16 and 60 are the two halves of one contract: the topology an operator picks must survive **UI → canonical object → UI**. Row 16 is change-then-persist, row 60 is choose-at-create-then-reflect. Neither half held, and they failed for *different* reasons — which is why the two fixes are different.

**No live proof was taken.** Every claim below is source-level or test-level. These rows flip only on a live walk, and `docs/ledger/` is untouched.

---

## Trees grepped

All four, by `package.json` name:

| path | package | grepped |
|---|---|---|
| `core/console/` | `org-console` | yes — 3 files mention topology, none is an app Topology tab |
| `core/marketplace/` | `org-marketplace` | yes — `BCPStep.svelte` is the **Sovereign-level** BCP choice, and it already enforces the two-distinct-regions rule this PR pushes down into the API |
| `products/catalyst/console/` | `catalyst-console` | yes — `TopologyPicker.svelte`, `routes/catalog/[name]/new` |
| `products/catalyst/bootstrap/ui/` | `ui` (sovereign-admin) | yes — 73 files; **both surfaces these rows name live here** |

Naming the surfaces explicitly, because the previous root cause for row 16 got this wrong and was retracted in the ledger cell:

- Row 16's `/app/<name>` is `consoleAppDetailRoute` → `AppDetail` in the **sovereign-admin** tree (`src/app/router.tsx:1546`; `router.tsx:588` says in as many words "the AppCard generates HREF `/app/<name>`"). The tab strip is `AppDetail.tsx:663` (`<TabButton id="topology">`) — that half of the clause is already satisfied.
- Row 60's "**Catalog** → New instance" is `InstancesSection`, mounted by `CatalogDetail.tsx:760`, posting `POST /catalyst/v1/apps/instances` — which matches the door named in this row's own earlier walk evidence. That dialog is **correct** and is not changed here; it already gates on ≥2 regions (`InstancesSection.tsx:671`). The broken create door is the sibling `POST /api/v1/sovereigns/{id}/applications` one, `InstallPage`.

---

## Row 16 — defect class **3**: it persists, and the read-back drops it

`products/catalyst/bootstrap/api/internal/handler/applications.go:310` typed the projection `Placement string`, and `:785` filled it with `placementForTopology(readTopology(obj))`.

`spec.placement` is dual-form by CRD design (#3373): a bare posture STRING, or an OBJECT additionally carrying `vcluster`, `clusters`, `regions`, and since #3969 the entire per-region `targets[]`. A string carries none of that.

This is the READ half of the round trip that **#6136 (PR #6142) fixed the WRITE half of**. #6136 stopped the Topology-tab Save scalarising `spec.placement`, so the PlacementEditor's `targets[]` are finally *persisted* — and then this endpoint dropped them again on the way back out. It is the only read of the DESIRED placement the tab has.

Measured in the consumer rather than asserted — `products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.tsx:277-282`:

```ts
const specPlacement = app?.spec?.placement
if (specPlacement && typeof specPlacement === 'object') {
  const t = (specPlacement as Record<string, unknown>).targets
  if (Array.isArray(t) && t.length > 0) return declared(t as PlacementTarget[])
}
```

documented in place as *"the #3969 desired-state the operator explicitly chose in the editor (used pre-rollout / when the data plane is unavailable)"*. Against this endpoint `typeof specPlacement` was **always** `'string'`, so rung 2 — precisely the rung that renders a placement just Saved whose Pods have not moved yet — could never execute. Same for the `spec.placement.ownedDependencies` read at `TopologyTab.tsx:694-699`.

Net effect: PUT returns 200, the object accepts the targets, and the tab keeps rendering the pre-Save posture. The Save persisted and vanished.

**Fix** — `placementValueForStatus` (`applications.go`) reports the shape the CR holds, mirroring `placementValueForUpdate` on the write side so one dual-form producer faces each direction:

- object-form CR → object, verbatim, with `mode` rewritten to the canonical token (#3375 DoD-1);
- string-form or absent → the posture string via the pre-existing path, byte-identical to before, including its `singleton` display default;
- it never **synthesises** an object. An Application declaring only a posture reports only a posture — inventing `targets` would hand the tab a declared intention indistinguishable from an observed one, which is #5568's defect.

### The consumer half, and the regression it would otherwise have caused

Changing what the endpoint sends changes what the tab reads, so two consumer edits ship with it:

- **`ApplicationStatusResponse.spec.placement` was typed `string`** (`catalog.api.ts:288`) — *accurate*, while the endpoint really did flatten. That agreement is what made the object-form read a dead branch instead of a type error. Both sides now carry the CR's real shape. `TopologyTab` already declared the field dual-form locally; `SettingsTab`'s copy (which never reads it) is widened to match.
- **Rung 3, the legacy `mode + regions` projection, read the posture ONLY from the string form** (`TopologyTab.tsx:366-371`). Rung 3 is reached whenever rung 2 finds no `targets[]` — which is exactly the object-form `{mode, vcluster, regions}` the "+ New instance" dialog writes. Reading only the string would have left `mode` empty there, and `targetsFromLegacy` mints a Standby for every region after the first, so an **active-active** app would have rendered primary+standby. It now uses the same dual-form read `declaresStandby` has always used, and active-active / active-hot-standby over an identical object shape are each other's control in the new test.

---

## Row 60 — defect class **1** (the UI never sends it), with class **2** underneath

`products/catalyst/bootstrap/ui/src/pages/sovereign/InstallPage.tsx:109`:

```ts
placement: { mode: placementMode, regions: [region] },
```

One free-text `Region` input, hardcoded into a one-element list. Picking `active-hot-standby` submitted a **one-region hot-standby**, every time — the console could not express the choice at all.

And both write doors accepted it: `validateApplicationInstallRequest` (`applications.go:963`) and `validateApplicationUpdateRequest` (`applications_update.go:1107`) checked only `len(regions) >= 1`, for every mode. Nothing downstream can make that true:

- `core/controllers/internal/placement/placement.go:251-266` — `regions[0]` Primary, `regions[1..]` the standbys ⇒ a one-region list yields **zero** standbys;
- `core/controllers/application/internal/controller/continuum.go:165` — returns `(zero, false)` precisely because `len(standbys) == 0`, so **no Continuum CR is minted**, and the Continuum CR is what the Topology tab arms its Switchover against;
- `applications_preview.go:333` — marks a region standby only when `i > 0`.

Silent at every layer an operator can see: HTTP 201, `phase: Ready`, `spec.placement.mode: active-hot-standby` — with `status.perCluster[0].role: singleton` beside it. That is the shape **#6033** measured on hw293, and it is exactly why row 60's remaining leg is the *armed Switchover*.

**Fix**

1. `InstallPage` gains a standby/second-region control, rendered only for a posture that places one, and submits `regions: [primary, standby]`. Order matters and is asserted — `regions[0]` is the primary.
2. `placementRegionCountError` (new, `applications_placement_region_count.go`) refuses a multi-region posture over fewer than **2 DISTINCT** regions, wired into **both** write doors from **one** helper. Distinct, not entry count: the update door reaches the rule through `applicationUpdateRequestNormalize`'s targets fold, and `regionsFromPlacementTargets` **dedupes** — so a PlacementEditor Apply whose Primary and Standby name the same region arrives as active-hot-standby over one region. `PlacementEditor.addTarget` produces exactly that when the Sovereign reports a single region (`availableRegions.find(unused) ?? availableRegions[1] ?? availableRegions[0]`).

This is **not a new rule, it was an unenforced one.** Both surfaces that already ask an operator for a multi-region placement have always enforced it in the browser — `core/marketplace/src/components/BCPStep.svelte:230` ("Primary and replica regions must differ — pick two distinct regions to enable active-hot-standby") and `InstancesSection.tsx:671` ("#3599 validation — multi-region modes need ≥2 regions"). The doors behind them did not, so any caller that skipped those forms could write the shape the forms refuse.

### Deliberate behaviour change, called out

A caller that today POSTs `{mode: active-hot-standby, regions: [one]}` now gets a **400 that names the rule and the remedy** instead of a silent single-region "DR" app. That is the integrity gate #3375's own title asks for ("an integrity gate refuses a `ready`/active-hot-standby claim on a single-region prov"). A walker exercising row 50 through the API must send two regions; through either console surface it already does.

`MULTI_REGION_MODES` moved from `InstancesSection` to `widgets/topology/modes` so the create dialog, the install page and the Go mirror share **one** predicate rather than three copies.

---

## Mutant table — every mutant COMPILES

| # | Mutant | Target | rc RED | rc GREEN restored |
|---|---|---|---|---|
| 1 | `placementValueForStatus`: `if !isObject \|\| true { return posture }` — the old flattening | `go test -run Row16` | **1** (`Row16_EditorTargetsSurviveTheRoundTrip` + `Row16_Control_DifferentTopologyRoundTripsDifferently` FAIL; the string-form control stays green) | **0** |
| 2 | `placementRegionCountError`: `if !requires… \|\| true { return "" }` — rule neutered | `go test -run 'Row60\|RegionCount'` | **1** (5 refusal cases + both door tests FAIL) | **0** |
| 2B | `placementRegionCountError`: `&& false` — refuses every short list, **mode-blind** | `go test -run 'Row60\|RegionCount'` | **1** — and **only the CONTROLS fail** (`CONTROL_singleton_over_ONE_region_is_accepted`), which is what proves the controls discriminate rather than decorate | **0** |
| 3 | `InstallPage.placementRegions`: `if (!needsSecondRegion \|\| true) return [primary]` | `vitest run src/pages/sovereign/InstallPage` | **1** (2 failed / 5 passed) | **0** |
| 4 | `TopologyTab` rung-3 mode read: `false && specPlacement && …` — object branch disabled | `vitest run …/TopologyTab.dualform-placement-row16.test.tsx` | **1** (`active-active renders TWO PRIMARIES` FAIL; its active-hot-standby control stays green) | **0** |
| V | `validateApplicationInstallRequest` vocabulary switch: drop `active-passive` — a vacuity check on the drift guard whose FIXTURE this PR edited | `go test -run TestApplicationWireValidation_AcceptsCanonicalVocabulary` | **1** (`rejected accepted mode "active-passive"`) | **0** |

Mutant V exists because this PR changed a guard's FIXTURE (the vocabulary drift test seeded one region for every mode, which the new region rule refuses for the multi-region classes). Shaping that fixture from the rule's own predicate rather than a re-typed list keeps the guard's subject intact — and V proves it still bites: drop a canonical class from the validator and it goes red on exactly that class.

## Controls

- **Row 16, different value round-trips differently** — the same endpoint, same fixture shape, changing only the operator's pick: a **Cold** standby must read back `active-passive`, not `active-hot-standby`. Without it the test also passes for a projection printing a constant, which is exactly how a display-only defect hides.
- **Row 16, string stays a string** — a CR declaring only a posture must still report only a posture, so a fix that promoted everything to an object turns this red.
- **Row 60, singleton over one region is accepted** — the rule must discriminate by mode, not refuse every short list. Mutant 2B is the proof this control bites.
- **Row 60, active-hot-standby over two distinct regions is accepted**, and active-active over three — the rule is a floor, not an equality.
- **Row 60 UI, singleton still submits exactly one region** and the standby control is not even rendered.
- **Row 16 consumer, the flattened string is the control that establishes causality** — the same Application, same posture, same regions, differing only in SHAPE. Without it, "the object renders" would not show that the flattening was the defect.
- **Rung 3, active-active vs active-hot-standby over an identical object shape** must render differently, or the projection is ignoring the mode.

## Suites

- `go test ./internal/handler/` — **ok**, 300.9s, full package.
- `go vet ./internal/handler/` — clean.
- `npx vitest run` (sovereign-admin) — **249 files / 2241 passed**, 1 expected-fail (pre-existing).
- `npx tsc -b --noEmit` — clean. `eslint` on touched files reports only pre-existing `set-state-in-effect` findings on untouched lines.
- Guards: `check-no-banned-words.sh --commit-messages origin/main..HEAD` rc=0 · `check-walk-respects-scheduler.sh origin/main` rc=0 ("every green flip was on the scheduler's due-list" — this PR flips none) · `check-no-banned-object-names.sh` rc=0 · `check-guards-are-wired.sh` rc=0.

One pre-existing flake seen once under parallel load and green in isolation: `TestCheckSubdomain_BYONXDomainAvailable` resolves a real name against `127.0.0.53:53` and timed out. It touches no code in this change.

## Not claimed

- No live walk. Neither row is stamped; `docs/ledger/` is untouched. Row 60's *armed Switchover* still needs a real provision plus a Topology-tab read to confirm the Continuum CR now appears — this PR removes the producer-side reason it could not.
- Row 60's other create surface (`InstancesSection` → `POST /catalyst/v1/apps/instances`) was already correct and is unchanged.
- The preview door's default-fill path is deliberately left alone: it stamps a single default region when neither the body nor the CR names one, and applying the region rule there would 400 a "preview as-is" that never claimed a posture.

Refs #6231 #6033 #3375 #3687

