### PR TITLE
fix(provisioning): one unresolvable cart entry no longer sinks the whole per-Org apps tree (UAT 90/95/234)

### DIFF
--- a/core/services/provisioning/gitops/apps.go
+++ b/core/services/provisioning/gitops/apps.go
@@ -249,6 +249,45 @@ func LookupAppSpec(slug string) (AppSpec, bool) {
 	return spec, ok
 }
 
+// AppIsRenderable reports whether the generic Deployment generator can emit an
+// APPLIABLE manifest for this catalog slug — i.e. whether the slug resolves to
+// an AppSpec carrying an image.
+//
+// # Why an unrenderable slug must produce NOTHING rather than a husk (#5910)
+//
+// resolveAppSlugs (handlers.go) passes an id it cannot resolve through
+// UNCHANGED — deliberately, because callers may legitimately hand it values
+// that are already slugs. #5910 made that case observable but left the value
+// flowing into the generator, where GetAppSpec returns a bare AppSpec{} and
+// generateAppDeployment renders a Deployment with a null `image` and
+// `containerPort: 0`.
+//
+// That manifest is INVALID to the apiserver, and Flux aborts the WHOLE
+// `vcluster/apps` Kustomization on a single dry-run failure. So the blast
+// radius is not the one unresolvable cart entry — it is every co-installed app
+// in the same apply plus its database, the identical whole-tree abort #5423
+// documents (`inventory: 0`, the customer's WordPress and its MySQL never
+// applied). A cart holding one bad id therefore takes down the apps the
+// customer actually paid for.
+//
+// The old comment on GetAppSpec called the empty spec "fail loud rather than
+// silently succeed". That reasoning predates the whole-Kustomization abort:
+// today an invalid manifest does not fail loudly for one app, it fails
+// SILENTLY for all of them. Emitting nothing collapses the blast radius back
+// to the single entry that could not resolve, so the rest of the cart still
+// deploys and serves (UAT rows 90 / 95 / 234).
+//
+// This is the same remedy, keyed off the same property, that the
+// isHelmReleaseApp skip in GenerateAllWithAppConfigs already applies to the
+// #941 shape ("don't render an invalid `image: Required value` manifest").
+// Exported as ONE predicate because it has two call sites — the Deployment
+// render and the host-native route render — and a slug rendered by one but not
+// the other is either an unapplied file or a route to a backend that will
+// never exist.
+func AppIsRenderable(slug string) bool {
+	return strings.TrimSpace(GetAppSpec(slug).Image) != ""
+}
+
 // GetAppSpec returns the deployment spec for an app slug. Kept for
 // backwards-compat with callers that intentionally want the nginx fallback
 // (placeholder-for-demo cases only) — prefer LookupAppSpec in new code.

