### PR TITLE
test(openova-mcp): pin UAT row 213 as indistinguishability, not as the words not found (Refs #6122)

### DIFF
--- a/products/openova-mcp/README.md
+++ b/products/openova-mcp/README.md
@@ -119,7 +119,15 @@ server **inside hw173's catalyst-api pod** pointed at the real
 - A sovereign-admin `list_applications` returns the **real** Application CRs
   unfiltered.
 - An Org token (`org_id=acme`) sees **only** that Org's Applications.
-- An out-of-scope `get_application` for another Org returns **forbidden**.
+- A cross-Org `get_application` is refused.
+
+  ⚠️ That walk pre-dates #5522. It recorded the refusal as **forbidden**,
+  which is no longer the contract and must not be cited as one: the read
+  path now answers **not found** (`-32000`), deliberately, because a 403
+  would confirm the Application exists in another Organization. The write
+  path keeps 403. The rule is deny-by-LOOKUP vs deny-by-ASSERTION, not read
+  vs write — see `docs/adr/0013-cross-org-denial-shape.md`, UAT row 213,
+  #6122, and the `internal/tools` doc comment on `orgScopedNotFound`.
 
 See the walk evidence on issue #3988.
 

--- a/products/openova-mcp/cmd/openova-mcp/cross_org_indistinguishable_213_test.go
+++ b/products/openova-mcp/cmd/openova-mcp/cross_org_indistinguishable_213_test.go
@@ -1,0 +1,312 @@
+// cross_org_indistinguishable_213_test.go — UAT row 213 / #6122, the half
+// the code-only assertion cannot reach.
+//
+// WHAT ROW 213 ACTUALLY ASSERTS. Not "the refusal says not found". It asserts
+// that a caller CANNOT LEARN whether the Application exists in another
+// Organization. That is a statement about TWO Sovereigns, not one: the same
+// request, on a Sovereign where the name is owned by another Org and on a
+// Sovereign where the name exists nowhere, must be answered identically.
+//
+// WHY THE EXISTING GUARD DOES NOT REACH IT.
+// cross_org_denial_shape_213_test.go runs ONE world. It asserts code -32000,
+// no "403" in the data, and that the other Org's slug is absent. Every one of
+// those survives this handler:
+//
+//	if _, err := api.GetApplication(ctx, depID, in.Name, bearerOf(id)); err == nil {
+//	    return nil, fmt.Errorf("application %q not found in organization %q "+
+//	        "(check the owning organization)", in.Name, id.OrgID)
+//	}
+//
+// Code still -32000. Still says "not found". Still never names the other Org.
+// And it answers "does Organization X run an app called Y?" for every name an
+// attacker cares to try — the exact oracle ADR-0013 refuses. A single-world
+// test cannot see it, because in a single world there is nothing to compare
+// the answer against. That mutant is the vacuity proof for this file.
+//
+// SO EVERY ASSERTION HERE IS A COMPARISON BETWEEN WORLDS. The own-Org estate
+// is byte-identical in both; only the Sovereign-wide inventory differs. Any
+// divergence in the answer — code, message, data, or the set of upstream
+// requests made — is a channel.
+//
+// WHY A BEARER CARRYING deployment_id IS ONE OF THE CASES. An Org session
+// normally carries none, and the mutant above needs one: without a
+// deployment binding requireDeployment fails, the probe never runs, and the
+// two worlds look alike for a reason that has nothing to do with the
+// contract. Running the no-deployment shape ALONE would give this file no
+// discriminating power against the very edit it exists to catch. Both shapes
+// run; the no-deployment one is the realistic seeded bearer, the
+// deployment-bearing one is the shape in which a Sovereign-wide probe can
+// actually succeed.
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/golang-jwt/jwt/v5"
+
+	"github.com/openova-io/openova/products/openova-mcp/internal/catalystapi"
+	"github.com/openova-io/openova/products/openova-mcp/internal/identity"
+	"github.com/openova-io/openova/products/openova-mcp/internal/tools"
+)
+
+const (
+	// foreignApp is owned by the OTHER Organization. It is never present in
+	// walkoneEstate — the own-org seam that the caller can actually reach.
+	foreignApp = "uatm4-agenity"
+	// ghostApp exists nowhere on either Sovereign. It is the reference answer
+	// the foreign name's answer must equal.
+	ghostApp = "no-such-application"
+	// ownApp is in the caller's own estate — the control.
+	ownApp = "uat50-ahs-pg"
+
+	testDeploymentID = "a0077ba47e3720e5"
+)
+
+// sovereignWideInventory is what the deployment-addressed seam would answer
+// on the world where the foreign Application EXISTS. Nothing in the MCP is
+// entitled to read it from an Org context; it is served here precisely so a
+// handler that reaches for it produces a visibly different world.
+const sovereignWideInventory = `{"kind":"ApplicationList","total":1,"items":[
+	{"kind":"Application","name":"uatm4-agenity","namespace":"org-hw293walktwo","blueprint":"bp-agenity","phase":"Ready"}
+]}`
+
+// worldTransport wires the transport under test to a stub catalyst-api and
+// records every upstream path reached.
+//
+// foreignExists selects the world:
+//
+//	true  — the Sovereign-wide seam serves uatm4-agenity (another Org owns it)
+//	false — the Sovereign-wide seam has nothing; the name exists nowhere
+//
+// The own-org seam answers walkoneEstate in BOTH worlds, byte for byte. That
+// is what makes a difference in the reply attributable to the Sovereign-wide
+// inventory and nothing else.
+func worldTransport(t *testing.T, foreignExists bool) (*httpTransport, *[]string) {
+	t.Helper()
+	var seen []string
+	api := catalystapi.New("https://console.hw293walkone.omani.homes").
+		WithTenantHost("console.hw293walkone.omani.homes").
+		WithHTTPClient(&http.Client{Transport: stubRoundTrip(func(r *http.Request) (*http.Response, error) {
+			seen = append(seen, r.Method+" "+r.URL.Path)
+			switch {
+			case r.URL.Path == "/api/v1/org/applications":
+				return stubJSON(200, walkoneEstate), nil
+			case strings.HasPrefix(r.URL.Path, "/api/v1/sovereigns/"):
+				if foreignExists {
+					if strings.HasSuffix(r.URL.Path, "/applications/"+foreignApp) {
+						return stubJSON(200, `{"kind":"Application","metadata":{"name":"uatm4-agenity","namespace":"org-hw293walktwo"}}`), nil
+					}
+					if strings.HasSuffix(r.URL.Path, "/applications") {
+						return stubJSON(200, sovereignWideInventory), nil
+					}
+				}
+				return stubJSON(404, `{"error":"not-found"}`), nil
+			default:
+				return stubJSON(404, `{"error":"not-found"}`), nil
+			}
+		})})
+	return &httpTransport{
+		reg:      tools.NewRegistry(api),
+		resolver: identity.NewInsecureResolver(""),
+	}, &seen
+}
+
+func stubJSON(status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+	}
+}
+
+// bearerShapes are the two Org-scoped identities this file runs every
+// comparison under. See the file header for why the deployment-bearing one is
+// not padding.
+func bearerShapes(t *testing.T) []struct {
+	name   string
+	bearer string
+} {
+	t.Helper()
+	return []struct {
+		name   string
+		bearer string
+	}{
+		{
+			name: "seeded-org-bearer-no-deployment",
+			bearer: mintUnsigned(t, jwt.MapClaims{
+				"sub": "walker@hw293walkone", "org_id": "hw293walkone", "tier": "org-admin", "typ": "session",
+			}),
+		},
+		{
+			name: "org-bearer-carrying-deployment-binding",
+			bearer: mintUnsigned(t, jwt.MapClaims{
+				"sub": "walker@hw293walkone", "org_id": "hw293walkone", "tier": "org-admin", "typ": "session",
+				"deployment_id": testDeploymentID,
+			}),
+		},
+	}
+}
+
+// rawCallTool returns the RAW response body. The comparison below is on
+// bytes, not on a decoded struct: a decoded struct drops any field the test's
+// own type does not declare, so a handler that leaked an extra key would
+// compare equal. What the caller sees is the bytes.
+func rawCallTool(t *testing.T, tr *httpTransport, bearer, name string, args map[string]any) string {
+	t.Helper()
+	payload, err := json.Marshal(map[string]any{
+		"jsonrpc": "2.0", "id": 1, "method": "tools/call",
+		"params": map[string]any{"name": name, "arguments": args},
+	})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	rec := postMCP(t, tr, bearer, string(payload))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("%s: HTTP %d body %s", name, rec.Code, rec.Body.String())
+	}
+	return rec.Body.String()
+}
+
+// TestRow213_ForeignNameAnswersExactlyLikeANameThatExistsNowhere is the
+// clause, stated as the comparison it actually is.
+//
+// Same tool, same bearer, same own-org estate, same requested name. The only
+// difference between the two calls is whether another Organization on the
+// Sovereign owns that name. The two replies must be the SAME BYTES.
+func TestRow213_ForeignNameAnswersExactlyLikeANameThatExistsNowhere(t *testing.T) {
+	for _, shape := range bearerShapes(t) {
+		t.Run(shape.name, func(t *testing.T) {
+			existsElsewhere, _ := worldTransport(t, true)
+			existsNowhere, _ := worldTransport(t, false)
+
+			owned := rawCallTool(t, existsElsewhere, shape.bearer, "get_application", map[string]any{"name": foreignApp})
+			absent := rawCallTool(t, existsNowhere, shape.bearer, "get_application", map[string]any{"name": foreignApp})
+
+			// Both must be refusals — otherwise "identical" could mean the
+			// handler is answering the foreign Application to everyone.
+			assertNotFoundRefusal(t, "name owned by another Organization", owned)
+			assertNotFoundRefusal(t, "name that exists nowhere", absent)
+
+			if owned != absent {
+				t.Fatalf("row 213: the refusal DIFFERS depending on whether another Organization owns the name — "+
+					"that difference IS the existence oracle ADR-0013 refuses.\n owned-elsewhere: %s\n exists-nowhere: %s",
+					owned, absent)
+			}
+		})
+	}
+}
+
+// TestRow213_ForeignNameAnswersExactlyLikeAGhostName is the same comparison
+// run the other way round: hold the WORLD fixed and vary the NAME.
+//
+// It catches what the test above cannot. That one compares one name across
+// two worlds, so a handler that answered every miss with a constant leak-free
+// string would pass it — and would still be fine. This one compares two names
+// in the SAME world, which is the comparison an attacker actually gets to
+// make: they cannot switch Sovereigns, they can only try names. The message
+// must not encode which of the two kinds of miss it was.
+func TestRow213_ForeignNameAnswersExactlyLikeAGhostName(t *testing.T) {
+	for _, shape := range bearerShapes(t) {
+		t.Run(shape.name, func(t *testing.T) {
+			tr, _ := worldTransport(t, true)
+			foreign := rawCallTool(t, tr, shape.bearer, "get_application", map[string]any{"name": foreignApp})
+			ghostTr, _ := worldTransport(t, true)
+			ghost := rawCallTool(t, ghostTr, shape.bearer, "get_application", map[string]any{"name": ghostApp})
+
+			assertNotFoundRefusal(t, "foreign name", foreign)
+			assertNotFoundRefusal(t, "ghost name", ghost)
+
+			// The requested name is echoed by design (the caller supplied it),
+			// so normalise it away and require everything else to match.
+			normForeign := strings.ReplaceAll(foreign, foreignApp, "<NAME>")
+			normGhost := strings.ReplaceAll(ghost, ghostApp, "<NAME>")
+			if normForeign != normGhost {
+				t.Fatalf("row 213: a caller can tell a foreign name from a nonexistent one by the answer alone.\n"+
+					" foreign: %s\n ghost:   %s", foreign, ghost)
+			}
+		})
+	}
+}
+
+// TestRow213_AMissMakesNoSovereignWideProbe closes the side channel the two
+// byte comparisons above leave open.
+//
+// A handler could probe the Sovereign-wide seam, learn the answer, and then
+// deliberately return the same bytes either way. The bytes would match; the
+// LATENCY and the upstream request pattern would not, and on a live Sovereign
+// the probe is itself the privilege OrgScopeGuard exists to deny. So the set
+// of upstream requests must also be identical between the worlds, and must
+// contain no deployment-addressed path at all.
+func TestRow213_AMissMakesNoSovereignWideProbe(t *testing.T) {
+	for _, shape := range bearerShapes(t) {
+		t.Run(shape.name, func(t *testing.T) {
+			existsElsewhere, seenA := worldTransport(t, true)
+			existsNowhere, seenB := worldTransport(t, false)
+
+			rawCallTool(t, existsElsewhere, shape.bearer, "get_application", map[string]any{"name": foreignApp})
+			rawCallTool(t, existsNowhere, shape.bearer, "get_application", map[string]any{"name": foreignApp})
+
+			for _, p := range *seenA {
+				if strings.Contains(p, "/api/v1/sovereigns/") {
+					t.Fatalf("an Org-context lookup reached the Sovereign-wide seam %q — that probe is the "+
+						"existence oracle, whatever it then chooses to print. Reached: %v", p, *seenA)
+				}
+			}
+			if strings.Join(*seenA, "|") != strings.Join(*seenB, "|") {
+				t.Fatalf("the upstream request pattern differs between the two worlds — a timing oracle.\n"+
+					" owned-elsewhere: %v\n exists-nowhere: %v", *seenA, *seenB)
+			}
+			if len(*seenA) != 1 || (*seenA)[0] != "GET /api/v1/org/applications" {
+				t.Fatalf("an Org-context lookup must read the own-org seam exactly once, reached %v", *seenA)
+			}
+		})
+	}
+}
+
+// TestRow213_OwnOrgGetSucceedsInBothWorlds is THE CONTROL for this file, and
+// it shares every suspect property with the comparisons above: same worlds,
+// same bearers, same tool, same transport. Only the requested name changes,
+// to one the caller's own estate really holds.
+//
+// Without it, all three tests above are satisfied by a get_application that
+// refuses everything — identical refusals are trivially identical.
+func TestRow213_OwnOrgGetSucceedsInBothWorlds(t *testing.T) {
+	for _, shape := range bearerShapes(t) {
+		t.Run(shape.name, func(t *testing.T) {
+			for _, foreignExists := range []bool{true, false} {
+				tr, _ := worldTransport(t, foreignExists)
+				body := rawCallTool(t, tr, shape.bearer, "get_application", map[string]any{"name": ownApp})
+				if strings.Contains(body, `"error"`) {
+					t.Fatalf("own-Org get must succeed (foreignExists=%v), got %s", foreignExists, body)
+				}
+				if !strings.Contains(body, ownApp) {
+					t.Fatalf("own-Org get returned the wrong object (foreignExists=%v): %s", foreignExists, body)
+				}
+			}
+		})
+	}
+}
+
+// assertNotFoundRefusal checks the reply is the -32000 not-found refusal and
+// not something else that merely happens to be equal across two runs — a
+// crash, an unauthenticated frame, or a success.
+func assertNotFoundRefusal(t *testing.T, label, body string) {
+	t.Helper()
+	var frame rpcFrame
+	if err := json.Unmarshal([]byte(body), &frame); err != nil {
+		t.Fatalf("%s: undecodable frame %s: %v", label, body, err)
+	}
+	if frame.Error == nil {
+		t.Fatalf("%s: expected a refusal, got a result: %s", label, body)
+	}
+	if frame.Error.Code != -32000 {
+		t.Fatalf("%s: expected -32000 tool error, got code %d: %s", label, frame.Error.Code, body)
+	}
+	if !strings.Contains(string(frame.Error.Data), "not found") {
+		t.Fatalf("%s: expected a not-found refusal, got %s", label, body)
+	}
+}

