### PR TITLE
fix(funnel): a lost settlement-launch strands a PAID Org forever, and the app FQDN was pinned to one pool zone

### DIFF
--- a/core/services/billing/handlers/handlers.go
+++ b/core/services/billing/handlers/handlers.go
@@ -1270,41 +1270,54 @@ func (h *Handler) dispatchOrderPlaced(tenantID string, order *store.Order) {
 	// endpoint is idempotent. This is the ONLY caller that can launch a deferred
 	// Org (the endpoint 401s externally), so a failed/abandoned checkout — which
 	// never reaches this function — leaves the Org un-provisioned.
-	h.launchTenant(tenantID)
+	//
+	// #6242 — the error is deliberately NOT propagated into the checkout
+	// response. By this point the money is spent and the order row is
+	// committed, so failing the HTTP response would tell the customer their
+	// purchase did not happen when it did. The recovery is the settlement-launch
+	// reconciler (settlement_launch_reconciler.go), which re-offers this same
+	// call from the durable orders table until it lands.
+	if err := h.launchTenant(context.Background(), tenantID); err != nil {
+		slog.Error("dispatchOrderPlaced: settlement launch did not land — the reconciler will retry it (#6242)",
+			"tenant_id", tenantID, "order_id", order.ID, "error", err)
+	}
 }
 
 // launchTenant asks the tenant service to launch a DEFERRED (pending_payment)
 // Org once its checkout has settled (#4956). Server-to-server POST to the
 // cluster-internal launch endpoint — the same in-cluster tenant URL + path
-// family lookupTenantSubdomain already uses. Best-effort with a short timeout:
-// a transient tenant-service blip logs loud (the paid Org would be left parked)
-// but does not fail the settlement, and the operator can re-drive via the
-// tenant's day-2 surface. Idempotent on the tenant side.
-func (h *Handler) launchTenant(tenantID string) {
+// family lookupTenantSubdomain already uses. Idempotent on the tenant side:
+// InternalLaunchTenant CAS-transitions only from `pending_payment`, so a repeat
+// call on an already-launched Org is a benign 200 no-op.
+//
+// #6242 — this RETURNS its failure instead of logging it into the void. It used
+// to be `func(string)` with every failure path ending in a bare `return`, which
+// meant no caller could tell a delivered launch from a lost one, and so nothing
+// could retry it. A lost call left a PAID order beside an Organization parked at
+// `pending_payment` with no producer that would ever move it again. The error is
+// still not fatal to settlement — see dispatchOrderPlaced — but it is now
+// observable, which is what the reconciler needs to do its job.
+func (h *Handler) launchTenant(ctx context.Context, tenantID string) error {
 	if h.TenantURL == "" || tenantID == "" {
-		return
+		return nil
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
 	defer cancel()
 	url := h.TenantURL + "/tenant/internal/tenants/" + tenantID + "/launch"
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, nil)
 	if err != nil {
-		slog.Error("launchTenant: build request", "tenant_id", tenantID, "error", err)
-		return
+		return fmt.Errorf("build launch request for tenant %s: %w", tenantID, err)
 	}
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		slog.Error("launchTenant: tenant launch call failed — paid Org may be left parked at pending_payment (#4956)",
-			"tenant_id", tenantID, "error", err)
-		return
+		return fmt.Errorf("tenant launch call for %s failed: %w", tenantID, err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		slog.Error("launchTenant: tenant launch non-200 — paid Org may be left parked at pending_payment (#4956)",
-			"tenant_id", tenantID, "status", resp.StatusCode)
-		return
+		return fmt.Errorf("tenant launch for %s returned HTTP %d", tenantID, resp.StatusCode)
 	}
 	slog.Info("launchTenant: settlement launch dispatched", "tenant_id", tenantID)
+	return nil
 }
 
 // lookupTenantAppConfigs fetches the tenant's per-app configSchema values

--- a/core/services/billing/handlers/settlement_launch_reconciler.go
+++ b/core/services/billing/handlers/settlement_launch_reconciler.go
@@ -1,0 +1,215 @@
+// settlement_launch_reconciler.go — #6242. A settled order whose launch call was
+// lost must still reach the tenant service.
+//
+// THE DEFECT
+// ----------
+// Since #4956 the marketplace funnel creates the Organization with
+// `defer_launch: true`: the Org row is persisted but parked at
+// `pending_payment`, and it is launched ONLY when billing settles the checkout.
+// That launch is one HTTP call — `POST /tenant/internal/tenants/{id}/launch`,
+// made from dispatchOrderPlaced (handlers.go) with a 3s timeout.
+//
+// By the time it is made the customer has already paid. `CreditOnlyCheckout`
+// has committed the order as `completed` and burned the voucher redemption; on
+// the Stripe leg the webhook has already settled. The call is therefore the
+// LAST leg of a transaction whose earlier legs are durable — and it was the only
+// one with no recovery. Before this file, every failure path in launchTenant
+// ended in a bare `return` after an slog line, so a tenant service that was
+// rolling, a NetworkPolicy that had not converged, a 3s timeout, or a billing
+// pod restarting between the DB commit and the POST left the customer with a
+// paid order and an Organization that would never provision. `grep -rn
+// pending_payment --include=*.go core/services/` found twelve non-test sites and
+// not one of them was a sweeper.
+//
+// The code said so itself, twice, in its own log strings:
+//
+//	launchTenant: tenant launch call failed — paid Org may be left parked at pending_payment (#4956)
+//	launchTenant: tenant launch non-200 — paid Org may be left parked at pending_payment (#4956)
+//
+// A comment that names the hole is not a producer that closes it.
+//
+// WHY THE ORDERS TABLE IS THE RIGHT DRIVER
+// ----------------------------------------
+// `order.placed` is published to NATS and is durable, but on a Sovereign it is
+// an observer — it launches nothing (see dispatchOrderPlaced's own comment). The
+// durable record of "this customer paid" is the `orders` row, written inside the
+// same transaction that spends the credit. Sweeping THAT is what makes the
+// recovery survive a process restart: an in-memory retry queue dies with the
+// pod that owned it, and the pod dying between commit and POST is one of the
+// exact failures this exists to survive.
+//
+// WHY RE-OFFERING IS SAFE
+// -----------------------
+// `InternalLaunchTenant` (core/services/tenant/handlers/handlers.go) wins an
+// atomic `pending_payment -> provisioning` transition before firing anything,
+// and answers `{"launched": false}` for a tenant already past that state. So the
+// idempotency is enforced by the endpoint, on the row, under a CAS — not by this
+// sweep's bookkeeping. That is deliberate: a filter HERE deciding which orders
+// "still need" launching would be a second opinion that can be stale, and a
+// stale skip is exactly the failure being fixed. This file's job is to keep
+// OFFERING; the tenant service's job is to decide.
+//
+// WHAT IT DELIBERATELY DOES NOT DO
+// --------------------------------
+// It does not flip any order or tenant state, and it never reports a verdict
+// about an Organization. A sweep that could not reach the tenant service knows
+// only that it could not reach the tenant service — it says so and tries again
+// on the next tick, rather than recording a conclusion it did not observe.
+//
+// Refs #6242 · #4956 (the settlement gate) · #3376 · #3860.
+
+package handlers
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/openova-io/openova/core/services/billing/store"
+)
+
+// Settlement-launch reconciler defaults. All three are overridable by the
+// caller so main.go can tune them from env per Inviolable Principle #4.
+const (
+	// DefaultSettlementLaunchInterval is how often the sweep runs. A funnel
+	// customer is watching a provisioning page, so the recovery has to be
+	// measured in a minute or two, not an hour.
+	DefaultSettlementLaunchInterval = 2 * time.Minute
+
+	// DefaultSettlementLaunchLookback bounds how far back a settled order is
+	// still re-offered. Long enough to cover a tenant-service outage plus the
+	// operator noticing; short enough that an order the customer has long
+	// since abandoned becomes a support case rather than something that
+	// silently provisions weeks later.
+	DefaultSettlementLaunchLookback = 24 * time.Hour
+
+	// DefaultSettlementLaunchBatch caps one sweep so a large backlog cannot
+	// turn a recovery into a thundering herd against the tenant service.
+	DefaultSettlementLaunchBatch = 100
+)
+
+// settlementLaunchStore is the store subset the reconciler needs. Narrow by
+// design so a test can drive the real Run loop without a database.
+type settlementLaunchStore interface {
+	ListOrdersAwaitingLaunch(ctx context.Context, lookback time.Duration, limit int) ([]store.Order, error)
+}
+
+// settlementLauncher is the launch leg. In production this is the Handler's own
+// launchTenant, so the reconciler exercises the SAME call site the settlement
+// path uses — not a parallel re-implementation that could drift from it.
+type settlementLauncher interface {
+	launchTenant(ctx context.Context, tenantID string) error
+}
+
+// SettlementLaunchReconciler re-offers the tenant launch for every settled order
+// inside the lookback window, on a ticker.
+type SettlementLaunchReconciler struct {
+	// Store reads the settled orders. Required; a nil Store makes Run a no-op.
+	Store settlementLaunchStore
+
+	// Launcher performs the launch call. Required; wire the billing Handler.
+	Launcher settlementLauncher
+
+	// Interval, Lookback and Batch default to the Default… constants above
+	// when left zero.
+	Interval time.Duration
+	Lookback time.Duration
+	Batch    int
+}
+
+func (r *SettlementLaunchReconciler) interval() time.Duration {
+	if r.Interval > 0 {
+		return r.Interval
+	}
+	return DefaultSettlementLaunchInterval
+}
+
+func (r *SettlementLaunchReconciler) lookback() time.Duration {
+	if r.Lookback > 0 {
+		return r.Lookback
+	}
+	return DefaultSettlementLaunchLookback
+}
+
+func (r *SettlementLaunchReconciler) batch() int {
+	if r.Batch > 0 {
+		return r.Batch
+	}
+	return DefaultSettlementLaunchBatch
+}
+
+// Run sweeps until ctx is done. It is safe to call once per process; the
+// endpoint's CAS makes concurrent billing replicas safe too.
+func (r *SettlementLaunchReconciler) Run(ctx context.Context) {
+	if r == nil || r.Store == nil || r.Launcher == nil {
+		slog.Warn("settlement-launch reconciler not wired — a settled order whose launch call is lost will stay parked at pending_payment (#6242)")
+		return
+	}
+	interval := r.interval()
+	slog.Info("settlement-launch reconciler started (#6242)",
+		"interval", interval, "lookback", r.lookback(), "batch", r.batch())
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		// Sweep first, then wait. A billing pod that restarted mid-settlement
+		// is the case most in need of the sweep, and making it wait a full
+		// interval before the first attempt would add the interval to the
+		// customer's outage for no gain.
+		r.Sweep(ctx)
+		select {
+		case <-ctx.Done():
+			slog.Info("settlement-launch reconciler stopped", "reason", ctx.Err())
+			return
+		case <-ticker.C:
+		}
+	}
+}
+
+// Sweep performs exactly one pass. Exported so a test drives the real pass
+// rather than a stand-in, and so an operator surface could trigger one.
+//
+// Returns the number of orders whose launch call was accepted by the tenant
+// service this pass. That is a DELIVERY count, not a launch count — the tenant
+// service answers 200 both for "I launched it" and for "it was already
+// launched", and this side deliberately does not claim to know which.
+func (r *SettlementLaunchReconciler) Sweep(ctx context.Context) int {
+	if r == nil || r.Store == nil || r.Launcher == nil {
+		return 0
+	}
+	orders, err := r.Store.ListOrdersAwaitingLaunch(ctx, r.lookback(), r.batch())
+	if err != nil {
+		slog.Error("settlement-launch sweep: could not read settled orders — a stranded paid Org stays stranded this pass (#6242)",
+			"error", err)
+		return 0
+	}
+	if len(orders) == 0 {
+		return 0
+	}
+
+	// De-duplicate by tenant: several settled orders can belong to one Org
+	// (an add-on purchased after the first plan), and offering the launch once
+	// per order would multiply the calls for no extra effect.
+	seen := make(map[string]bool, len(orders))
+	delivered := 0
+	for _, o := range orders {
+		if ctx.Err() != nil {
+			return delivered
+		}
+		if o.TenantID == "" || seen[o.TenantID] {
+			continue
+		}
+		seen[o.TenantID] = true
+		if err := r.Launcher.launchTenant(ctx, o.TenantID); err != nil {
+			// Not an error verdict about the Organization — only about this
+			// attempt. The next tick tries again.
+			slog.Warn("settlement-launch sweep: launch call did not land, will retry next pass (#6242)",
+				"tenant_id", o.TenantID, "order_id", o.ID, "error", err)
+			continue
+		}
+		delivered++
+	}
+	slog.Info("settlement-launch sweep complete (#6242)",
+		"settled_orders", len(orders), "distinct_tenants", len(seen), "delivered", delivered)
+	return delivered
+}