--- a/core/services/provisioning/gitops/gitops.go
+++ b/core/services/provisioning/gitops/gitops.go
@@ -728,6 +728,20 @@ func (g *ManifestGenerator) GenerateAllWithAppConfigs(slug, planSlug string, app
 		if isHelmReleaseApp(a) {
 			continue
 		}
+		// #5910 — a cart entry that resolves to NO catalog AppSpec (an
+		// unresolved UUID passed through resolveAppSlugs, or a slug this
+		// build's catalog does not carry) would render a Deployment with a
+		// null `image` and `containerPort: 0`. Flux aborts the ENTIRE
+		// vcluster/apps Kustomization on one invalid doc, so that husk takes
+		// every co-installed app and its DB down with it. Emit nothing for it
+		// instead — same remedy as the isHelmReleaseApp skip above — so the
+		// customer's other purchased apps still apply and serve. See
+		// AppIsRenderable for the full rationale.
+		if !AppIsRenderable(a) {
+			slog.Error("provisioning/gitops: cart entry resolves to no catalog AppSpec — emitting NO manifest for it so the rest of the cart still applies (#5910)",
+				"tenant", slug, "app", a)
+			continue
+		}
 		spec := GetAppSpec(a)
 		// MIRROR-EVERYTHING (#3785, Refs #3376 #3761): route the app image
 		// (main container + the InitCommand initContainer that reuses it)

--- a/core/services/provisioning/gitops/perorg_apps_tree.go
+++ b/core/services/provisioning/gitops/perorg_apps_tree.go
@@ -208,6 +208,16 @@ func (g *ManifestGenerator) GeneratePerOrgHostAppRoutes(slug, planSlug string, a
 		if isHelmReleaseApp(a) {
 			continue // carries its own chart-emitted HTTPRoute; syncs no Service
 		}
+		// #5910 — the SAME predicate the Deployment render uses. An entry that
+		// resolves to no catalog AppSpec emits no Deployment and no Service, so
+		// a route for it would bind a `<app>-x-<slug>-x-vcluster` backend that
+		// can never exist (ResolvedRefs=False / BackendNotFound). Skipping it
+		// here is what keeps the file set and this route set on ONE predicate:
+		// a slug rendered by one and not the other is either an unapplied file
+		// or a permanently-dangling route.
+		if !AppIsRenderable(a) {
+			continue
+		}
 		name := fmt.Sprintf("app-%s-hostroute.yaml", a)
 		out[PerOrgHostAppsDir+"/"+name] = generateHostNativeAppRoute(hostNS, slug, a, g.parentDomain())
 		docs = append(docs, name)

--- a/core/services/provisioning/gitops/perorg_apps_tree_unresolved_id_5910_test.go
+++ b/core/services/provisioning/gitops/perorg_apps_tree_unresolved_id_5910_test.go
@@ -83,28 +83,30 @@ func TestPerOrgAppsTree_UnresolvedIDRendersNoWorkload_5910(t *testing.T) {
 			// could never fire — a guard testing a shape that cannot occur. It is
 			// asserted below against the shape that is actually produced.
 			//
-			// CHARACTERISATION: these assertions pin the CURRENT broken output on
-			// purpose. When the fix lands upstream in resolveAppSlugs, this test
-			// SHOULD go red and be rewritten — that failure is the signal, not a
-			// regression.
-			husk, ok := files["vcluster/apps/app-"+unresolved+".yaml"]
-			if !ok {
-				t.Fatalf("#5910: expected a Deployment rendered for the unresolved id "+
-					"(that is the defect being pinned); keys: %v", keysOf(files))
+			// THE FIX (AppIsRenderable, apps.go): the unresolvable entry now
+			// renders NOTHING. This test was written as a characterisation of
+			// the broken output and its own comment said it should be rewritten
+			// when the fix landed — this is that rewrite.
+			//
+			// Asserting the FILE IS ABSENT is the whole point: it is the husk's
+			// existence, not its contents, that fails the Kustomization.
+			if husk, ok := files["vcluster/apps/app-"+unresolved+".yaml"]; ok {
+				t.Errorf("#5910: an unresolvable cart id STILL renders a Deployment. That manifest "+
+					"carries a null `image` and `containerPort: 0`, is invalid to the apiserver, and "+
+					"per #4389 fails the WHOLE vcluster/apps Kustomization — so every co-installed "+
+					"app in the same apply never lands (UAT rows 90/95/234):\n%s", husk)
 			}
-			if !strings.Contains(husk, "containerPort: 0") {
-				t.Errorf("#5910: expected the invalid `containerPort: 0` this defect produces — "+
-					"if this no longer renders, the upstream fix may have landed and this "+
-					"characterisation test must be rewritten:\n%s", husk)
+			// And nothing else may carry the raw id either — a route or a db doc
+			// naming it would be a dangling reference in the kustomization index,
+			// which breaks the build just as completely (the #4567 shape).
+			for path := range files {
+				if strings.Contains(path, unresolved) {
+					t.Errorf("#5910: file %q still names the unresolvable id; it can only "+
+						"reference objects that are never created", path)
+				}
 			}
-			if !strings.Contains(husk, "\n          image: \n") &&
-				!strings.Contains(husk, "\n                  image: \n") &&
-				!strings.Contains(husk, "image:\n") {
-				t.Errorf("#5910: expected a bare/null `image:` from the empty AppSpec:\n%s", husk)
-			}
-			t.Logf("#5910 CONFIRMED at the render seam: unresolved id renders an UNAPPLIABLE "+
-				"Deployment (null image, containerPort 0), which per #4389 fails the whole "+
-				"vcluster/apps Kustomization — taking co-installed apps down with it")
+			t.Logf("#5910 FIXED at the render seam: the unresolvable id contributes no manifest, "+
+				"so the vcluster/apps Kustomization stays appliable for the rest of the cart")
 		})
 	}
 }
@@ -127,6 +129,128 @@ func TestPerOrgAppsTree_UnresolvedIDIsIndistinguishable_5910(t *testing.T) {
 		t.Errorf("expected an unresolved UUID and an unknown slug to render identically at this seam "+
 			"(that indistinguishability IS the defect, #5910) — got %d vs %d files",
 			len(uuidFiles), len(wordFiles))
+	}
+}
+
+// TestPerOrgAppsTree_UnresolvableEntryDoesNotSinkTheCart_5910 is the assertion
+// the rows actually depend on, and the one the characterisation test above could
+// not make: the BLAST RADIUS.
+//
+// UAT row 90 is the funnel's terminal acceptance — the purchased WordPress must
+// SERVE. Row 234 is the same claim for the mail Blueprint. Neither is about the
+// unresolvable entry at all; they fail because Flux aborts the ENTIRE
+// vcluster/apps Kustomization on one invalid doc, so a single bad cart id takes
+// WordPress and its MySQL down with it (`inventory: 0` — the #5423 shape).
+//
+// So the property under test is not "the bad entry is dropped", it is "the GOOD
+// entries survive alongside it".
+func TestPerOrgAppsTree_UnresolvableEntryDoesNotSinkTheCart_5910(t *testing.T) {
+	const unresolved = "0f8b2c41-9d3e-4a77-b512-6ac0e9f31d84"
+
+	// Row 95 is literally "two Orgs, two TLDs, two running apps, identical
+	// mechanism", so the second Org is a CONTROL that shares the suspect
+	// property (a mixed cart) while differing in the one dimension the row
+	// names — the pool TLD. Both must survive identically; a fix that worked
+	// only on the primary pool would pass with one Org and fail row 95.
+	orgs := []struct{ slug, tld string }{
+		{"g95walkone", "omani.homes"},
+		{"g95walktwo", "omani.trade"},
+	}
+
+	for _, org := range orgs {
+		for _, plan := range []string{"s", "m"} {
+			t.Run(org.slug+"/"+org.tld+"/plan="+plan, func(t *testing.T) {
+				g := NewManifestGenerator("clusters/sov/org-tenants")
+				g.ParentDomain = org.tld
+
+				// The realistic funnel cart: a real purchase, its database, and
+				// one entry whose catalog id never resolved.
+				cart := []string{"wordpress", "mysql", unresolved}
+				files, appDocs := g.GeneratePerOrgAppsTree(org.slug, plan, cart, "pw123")
+
+				// 1. The paid-for app still renders — row 90's subject.
+				wp, ok := files["vcluster/apps/app-wordpress.yaml"]
+				if !ok {
+					t.Fatalf("row 90: the purchased WordPress rendered NO manifest when the cart also "+
+						"held an unresolvable id — the customer paid and nothing serves. keys: %v",
+						keysOf(files))
+				}
+				// 2. It renders under THIS Org's chosen TLD — row 95's mechanism.
+				// The app host must match the pool the per-Org console/listener
+				// live on, or it resolves to a gateway holding no listener for it.
+				wantHost := "wordpress." + org.slug + "." + org.tld
+				if !strings.Contains(wp, wantHost) {
+					t.Errorf("row 95: WordPress did not render under this Org's pool zone; want host %q "+
+						"(console==apps invariant, #4999/#4421):\n%s", wantHost, wp)
+				}
+				// 3. Its database still renders — the co-installed sibling that
+				// the whole-Kustomization abort used to take down with it.
+				if _, ok := files["vcluster/apps/db-mysql.yaml"]; !ok {
+					t.Errorf("#5910: the co-installed MySQL did not render, so WordPress would have no "+
+						"database even if it applied. keys: %v", keysOf(files))
+				}
+				// 4. The unresolvable entry contributes nothing.
+				if _, ok := files["vcluster/apps/app-"+unresolved+".yaml"]; ok {
+					t.Errorf("#5910: the unresolvable entry still rendered a husk that invalidates the "+
+						"whole apply")
+				}
+				// 5. The kustomization INDEX must not name it either. An index
+				// entry with no file breaks the kustomize build outright (#4567),
+				// which is the same total failure by another route.
+				for _, d := range appDocs {
+					if strings.Contains(d, unresolved) {
+						t.Errorf("#5910: appDocs indexes %q, but no such file is emitted — a dangling "+
+							"reference fails the whole kustomize build (#4567)", d)
+					}
+				}
+				// 6. And the index MUST still carry the real app, so this test
+				// cannot be satisfied by a generator that indexes nothing.
+				indexed := false
+				for _, d := range appDocs {
+					if d == "app-wordpress.yaml" {
+						indexed = true
+					}
+				}
+				if !indexed {
+					t.Errorf("VACUITY: app-wordpress.yaml is not in appDocs %v — the index assertion "+
+						"above would pass on an empty list", appDocs)
+				}
+			})
+		}
+	}
+}
+
+// TestPerOrgHostAppRoutes_NoRouteForUnrenderableEntry_5910 pins the SECOND call
+// site of the shared predicate. The vcluster tier emits a host-native HTTPRoute
+// per Deployment-shaped app; for an entry that renders no Deployment and no
+// Service, that route would bind `<id>-x-<slug>-x-vcluster` — a backend that can
+// never exist — and sit ResolvedRefs=False forever.
+//
+// The control is in the same call: the real app in the same cart MUST still get
+// its route, so this cannot pass by emitting no routes at all.
+func TestPerOrgHostAppRoutes_NoRouteForUnrenderableEntry_5910(t *testing.T) {
+	const unresolved = "0f8b2c41-9d3e-4a77-b512-6ac0e9f31d84"
+
+	g := NewManifestGenerator("clusters/sov/org-tenants")
+	g.ParentDomain = "omani.trade"
+
+	// "m" is a vcluster-tier plan — the only tier that emits host-native routes.
+	files, docs := g.GeneratePerOrgHostAppRoutes("g95walktwo", "m",
+		[]string{"wordpress", unresolved})
+
+	if _, ok := files[PerOrgHostAppsDir+"/app-wordpress-hostroute.yaml"]; !ok {
+		t.Fatalf("CONTROL FAILED: the real app got no host-native route, so the absence assertion "+
+			"below would pass on nothing. keys: %v", keysOf(files))
+	}
+	if _, ok := files[PerOrgHostAppsDir+"/app-"+unresolved+"-hostroute.yaml"]; ok {
+		t.Errorf("#5910: a host-native HTTPRoute was emitted for an entry that renders no Service — "+
+			"it can only ever report ResolvedRefs=False / BackendNotFound")
+	}
+	for _, d := range docs {
+		if strings.Contains(d, unresolved) {
+			t.Errorf("#5910: host-apps index names %q with no matching file — a dangling reference "+
+				"breaks the whole kustomize build (#4567)", d)
+		}
 	}
 }
 