--- a/products/openova-mcp/internal/tools/catalogue.go
+++ b/products/openova-mcp/internal/tools/catalogue.go
@@ -275,7 +275,7 @@ func handleGetApplication(ctx context.Context, id *identity.Identity, api *catal
 		// would answer every "does Organization X run an app called Y?"
 		// question an attacker cares to ask. The message names only the
 		// CALLER's own Organization for the same reason.
-		return nil, fmt.Errorf("application %q not found in organization %q", in.Name, id.OrgID)
+		return nil, orgScopedNotFound(in.Name, id.OrgID)
 	}
 
 	// Sovereign context: the deployment-addressed get-by-name seam. A
@@ -287,6 +287,32 @@ func handleGetApplication(ctx context.Context, id *identity.Identity, api *catal
 		return nil, err
 	}
 	return api.GetApplication(ctx, depID, in.Name, bearerOf(id))
+}
+
+// orgScopedNotFound builds the ONE refusal an Org-context by-name lookup is
+// allowed to produce (UAT row 213 / #6122, ADR-0013).
+//
+// THE CONTRACT IS INDISTINGUISHABILITY, not merely the words "not found".
+// The bytes this returns must be identical for a name that exists in ANOTHER
+// Organization and for a name that exists NOWHERE ON THE SOVEREIGN. Anything
+// that varies between those two cases — a different code, a different
+// wording, a "check the owning organization" hint, an extra field, even a
+// different upstream request pattern a caller could time — reconstructs the
+// existence oracle the not-found answer exists to deny. `-32003 forbidden`
+// is the loud version of that leak; a helpfully-worded `-32000` is the quiet
+// one, and the quiet one passes a test that only reads the code.
+//
+// It takes only the requested name and the CALLER'S OWN Org, because those
+// are the only two facts this path is entitled to know. There is deliberately
+// no parameter through which a foreign Organization could ever be threaded.
+//
+// Kept as ONE constructor so the contract has ONE site to hold. Two inline
+// fmt.Errorf calls on two branches is exactly how a well-meaning "make the
+// error more helpful" edit lands on one of them and splits the two cases
+// apart. Pinned end-to-end (real handler, real transport, both worlds) by
+// cmd/openova-mcp/cross_org_indistinguishable_213_test.go.
+func orgScopedNotFound(name, callerOrgID string) error {
+	return fmt.Errorf("application %q not found in organization %q", name, callerOrgID)
 }
 
 // handleCreateApplication installs an Application in the caller's Org by

