### PR TITLE
fix(cutover): Case 40 could not detect what it asserts — pipefail turned every match into 141

### DIFF
--- a/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
+++ b/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
@@ -1605,6 +1605,54 @@ echo "[cutover-contract] Case 40: cutover step + resolver ConfigMaps re-render o
 # (self-sovereign-cutover-status) keeps, to preserve mid-cutover progress across a
 # chart uninstall (Case 6). This gate locks that invariant so a future edit cannot
 # re-introduce the inert-mid-cutover bug (the #3668/#3710 shape that seeded #4417).
+#
+# #6235 — THIS GATE COULD NOT DETECT WHAT IT ASSERTS. Two defects, one line:
+#
+#   if awk "/^  name: ${cm}\$/,/^---\$/" render.yaml | grep -q 'helm.sh/...: keep'
+#
+# (1) FAIL-OPEN, and this is the dominant behaviour. The script runs under
+#     `set -euo pipefail` (line 37). `grep -q` exits the instant it matches, awk
+#     is then killed by SIGPIPE (141), and pipefail promotes 141 to the pipeline
+#     status — so a FOUND match returns non-zero and the `if` reads it as "no
+#     match". Measured on the default render: the three ranges that contain the
+#     string all return rc=141. Proof by mutant — a genuine
+#     `helm.sh/resource-policy: keep` added to step-05's metadata.annotations
+#     renders cleanly and the pre-fix gate reports PASS on it.
+#
+# (2) FALSE POSITIVE when the race lands the other way. The range was the WHOLE
+#     document including `data:`, and every step CM carries its shell script
+#     there. #5216 (2026-07-18) added to _helpers.tpl:222 the literal line
+#         # helm.sh/resource-policy: keep so nothing prunes the applied copy.
+#     — a COMMENT ABOUT the annotation. When awk finishes before grep exits (a
+#     short range, or scheduling), the pipeline returns 0 and Case 40 fires on
+#     that comment. Observed exactly once here, on cutover-step-09, which
+#     `exit 1`s the script and takes Cases 41-91 with it — including the #6198
+#     and #6214 gates added the same day. Re-runs of the identical tree pass, so
+#     it is a flake, not a standing red; blueprint-release.yaml has stayed green.
+#
+# The repair removes the pipeline entirely: `yq` reads the field, and the awk
+# fallback captures into a variable before matching, so no consumer can ever
+# SIGPIPE a producer again. The predicate lives in ONE function used by the real
+# check, the positive half AND the control, so the control cannot drift from
+# what the gate actually runs.
+#
+# c40_keep_policy <configmap-name> <rendered-yaml> — echoes "keep" or "none".
+c40_keep_policy() {
+  local _name="$1" _file="$2" _meta
+  if command -v yq >/dev/null 2>&1; then
+    yq "select(.kind == \"ConfigMap\" and .metadata.name == \"${_name}\") | .metadata.annotations.\"helm.sh/resource-policy\" // \"none\"" "$_file"
+    return 0
+  fi
+  # No yq: slice ONLY the metadata block (name -> the `data:` key at column 0,
+  # which always follows it) and match on the captured text, never through a
+  # pipe into an early-exiting reader.
+  _meta="$(awk "/^  name: ${_name}\$/,/^data:\$/" "$_file")"
+  case "$_meta" in
+    *"helm.sh/resource-policy: keep"*) echo keep ;;
+    *) echo none ;;
+  esac
+}
+
 for cm in cutover-offline-mirror-resolver \
           cutover-step-01-gitea-mirror cutover-step-02-harbor-projects \
           cutover-step-03-harbor-prewarm cutover-step-04-registry-pivot \
@@ -1612,25 +1660,52 @@ for cm in cutover-offline-mirror-resolver \
           cutover-step-07-catalyst-api-env-patch cutover-step-08-egress-block-test \
           cutover-step-09-gitea-token-mint cutover-step-10-vcluster-registry-pivot \
           cutover-step-11-crossplane-provider-pivot; do
-  # The metadata name renders at exactly 2-space indent (`  name: <cm>`); the
-  # deep-indented volume/configMap refs inside podSpec do NOT match, so the awk
-  # range spans exactly this one ConfigMap document (name → next `---`).
   if ! grep -q "^  name: ${cm}$" "$TMP/render.yaml"; then
     echo "FAIL: expected ConfigMap ${cm} not found in render (Case 40 list drifted from the chart)" >&2
     exit 1
   fi
