### PR TITLE
docs(path-to-100): mark the secondary-kubeconfig producer SUPERSEDED — it shipped

### DIFF
--- a/docs/ledger/PATH-TO-100.md
+++ b/docs/ledger/PATH-TO-100.md
@@ -186,7 +186,29 @@ supply the input. Both `secondaryKubeconfigsForCutover` (`:174`) and
 `onDiskSecondaryKubeconfigPrefixes` (`:228`) already do the resolution — only
 the call site is cutover-scoped.
 
-**Fix:** give the Secret a pre-cutover producer. Materialize it from the same
+> 🟢 **SUPERSEDED 2026-08-13 — the pre-cutover producer prescribed below ALREADY
+> SHIPPED. Do not re-implement it.** `RunSecondaryKubeconfigSecretMaterializer`
+> (`products/catalyst/bootstrap/api/internal/handler/secondary_kubeconfig_secret_materializer.go:117`)
+> is a level-triggered materializer started **unconditionally** at
+> `products/catalyst/bootstrap/api/cmd/api/main.go:1119` — not inside `runCutover`.
+> It landed `8c225b9c9` on 2026-08-11 (#6027) and its own startup log reads
+> *"the per-Org console credential for a peer region no longer waits on a cutover"*.
+>
+> The "ONLY writer … exactly ONE call site … unreachable **by construction**"
+> analysis above was true when written and is false now. It is left in place
+> because the consumer-side citations remain accurate; only the producer verdict
+> changed.
+>
+> **The coupling note below is now the LIVE half.** A materializer can only
+> publish what is on disk, so cluster A1's `runSecondaryKubeconfigDelivery` must
+> put a PARSEABLE region-b kubeconfig at
+> `/var/lib/catalyst/kubeconfigs/<depID>-<regionKey>.yaml`. Check the DISK
+> contents first: an empty Secret with a healthy producer means the disk input is
+> missing or unparseable — a different defect from "no producer exists", and the
+> one a walker should rule out before filing anything.
+
+**Fix (HISTORICAL — shipped, see the note above):** give the Secret a pre-cutover
+producer. Materialize it from the same
 on-disk `/var/lib/catalyst/kubeconfigs/<depID>-<regionKey>.yaml` set at Phase-1
 convergence (or on the org-controller's own reconcile), not only inside
 `runCutover`. **Coupling to state:** cluster A1's `runSecondaryKubeconfigDelivery`


### PR DESCRIPTION
`PATH-TO-100.md`'s Cluster-B entry tells any future session that the per-Org multi-region console fan-out is **"unreachable by construction"** and prescribes:

> **Fix:** give the Secret a pre-cutover producer.

**That producer shipped two days ago.**

`RunSecondaryKubeconfigSecretMaterializer`
(`products/catalyst/bootstrap/api/internal/handler/secondary_kubeconfig_secret_materializer.go:117`)
is a level-triggered materializer started **unconditionally** at
`products/catalyst/bootstrap/api/cmd/api/main.go:1119` — not inside `runCutover`.
It landed `8c225b9c9` on **2026-08-11** (#6027), and its own startup log reads:

> *"the per-Org console credential for a peer region no longer waits on a cutover"*

The "ONLY writer … exactly ONE call site … unreachable by construction" analysis was true when written and is false now.

## Why this matters more than a doc typo

A fix map that prescribes already-shipped work is how a session burns a fleet re-implementing something that runs in production today. This is exactly the class the repo's own discipline names: **name the component that WRITES the surface before filing new-code/needs-design.** The entry *did* name a writer — it just went stale two days later, and nothing re-checked it.

## What this PR does

- Marks the producer verdict **superseded**, with the file:line and the landing commit.
- **Leaves the consumer-side citations in place** — they are still accurate. Only the producer verdict changed.
- **Promotes the coupling note to the live half**, because that is now the real remaining work: a materializer can only publish what is on disk, so cluster A1's `runSecondaryKubeconfigDelivery` must put a PARSEABLE region-b kubeconfig at `/var/lib/catalyst/kubeconfigs/<depID>-<regionKey>.yaml`.
- Gives the walker the diagnostic that distinguishes them: **check the disk first.** An empty Secret with a healthy producer means the disk input is missing or unparseable — a different defect from "no producer exists", and the one to rule out before filing anything.

Found while verifying a sub-agent's refutation rather than taking it on trust; the file, the function at `:117`, the call site at `:1119` and the landing date were each confirmed directly.

Refs #6027