--- a/products/openova-mcp/internal/tools/org_read_class_213_test.go
+++ b/products/openova-mcp/internal/tools/org_read_class_213_test.go
@@ -1,0 +1,262 @@
+// org_read_class_213_test.go — UAT row 213 / #6122, generalised from the
+// instance to the CLASS.
+//
+// Row 213 names get_application, but the property it asserts is not about one
+// tool: no Org-context read may put another Organization's data, or another
+// Organization's EXISTENCE, in front of the caller. get_application is simply
+// where it was measured. A fix that holds only there leaves the class open —
+// and the class is small enough to enumerate exhaustively, so it is.
+//
+// EVERY Org-context-reachable tool in catalogue() appears in the table below.
+// If a tool is added to the catalogue and not added here, TestOrgReadClass_
+// TableCoversEveryOrgReachableTool fails: the table cannot silently fall
+// behind the surface it claims to cover.
+//
+// HOW THE STUB IS BUILT, AND WHY IT MATTERS. The backend serves a POISONED
+// Sovereign-wide inventory: the deployment-addressed seam really does hold the
+// other Organization's Application, and the Organizations directory really
+// does list both Orgs. A stub that served only own-Org data could not tell a
+// correctly-scoped tool from a tool with no scoping at all — it would be the
+// "guard tested against a surface that cannot fail" shape. Here every tool has
+// something to leak, and must not.
+//
+// THE IDENTITY CARRIES deployment_id ON PURPOSE. A seeded Org bearer carries
+// none, and with none a tool that reached for the Sovereign-wide seam would
+// fail at requireDeployment and look scoped for the wrong reason. Handing the
+// caller a deployment binding removes that accident: any tool that wants the
+// Sovereign-wide seam can now actually have it, so declining it is a real
+// choice the test can observe.
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/openova-io/openova/products/openova-mcp/internal/catalystapi"
+	"github.com/openova-io/openova/products/openova-mcp/internal/identity"
+)
+
+const (
+	classOwnOrg     = "hw293walkone"
+	classForeignApp = "uatm4-agenity"
+	classOwnApp     = "uat50-ahs-pg"
+	classDeployment = "a0077ba47e3720e5"
+)
+
+// classForeignNeedles identify the OTHER Organization. None may appear in any
+// tool's answer. The foreign APP NAME is deliberately not in this set: when a
+// caller asks for it by name the refusal echoes what the caller supplied,
+// which discloses nothing they did not already know.
+var classForeignNeedles = []string{
+	"hw293walktwo", "org-hw293walktwo", "other@hw293walktwo", "Walk Two Ltd", "22222222-bbbb",
+}
+
+// classOwnEstate — GET /api/v1/org/applications, server-side confined to the
+// caller's Organization. This is the only Application data an Org caller is
+// entitled to, and the only one the tools may end up projecting.
+const classOwnEstate = `{"apps":[
+	{"id":"uat50-ahs-pg","slug":"postgres","title":"uat50-ahs-pg","status":"installed",
+	 "environment":"hw293walkone-prod","blueprint":"bp-postgres","instance":true}
+],"bootstrapKit":[]}`
+
+// classSovereignWide — the deployment-addressed seam. Holds the OTHER
+// Organization's Application. Reaching this from an Org context is the defect.
+const classSovereignWide = `{"kind":"ApplicationList","total":2,"items":[
+	{"kind":"Application","name":"uat50-ahs-pg","namespace":"org-hw293walkone","phase":"Ready"},
+	{"kind":"Application","name":"uatm4-agenity","namespace":"org-hw293walktwo","blueprint":"bp-agenity","phase":"Ready"}
+]}`
+
+// classDirectory — the Sovereign-WIDE Organizations directory, unconfined.
+// list_organizations legitimately reads this endpoint (it is the only
+// directory there is) and must filter it down to the caller's own row.
+const classDirectory = `{"items":[
+ {"org_tenant_id":"11111111-aaaa","state":"ready","subdomain":"hw293walkone",
+  "admin_email":"walker@hw293walkone","company_name":"Walk One Ltd"},
+ {"org_tenant_id":"22222222-bbbb","state":"ready","subdomain":"hw293walktwo",
+  "admin_email":"other@hw293walktwo","company_name":"Walk Two Ltd"}
+]}`
+
+const classCatalog = `{"items":[{"name":"bp-postgres","version":"1.0.0"}]}`
+
+// classAPI returns a client over the poisoned backend plus the recorder of
+// every path the tool under test actually reached.
+func classAPI(t *testing.T) (*catalystapi.Client, *[]string) {
+	t.Helper()
+	var seen []string
+	api := catalystapi.New("https://console.hw293walkone.omani.homes").
+		WithTenantHost("console.hw293walkone.omani.homes").
+		WithHTTPClient(&http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			seen = append(seen, r.URL.Path)
+			switch {
+			case r.URL.Path == "/api/v1/org/applications":
+				return jsonResp(200, classOwnEstate), nil
+			case r.URL.Path == "/api/v1/organizations":
+				return jsonResp(200, classDirectory), nil
+			case r.URL.Path == "/api/v1/catalog":
+				return jsonResp(200, classCatalog), nil
+			case strings.HasPrefix(r.URL.Path, "/api/v1/sovereigns/"):
+				return jsonResp(200, classSovereignWide), nil
+			default:
+				return jsonResp(404, `{"error":"not-found"}`), nil
+			}
+		})})
+	return api, &seen
+}
+
+// orgReadCase is one row of the class.
+type orgReadCase struct {
+	tool    string
+	handler HandlerFunc
+	args    string
+	// wantErr — the call is expected to be refused. The refusal is still
+	// checked for foreign needles: a leak in an error message is a leak.
+	wantErr bool
+	// mayReadDirectory — list_organizations is the one Org-context read whose
+	// scoping is a client-side filter over a Sovereign-WIDE endpoint rather
+	// than a seam choice, so it alone is permitted to call
+	// /api/v1/organizations. It is held to the same output rule as everything
+	// else. Its filter is pinned in detail by org_scope_213_test.go.
+	mayReadDirectory bool
+}
+
+func orgReadCases() []orgReadCase {
+	return []orgReadCase{
+		{tool: "whoami", handler: handleWhoami},
+		{tool: "list_organizations", handler: handleListOrganizations, mayReadDirectory: true},
+		{tool: "list_environments", handler: handleListEnvironments},
+		{tool: "list_applications", handler: handleListApplications},
+		{tool: "list_blueprints", handler: handleListBlueprints},
+		{tool: "get_application", handler: handleGetApplication, args: `{"name":"uat50-ahs-pg"}`},
+		{tool: "get_application/foreign-name", handler: handleGetApplication,
+			args: `{"name":"uatm4-agenity"}`, wantErr: true},
+	}
+}
+
+// TestOrgReadClass_NoToolLeaksAnotherOrganization is the class assertion: run
+// every Org-context read against a backend that HAS the other Organization's
+// data, and require that none of it comes back.
+func TestOrgReadClass_NoToolLeaksAnotherOrganization(t *testing.T) {
+	for _, tc := range orgReadCases() {
+		t.Run(tc.tool, func(t *testing.T) {
+			api, _ := classAPI(t)
+			id := orgIdentity(classOwnOrg, classDeployment, identity.TierAdmin)
+
+			out, err := tc.handler(context.Background(), id, api, json.RawMessage(tc.args))
+			answer := renderAnswer(t, out, err)
+
+			if tc.wantErr && err == nil {
+				t.Fatalf("%s: expected a refusal, got %s", tc.tool, answer)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("%s: expected success, got error %v", tc.tool, err)
+			}
+			for _, needle := range classForeignNeedles {
+				if strings.Contains(answer, needle) {
+					t.Fatalf("%s leaked %q from the other Organization: %s", tc.tool, needle, answer)
+				}
+			}
+			if strings.Contains(answer, classForeignApp) && !tc.wantErr {
+				t.Fatalf("%s returned the other Organization's Application: %s", tc.tool, answer)
+			}
+		})
+	}
+}
+
+// TestOrgReadClass_NoToolReachesTheSovereignWideSeam is the mechanism half.
+//
+// The test above measures the ANSWER; a tool could reach the Sovereign-wide
+// seam, read another Org's estate, and filter it out before replying — the
+// answer would be clean and the privilege would still have been exercised.
+// That is what #5516 removed and what OrgScopeGuard 403s in production, so a
+// clean answer obtained that way is a fault that happens to be invisible.
+func TestOrgReadClass_NoToolReachesTheSovereignWideSeam(t *testing.T) {
+	for _, tc := range orgReadCases() {
+		t.Run(tc.tool, func(t *testing.T) {
+			api, seen := classAPI(t)
+			id := orgIdentity(classOwnOrg, classDeployment, identity.TierAdmin)
+			_, _ = tc.handler(context.Background(), id, api, json.RawMessage(tc.args))
+
+			for _, p := range *seen {
+				if strings.HasPrefix(p, "/api/v1/sovereigns/") {
+					t.Fatalf("%s reached the deployment-addressed Sovereign-wide seam %q from an Org context "+
+						"(OrgScopeGuard 403s it live; #5516). Reached: %v", tc.tool, p, *seen)
+				}
+				if p == "/api/v1/organizations" && !tc.mayReadDirectory {
+					t.Fatalf("%s read the Sovereign-wide Organizations directory. Reached: %v", tc.tool, *seen)
+				}
+			}
+		})
+	}
+}
+
+// TestOrgReadClass_SovereignAdminStillReadsEverything is the CONTROL for both
+// tests above, and it shares their suspect property: same tools, same backend,
+// same poisoned inventory. Only the caller's context differs.
+//
+// Without it, a get_application that refuses everything and a
+// list_applications that returns nothing satisfy every assertion in this file.
+// A sovereign-admin legitimately reads across Organizations, so the same
+// backend must hand them the data an Org caller was denied — proving the two
+// tests above measure the Org boundary and not a dead facade.
+func TestOrgReadClass_SovereignAdminStillReadsEverything(t *testing.T) {
+	api, seen := classAPI(t)
+	out, err := handleListApplications(context.Background(), sovereignIdentity(classDeployment), api, nil)
+	if err != nil {
+		t.Fatalf("sovereign-admin list_applications failed: %v", err)
+	}
+	answer := renderAnswer(t, out, nil)
+	if !strings.Contains(answer, classForeignApp) {
+		t.Fatalf("a sovereign-admin must see every Organization's Applications — the backend served them "+
+			"and the facade dropped them, so the Org-context tests above prove nothing: %s", answer)
+	}
+	if len(*seen) == 0 || !strings.HasPrefix((*seen)[0], "/api/v1/sovereigns/") {
+		t.Fatalf("a sovereign-admin must read the deployment-addressed seam, reached %v", *seen)
+	}
+}
+
+// TestOrgReadClass_TableCoversEveryOrgReachableTool keeps this file honest as
+// the catalogue grows. A new Org-context tool added to catalogue() without a
+// row here would otherwise be covered by nothing while this file's name
+// promised the class.
+func TestOrgReadClass_TableCoversEveryOrgReachableTool(t *testing.T) {
+	covered := map[string]bool{}
+	for _, tc := range orgReadCases() {
+		covered[strings.SplitN(tc.tool, "/", 2)[0]] = true
+	}
+	// create_application is a WRITE and its cross-Org rule is deny-by-
+	// ASSERTION (403, ADR-0013) — a different contract, pinned by
+	// TestCreateApplicationCrossOrgDenied and the wire-level row-213 file.
+	covered["create_application"] = true
+
+	orgCallerID := orgIdentity(classOwnOrg, classDeployment, identity.TierAdmin)
+	var missing []string
+	for _, tool := range NewRegistry(nil).List(orgCallerID) {
+		if !covered[tool.Name] {
+			missing = append(missing, tool.Name)
+		}
+	}
+	sort.Strings(missing)
+	if len(missing) > 0 {
+		t.Fatalf("these tools are reachable in an Org context but absent from the row-213 class table: %v — "+
+			"add a case to orgReadCases() (and decide what the tool may reach) before shipping them", missing)
+	}
+}
+
+// renderAnswer flattens a handler's (result, error) into one searchable
+// string, so a leak is caught whether it rode out in the payload or in the
+// error text.
+func renderAnswer(t *testing.T, out any, err error) string {
+	t.Helper()
+	if err != nil {
+		return err.Error()
+	}
+	blob, merr := json.Marshal(out)
+	if merr != nil {
+		t.Fatalf("marshal handler result: %v", merr)
+	}
+	return string(blob)
+}