-  if awk "/^  name: ${cm}\$/,/^---\$/" "$TMP/render.yaml" | grep -q 'helm.sh/resource-policy: keep'; then
+  if [ "$(c40_keep_policy "$cm" "$TMP/render.yaml")" = keep ]; then
     echo "FAIL: ConfigMap ${cm} carries helm.sh/resource-policy: keep — it will NOT re-render on a helm upgrade, so a mid-cutover chart fix is INERT (#4982 Finding A). Drop keep from step/resolver CMs; only self-sovereign-cutover-status keeps." >&2
     exit 1
   fi
 done
 # Positive half of the invariant: the status CM MUST keep (mirror of Case 6, kept
 # here so Case 40 fully specifies the keep policy across ALL cutover ConfigMaps).
-if ! awk '/^  name: self-sovereign-cutover-status$/,/^---$/' "$TMP/render.yaml" | grep -q 'helm.sh/resource-policy: keep'; then
+if [ "$(c40_keep_policy self-sovereign-cutover-status "$TMP/render.yaml")" != keep ]; then
   echo "FAIL: self-sovereign-cutover-status ConfigMap must carry helm.sh/resource-policy: keep to preserve mid-cutover progress (#4982 Finding A / Case 6)" >&2
   exit 1
 fi
-echo "  PASS (resolver + 11 step CMs re-render on upgrade; only the status CM keeps)"
+# CONTROL — this is the assertion the pre-#6235 gate silently failed, so it is
+# the one that must be executed rather than reasoned about. A step-shaped CM
+# carrying a REAL metadata.annotations keep, run through the SAME function the
+# loop above calls, must come back "keep". Without it the repair could have
+# swapped a flaky false positive for a permanently dead gate and looked greener.
+cat > "$TMP/c40-control.yaml" <<'C40CTL'
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cutover-step-99-control
+  annotations:
+    helm.sh/resource-policy: keep
+data:
+  stepName: control
+C40CTL
+if [ "$(c40_keep_policy cutover-step-99-control "$TMP/c40-control.yaml")" != keep ]; then
+  echo "FAIL: CONTROL — the annotation-anchored keep check did NOT detect a genuine metadata.annotations keep on a step CM; Case 40 is fail-open again (#6235, #4982 Finding A)" >&2
+  exit 1
+fi
+# CONTROL 2 — the comment in _helpers.tpl:222 that used to trip this gate is
+# still in the render. Prove the new predicate does NOT read it as a keep: pick
+# a step CM whose script body contains the phrase and assert it reads "none".
+if ! grep -q 'helm.sh/resource-policy: keep so nothing prunes' "$TMP/render.yaml"; then
+  echo "FAIL: CONTROL 2 is vacuous — the _helpers.tpl comment that caused the #6235 false positive is no longer in the render, so this control proves nothing. Re-point it at a body that still carries the phrase, or drop it." >&2
+  exit 1
+fi
+if [ "$(c40_keep_policy cutover-step-09-gitea-token-mint "$TMP/render.yaml")" != none ]; then
+  echo "FAIL: CONTROL 2 — a step CM whose SCRIPT BODY mentions helm.sh/resource-policy: keep was read as carrying the annotation; the #6235 body/metadata confusion is back" >&2
+  exit 1
+fi
+echo "  PASS (resolver + 11 step CMs re-render on upgrade; only the status CM keeps; CONTROL proves a real metadata keep is caught, CONTROL 2 proves the _helpers.tpl comment is not)"
 
 echo "[cutover-contract] Case 41: Step-03 harbor-prewarm has a settled-roll pre-flight (Phase A0) that fail-closes on a mid-roll env BEFORE building the mirror (#4982 Finding B, Refs #3379)"
 # #4982 Finding B: harbor-prewarm mirrors the RUNNING / declared-template image
@@ -4638,5 +4713,102 @@ if ! grep -q 'acme/some-tenant-app' "$TMP/c90/out.txt"; then
   exit 1
 fi
 echo "  PASS (#6198: the chart's own workloads are excluded from its own settled-roll gate, and the CONTROL proves a foreign unsettled Deployment is still caught and named)"