### PR DESCRIPTION
## UAT cluster C — the funnel / customer-Org chain (R16, 87, 90, 95, 234)

Root-caused as one chain: checkout → Org provisioned → redirect to per-Org console → the purchased app SERVES at its own FQDN → and for 95, a second Org on a different TLD.

**Headline: four of the five rows are downstream of causes that are already fixed and merged. One live source-side defect remained, and this PR fixes it.**

### Trees grepped

All four front-end trees, plus the backend:

| Tree | Package | Checked for |
|---|---|---|
| `core/marketplace/` | `org-marketplace` | checkout, launch, redirect, readiness poll — **this is where the funnel lives** |
| `core/console/` | `org-console` | per-Org tenant console (not the funnel) |
| `products/catalyst/bootstrap/ui/` | `ui` | sovereign-admin console (not the funnel) |
| `products/catalyst/console/` | `catalyst-console` | Catalyst-side assets |

Backend: `core/services/{gateway,auth,tenant,billing,provisioning,catalog}`, `core/controllers/organization`, `products/catalyst/bootstrap/api`, `platform/stalwart-tenant/chart`.

### Prior art (cited, not re-derived)

Three historically distinct "the app route/host is wrong or missing" causes were each independently reached and each is **already retired by a merged fix** — all verified `git merge-base --is-ancestor <sha> HEAD` → rc=0 in this worktree:

| Cause | Fix | Ancestor of HEAD |
|---|---|---|
| #4993 — vcluster syncer registers no httproute reflector, so the app route never reaches the host Gateway (404) | `4f74c8c05` | rc=0 |
| #5423 — a HelmRelease doc in the kubeConfig-targeted apps tree poisons the whole Kustomization; routes applied, backends did not (`inventory: 0`, rows 86/90/233/234) | `fe6f1a288` | rc=0 |
| #6186 — per-Org app hosts resolved to a gateway holding no listener for them (rows 90/234) | `00b4b5b97` | rc=0 |
| #5246/#5511/#5957 — per-Org console listeners land in every region | `0439fbea8`, `908f76b0e` | rc=0 |
| #5635 — per-Org app hosts served from every region via ClusterMesh stubs | `de754137a` | rc=0 |

I also **refuted two stale ledger claims** (evidence below) rather than building on them.

### The earliest break, layer by layer

I walked the chain and each layer is source-complete:

1. **Sign-in / PIN** — `core/services/auth/handlers/routes.go:9,17,18,19` DO register `/auth/magic-link`, `/auth/send-pin`, `/auth/verify`, `/auth/verify-pin`. ⚠️ **This refutes the claim recorded in UAT row 90** that "a repo-wide grep across `core/services/` for any signup / register / otp / verify route returns NOTHING" and that checkout is Google-OAuth-only. The PIN flow is present and is what `core/marketplace/src/lib/api.ts:259,265` calls. The live 502 on PIN issuance is the mothership mail outage (#6197), an environment fault, not this code path.
2. **Redirect contract** — not a naive redirect. `CheckoutStep.svelte:263` → `consoleLaunchHref` → the `/launching` interstitial, which polls the **same-origin** `/api/provisioning/console-ready` (`console_ready.go:128`), which does the cross-host `GET /healthz` server-side. Gated on the destination actually serving. Sound.
3. **DNS** — `tenant_dns.go:182-192` writes `console.<slug>` **and** `*.<slug>.<parent>`, both at the console IP; `organization_dns.go:269` writes the same set at the same target post-#6186. Both doors agree.
4. **TLS listener** — `tenant_console_tls.go:307` appends a `*.<slug>.<parent>` listener pair with `allowedRoutes.namespaces.from: All` (`:509`), so it matches `wordpress.<slug>.<parent>` and `mail.<slug>.<parent>`, not just the console host.
5. **Region fan-out** — the "MISSING PRODUCER for `catalyst/cutover-secondary-kubeconfigs`" recorded in `PATH-TO-100.md:135-196` is **stale**. A non-cutover producer exists and is wired: `secondary_kubeconfig_secret_materializer.go:117` `RunSecondaryKubeconfigSecretMaterializer`, launched unconditionally at `products/catalyst/bootstrap/api/cmd/api/main.go:1119`. The second region witness (`tenant_console_tls_regions.go:380`) takes the **max** of ClusterMesh and `configuredRegions`, so a ClusterMesh Secret that has not appeared can no longer read as "single region" — and that chart wiring is guarded, vacuity-check included, by `products/catalyst/chart/tests/org-controller-region-witness-contract.sh` Case 4.
6. **App route + Service** — `generateAppHTTPRoute` (`gitops.go:2092`) binds `port: 80` and the generated Service is `port: 80 / targetPort: spec.Port` (`gitops.go:2046`), so it is correct for every app regardless of container port.
7. **Per-Org TLD (row 95)** — `resolveOrgParentDomain` honours the customer's pick when served, in both doors; `parent_domain` is carried on **both** transports of the install event (`tenant/handlers/handlers.go:461`, `apps.go:193`) and both decode into the same `appChangeData.ParentDomain`.

**The one break still live: `core/services/provisioning/gitops/gitops.go:731` (pre-fix) — an unresolvable cart entry renders an unappliable Deployment, and Flux aborts the WHOLE `vcluster/apps` Kustomization on it.**

`resolveAppSlugs` (`handlers/handlers.go:395`) passes an unresolved catalog id through unchanged — deliberately. #5910 made that observable and says so in its own comment: *"This does not change the resolution behaviour ... It makes the unresolvable case OBSERVABLE."* So the value still reaches the generator, `GetAppSpec` (`apps.go:259`) returns a bare `AppSpec{}`, and a Deployment renders with a null `image` and `containerPort: 0`.

That single invalid doc fails the entire apply — the same whole-tree abort #5423 documents. **The damage is not the bad entry; it is the WordPress and MySQL the customer paid for, in the same cart.** `GetAppSpec`'s "fail loud rather than silently succeed" comment predates that abort: today an invalid manifest does not fail loudly for one app, it fails silently for all of them.

### Which rows are downstream of what

| Row | Status |
|---|---|
| **90** (terminal acceptance — purchased app serves) | Directly protected by this PR when the cart holds an unresolvable entry. Otherwise **stale-pending-walk**: #4993 + #5423 + #6186 all merged, none walked since #6186 landed 2026-08-12. |
| **95** (2nd Org, different TLD) | This PR's own row — #5910 is row 95's named mechanism, and the fix's control is literally two Orgs on two TLDs. |
| **234** (mail serves) | Downstream of 90. `bp-stalwart-tenant`'s chart contract matches what the funnel stamps (`ingress.webmail.host` / `parentRef` → `cilium-gateway-console`/`kube-system`, chart `values.yaml:494-535`). Deploy-gated on chart 0.1.14 (`935d23842`). |
| **R16, 87** (one Org door; redirect to per-Org console) | Downstream of the region fan-out, not of this defect. Both producers now exist (item 5 above); the `PATH-TO-100.md` "missing producer" warrant is stale and should not be re-implemented. |

### The fix

One exported predicate, `AppIsRenderable` (`apps.go`), with **two** call sites — the Deployment render and the host-native route render. Two call sites because a slug rendered by one and not the other is either an unapplied file or a route whose backend can never exist. This is the same remedy already applied two lines above for the #941 shape.

Unchanged: resolution behaviour, the pass-through, the #5910 warning, every renderable slug's output, and `placeholder`'s nginx spec.

### Mutant table — both mutants compile

| Step | rc | Result |
|---|---|---|
| baseline `go test ./gitops/ -run 5910` | 0 | GREEN |
| **mutant A** — revert the Deployment-render skip (`&& false`) | **1** | **RED** on both Orgs, both TLDs, both tiers |
| restore A | 0 | GREEN |
| **mutant B** — revert the host-native route skip (`&& false`) | **1** | **RED**, and specifically on `NoRouteForUnrenderableEntry` |
| restore B, full module `go test ./...` | 0 | GREEN |

Mutant A leaves the route test green and mutant B leaves the cart tests green — the two call sites are discriminated, not covered by one blanket assertion.

### The control

Row 95's clause *is* the control: `UnresolvableEntryDoesNotSinkTheCart_5910` runs the identical mixed cart over **two Orgs on two different pool TLDs** (`omani.homes` / `omani.trade`) and both tiers, and asserts each Org's WordPress renders under **its own** zone (`wordpress.<slug>.<tld>`) — so a fix that only worked on the primary pool would pass with one Org and fail row 95. Plus a vacuity arm: the real app must still appear in `appDocs`, so the absence assertions cannot pass on a generator that indexes nothing.

### Live proof

**None taken.** This is a render-seam fix verified offline. No live cluster was read or written during the fix, no provisioning API was called, no NodePort was involved, and **no UAT row is stamped** — these rows flip only on a live funnel walk.

Refs #5910 #5423 #3376 #4389 #6186 #6197

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HvMZTDx7W6EPZMmjyXmYh1