### PR DESCRIPTION
Refs #6122 (UAT row 213) · Pillar 4 — per-Org Agenity workspace + `bp-openova-mcp` RBAC surface

## What row 213 asserts, and what was actually pinned

Row 213 asserts that a cross-Org `get_application` **cannot tell the caller whether the Application exists in another Organization**. The shipped code answers `-32000` not-found, and `cross_org_denial_shape_213_test.go` already pinned that at the wire.

But that guard runs **one world**. It asserts: code is `-32000`, the data contains no `403`, the data contains `not found`, and the other Org's slug is absent. Every one of those survives this handler:

```go
if _, err := api.GetApplication(ctx, depID, in.Name, bearerOf(id)); err == nil {
    return nil, fmt.Errorf("application %q not found in organization %q "+
        "(check the owning organization)", in.Name, id.OrgID)
}
```

Code still `-32000`. Still says "not found". Still never names the other Organization. And it answers *"does Organization X run an app called Y?"* for every name an attacker cares to try — the exact oracle ADR-0013 refuses. **A single-world test cannot see it**, because in a single world there is nothing to compare the answer against.

The property is a comparison between two worlds. So the tests are comparisons.

## What changed

**`cmd/openova-mcp/cross_org_indistinguishable_213_test.go`** (new) — the wire level, where the row is measured. The own-Org estate is byte-identical in both worlds; only the Sovereign-wide inventory differs.