+
+echo "[cutover-contract] Case 92: the cutover-order labels are a CONTIGUOUS 1..N permutation — no duplicate, no gap (#6235, UAT row 166)"
+# UAT row 166 asks the `cutover` group on /jobs to read all-11-green. The order
+# the group renders in is not the filename order — catalyst-api's
+# listCutoverSteps (api/internal/handler/cutover.go:513) sorts on the integer
+# `bp.openova.io/cutover-order` label and, ON A TIE, falls back to the ConfigMap
+# NAME. That tiebreak is alphabetical, which is exactly the #6093 defect the
+# order labels exist to prevent: two steps sharing an order silently restore
+# lexicographic sequencing for that pair.
+#
+# Nothing else in this file can see that. Case 2 counts the step CMs (11) — a
+# count is satisfied by any permutation and by any duplicate. Case 91 pins the
+# egress-block-test as strictly last — a relation between one step and the max,
+# blind to a collision or a hole among the other ten. #6214 renumbered four
+# labels by hand; a fifth hand-edit that lands two steps on the same integer
+# would pass both existing gates.
+#
+# Assert the whole map at once: the sorted order values must equal 1..N exactly.
+# That is one predicate for three defects — duplicate, gap, and off-by-one base.
+yq 'select(.kind == "ConfigMap" and .metadata.labels."app.kubernetes.io/component" == "cutover-step")
+    | .metadata.labels."bp.openova.io/cutover-order" + " " + .data.stepName' \
+  "$TMP/render.yaml" | grep -vx -- --- | sort -n > "$TMP/c92-orders.txt"
+c92_n="$(wc -l < "$TMP/c92-orders.txt")"
+if [ "$c92_n" -ne 11 ]; then
+  echo "FAIL: expected 11 order-bearing step ConfigMaps, read $c92_n (#6235)" >&2
+  cat "$TMP/c92-orders.txt" >&2
+  exit 1
+fi
+c92_got="$(cut -d' ' -f1 "$TMP/c92-orders.txt" | paste -sd, -)"
+c92_want="$(seq 1 "$c92_n" | paste -sd, -)"
+if [ "$c92_got" != "$c92_want" ]; then
+  # Name the actual shape so the operator sees WHICH kind of break it is.
+  c92_dupes="$(cut -d' ' -f1 "$TMP/c92-orders.txt" | sort -n | uniq -d | paste -sd' ' -)"
+  echo "FAIL: the cutover-order labels are not a contiguous 1..$c92_n permutation (#6235, UAT row 166)." >&2
+  echo "       got:  $c92_got" >&2
+  echo "       want: $c92_want" >&2
+  [ -n "$c92_dupes" ] && echo "       DUPLICATE order value(s): $c92_dupes — listCutoverSteps ties break on ConfigMap NAME, so those steps sequence alphabetically (the #6093 defect)" >&2
+  echo "       full map:" >&2
+  sed 's/^/         /' "$TMP/c92-orders.txt" >&2
+  exit 1
+fi
+# CONTROL — the predicate must REJECT a duplicate, or it is only counting rows.
+# Same eleven steps, orders 9 and 10 collapsed onto 9: a shape that renders
+# perfectly and that Case 2 (count) and Case 91 (egress strictly last) both pass.
+printf '1\n2\n3\n4\n5\n6\n7\n8\n9\n9\n11\n' > "$TMP/c92-dupe.txt"
+c92_ctl_got="$(sort -n "$TMP/c92-dupe.txt" | paste -sd, -)"
+if [ "$c92_ctl_got" = "$c92_want" ]; then
+  echo "FAIL: CONTROL — a duplicated order value compared EQUAL to the contiguous 1..$c92_n sequence; Case 92's predicate cannot detect a collision (#6235)" >&2
+  exit 1
+fi
+echo "  PASS (#6235: cutover-order is a contiguous 1..$c92_n permutation — $c92_got; CONTROL proves a duplicate order is rejected)"
+
+echo "[cutover-contract] Case 93: the pre-seeded status ConfigMap's step slugs EQUAL the step ConfigMaps' stepNames (#6235, UAT row 166)"
+# The /jobs cutover group is seeded by chrootSeedCutoverActivity
+# (api/internal/handler/jobs.go:503-509), which UNIONs two sources:
+#   ordered  — listCutoverSteps, from the step ConfigMaps' order labels
+#   durable  — listStepNamesFromStatus, the `step.<slug>.result` keys pre-seeded
+#              into self-sovereign-cutover-status by 09-cutover-status-configmap.yaml
+# The union is deliberate (#3646: a completed cutover whose step CMs were reaped
+# must still render). Its cost is that the SEED is authoritative for existence:
+# a slug that appears ONLY in the status ConfigMap becomes a row on the cutover
+# group that has no step ConfigMap behind it, so the engine never runs it, and it
+# can never leave `pending`. The group could then never read all-11-green — UAT
+# row 166 would fail forever on a chain that is otherwise perfectly healthy, and
+# the failure would look like a stuck step rather than a typo in a template.
+#
+# One transposed character in either file produces it, and every other gate is
+# blind: the seed keys carry no order label (Cases 2/92 skip them), no podSpec
+# (Case 3 skips them), and the count `totalSteps` is a hand-written literal.
+c93_steps="$(yq 'select(.kind == "ConfigMap" and .metadata.labels."app.kubernetes.io/component" == "cutover-step") | .data.stepName' "$TMP/render.yaml" | grep -vx -- --- | sort)"
+c93_seed="$(yq 'select(.kind == "ConfigMap" and .metadata.name == "self-sovereign-cutover-status") | .data | keys | .[]' "$TMP/render.yaml" \
+  | sed -n 's/^step\.\(.*\)\.result$/\1/p' | sort)"
+if [ "$c93_steps" != "$c93_seed" ]; then
+  echo "FAIL: the status ConfigMap's pre-seeded step slugs do not match the step ConfigMaps' stepNames (#6235, UAT row 166)." >&2
+  echo "       only in the step ConfigMaps (seeded nowhere — absent from the durable record):" >&2
+  comm -23 <(printf '%s\n' "$c93_steps") <(printf '%s\n' "$c93_seed") | sed 's/^/         /' >&2
+  echo "       only in the status seed (a /jobs row with no step behind it — can never go green):" >&2
+  comm -13 <(printf '%s\n' "$c93_steps") <(printf '%s\n' "$c93_seed") | sed 's/^/         /' >&2
+  exit 1
+fi
+# totalSteps is what the wizard renders as the denominator ("3 of 11"). A drift
+# here does not strand a row, but it misreports the chain length on every screen
+# that shows progress, including the one UAT row 166 is read off.
+c93_total="$(yq 'select(.kind == "ConfigMap" and .metadata.name == "self-sovereign-cutover-status") | .data.totalSteps' "$TMP/render.yaml")"
+c93_count="$(printf '%s\n' "$c93_steps" | wc -l)"
+if [ "$c93_total" != "$c93_count" ]; then
+  echo "FAIL: status ConfigMap totalSteps=\"$c93_total\" but the chart renders $c93_count steps (#6235, UAT row 166)" >&2
+  exit 1
+fi
+# CONTROL — the comparison must REJECT a one-character slug drift. Without this,
+# an assertion that both lists are merely non-empty would look identical here.
+c93_typo="$(printf '%s\n' "$c93_seed" | sed 's/^gitea-token-mint$/gitea-token-mints/' | sort)"
+if [ "$c93_steps" = "$c93_typo" ]; then
+  echo "FAIL: CONTROL — a seed slug typo'd to 'gitea-token-mints' still compared EQUAL to the step stepNames; Case 93 cannot detect a stranded row (#6235)" >&2
+  exit 1
+fi
+echo "  PASS (#6235: $c93_count step slugs seeded, exactly matching the step ConfigMaps; totalSteps=$c93_total; CONTROL proves a one-character slug drift is rejected)"
 
 echo "[cutover-contract] All gates green."