--- a/core/services/billing/handlers/settlement_launch_reconciler_6242_test.go
+++ b/core/services/billing/handlers/settlement_launch_reconciler_6242_test.go
@@ -1,0 +1,288 @@
+// settlement_launch_reconciler_6242_test.go — #6242.
+//
+// The guard here is deliberately driven through the REAL settlement call site
+// (dispatchOrderPlaced) and the REAL sweep (SettlementLaunchReconciler.Sweep)
+// wired to the REAL launch leg (*Handler.launchTenant). Testing a stand-in
+// launcher would pin a helper while leaving the call site — the thing that
+// actually strands paid Organizations — unpinned, which is how #4956's happy
+// path came to be the only thing covered.
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/openova-io/openova/core/services/billing/store"
+)
+
+// flakyTenantService is a stand-in for the tenant service that can be taken
+// down and brought back up mid-test — the failure this whole mechanism exists
+// to survive. It records every launch path it is asked for.
+type flakyTenantService struct {
+	mu      sync.Mutex
+	up      bool
+	touched []string
+}
+
+func newFlakyTenantService(up bool) (*flakyTenantService, *httptest.Server) {
+	f := &flakyTenantService{up: up}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		f.mu.Lock()
+		defer f.mu.Unlock()
+		if !f.up {
+			// The shape of a tenant service mid-roll: reachable socket,
+			// refusing work. Chosen over closing the listener because it is
+			// the harder case — the request completes, so only the STATUS
+			// distinguishes a lost launch from a delivered one.
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		f.touched = append(f.touched, r.Method+" "+r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"t","launched":true,"status":"provisioning"}`))
+	}))
+	return f, srv
+}
+
+func (f *flakyTenantService) setUp(up bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.up = up
+}
+
+func (f *flakyTenantService) launches() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]string, len(f.touched))
+	copy(out, f.touched)
+	return out
+}
+
+// fakeAwaitingLaunchStore feeds the reconciler a fixed order set.
+type fakeAwaitingLaunchStore struct {
+	orders []store.Order
+	err    error
+	calls  int
+}
+
+func (f *fakeAwaitingLaunchStore) ListOrdersAwaitingLaunch(context.Context, time.Duration, int) ([]store.Order, error) {
+	f.calls++
+	return f.orders, f.err
+}
+
+// TestSettlementLaunch_RecoversAnOrgStrandedByALostLaunchCall is the whole
+// point of #6242, walked in the order it happens in production:
+//
+//  1. the checkout settles while the tenant service is refusing work — the
+//     launch call is LOST and the paid Org is stranded at pending_payment;
+//  2. the tenant service comes back;
+//  3. the sweep re-offers the launch and it lands.
+//
+// Step 1 is asserted, not assumed: if the settlement path somehow delivered
+// the launch while the service was down, step 3 would prove nothing.
+func TestSettlementLaunch_RecoversAnOrgStrandedByALostLaunchCall(t *testing.T) {
+	tenantSvc, srv := newFlakyTenantService(false) // down at settlement time
+	defer srv.Close()
+
+	h := &Handler{TenantURL: srv.URL}
+	order := &store.Order{ID: "ord-1", TenantID: "tnt-stranded", Status: "completed"}
+
+	// 1. Settlement happens with the tenant service down. The real call site.
+	h.dispatchOrderPlaced(order.TenantID, order)
+	if got := tenantSvc.launches(); len(got) != 0 {
+		t.Fatalf("precondition broken: launch was delivered while the tenant service was down: %v", got)
+	}
+
+	// 2. The tenant service recovers.
+	tenantSvc.setUp(true)
+
+	// 3. The sweep must find the settled order and re-offer the launch.
+	rec := &SettlementLaunchReconciler{
+		Store:    &fakeAwaitingLaunchStore{orders: []store.Order{*order}},
+		Launcher: h,
+	}
+	delivered := rec.Sweep(context.Background())
+
+	if delivered != 1 {
+		t.Errorf("Sweep delivered %d launches, want 1", delivered)
+	}
+	got := tenantSvc.launches()
+	want := "POST /tenant/internal/tenants/tnt-stranded/launch"
+	if len(got) != 1 || got[0] != want {
+		t.Fatalf("stranded Org was not recovered: tenant service saw %v, want exactly [%q]", got, want)
+	}
+}
+
+// TestSettlementLaunch_SweepDeduplicatesByTenant is the CONTROL that a sweep
+// which simply POSTs for every row cannot pass.
+//
+// Three settled orders share one Organization (a plan plus two add-on
+// purchases) and a fourth belongs to a different one. Correct behaviour is two
+// calls, one per Organization — not four.
+func TestSettlementLaunch_SweepDeduplicatesByTenant(t *testing.T) {
+	tenantSvc, srv := newFlakyTenantService(true)
+	defer srv.Close()
+
+	h := &Handler{TenantURL: srv.URL}
+	rec := &SettlementLaunchReconciler{
+		Store: &fakeAwaitingLaunchStore{orders: []store.Order{
+			{ID: "ord-1", TenantID: "tnt-a", Status: "completed"},
+			{ID: "ord-2", TenantID: "tnt-a", Status: "completed"},
+			{ID: "ord-3", TenantID: "tnt-b", Status: "completed"},
+			{ID: "ord-4", TenantID: "tnt-a", Status: "completed"},
+		}},
+		Launcher: h,
+	}
+
+	if delivered := rec.Sweep(context.Background()); delivered != 2 {
+		t.Errorf("Sweep delivered %d launches for 2 distinct Organizations, want 2", delivered)
+	}
+	got := tenantSvc.launches()
+	if len(got) != 2 {
+		t.Fatalf("tenant service saw %d launch calls for 2 Organizations, want 2: %v", len(got), got)
+	}
+	seen := map[string]bool{}
+	for _, g := range got {
+		if seen[g] {
+			t.Fatalf("duplicate launch call %q — the sweep does not de-duplicate by tenant: %v", g, got)
+		}
+		seen[g] = true
+	}
+	for _, want := range []string{
+		"POST /tenant/internal/tenants/tnt-a/launch",
+		"POST /tenant/internal/tenants/tnt-b/launch",
+	} {
+		if !seen[want] {
+			t.Errorf("missing launch call %q: %v", want, got)
+		}
+	}
+}
+
+// TestSettlementLaunch_SweepSkipsOrdersWithNoTenant is the CONTROL for a row
+// that is settled — sharing the suspect property — but has no Organization to
+// launch. Posting for it would hit `/tenant/internal/tenants//launch`, which is
+// a 400 on a real tenant service and a wasted call on any.
+func TestSettlementLaunch_SweepSkipsOrdersWithNoTenant(t *testing.T) {
+	tenantSvc, srv := newFlakyTenantService(true)
+	defer srv.Close()
+
+	h := &Handler{TenantURL: srv.URL}
+	rec := &SettlementLaunchReconciler{
+		Store: &fakeAwaitingLaunchStore{orders: []store.Order{
+			{ID: "ord-orphan", TenantID: "", Status: "completed"},
+		}},
+		Launcher: h,
+	}
+
+	if delivered := rec.Sweep(context.Background()); delivered != 0 {
+		t.Errorf("Sweep delivered %d launches for a tenant-less order, want 0", delivered)
+	}
+	if got := tenantSvc.launches(); len(got) != 0 {
+		t.Fatalf("tenant service was called for a tenant-less order: %v", got)
+	}
+}
+
+// TestSettlementLaunch_SweepReportsNoDeliveryWhenTheServiceIsDown pins that a
+// failed pass reports ZERO delivered rather than counting attempts. The count
+// is the only signal an operator has that the recovery is working; inflating it
+// with attempts would be a verdict from absent evidence.
+func TestSettlementLaunch_SweepReportsNoDeliveryWhenTheServiceIsDown(t *testing.T) {
+	_, srv := newFlakyTenantService(false)
+	defer srv.Close()
+
+	h := &Handler{TenantURL: srv.URL}
+	rec := &SettlementLaunchReconciler{
+		Store: &fakeAwaitingLaunchStore{orders: []store.Order{
+			{ID: "ord-1", TenantID: "tnt-a", Status: "completed"},
+		}},
+		Launcher: h,
+	}
+	if delivered := rec.Sweep(context.Background()); delivered != 0 {
+		t.Errorf("Sweep reported %d delivered against a down tenant service, want 0", delivered)
+	}
+}
+
+// TestSettlementLaunch_SweepSurvivesAStoreError pins that an unreadable orders
+// table is a bad PASS, not a crash and not a claim. The next tick retries.
+func TestSettlementLaunch_SweepSurvivesAStoreError(t *testing.T) {
+	tenantSvc, srv := newFlakyTenantService(true)
+	defer srv.Close()
+
+	h := &Handler{TenantURL: srv.URL}
+	rec := &SettlementLaunchReconciler{
+		Store:    &fakeAwaitingLaunchStore{err: context.DeadlineExceeded},
+		Launcher: h,
+	}
+	if delivered := rec.Sweep(context.Background()); delivered != 0 {
+		t.Errorf("Sweep reported %d delivered after a store error, want 0", delivered)
+	}
+	if got := tenantSvc.launches(); len(got) != 0 {
+		t.Fatalf("tenant service was called despite the store read failing: %v", got)
+	}
+}
+
+// TestSettlementLaunch_RunSweepsBeforeItsFirstTick pins that a billing pod
+// which restarted mid-settlement does not make the stranded customer wait a
+// whole interval. Run must sweep immediately, then tick.
+func TestSettlementLaunch_RunSweepsBeforeItsFirstTick(t *testing.T) {
+	tenantSvc, srv := newFlakyTenantService(true)
+	defer srv.Close()
+
+	h := &Handler{TenantURL: srv.URL}
+	rec := &SettlementLaunchReconciler{
+		Store: &fakeAwaitingLaunchStore{orders: []store.Order{
+			{ID: "ord-1", TenantID: "tnt-a", Status: "completed"},
+		}},
+		Launcher: h,
+		// An interval far longer than the test: any launch observed can only
+		// have come from the pre-tick sweep.
+		Interval: time.Hour,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		rec.Run(ctx)
+		close(done)
+	}()
+
+	deadline := time.After(3 * time.Second)
+	for {
+		if len(tenantSvc.launches()) > 0 {
+			break
+		}
+		select {
+		case <-deadline:
+			cancel()
+			<-done
+			t.Fatal("Run made no launch call within 3s against a 1h interval — it waits for its first tick before sweeping")
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("Run did not stop when its context was cancelled")
+	}
+}
+
+// TestSettlementLaunch_RunIsInertWhenUnwired pins that a half-wired reconciler
+// returns instead of panicking or spinning — the Catalyst-Zero / dev-loop case.
+func TestSettlementLaunch_RunIsInertWhenUnwired(t *testing.T) {
+	done := make(chan struct{})
+	go func() {
+		(&SettlementLaunchReconciler{Launcher: &Handler{}}).Run(context.Background())
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run with no Store did not return promptly")
+	}
+}

--- a/core/services/billing/handlers/settlement_launch_test.go
+++ b/core/services/billing/handlers/settlement_launch_test.go
@@ -117,5 +117,10 @@ func TestDispatchOrderPlaced_LaunchesDeferredOrgOnSettlement(t *testing.T) {
 // panic or block, mirroring the existing lookupTenantSubdomain guard.
 func TestLaunchTenant_NoopWhenTenantURLUnset(t *testing.T) {
 	h := &Handler{}
-	h.launchTenant("tid") // TenantURL empty → no-op, must not panic.
+	// TenantURL empty → no-op, must not panic. #6242: the no-op reports nil,
+	// not an error — an unwired Catalyst-Zero loop has nothing to retry, and
+	// reporting failure here would make the reconciler log an outage forever.
+	if err := h.launchTenant(context.Background(), "tid"); err != nil {
+		t.Fatalf("launchTenant with empty TenantURL = %v, want nil", err)
+	}
 }

--- a/core/services/billing/main.go
+++ b/core/services/billing/main.go
@@ -220,6 +220,24 @@ func main() {
 		slog.Warn("NATS_URL is empty — metering consumer disabled (HTTP path still active)")
 	}
 
+	// #6242 — settlement-launch reconciler. dispatchOrderPlaced's launch call
+	// is the last, non-durable leg of a transaction whose earlier legs (the
+	// order row, the spent credit, the burned voucher) are already committed.
+	// Losing it left a PAID Organization parked at `pending_payment` with
+	// nothing that would ever move it again. This sweep re-offers the same
+	// call from the durable orders table, so the recovery survives a restart
+	// of this very process. Idempotent by construction — the tenant service's
+	// launch endpoint CAS-transitions only from `pending_payment`.
+	settlementLaunch := &handlers.SettlementLaunchReconciler{
+		Store:    billingStore,
+		Launcher: h,
+		Interval: getEnvDuration("SETTLEMENT_LAUNCH_INTERVAL", handlers.DefaultSettlementLaunchInterval),
+		Lookback: getEnvDuration("SETTLEMENT_LAUNCH_LOOKBACK", handlers.DefaultSettlementLaunchLookback),
+	}
+	settlementCtx, stopSettlementLaunch := context.WithCancel(context.Background())
+	defer stopSettlementLaunch()
+	go settlementLaunch.Run(settlementCtx)
+
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /healthz", health.Handler())
 
@@ -267,4 +285,22 @@ func getEnv(key, fallback string) string {
 		return v
 	}
 	return fallback
+}
+
+// getEnvDuration reads a Go duration string (e.g. "90s", "2m") from env.
+// An unset OR unparseable value falls back to the caller's default and says so
+// — a typo in a tuning knob must not silently disable the recovery sweep it
+// tunes (#6242).
+func getEnvDuration(key string, fallback time.Duration) time.Duration {
+	raw := strings.TrimSpace(os.Getenv(key))
+	if raw == "" {
+		return fallback
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil || d <= 0 {
+		slog.Warn("ignoring unusable duration env — using default",
+			"env", key, "value", raw, "default", fallback, "error", err)
+		return fallback
+	}
+	return d
 }

--- a/core/services/billing/store/settlement_launch_orders_6242_test.go
+++ b/core/services/billing/store/settlement_launch_orders_6242_test.go
@@ -1,0 +1,150 @@
+// settlement_launch_orders_6242_test.go — #6242.
+//
+// ListOrdersAwaitingLaunch is the durable driver of the settlement-launch
+// reconciler: it decides which paid Organizations get their lost launch call
+// re-offered. Its whole value is in what it EXCLUDES, so it is tested against a
+// real Postgres rather than sqlmock — a sqlmock expectation would assert the
+// literal query string, which is the shape that cannot tell a working WHERE
+// clause from a typo'd one. Same reasoning as voucher_integration_test.go, and
+// the same BILLING_TEST_PG_URL gate (skipped, never mocked, when unset).
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// mkOrderAt inserts an order and then back-dates its created_at, so a test can
+// place a row on either side of the lookback cutoff. CreateOrder always stamps
+// created_at server-side, which is correct for production and useless for
+// exercising a time window, hence the explicit UPDATE.
+func mkOrderAt(t *testing.T, s *Store, custID, tenantID, status string, age time.Duration) *Order {
+	t.Helper()
+	ctx := context.Background()
+	o := &Order{
+		CustomerID: custID,
+		TenantID:   tenantID,
+		PlanID:     "plan-m",
+		AmountOMR:  10,
+		Status:     status,
+	}
+	if err := s.CreateOrder(ctx, o); err != nil {
+		t.Fatalf("create order (tenant=%q status=%q): %v", tenantID, status, err)
+	}
+	if age > 0 {
+		if _, err := s.db.ExecContext(ctx,
+			`UPDATE orders SET created_at = $1 WHERE id = $2`, time.Now().Add(-age), o.ID); err != nil {
+			t.Fatalf("backdate order %s: %v", o.ID, err)
+		}
+	}
+	return o
+}
+
+func tenantIDsOf(orders []Order) map[string]int {
+	out := map[string]int{}
+	for _, o := range orders {
+		out[o.TenantID]++
+	}
+	return out
+}
+
+// TestListOrdersAwaitingLaunch_ReturnsSettledAndExcludesTheRest is the store
+// half of #6242.
+//
+// The CONTROLS all share the suspect property — every one of them is a real
+// row in the same `orders` table, inserted by the same CreateOrder, differing
+// from the subject in exactly ONE dimension. So a query that "returns orders"
+// cannot pass: it has to return the settled, tenant-bearing, recent ones and
+// no others.
+//
+//	subject   — completed, has a tenant, recent            => MUST appear
+//	control A — completed, has a tenant, older than lookback => must NOT appear
+//	control B — pending (customer never paid), recent        => must NOT appear
+//	control C — completed but no tenant (no Org to launch)   => must NOT appear
+//
+// Control B is the one that matters most: returning it would make the
+// reconciler launch Organizations for orders that were never settled, turning a
+// recovery sweep into a way to get a free Organization by abandoning checkout.
+func TestListOrdersAwaitingLaunch_ReturnsSettledAndExcludesTheRest(t *testing.T) {
+	s, _, cleanup := freshSchema(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	cust := mkCustomer(t, s, "awaiting-launch")
+
+	subject := mkOrderAt(t, s, cust.ID, "tenant-subject", "completed", 0)
+	stale := mkOrderAt(t, s, cust.ID, "tenant-stale", "completed", 48*time.Hour)
+	unpaid := mkOrderAt(t, s, cust.ID, "tenant-unpaid", "pending", 0)
+	orphan := mkOrderAt(t, s, cust.ID, "", "completed", 0)
+
+	got, err := s.ListOrdersAwaitingLaunch(ctx, 24*time.Hour, 100)
+	if err != nil {
+		t.Fatalf("ListOrdersAwaitingLaunch: %v", err)
+	}
+	byTenant := tenantIDsOf(got)
+
+	if byTenant["tenant-subject"] != 1 {
+		t.Errorf("settled recent order %s (tenant-subject) not returned: got %+v", subject.ID, byTenant)
+	}
+	if byTenant["tenant-stale"] != 0 {
+		t.Errorf("order %s older than the lookback was returned — the window does not filter", stale.ID)
+	}
+	if byTenant["tenant-unpaid"] != 0 {
+		t.Errorf("UNPAID order %s was returned — the sweep would launch an Organization the customer never paid for", unpaid.ID)
+	}
+	if byTenant[""] != 0 {
+		t.Errorf("order %s with no tenant was returned — the sweep would POST a malformed launch URL", orphan.ID)
+	}
+}
+
+// TestListOrdersAwaitingLaunch_LookbackIsHonoured pins that the window is a
+// real parameter and not a constant baked into the SQL: the SAME stale row that
+// is excluded at a 24h lookback must be INCLUDED at 72h. A query ignoring its
+// argument passes the test above and fails this one.
+func TestListOrdersAwaitingLaunch_LookbackIsHonoured(t *testing.T) {
+	s, _, cleanup := freshSchema(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	cust := mkCustomer(t, s, "lookback-window")
+	mkOrderAt(t, s, cust.ID, "tenant-48h", "completed", 48*time.Hour)
+
+	narrow, err := s.ListOrdersAwaitingLaunch(ctx, 24*time.Hour, 100)
+	if err != nil {
+		t.Fatalf("narrow lookback: %v", err)
+	}
+	if n := tenantIDsOf(narrow)["tenant-48h"]; n != 0 {
+		t.Fatalf("48h-old order returned at a 24h lookback (got %d)", n)
+	}
+
+	wide, err := s.ListOrdersAwaitingLaunch(ctx, 72*time.Hour, 100)
+	if err != nil {
+		t.Fatalf("wide lookback: %v", err)
+	}
+	if n := tenantIDsOf(wide)["tenant-48h"]; n != 1 {
+		t.Fatalf("48h-old order NOT returned at a 72h lookback (got %d) — the lookback argument is ignored", n)
+	}
+}
+
+// TestListOrdersAwaitingLaunch_LimitCapsTheBatch pins the batch cap, which is
+// what keeps a backlog from becoming a thundering herd against the tenant
+// service.
+func TestListOrdersAwaitingLaunch_LimitCapsTheBatch(t *testing.T) {
+	s, _, cleanup := freshSchema(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	cust := mkCustomer(t, s, "batch-cap")
+	for i := 0; i < 5; i++ {
+		mkOrderAt(t, s, cust.ID, "tenant-batch-"+string(rune('a'+i)), "completed", 0)
+	}
+
+	got, err := s.ListOrdersAwaitingLaunch(ctx, 24*time.Hour, 2)
+	if err != nil {
+		t.Fatalf("ListOrdersAwaitingLaunch: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("limit=2 returned %d rows — the batch cap is not applied", len(got))
+	}
+}

--- a/core/services/billing/store/store.go
+++ b/core/services/billing/store/store.go
@@ -517,6 +517,70 @@ func (s *Store) ListRecentOrders(ctx context.Context) ([]Order, error) {
 	return orders, rows.Err()
 }
 
+// ListOrdersAwaitingLaunch returns SETTLED orders that carry a tenant, newest
+// first, created within `lookback` of now.
+//
+// #6242. This is the durable record the settlement-launch reconciler sweeps.
+// The `orders` row is written inside the same transaction that spends the
+// customer's credit (CreditOnlyCheckout) or is flipped by the Stripe webhook,
+// so a row in `completed` is proof the customer PAID. The launch that turns
+// that payment into a running Organization is a single fire-and-forget HTTP
+// call (handlers.go launchTenant), and losing it stranded the paid Org at
+// `pending_payment` with nothing to retry it.
+//
+// Deliberately NOT joined against tenant status: billing owns no tenant table,
+// and asking the tenant service per row would trade one lost call for N. The
+// launch endpoint is itself the authority — it CAS-transitions only from
+// `pending_payment` and answers `launched:false` for everything else — so
+// re-offering an already-launched order is a cheap no-op, and a row that
+// SHOULD launch can never be filtered out here by a stale second opinion.
+//
+// The lookback bounds the sweep: an order old enough that the customer has
+// given up is a support case, not something to silently provision weeks later.
+func (s *Store) ListOrdersAwaitingLaunch(ctx context.Context, lookback time.Duration, limit int) ([]Order, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+	cutoff := time.Now().Add(-lookback)
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT o.id, o.customer_id, o.tenant_id, o.plan_id, o.apps, o.addons, o.topology,
+		        o.amount_omr, o.amount_baisa, o.status, o.stripe_session_id, o.created_at,
+		        o.promo_code, pc.deleted_at
+		   FROM orders o
+		   LEFT JOIN promo_codes pc ON pc.code = o.promo_code
+		  WHERE o.status = 'completed'
+		    AND o.tenant_id IS NOT NULL
+		    AND o.tenant_id <> ''
+		    AND o.created_at >= $1
+		  ORDER BY o.created_at DESC LIMIT $2`, cutoff, limit,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("store: list orders awaiting launch: %w", err)
+	}
+	defer rows.Close()
+
+	var orders []Order
+	for rows.Next() {
+		var o Order
+		var sessionID sql.NullString
+		var promoCode sql.NullString
+		var promoDeletedAt sql.NullTime
+		if err := rows.Scan(&o.ID, &o.CustomerID, &o.TenantID, &o.PlanID, &o.Apps, &o.Addons, &o.Topology,
+			&o.AmountOMR, &o.AmountBaisa, &o.Status, &sessionID, &o.CreatedAt,
+			&promoCode, &promoDeletedAt); err != nil {
+			return nil, fmt.Errorf("store: scan order awaiting launch: %w", err)
+		}
+		o.StripeSessionID = sessionID.String
+		o.PromoCode = promoCode.String
+		o.PromoDeleted = promoDeletedAt.Valid
+		orders = append(orders, o)
+	}
+	if orders == nil {
+		orders = []Order{}
+	}
+	return orders, rows.Err()
+}
+
 // ---------------------------------------------------------------------------
 // Subscriptions
 // ---------------------------------------------------------------------------

--- a/core/services/provisioning/gitops/apps.go
+++ b/core/services/provisioning/gitops/apps.go
@@ -112,9 +112,14 @@ var KnownApps = map[string]AppSpec{
 		Image: "calcom/cal.com:v6.2.0", Port: 3000,
 		NeedsDB: "postgres",
 		RAMMI:   "256Mi", CPUMilli: "100m",
+		// #6242 — PARENTDOMAIN, never a literal pool zone. See the placeholder
+		// contract on generateAppDeployment: this Org's zone is whichever of
+		// the four .omani.* pools the customer picked in the funnel, so a
+		// baked-in `omani.rest` pointed every cal.com callback at a domain the
+		// Org does not own the moment a second Org picked a second TLD.
 		EnvVars: map[string]string{
-			"NEXT_PUBLIC_WEBAPP_URL": "https://TENANT.omani.rest/calcom",
-			"NEXTAUTH_URL":           "https://TENANT.omani.rest/calcom",
+			"NEXT_PUBLIC_WEBAPP_URL": "https://TENANT.PARENTDOMAIN/calcom",
+			"NEXTAUTH_URL":           "https://TENANT.PARENTDOMAIN/calcom",
 		},
 	},
 	"chatwoot": {
@@ -138,7 +143,8 @@ var KnownApps = map[string]AppSpec{
 		RAMMI:   "256Mi", CPUMilli: "100m",
 		EnvVars: map[string]string{
 			"NODE_ENV": "production",
-			"url":      "https://TENANT.omani.rest/ghost",
+			// #6242 — PARENTDOMAIN, never a literal pool zone (see cal-com).
+			"url": "https://TENANT.PARENTDOMAIN/ghost",
 		},
 		DBEnvStyle:  "ghost",
 		ContentPath: "/var/lib/ghost/content",

--- a/core/services/provisioning/gitops/gitops.go
+++ b/core/services/provisioning/gitops/gitops.go
@@ -553,7 +553,7 @@ func (g *ManifestGenerator) GenerateAllWithAppConfigs(slug, planSlug string, app
 	// bp-cnpg-pair HR, which must live on the host with HR-level kubeConfig —
 	// never inside the vcluster-redirected apps/ tree).
 	hostFiles := map[string]string{
-		"ingress.yaml":           generateHostIngress(hostNS, slug, appSlugs),
+		"ingress.yaml":           generateHostIngress(hostNS, slug, g.parentDomain(), appSlugs),
 		"apps-sync.yaml":         generateAppsSyncKustomization(hostNS, slug, g.BasePath, isVcluster, g.appsSyncSourceRepo()),
 		"provisioning-rbac.yaml": generateProvisioningTenantRBAC(hostNS),
 	}
@@ -893,7 +893,7 @@ spec:
 `, slug, ns, sourceRepo, basePath, slug, kubeConfig)
 }
 
-func generateHostIngress(ns, slug string, appSlugs []string) string {
+func generateHostIngress(ns, slug, parentDomain string, appSlugs []string) string {
 	// HelmRelease-shaped apps (openclaw #4272, stalwart-mail #4307) carry their
 	// OWN chart-emitted HTTPRoute parented to cilium-gateway-console — they must
 	// NOT also appear in this traefik host ingress (a second route to a service
@@ -951,6 +951,13 @@ func generateHostIngress(ns, slug string, appSlugs []string) string {
 `, prefix, syncedName(app))
 	}
 
+	// #6242 — the host is the ORG'S pool zone, not a literal. Both the rule
+	// host and the TLS SAN read `<slug>.omani.rest` before this change,
+	// regardless of which pool zone the customer picked in the funnel, so on a
+	// Sovereign serving more than one pool TLD every Org's Ingress claimed a
+	// hostname in one particular zone. parentDomain is the per-Org value the
+	// rest of this generator already renders under.
+	host := appPublicHost(slug, parentDomain)
 	return fmt.Sprintf(`apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -961,14 +968,29 @@ metadata:
 spec:
   ingressClassName: traefik
   rules:
-    - host: %s.omani.rest
+    - host: %s
       http:
         paths:
 %s  tls:
     - hosts:
-        - %s.omani.rest
+        - %s
       secretName: tenant-%s-tls
-`, ns, slug, paths, slug, slug)
+`, ns, host, paths, host, slug)
+}
+
+// appPublicHost composes the Org-scoped public hostname `<slug>.<parentDomain>`.
+//
+// #6242 — the ONE derivation for the funnel generator's Org-scoped hosts, so a
+// pool zone can never be reintroduced as a literal at one site while the others
+// stay correct. An empty parentDomain (a degenerate generator with no pool wired)
+// yields the bare slug rather than a trailing-dot hostname; the caller's manifest
+// is then obviously wrong instead of subtly wrong.
+func appPublicHost(slug, parentDomain string) string {
+	parentDomain = strings.Trim(strings.TrimSpace(strings.ToLower(parentDomain)), ".")
+	if parentDomain == "" {
+		return slug
+	}
+	return slug + "." + parentDomain
 }
 
 // --- in-vCluster manifests (applied with vCluster kubeconfig) ---
@@ -1811,9 +1833,31 @@ func generateAppDeployment(ns, slug, planSlug, appSlug string, spec AppSpec, dbP
 	}
 	staticKeys = sortStrings(staticKeys)
 
+	// The AppSpec EnvVars carry two placeholders, both substituted here and
+	// nowhere else: `TENANT` -> this Org's slug, and `PARENTDOMAIN` -> the pool
+	// zone this Org actually lives under.
+	//
+	// #6242 — PARENTDOMAIN replaces what used to be a literal `omani.rest`
+	// baked into cal.com's NEXTAUTH_URL / NEXT_PUBLIC_WEBAPP_URL and Ghost's
+	// `url` (apps.go). Those are self-referential URLs the app hands back to
+	// the browser for callbacks and canonical links, so an Org whose funnel
+	// pick was `omani.trade` or `omani.homes` got an app configured to send its
+	// own users to a hostname on a DIFFERENT Organization's pool zone — one
+	// this Org has no cert, no A-record and no HTTPRoute for. It is invisible
+	// on a single-TLD Sovereign and breaks exactly when a second Org picks a
+	// second TLD.
+	//
+	// parentDomain is already this call's per-Org argument (the generator is
+	// cloned per Org at consumer.go's resolveOrgParentDomain seam), so no new
+	// plumbing is needed — only the removal of the literal. An empty
+	// parentDomain leaves the placeholder untouched rather than producing a
+	// URL with a dangling dot.
 	var envLines string
 	for _, k := range staticKeys {
 		val := strings.ReplaceAll(spec.EnvVars[k], "TENANT", slug)
+		if parentDomain != "" {
+			val = strings.ReplaceAll(val, "PARENTDOMAIN", parentDomain)
+		}
 		envLines += fmt.Sprintf("            - name: %s\n              value: \"%s\"\n", k, val)
 	}
 
@@ -1895,10 +1939,10 @@ func generateAppDeployment(ns, slug, planSlug, appSlug string, spec AppSpec, dbP
             - name: DB_DATABASE
               value: "%s"
             - name: APP_URL
-              value: "https://%s.omani.rest"
+              value: "https://%s"
             - name: APP_KEY
               value: "%s"
-`, dbPassword, dbPassword, appDB, slug, randomAppKey())
+`, dbPassword, dbPassword, appDB, appPublicHost(slug, parentDomain), randomAppKey())
 		case "ghost":
 			envLines += fmt.Sprintf(`            - name: database__client
               value: "mysql"

--- a/core/services/provisioning/gitops/pool_tld_per_org_6242_test.go
+++ b/core/services/provisioning/gitops/pool_tld_per_org_6242_test.go
@@ -1,0 +1,159 @@
+// pool_tld_per_org_6242_test.go — #6242, the UAT row-95 shape.
+//
+// Row 95 asserts "two Orgs, two TLDs, two running apps, identical mechanism".
+// The funnel resolver has honoured the customer's pool pick per-Org since
+// #4999, and the generator is cloned per Org at consumer.go's
+// resolveOrgParentDomain seam — but three rendered artifacts still carried a
+// LITERAL `omani.rest`, so an Org whose pick was any other pool zone got
+// manifests pointing at a zone it does not own:
+//
+//	gitops.go generateHostIngress   — the rule host AND the TLS SAN
+//	gitops.go bookstack DBEnvStyle  — APP_URL
+//	apps.go   cal-com / ghost       — NEXTAUTH_URL, NEXT_PUBLIC_WEBAPP_URL, url
+//
+// WHY THIS TEST RENDERS TWO ORGS AND NOT ONE
+// ------------------------------------------
+// A single-Org test is vacuous here by construction: pick `omani.rest` as the
+// fixture zone and the hardcoded literal produces byte-identical output to the
+// fix. The bug is INVISIBLE on a Sovereign serving one pool TLD and appears
+// only when a second Org lands on a second one — which is exactly why it
+// survived. So the control shares the suspect property: a second Organization,
+// same app set, same generator type, same code path, differing ONLY in its pool
+// zone. Each Org's render must carry its OWN zone and must not mention the
+// other's.
+package gitops
+
+import (
+	"strings"
+	"testing"
+)
+
+// poolZoneAppSlugs are the apps that actually embed a public hostname in what
+// they render: one per affected role. bookstack exercises the DBEnvStyle
+// branch, cal-com and ghost the AppSpec.EnvVars placeholder path, and wordpress
+// is the plain Deployment that the host Ingress routes.
+var poolZoneAppSlugs = []string{"wordpress", "bookstack", "cal-com", "ghost"}
+
+// renderForZone renders one Organization's full tree under a given pool zone.
+func renderForZone(t *testing.T, slug, zone string) map[string]string {
+	t.Helper()
+	g := &ManifestGenerator{
+		BasePath:     "clusters/contabo-mkt/tenants",
+		ParentDomain: zone,
+	}
+	out := g.GenerateAllWithAppConfigs(slug, "m", poolZoneAppSlugs, "pw", nil)
+	if len(out) == 0 {
+		t.Fatalf("generator produced no manifests for %s under %s", slug, zone)
+	}
+	return out
+}
+
+// TestPoolZoneIsPerOrg_TwoOrgsTwoTLDs is the row-95 guard.
+func TestPoolZoneIsPerOrg_TwoOrgsTwoTLDs(t *testing.T) {
+	const (
+		zoneA = "omani.trade"
+		zoneB = "omani.homes"
+	)
+	orgs := []struct{ slug, zone, otherZone string }{
+		{"alpha", zoneA, zoneB},
+		{"bravo", zoneB, zoneA},
+	}
+
+	for _, org := range orgs {
+		files := renderForZone(t, org.slug, org.zone)
+
+		ownHost := org.slug + "." + org.zone
+		sawOwnHost := false
+
+		for name, body := range files {
+			// No render may name the OTHER Organization's pool zone. This is
+			// the assertion the hardcoded literal fails: with `omani.rest`
+			// baked in, neither Org names its own zone and both name a third.
+			if strings.Contains(body, org.otherZone) {
+				t.Errorf("%s/%s names the other Organization's pool zone %q:\n%s",
+					org.slug, name, org.otherZone, excerptAround(body, org.otherZone))
+			}
+			// Nor may any render name a pool zone that is neither Org's — the
+			// control that catches a literal surviving at a site this test
+			// does not otherwise inspect.
+			for _, stray := range []string{"omani.rest", "omani.works"} {
+				if stray == org.zone || stray == org.otherZone {
+					continue
+				}
+				if strings.Contains(body, stray) {
+					t.Errorf("%s/%s names pool zone %q, which no Organization in this test picked — a hardcoded literal:\n%s",
+						org.slug, name, stray, excerptAround(body, stray))
+				}
+			}
+			if strings.Contains(body, ownHost) {
+				sawOwnHost = true
+			}
+		}
+
+		// Assert on the VALUE, not merely the absence of the wrong one: the
+		// Org's real host must actually appear, or a render that dropped every
+		// hostname would pass the exclusions above.
+		if !sawOwnHost {
+			t.Errorf("no manifest for %s contains its own host %q — the zone was dropped, not re-pointed",
+				org.slug, ownHost)
+		}
+	}
+}
+
+// TestPoolZoneIsPerOrg_HostIngressCarriesTheOrgZone pins the two Ingress sites
+// (rule host + TLS SAN) by name, so a regression reports WHICH artifact drifted
+// rather than only that something did.
+func TestPoolZoneIsPerOrg_HostIngressCarriesTheOrgZone(t *testing.T) {
+	const zone = "omani.trade"
+	ing := generateHostIngress("charlie", "charlie", zone, []string{"wordpress"})
+	if ing == "" {
+		t.Fatal("generateHostIngress rendered nothing for a routable app")
+	}
+	want := "charlie." + zone
+	if n := strings.Count(ing, want); n != 2 {
+		t.Errorf("host Ingress names %q %d time(s), want 2 (rule host + TLS SAN):\n%s", want, n, ing)
+	}
+	if strings.Contains(ing, "omani.rest") {
+		t.Errorf("host Ingress still carries the hardcoded omani.rest:\n%s", ing)
+	}
+}
+
+// TestPoolZoneIsPerOrg_EnvPlaceholderSubstituted pins the AppSpec placeholder
+// contract itself: PARENTDOMAIN must be substituted, never emitted raw. A
+// literal `PARENTDOMAIN` in a rendered URL is a worse failure than the old
+// hardcoded zone — it is not even a hostname.
+func TestPoolZoneIsPerOrg_EnvPlaceholderSubstituted(t *testing.T) {
+	files := renderForZone(t, "delta", "omani.homes")
+	for name, body := range files {
+		if strings.Contains(body, "PARENTDOMAIN") {
+			t.Errorf("%s emits the raw PARENTDOMAIN placeholder:\n%s", name, excerptAround(body, "PARENTDOMAIN"))
+		}
+		if strings.Contains(body, "TENANT.") {
+			t.Errorf("%s emits the raw TENANT placeholder:\n%s", name, excerptAround(body, "TENANT."))
+		}
+	}
+}
+
+// TestAppPublicHost_NoTrailingDotOnAnEmptyZone pins the degenerate case: a
+// generator with no pool wired must yield the bare slug, not `slug.`, which
+// would render a syntactically invalid hostname into a manifest.
+func TestAppPublicHost_NoTrailingDotOnAnEmptyZone(t *testing.T) {
+	for _, zone := range []string{"", "   ", "."} {
+		if got := appPublicHost("echo", zone); got != "echo" {
+			t.Errorf("appPublicHost(%q, %q) = %q, want %q", "echo", zone, got, "echo")
+		}
+	}
+	if got := appPublicHost("echo", " Omani.Trade. "); got != "echo.omani.trade" {
+		t.Errorf("appPublicHost did not normalise the zone: got %q", got)
+	}
+}
+
+// excerptAround returns the line containing needle, for a legible failure.
+func excerptAround(body, needle string) string {
+	for _, line := range strings.Split(body, "\n") {
+		if strings.Contains(line, needle) {
+			return strings.TrimSpace(line)
+		}
+	}
+	return ""
+}


### PR DESCRIPTION
## What this is

Root-cause of the four funnel / Org-door rows in `docs/ledger/UAT.md` (R16, 87, 90, 95), plus the fixes for the two defects that root-cause actually found. DoD Pillar 1 — marketplace + voucher onboarding.

`docs/ledger/UAT.md` is deliberately **not touched**. Source proof is not a walk.

## Per-row verdict

| Row | Clause | Class | Evidence | What I did |
|---|---|---|---|---|
| **R16** (#4290) | funnel + BSS Org doors collapsed onto ONE path; `console.<slug>` lands 200 | **(c)** correct in code, needs a live walk — **and the ledger's own warrant is now stale** | The three-door collapse shipped: Door 4 (`core/marketplace-api/provisioner/`) is **deleted**; Door 3's independent boundary is gone — `gitops.go:512` is `hostNS := slug`, and the surviving `tenant-%s-*` strings are Secret/Kustomization NAMES, not namespaces; Door 1's `ensureOrgNamespace` now takes a slug, not `org-<uuid>`. The ledger cell says #5957 is "deployed and inert" because `tenant_console_tls_regions.go` had only the ClusterMesh witness — **that was fixed by #6027/#6107 after the cell was written.** The file now takes the MAX of two witnesses (`tenant_console_tls_regions.go:380-384`), and the second one is wired end to end: chart `organization-controller-deployment.yaml:239` → `cmd/main.go:319` → `Reconciler.ConfiguredRegions`. I checked the call site, not just the helper. | No code change. The row's stated root cause no longer exists in `main`. |
| **87** (#3376 #3860) | after Launch the marketplace redirects to the per-Org console, publicly-trusted TLS | **(b)** defective — one hop had no recovery | `CheckoutStep.svelte:250` hands off via `/auth/org-handover` and polls the per-Org `/healthz` first, so the redirect itself is sound. The break is upstream: the Org must LAUNCH before there is anything to redirect to, and `handlers.go:1283` `launchTenant` was `func(string)` — fire-and-forget, every failure path a bare `return`. **Fixed** (commit 1). |
| **90** (#3376 #3860) | terminal: the purchased app SERVES at its own FQDN | **(b)** defective, same root cause + a second one | Every serving hop exists and is correct — HTTPRoute (`gitops.go:2109`) not a Traefik Ingress on the per-Org path (the Ingress is dropped at `perorg_apps_tree.go:161-165`), wildcard Certificate (`tenant_console_tls.go:397`), Gateway listener (`:503`), wildcard DNS A-record (`tenant_dns.go:182`), host↔vcluster Service sync (`manifests.go:370`). What was broken: (a) the app can only serve if the Org launched — commit 1; (b) `gitops.go` and `apps.go` hardcoded `omani.rest` into the app's own public URLs — commit 2. |
| **95** (#3376) | the 2nd Org's app serves at its own **different-TLD** FQDN | **(b)** defective — this row is what the hardcoded zone actually broke | Per-Org zone selection is real: `resolveOrgParentDomain` (#4999) honours the funnel pick when served, it rides `spec.tenantPublic.parentDomain` on the Org CR (`organization_create.go:184`), and the generator is cloned per Org (`consumer.go:716-721`). But three rendered artifacts carried a literal `omani.rest`, which is **invisible on a one-TLD Sovereign and appears exactly when a second Org picks a second TLD** — the row's own assertion. **Fixed** (commit 2). |

Rows 87/90/95 additionally need a live two-Org funnel walk to flip; nothing in this PR flips them.

## Commit 1 — the settlement→launch hop had no recovery

Since #4956 the funnel creates the Org with `defer_launch: true`: parked at `pending_payment`, launched only when billing settles. That launch was one 3s HTTP POST whose every failure path was `slog.Error(...); return`, from a function returning nothing — so no caller could tell a delivered launch from a lost one, and nothing retried it.

By then the money is gone: `CreditOnlyCheckout` has committed the order `completed` and burned the voucher. One lost call — tenant service rolling, unconverged NetworkPolicy, the 3s timeout, or the billing pod restarting between the DB commit and the POST — left a **paid order beside an Organization that would never provision**. `grep -rn pending_payment --include=*.go core/services/` finds twelve non-test sites, none a sweeper. The code named the hole itself, twice, in its own log strings; a comment that names a hole is not a producer that closes it. The pre-existing guard pinned only that the call is *made* on the happy path.

Fix: a reconciler driven off the `orders` table — the durable record of "this customer paid", written in the same transaction that spends the credit. That is what makes the recovery survive a restart of the very process that lost the call. Re-offering is safe by construction: `InternalLaunchTenant` wins an atomic `pending_payment → provisioning` CAS and answers `launched:false` otherwise, so idempotency is enforced by the endpoint on the row — deliberately not by the sweep's own bookkeeping, since a stale skip there is the exact failure being fixed. `order.placed` is unchanged; it is durable but on a Sovereign it is an observer that launches nothing.

## Commit 2 — the app's public hostname was pinned to one pool zone

`generateHostIngress` (rule host + TLS SAN), bookstack's `APP_URL`, and cal-com/ghost's `NEXTAUTH_URL` / `NEXT_PUBLIC_WEBAPP_URL` / `url` all carried a literal `omani.rest`. The env ones are the sharper edge — those are self-referential URLs the app hands the browser for callbacks, so an Org on `omani.trade` was configured to send its own users to another Organization's zone, where it has no cert, no A-record and no HTTPRoute. `parentDomain` was already an argument on both paths, so this removes literals rather than adding plumbing; `appPublicHost` is now the single derivation so a literal cannot creep back at one site while the others stay right.

## Vacuity proof — 15 mutants, 15 caught, 0 vacuous guards

Each mutant compiles and is applied one site at a time.

```
M1 sweep never calls launchTenant                  RED    N1 Ingress rule host back to omani.rest         RED
M2 sweep drops tenant de-duplication               RED    N2 Ingress TLS SAN back to omani.rest           RED
M3 sweep stops skipping tenant-less orders         RED    N3 bookstack APP_URL back to omani.rest         RED
M4 Run waits for its first tick before sweeping    RED    N4 cal-com + ghost env URLs back to omani.rest  RED
M5 launchTenant swallows a non-200                 RED    N5 PARENTDOMAIN substitution removed            RED
M6 query drops the settled-status filter           RED    N6 appPublicHost trailing dot on empty zone     RED
M7 query ignores the lookback cutoff               RED
M8 query ignores the batch limit                   RED
M9 query drops the empty-tenant filter             RED
```

Test discipline notes:

- The reconciler guard drives the **real** production order — settle with the tenant service refusing work, **assert the launch was genuinely lost**, bring it back, sweep — wired to the real `*Handler.launchTenant`. The call site is pinned, not just a helper.
- The store guards run against a **real Postgres** (`BILLING_TEST_PG_URL`, the gate `voucher_integration_test.go` already uses), verified locally on 14.23. That query's whole value is what it EXCLUDES, and a sqlmock expectation asserts the literal query string — it cannot tell a working `WHERE` from a typo'd one. Controls share the suspect property: every one is a real row in the same table from the same `CreateOrder`, differing in exactly one dimension. The unpaid control matters most — returning it would let a customer get an Organization by abandoning checkout.
- The pool-zone guard renders **two** Orgs on two TLDs, because a one-Org test is vacuous by construction here: pick `omani.rest` as the fixture and the buggy code is byte-identical to the fixed code.

`go build`, `go vet`, `go test ./...` green in both modules. `check-no-banned-words.sh --working-tree` — every added line and every new file contributes zero (the repo's ~338 pre-existing hits are untouched; the three that match my touched file are pre-existing lines in `gitops.go` I did not author).

## Two findings I did NOT turn into code, and why

Both are real; neither is settleable from source alone, so inventing a fix would be guessing.

1. **`TENANT_POOL_DOMAINS` is read by Go and templated by nothing.** `grep -rn TENANT_POOL_DOMAINS` over `products/catalyst/chart/`, `clusters/` and `platform/` returns **zero** YAML hits — the knob exists only in `core/services/{tenant,provisioning}/handlers/pool_domains.go`. So `PoolDomainsFromEnv()` always returns nil in a deployed cluster and the served set silently falls back to the hardcoded four `.omani.*` zones, while the operator-facing warning at `tenant/handlers/handlers.go:284` tells operators to "add the zone to `TENANT_POOL_DOMAINS`" — a knob no manifest exposes. **Not shipped here** because the fallback is currently *correct* for our Sovereigns, so this blocks no row, and exposing it is a chart change needing the five-site lockstep plus an umbrella republish — worth its own PR rather than riding along under a gate I would be rushing. Written up on #6242.
2. **The funnel's TLD offer is a hardcoded literal.** `core/marketplace/src/components/AddonsStep.svelte:36` hardcodes the four zones client-side rather than deriving them from what the Sovereign serves, and includes `omani.works`, which on our live clusters is the **Sovereign apex**, not an org-pool zone. Whether that is a defect depends on per-Sovereign deployment config I cannot read from source — the backend default served set *does* include `omani.works`, so code-internally the offer and the resolver agree. Naming it as a code defect would be inventing one. Written up on #6242.

Also noted for whoever walks row 90 next, not fixed here: `provisioning_postconditions.go` verifies the per-Org **console** listener pair but never that the purchased app's HTTPRoute is `Accepted`/`ResolvedRefs`. An app route that resolves to nothing therefore leaves the Organization reading fully provisioned — the terminal condition row 90 asserts has no verifier behind it.

Refs #6242 Refs #4290 Refs #3376 Refs #3860

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HvMZTDx7W6EPZMmjyXmYh1