| Test | Comparison |
|---|---|
| `ForeignNameAnswersExactlyLikeANameThatExistsNowhere` | one name, two worlds → **the same bytes** (raw body, not a decoded struct, so an extra key cannot compare equal) |
| `ForeignNameAnswersExactlyLikeAGhostName` | two names, one world → identical after normalising away the caller's own echoed input. This is the comparison an attacker actually gets: they cannot switch Sovereigns, they can only try names |
| `AMissMakesNoSovereignWideProbe` | the upstream request pattern is identical between worlds and touches no `/api/v1/sovereigns/` path — closes the latency/privilege channel a handler leaves open if it probes and then prints the same bytes anyway |
| `OwnOrgGetSucceedsInBothWorlds` | **control** — same worlds, same bearers, same tool, same transport, own name. Without it, identical refusals are trivially satisfied by a tool that refuses everything |

Every case runs under **two bearer shapes**. The seeded Org bearer carries no `deployment_id`; the mutant above needs one, and without it `requireDeployment` fails, the probe never runs, and the two worlds look alike for a reason unrelated to the contract. Running only the realistic shape would have left this file with no discriminating power against the very edit it exists to catch.

**`internal/tools/org_read_class_213_test.go`** (new) — the same rule as a class, not an instance. Every Org-context-reachable tool runs against a backend that *really* holds the other Organization's data (poisoned Sovereign-wide inventory + unconfined Organizations directory), with an identity that *really* carries a deployment binding, so every tool has something to leak and a working path to leak it through. Assertions: no foreign identifier in the answer (payload **or** error text), and no tool reaches the deployment-addressed seam. `TableCoversEveryOrgReachableTool` fails if a tool is added to `catalogue()` without a row, so the table cannot fall behind the surface it claims to cover. Control: a sovereign-admin still reads across every Organization from the same backend — otherwise a dead facade would satisfy the whole file.