--- a/products/catalyst/bootstrap/api/internal/handler/jobs_cutover_step_order_6093_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/jobs_cutover_step_order_6093_test.go
@@ -36,20 +36,35 @@ import (
 
 // theElevenStepsInChartOrder is the declared execution order carried by
 // the `bp.openova.io/cutover-order` label on the cutover-step-NN-<slug>
-// ConfigMaps — read live off hw293 and identical to the ADR-0002 /
-// CLAUDE.md eleven-step chain.
+// ConfigMaps.
+//
+// UPDATED for #6214 (2026-08-13). The labels were renumbered so the
+// deny-egress hold runs strictly LAST: gitea-token-mint 9->8,
+// vcluster-registry-pivot 10->9, crossplane-provider-pivot 11->10,
+// egress-block-test 8->11. Step-08's pre-hold lints assert that every
+// Flux source, workload image and Crossplane Provider package already
+// resolves Sovereign-local — two of the steps that PRODUCE that state
+// used to run after it, so cutoverComplete was structurally unreachable
+// on any Sovereign carrying an external Provider.
+//
+// Note the FILENAMES are deliberately unchanged (08-egress-block-test-job.yaml
+// still carries order 11); the label is authoritative, so read the label,
+// never the filename prefix. Verified against
+// platform/self-sovereign-cutover/chart/templates/*.yaml at chart 0.1.182,
+// and pinned there by cutover-contract.sh Case 91 (egress strictly last)
+// and Case 92 (the labels are a contiguous 1..11 permutation).
 var theElevenStepsInChartOrder = []string{
-	"gitea-mirror",              // 01
-	"harbor-projects",           // 02
-	"harbor-prewarm",            // 03
-	"registry-pivot",            // 04
-	"flux-gitrepository-patch",  // 05
-	"helmrepository-patches",    // 06
-	"catalyst-api-env-patch",    // 07
-	"egress-block-test",         // 08 — the deny-egress sovereignty proof
-	"gitea-token-mint",          // 09
-	"vcluster-registry-pivot",   // 10
-	"crossplane-provider-pivot", // 11
+	"gitea-mirror",              // label 1
+	"harbor-projects",           // label 2
+	"harbor-prewarm",            // label 3
+	"registry-pivot",            // label 4
+	"flux-gitrepository-patch",  // label 5
+	"helmrepository-patches",    // label 6
+	"catalyst-api-env-patch",    // label 7
+	"gitea-token-mint",          // label 8  (file 09-)
+	"vcluster-registry-pivot",   // label 9  (file 10-)
+	"crossplane-provider-pivot", // label 10 (file 11-)
+	"egress-block-test",         // label 11 (file 08-) — the deny-egress proof, LAST
 }
 
 // statusKeysFor builds the durable status map the chart pre-seeds at
@@ -95,8 +110,16 @@ func TestMergeCutoverStepOrder_ChartOrderWins(t *testing.T) {
 
 	// Name the single most misleading consequence explicitly, so a
 	// regression reads as what it is rather than as a diff of two lists.
-	if idx := indexOfSlug(got, "egress-block-test"); idx != 7 {
-		t.Errorf("egress-block-test is the step-08 deny-egress sovereignty proof; projected at position %d, want position 8", idx+1)
+	//
+	// Asserted as a RELATION (last), not the literal 8 it used to be. That
+	// literal was written before #6214 renumbered the labels, and it had
+	// become a trap pointing the wrong way: anyone correcting the fixture
+	// above to the real chart order would have been failed by this line and
+	// pushed to revert the correction — the guard arguing against the fix it
+	// is supposed to protect. Renumbering stays free; moving the deny-egress
+	// hold off the end does not. Mirrors cutover-contract.sh Case 91.
+	if idx, last := indexOfSlug(got, "egress-block-test"), len(theElevenStepsInChartOrder)-1; idx != last {
+		t.Errorf("egress-block-test is the deny-egress sovereignty proof and must project LAST (it proves the end state, so nothing may run after it — #6214); projected at position %d of %d, want position %d", idx+1, len(got), last+1)
 	}
 }
 

--- a/products/catalyst/bootstrap/ui/src/shared/types/cutover.test.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/types/cutover.test.ts
@@ -94,6 +94,14 @@ describe('CUTOVER_STEPS — canonical 11-step list', () => {
     // `bp.openova.io/cutover-order` labels 01..11. The catalyst-api engine
     // discovers + runs them in this order. The slug is `helmrepository-patches`
     // (the prior `helmrepo-patches` never matched the chart).
+    //
+    // #6214 (2026-08-13): egress-block-test moved from label 8 to label 11 and
+    // gitea-token-mint / vcluster-registry-pivot / crossplane-provider-pivot
+    // each moved down one, so the deny-egress hold runs strictly LAST. The
+    // chart FILENAMES did not change — 08-egress-block-test-job.yaml carries
+    // order 11 — so this expectation must be read off the LABEL, never the
+    // file prefix. It is pinned chart-side by cutover-contract.sh Case 91
+    // (egress strictly last) and Case 92 (contiguous 1..11 permutation).
     expect(CUTOVER_STEPS.map((s) => s.id)).toEqual([
       'gitea-mirror',
       'harbor-projects',
@@ -102,11 +110,19 @@ describe('CUTOVER_STEPS — canonical 11-step list', () => {
       'flux-gitrepository-patch',
       'helmrepository-patches',
       'catalyst-api-env-patch',
-      'egress-block-test',
       'gitea-token-mint',
       'vcluster-registry-pivot',
       'crossplane-provider-pivot',
+      'egress-block-test',
     ])
+  })
+
+  it('runs the deny-egress hold LAST — it proves the end state (#6214)', () => {
+    // A relation, not a literal index: renumbering stays free, moving the
+    // hold off the end does not. This is the front-end mirror of
+    // cutover-contract.sh Case 91 and the catalyst-api
+    // jobs_cutover_step_order_6093_test.go assertion.
+    expect(CUTOVER_STEPS[CUTOVER_STEPS.length - 1]!.id).toBe('egress-block-test')
   })
 
   it('every step has a non-empty label and description', () => {

--- a/products/catalyst/bootstrap/ui/src/shared/types/cutover.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/types/cutover.ts
@@ -113,8 +113,15 @@ export interface CutoverStepDef {
  *   01 gitea-mirror · 02 harbor-projects · 03 harbor-prewarm ·
  *   04 registry-pivot · 05 flux-gitrepository-patch ·
  *   06 helmrepository-patches · 07 catalyst-api-env-patch ·
- *   08 egress-block-test · 09 gitea-token-mint ·
- *   10 vcluster-registry-pivot · 11 crossplane-provider-pivot
+ *   08 gitea-token-mint · 09 vcluster-registry-pivot ·
+ *   10 crossplane-provider-pivot · 11 egress-block-test
+ *
+ * #6214 (2026-08-13): those numbers are the `bp.openova.io/cutover-order`
+ * LABELS, which were renumbered so the deny-egress hold runs strictly last —
+ * it proves the end state, so it cannot precede the steps that establish it.
+ * The chart FILENAMES were deliberately left alone, so 08-egress-block-test-job.yaml
+ * now carries order 11 and 09/10/11-*.yaml carry 8/9/10. Read the label, never
+ * the filename. This list previously still carried the pre-#6214 sequence.
  * NOTE the slug is `helmrepository-patches` (NOT the prior `helmrepo-patches`)
  * — the old FE id never matched the chart, so that row could never light up.
  */
@@ -206,13 +213,6 @@ export const CUTOVER_STEPS: readonly CutoverStepDef[] = [
       'the upstream-fallback default.',
   },
   {
-    id: 'egress-block-test',
-    label: 'Egress-block self-test',
-    description:
-      'Apply a NetworkPolicy denying egress to github.com + ghcr.io + ' +
-      'harbor.openova.io for 10 minutes; assert all reconciles stay green.',
-  },
-  {
     id: 'gitea-token-mint',
     label: 'Mint local Gitea token',
     description:
@@ -232,6 +232,16 @@ export const CUTOVER_STEPS: readonly CutoverStepDef[] = [
     description:
       'Rewrite Crossplane provider + function package refs from upstream ' +
       'registries to the local Harbor proxy projects.',
+  },
+  {
+    // LAST by design (#6214). The hold proves the END state — every Flux
+    // source, workload image and Crossplane package already resolving
+    // Sovereign-local — so it cannot precede the steps that establish it.
+    id: 'egress-block-test',
+    label: 'Egress-block self-test',
+    description:
+      'Apply a NetworkPolicy denying egress to github.com + ghcr.io + ' +
+      'harbor.openova.io for 10 minutes; assert all reconciles stay green.',
   },
 ] as const
 


### PR DESCRIPTION
Source-side verification of UAT cluster A (the cutover chain) — rows **G11**, **166**, **227**.
**No live cluster was touched and no cutover was triggered.** All three rows still need a live
cutover walk to flip; what follows is the mechanism check only.

---

## The headline: Case 40 could not detect the defect it exists to catch

`platform/self-sovereign-cutover/chart/tests/cutover-contract.sh` Case 40 keeps
`helm.sh/resource-policy: keep` off the cutover step ConfigMaps — a step CM carrying it is excluded
from the helm-upgrade UPDATE set, so a mid-cutover chart fix lands inert (#4982 Finding A, live
hw239). One line, two defects in opposite directions:

```sh
if awk "/^  name: ${cm}\$/,/^---\$/" render.yaml | grep -q 'helm.sh/resource-policy: keep'
```

### 1. Fail-open — the dominant behaviour

The script runs under `set -euo pipefail` (`cutover-contract.sh:37`). `grep -q` exits the instant it
matches, `awk` is then killed by SIGPIPE (141), and **pipefail promotes 141 to the pipeline status**
— so a *found* match returns non-zero and the `if` reads it as "no match". Measured on the default
render, for the three ranges that actually contain the string:

```
cutover-step-06-helmrepository-patches: range=1535 lines, hits=1, pipeline rc=141
cutover-step-07-catalyst-api-env-patch: range=741  lines, hits=1, pipeline rc=141
cutover-step-09-gitea-token-mint:       range=262  lines, hits=1, pipeline rc=141
```

**Proof by mutant.** A genuine `helm.sh/resource-policy: keep` added to step-05's
`metadata.annotations` renders cleanly (`helm template` rc=0, annotation confirmed present via `yq`):

| test version | result |
|---|---|
| pre-fix (`origin/main`) | **PASS** — rc=0, 82 cases. The defect is invisible to it. |
| this PR | **FAIL** at Case 40, naming `cutover-step-05-flux-gitrepository-patch` |

### 2. False positive when the race lands the other way

The range was the **whole document** including `data:`, and every step CM carries its shell script
there. #5216 (2026-07-18) added to `platform/self-sovereign-cutover/chart/templates/_helpers.tpl:222`:

```
# helm.sh/resource-policy: keep so nothing prunes the applied copy.
```

A comment *about* the annotation. When `awk` finishes before `grep` exits, the pipeline returns 0 and
Case 40 fires on that comment. I hit exactly that on the first run of this session — rc=1, **42 of 82
cases**, failing on `cutover-step-09-gitea-token-mint` — which `exit 1`s the script and takes
**Cases 41–91** with it, including the **#6198** and **#6214** gates added that same day. Re-runs of
the identical tree pass, so this is a **flake, not a standing red**.

**Correction to a claim worth stating plainly:** CI *does* run this script —
`.github/workflows/blueprint-release.yaml:450` executes `chart/tests/*.sh` — but only on **push to
`main`**, never on a PR. It has been green there throughout, which is exactly what the fail-open
analysis predicts. So the gate is a post-merge gate that mostly cannot fail, and occasionally fails
for the wrong reason.

### The repair

`cutover-contract.sh:1596-1690` — the pipeline is gone. `yq` reads the field; the awk fallback
captures into a variable and matches with a `case` statement, so no consumer can SIGPIPE a producer
again. The predicate lives in **one function** (`c40_keep_policy`) that the real loop, the positive
half and both controls all call, so a control cannot drift from what the gate runs.

- **CONTROL** — a synthetic step CM with a real `metadata.annotations` keep must read `keep`. This is
  the assertion the old gate silently failed, so it is executed rather than reasoned about; without it
  the repair could have swapped a flaky false positive for a permanently dead gate and looked greener.
- **CONTROL 2** — a step CM whose *script body* still carries the `_helpers.tpl` phrase must read
  `none`, and the control refuses to run vacuously if that phrase ever leaves the render.

The no-yq branch is exercised separately under the same `pipefail` settings: the three step CMs whose
bodies carry the phrase read `none`, the status CM reads `keep`, a synthetic annotated CM reads `keep`.

---

## Row 166 — can the `/jobs` cutover group render all 11, in order?

**Mechanism.** The group is seeded by `chrootSeedCutoverActivity`
(`products/catalyst/bootstrap/api/internal/handler/jobs.go:503-509`), which UNIONs two sources:
`listCutoverSteps` (order-bearing, from the `bp.openova.io/cutover-order` labels) and
`listStepNamesFromStatus` (the durable `step.<slug>.result` keys). Ordering comes from
`listCutoverSteps` at `handler/cutover.go:513`.

**Verdict: the runtime path is correct** — 11 slugs, ordered by label, egress-block-test last per
#6214, and the pre-seeded slugs in `09-cutover-status-configmap.yaml` match the 11 `stepName` values
exactly. But **two properties it depends on were asserted nowhere**, both the "structurally cannot
show 11 green" shape:

**Case 92 — the labels must be a contiguous `1..N` permutation.** `listCutoverSteps` sorts on the
integer label and, *on a tie, falls back to the ConfigMap NAME* (`cutover.go:513-521`) — alphabetical,
i.e. exactly the #6093 defect the labels exist to prevent. Nothing else could see it: Case 2 counts
the step CMs (a count passes on any permutation *and* any duplicate), and Case 91 pins only that
egress-block-test is the maximum — blind to a collision or a hole among the other ten. #6214
renumbered four labels by hand.

**Case 93 — the status seed's slugs must equal the step CMs' `stepName`s.** Because the two sources
are UNIONed (deliberately, per #3646 — a completed cutover whose step CMs were reaped must still
render), the seed is authoritative for *existence*: a slug present only in the status ConfigMap
becomes a row on the cutover group with no step behind it. It never runs, never leaves `pending`, and
**the group could never read all-11-green** — row 166 would fail forever on an otherwise healthy
chain, looking like a stuck step rather than a typo. Every other gate is blind: seed keys carry no
order label (Cases 2/92 skip them), no podSpec (Case 3 skips them), and `totalSteps` is a hand-written
literal, which the case now pins to the rendered count.

**Two stale order mirrors, one actively fighting #6214.** Both documented as mirroring the chart's
`cutover-order` labels; both still carried the pre-#6214 sequence:

- `products/catalyst/bootstrap/api/internal/handler/jobs_cutover_step_order_6093_test.go:121` asserted
  `egress-block-test` at index 7 — *"want position 8"*. A trap pointing the wrong way: anyone
  correcting the fixture to the real chart order gets failed by this line and pushed to revert. Now
  asserts the RELATION (projects LAST), matching Case 91.
- `products/catalyst/bootstrap/ui/src/shared/types/cutover.ts:157` — the canonical FE list, which seeds
  `buildInitialCutoverStatus()`. Reordered, with a new relation test in `cutover.test.ts`.

The UI vitest gate (`catalyst-build.yaml`) only runs on push to `main`, so the FE change was validated
locally by importing the module under `node --experimental-strip-types`: 11 steps, chart order,
`buildInitialCutoverStatus()` last step = `egress-block-test`.

---

## Row 227 — does a post-cutover Sovereign refuse an upstream catalog bump?

**Mechanism.** Step 05 repoints the Flux `GitRepository` at the local Gitea; step 06 repoints the OCI
`HelmRepository` URLs at the local Harbor. The Blueprint CR install path resolves through
`spec.manifests.source.ref` — a *name*, not a URL — defaulting to `CatalogSourceRef = "openova-catalog"`
(`core/controllers/application/internal/controller/application_controller.go:465-472, 1116, 1364`),
whose HelmRepository is in step 06's curated list
(`platform/self-sovereign-cutover/chart/values.yaml:1046`). `blueprint_controller.go:417` does no
network I/O and no OCI resolution, so no Blueprint CR moves on its own.

**Verdict at cutover time: correct, and already guarded.** The fail-closed net is step-08's pre-hold
source lint, which enumerates `gitrepositories ocirepositories` as well as HelmRepositories — pinned
per-region by **Case 76** at `cutover-contract.sh:4278`. I added nothing here because the assertion
already exists and already discriminates.

**Residual, and it is real — reported, not fixed here.** Row 227's clause is about the *post*-cutover
steady state, and step 05 patches **one hardcoded `flux-system/openova` object, once**, with no
enumeration and no re-assertion (`05-flux-gitrepository-patch-job.yaml:92-95, 250`; no
`kubectl get gitrepositories -A` anywhere in the step). Meanwhile
`infra/providers/_shared/cloudinit-control-plane.tftpl:506-518` writes `flux-bootstrap.yaml` declaring
that same object with `spec.url = ${gitops_repo_url}` — default `https://github.com/openova-io/openova`
(`infra/providers/hetzner/variables.tf:797-801`) — and `:1750` applies it, for the primary CP
(`hetzner/main.tf:879`) **and every secondary region** (`main.tf:1462`). Any CP node replacement,
scale-out, or region added after cutover re-tethers the root GitRepository to GitHub; the only
post-cutover watcher (`12-daytwo-harbor-pin-reconciler.yaml:1332-1396`) is **detect-only**.

Full inventory, including two lower-ranked residuals (`loft`/`vcluster-system` outside step 06's
namespace *and* prefix selectors; per-Org tenant HelmReleases rendering `version: "*"` because
`CATALYST_ORG_BP_*_VER` is set nowhere) and the paths I checked and cleared, is on
**#6235** — these are infra-tree changes that no chart contract test can exercise, and I did not want
to ship them unverified alongside a test-only PR.

---

## Row G11 — the 11-step chain's preconditions and step contract

The brief asked for a step whose success is not actually asserted. At the gate level the answer is
Case 40 itself: it asserted a property of all 12 cutover ConfigMaps and could not fail on any of them.
Its occasional flake also takes Cases 41–91 offline for that run. The chain's ordering precondition is
now pinned by Cases 91 + 92. G11's terminal proof still requires the live 10-minute deny-egress hold;
not taken.

---

## Mutation table

Every mutant renders cleanly (`helm template` rc=0) — a mutant that breaks the render proves nothing.
Full suite per mutant; `fired_at` is the first case to fail.

| # | mutant | renders | suite rc | fired at |
|---|---|---|---|---|
| baseline | clean tree | 0 | **0** | — (82 cases, all green) |
| **M1** | real `keep` in step-05 `metadata.annotations` | 0 | **pre-fix 0 / fixed 1** | **pre-fix PASSES it (fail-open); fixed → Case 40**, names the CM |
| M2 | duplicate order: step-07 `"7"` → `"6"` | 0 | 1 | **Case 92** — `got 1,2,3,4,5,6,6,8,9,10,11` / `DUPLICATE order value(s): 6` |
| M3 | gap: step-06 `"6"` → `"0"` (egress still last, Case 91 passes) | 0 | 1 | **Case 92** |
| M4 | seed slug typo → `gitea-token-mints` | 0 | 1 | **Case 93** — names the stranded row |
| M5 | `totalSteps: "11"` → `"10"` | 0 | 1 | **Case 93** |
| restored | — | 0 | **0** | — |
| G1 | Go fixture: `egress-block-test` back to index 7 (compiles) | n/a | 1 | `TestMergeCutoverStepOrder_ChartOrderWins` — *"position 8 of 11, want 11"* |
| G1r | restored | n/a | **0** | — |

M1 is the load-bearing one: it is the *before/after* proof that Case 40 changed from undetecting to
detecting. M2 and M3 are the pair that pass Case 2 (count) **and** Case 91 (egress strictly last), so
only Case 92 can see them. Each new case carries an in-suite CONTROL so none can pass vacuously.

## Pre-cutover control for row 227

Not claimed. I did not add a 227 assertion, precisely because the control the brief demands could not
be satisfied honestly: the cutover-time property is already pinned by Case 76, and the residual is a
*post*-cutover re-tether in the infra tree that no chart render — pre- or post-cutover — can
distinguish. Asserting it from `cutover-contract.sh` would have been a test that passes in both states,
which is the thing the brief warned against.

## Gates

```
scripts/check-no-banned-words.sh --commit-messages origin/main..HEAD   OK
scripts/check-cutover-version-floor.py    OK — 7 pins / 5 lockstep sites at 0.1.182 >= floor 0.1.172
scripts/check-chart-version-bumped.sh     PASS — no chart rendered-surface changes (tests/ only)
go vet ./internal/handler/                OK
go test ./internal/...                    ok (full package set)
bash tests/cutover-contract.sh            rc=0, 82 cases
no-yq fallback branch                     OK (5/5 under set -euo pipefail)
```

No chart version bump: this PR changes `chart/tests/` only, outside the rendered surface
(`templates/`, `values.yaml`, `values.schema.json`, `crds/`) the bump gate scopes to. No template,
values or lockstep site is touched.

Refs #6235
Refs #6214
Refs #6198
Refs #6093
Refs #4983

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HvMZTDx7W6EPZMmjyXmYh1
