### PR TITLE
chore(lockstep): republish the umbrella for bp-guacamole 0.2.39 — main is red on the #5734 gate

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1395,7 +1395,7 @@ spec:
       # 1.4.1440 — #5991 (UAT row 115): catalog-seed advances bp-guacamole
       #   0.2.37 -> 0.2.38, the release that writes a Guacamole connection at
       #   all. Lockstep w/ products/catalyst/chart/Chart.yaml.
-      version: 1.4.1443
+      version: 1.4.1445
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3917,7 +3917,7 @@ name: bp-catalyst-platform
 #   half: without this republish a pinned Sovereign resolves 0.2.37 and the list
 #   stays empty. This chart's own templates are unchanged apart from the seed
 #   entry.
-version: 1.4.1443
+version: 1.4.1445
 # 1.4.1229 — #5389: catalog-seed bp-newapi declares its `ui` endpoint
 #   (newapi.<fqdn>, ssoEnabled, launchDefault, ssoInitPath "/") instead of
 #   `endpoints: []`. The empty list made userUIGatePasses fail closed, which


### PR DESCRIPTION
**`main` is currently RED on the #5734 umbrella-republish gate.** This unblocks it.

## The failure, from the gate's own output on `origin/main`

```
FAIL: umbrella-republish gate (#5734) — 2 catalog-seed pin(s) were last moved
by a commit AFTER WHICH products/catalyst/chart/Chart.yaml's `version:` ...

  bp-guacamole spec.version   = '0.2.39' (blueprints.yaml:1743, be7cfd557559)
  bp-guacamole source.version = '0.2.39' (blueprints.yaml:1771, be7cfd557559)
      the umbrella chart version was 1.4.1443 then and is STILL 1.4.1443 now.
```

`be7cfd557` moved both bp-guacamole pins to `0.2.39` and the umbrella never caught up.

## Why this matters beyond a red badge

The gate is not decorative: a catalog-seed pin that moves without an umbrella republish ships a Blueprint the umbrella does not actually deliver. And because it fails on **every PR built on main**, it gets misread as *"my PR broke it"* — one sub-agent already had to annotate its own PR explaining the red was not its doing. Left alone it taxes every reviewer downstream.

## The change

Umbrella `1.4.1443` → **`1.4.1445`**, with the bootstrap-kit slot-13 pin in the same commit — exactly what the gate's failure text prescribes. Catalog regenerated; a second generator run yields no further diff.

**`1.4.1444` is deliberately skipped.** It is held by the open #6234, so taking it here would make whichever merged second conflict all over again. Verified unclaimed against all open PR heads before taking `1.4.1445`.

## Verification

| gate | before (on main) | after (this commit) |
|---|---|---|
| `check-umbrella-republish-gate.py` | **rc=1** | **rc=0** — 160 pins / 80 Blueprints |
| `check-bootstrap-kit-pin-sync.sh` | rc=0 | rc=0 |
| `check-catalog-seed-lockstep.sh` | rc=0 | rc=0 |

Note the gate evaluates **committed** history, not the working tree — it still reported rc=1 with the edit staged and only passed once committed. Worth knowing before concluding a fix didn't work.

## Root cause is upstream of this PR

`build-bp-guacamole.yaml:147` bumps `Chart.yaml` and never calls `sync-catalog-seed-pin.py`, so **every** bot bump re-breaks this. Filed separately as #6238 — this PR clears the current red; the workflow fix stops it recurring.

Refs #5734