**`internal/tools/catalogue.go`** — the not-found message becomes `orgScopedNotFound(name, callerOrgID)`. Identical bytes on the wire. It takes only the requested name and the **caller's own** Org, so there is no parameter through which a foreign Organization could ever be threaded, and the contract (indistinguishability, not the words "not found") is stated at the one site that has to hold it.

**`products/openova-mcp/README.md`** — the hw173 live-acceptance note read *"a cross-Org `get_application` for another Org returns **forbidden**"*. That pre-dates #5522 and contradicts both the running code and ADR-0013; a future reader restoring 403 would have cited it as authority. Corrected in place with a pointer to the adjudication.

## Sibling audit — verdicts

| Tool | Org-context seam | Verdict |
|---|---|---|
| `get_application` | `GET /api/v1/org/applications`, server-side confined | **Covered.** The row's clause; both new files. |
| `list_applications` | same own-org seam | **Covered.** Was leak-capable under the M2 mutant below and nothing caught it; now pinned. |
| `list_environments` | derived from the same own-org read | **Covered.** Same M2 exposure, same fix. |
| `list_organizations` | `GET /api/v1/organizations` — Sovereign-**wide**, scoped by a client-side filter | **Covered**, and the one tool whose scoping is not decided by seam choice. Its filter is pinned in detail by the pre-existing `org_scope_213_test.go`; the new class table holds it to the same output rule and permits it that one endpoint explicitly. |
| `list_blueprints` | `GET /api/v1/catalog` | **Covered.** Sovereign-wide by design (every Org sees the same catalog); carries no Org data. |
| `whoami` | none | **Covered.** Echoes the caller's own resolved claims. |
| `create_application` | write path | **Audited, deliberately different.** Deny-by-ASSERTION → `-32003` / 403, because the caller named the Organization themselves. Not changed; pinned by `TestCreateApplicationCrossOrgDenied` and `TestRow213_CrossOrgCreateIs403`, and whitelisted in the coverage test with the reason. |

**Not covered:** the Sovereign-context branch of `get_application`, which interpolates the name into `/api/v1/sovereigns/{id}/applications/{name}` unescaped. That path is sovereign-admin only and reads across every Organization by design, so it is not a row-213 surface — noted here rather than changed, since it is a separate question from this row.

## Vacuity proof

**M1 — the existence probe** (the option-1 handler quoted at the top), applied to `handleGetApplication`:

*Pre-existing tests, whole module, under M1:*

```
ok internal/catalystapi · ok internal/identity · ok internal/tools
--- PASS: TestRow213_OwnOrgGetSucceeds
--- PASS: TestRow213_CrossOrgGetIsNotFoundNot403
--- PASS: TestRow213_CrossOrgCreateIs403
--- PASS: TestRow213_TheTwoShapesAreDifferentOnPurpose
```

Every existing guard green. *New tests under M1:*

```
--- FAIL: TestRow213_ForeignNameAnswersExactlyLikeANameThatExistsNowhere/org-bearer-carrying-deployment-binding
    row 213: the refusal DIFFERS depending on whether another Organization owns the name —
    that difference IS the existence oracle ADR-0013 refuses.
     owned-elsewhere: {"code":-32000,"data":"application \"uatm4-agenity\" not found in organization \"hw293walkone\" (check the owning organization)"}
     exists-nowhere:  {"code":-32000,"data":"application \"uatm4-agenity\" not found in organization \"hw293walkone\""}
--- FAIL: TestRow213_ForeignNameAnswersExactlyLikeAGhostName/org-bearer-carrying-deployment-binding
--- FAIL: TestRow213_AMissMakesNoSovereignWideProbe/org-bearer-carrying-deployment-binding
    an Org-context lookup reached the Sovereign-wide seam
    "GET /api/v1/sovereigns/a0077ba47e3720e5/applications/uatm4-agenity"
```

The control `OwnOrgGetSucceedsInBothWorlds` stayed green under M1, as a control should.

**M2 — the plausible optimisation.** `listApplicationsForCaller` prefers the deployment-addressed seam when an Org identity happens to carry a `deployment_id`:

```go
if depID, derr := requireDeployment(id); derr == nil {
    return api.ListApplications(ctx, depID, bearerOf(id))
}
```

*Every pre-existing `internal/tools` test stayed green* (they all use the no-deployment identity). The new class test:

```
--- FAIL: TestOrgReadClass_NoToolLeaksAnotherOrganization/list_applications
    list_applications leaked "hw293walktwo" from the other Organization:
    {"items":[…,{"name":"uatm4-agenity","namespace":"org-hw293walktwo",…}]}
--- FAIL: TestOrgReadClass_NoToolLeaksAnotherOrganization/list_environments
--- FAIL: TestOrgReadClass_NoToolReachesTheSovereignWideSeam/list_applications
--- FAIL: TestOrgReadClass_NoToolReachesTheSovereignWideSeam/list_environments
```

Both mutants reverted; `gofmt -l`, `go vet ./...`, `go test ./... -count=1` all clean on the module.

## What this does NOT do

`docs/ledger/UAT.md` row 213 is **left at ❌ and untouched**. The row needs a live two-Org exercise on a Sovereign with two Organizations and an Org-scoped MCP bearer; source proof is not walk evidence, and flipping the row here would be exactly the treadmill `scripts/check-walk-respects-scheduler.sh` refuses. What this PR removes is the possibility that the code silently drifts off the contract between now and that walk — under M1 the drift was invisible to every guard in the module.

`docs/adr/0013-cross-org-denial-shape.md` is unchanged (ADRs are immutable); the new guard names it, not the other way round.
