### PR TITLE
fix(anthropic-seed): a credential that cannot authenticate is not a seeded Sovereign (UAT R19/G8/G9)

### DIFF
--- a/products/agenity/README.md
+++ b/products/agenity/README.md
@@ -220,6 +220,52 @@ the OAuth journey until upstream `claude-code` gains a reliable
 non-interactive refresh — track it as a recurring per-Sovereign chore, not a
 one-time seed.
 
+### The Sovereign-side verdict: absent, unusable and valid are three states (#6250)
+
+Everything above is the per-Org (workspace) half. The producer half —
+`seedAnthropicToken`, which writes this OpenBao path at Org-create and every ten
+minutes thereafter — used to answer only **two** of the three questions an
+operator can be in, and the missing one is the one a stale Sovereign is
+usually in:
+
+| Sovereign state | catalyst-api verdict | what the operator sees |
+|---|---|---|
+| **absent** — no credential configured | `skipped-no-env`, loud ERROR naming the Secret to create | correct, and correct since #4277 |
+| **valid** — a `claudeAiOauth` blob that can authenticate | `seeded` | correct |
+| **unusable** — configured and cannot authenticate | ~~`seeded`~~ → `unusable-credential-seeded` | **was reported as success** |
+
+`unusable` covers three real operator states, each with its own remediation, so
+the log line names which one it is:
+
+- **key-only** — `apiKey` is set and `credentialsJson` is empty. `claude-code`
+  authenticates from the OAuth blob, so this cannot spawn an agent at all.
+- **malformed** — `credentialsJson` is not a `claudeAiOauth` document. The
+  commonest shape is a bare `sk-ant-oat01-…` token pasted into that field.
+- **expired** — the right document, an `accessToken` past its `expiresAt`.
+  Given the hours-long lifetime described above, this is the **steady state**
+  of a credential nobody rotated, not a rare edge. Remediation is **rotation**,
+  not creation — which is why it must not share a message with `absent`.
+
+Two consequences worth knowing before reading a log:
+
+- The unusable value **is still written** to the OpenBao path, deliberately, so
+  the per-Org ExternalSecret syncs and the workspace's own init container can
+  diagnose from the real bytes rather than reporting a generic "credential never
+  arrived". What changed is that catalyst-api no longer calls it seeded.
+- The write is **withheld** when the stored path already holds a credential that
+  works (outcome `unusable-credential-withheld`) — a fat-fingered rotation must
+  not demote a Sovereign whose workspaces authenticate today.
+
+The ten-minute self-heal loop asks the same question of what is **already
+stored**: its health check is `credentialsJson` being present *and usable*, not
+`apiKey` **or** `credentialsJson` being non-empty. Under the old check a path
+holding an apiKey and an empty `credentialsJson` read healthy and the loop went
+silent for the life of the cluster, while every Agenity workspace on the
+Sovereign refused to start. A stored credential that cannot work now re-seeds if
+a usable source exists, and otherwise keeps reporting
+`[SEED-RECONCILE] 🛑 self-heal did NOT take` with the rotation remediation
+attached.
+
 > **Why not chart-seed it?** A Helm-seeded placeholder would pin an **empty**
 > value forever under the reflector/ESO empty-seed trap (the bp-wordpress-tenant
 > empty-password lesson) — the agent would then hold a permanently-blank

--- a/products/catalyst/bootstrap/api/internal/handler/anthropic_credential_class.go
+++ b/products/catalyst/bootstrap/api/internal/handler/anthropic_credential_class.go
@@ -1,0 +1,230 @@
+// anthropic_credential_class.go — what the platform's Anthropic credential IS,
+// as distinct from whether one is configured at all (#4277 / #4111 / #4482).
+//
+// THE COLLAPSE THIS FILE EXISTS TO UNDO
+//
+//	The Org-create → workspace-pod seam has to answer three different
+//	questions, and until now it answered two:
+//
+//	  ABSENT   — the Sovereign holds no Anthropic credential at all. Reported:
+//	             seedAnthropicToken returns skipped-no-env and logs the founder
+//	             gap loudly. Correct, and it has been correct since #4277.
+//	  VALID    — the credential is a claudeAiOauth pair the spawned claude-code
+//	             can authenticate with. Reported: outcome "seeded".
+//	  INVALID  — a credential IS configured and CANNOT work: a bare API key
+//	             where an OAuth blob was required, a blob that is not JSON, a
+//	             blob with no accessToken, or a blob whose accessToken already
+//	             expired. Reported: ***also "seeded"***.
+//
+//	That third case took the second case's verdict. The producer wrote the
+//	unusable value, logged "wrote OpenBao path so every Org's agenity
+//	ExternalSecret resolves", and the seed reconciler — which asks only whether
+//	`apiKey` OR `credentialsJson` is non-empty — then read the path as HEALTHY
+//	and went silent for the life of the cluster. Meanwhile every per-Org
+//	Agenity workspace either waited out its credential timeout and exited
+//	Init:Error (#6163 FREEZE 2) or came up and 401'd on every agent spawn
+//	(FREEZE 3). The Sovereign-level signal said green; the per-Org reality was
+//	red; nothing in between reconciled the two.
+//
+//	Expiry is not a rare edge here. The seeded blob is a claudeAiOauth pair
+//	whose accessToken lives HOURS and nothing in this repo refreshes it, so an
+//	unrotated credential spends most of its life in the INVALID class.
+//
+// WHAT THIS FILE PROVIDES
+//
+//	One classifier, used by both halves of the seam so they cannot disagree:
+//	the producer (sovereign_anthropic_seed.go) decides what to write and what
+//	to call it, and the seed reconciler (sovereign_seed_reconciler.go) decides
+//	whether the STORED value is healthy. A single function means "healthy" at
+//	the Sovereign layer and "usable" at the workspace layer are the same
+//	predicate rather than two drifting approximations of it.
+//
+//	The verdict deliberately matches the one the bp-agenity init container
+//	reaches for the same blob (products/agenity/chart/templates/statefulset.yaml
+//	seed-claude-creds — the `EXPIRED` / `OK` / `NOEXP` parse). Same input, same
+//	answer, two layers apart.
+//
+// Per docs/PRINCIPLES.md #10 (credential hygiene): nothing here returns, logs
+// or embeds a token, key or blob — only a class, byte lengths and elapsed
+// hours.
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/openbao"
+)
+
+// anthropicCredentialClass — the three-way verdict the seam owes its operator,
+// with the unusable case split by CAUSE because the remediation differs
+// (supply one / fix the shape / rotate it).
+type anthropicCredentialClass string
+
+const (
+	// anthropicCredAbsent — no credential configured at all. The founder gap
+	// #4277 documents. Remediation: supply one.
+	anthropicCredAbsent anthropicCredentialClass = "absent"
+	// anthropicCredKeyOnly — an apiKey is set but credentialsJson is empty.
+	// claude-code authenticates from the OAuth blob, so this cannot spawn an
+	// agent: the bp-agenity init container waits out credentialWait and exits
+	// non-zero (#6163 FREEZE 2). Remediation: supply credentialsJson.
+	anthropicCredKeyOnly anthropicCredentialClass = "key-only"
+	// anthropicCredMalformed — credentialsJson is present but is not a
+	// claudeAiOauth blob: not JSON, no claudeAiOauth object, or no
+	// accessToken. The commonest real shape is a bare `sk-ant-oat01-…` string
+	// pasted into the credentialsJson field, which #4111 records as rejected.
+	// Remediation: supply the full {"claudeAiOauth":{…}} document.
+	anthropicCredMalformed anthropicCredentialClass = "malformed"
+	// anthropicCredExpired — a well-formed blob whose accessToken expired.
+	// Distinct from malformed because the credential is RIGHT and merely old:
+	// remediation is rotation, not a shape fix.
+	anthropicCredExpired anthropicCredentialClass = "expired"
+	// anthropicCredValid — a claudeAiOauth blob with an accessToken that has
+	// not expired (or carries no expiresAt, i.e. a non-expiring credential).
+	// The ONLY class that may be described as seeded.
+	anthropicCredValid anthropicCredentialClass = "valid"
+)
+
+// usable reports whether a credential of this class can actually authenticate a
+// spawned agent. Exactly one class qualifies — which is the point: every caller
+// asks this instead of re-deriving "well, apiKey is non-empty, close enough".
+func (c anthropicCredentialClass) usable() bool { return c == anthropicCredValid }
+
+// anthropicCredentialRemediation — the ONE concrete action that moves a class
+// to valid, carried on the log line the sovereign-admin actually finds.
+// Per docs/PRINCIPLES.md #10 these name the Secret and the field to populate,
+// never a value.
+func anthropicCredentialRemediation(c anthropicCredentialClass) string {
+	switch c {
+	case anthropicCredKeyOnly:
+		return "the credentialsJson field is EMPTY — claude-code authenticates from the OAuth blob, not from apiKey. " +
+			"Set credentialsJson on catalyst-system/sovereign-anthropic-credentials to the full {\"claudeAiOauth\":{…}} document (#4111)."
+	case anthropicCredMalformed:
+		return "credentialsJson is not a claudeAiOauth document (a bare sk-ant-… token in that field is rejected). " +
+			"Set it to the full {\"claudeAiOauth\":{\"accessToken\":…,\"refreshToken\":…,\"expiresAt\":…}} JSON on " +
+			"catalyst-system/sovereign-anthropic-credentials (#4111)."
+	case anthropicCredExpired:
+		return "the credential is the right SHAPE but its accessToken has expired, and nothing in this platform refreshes it. " +
+			"ROTATE catalyst-system/sovereign-anthropic-credentials with a fresh credentialsJson; the next seed pass picks it " +
+			"up live with no catalyst-api roll (#6163)."
+	case anthropicCredAbsent:
+		return seedRemediation["anthropic"]
+	}
+	return ""
+}
+
+// classifyAnthropicCredential returns the class of the (apiKey, credentialsJSON)
+// pair plus a credential-free detail string for the log line.
+//
+// The detail carries byte lengths and elapsed/remaining hours only — never any
+// part of the credential itself.
+func classifyAnthropicCredential(apiKey, credentialsJSON string) (anthropicCredentialClass, string) {
+	apiKey = strings.TrimSpace(apiKey)
+	credentialsJSON = strings.TrimSpace(credentialsJSON)
+
+	if credentialsJSON == "" {
+		if apiKey == "" {
+			return anthropicCredAbsent, "neither apiKey nor credentialsJson is set"
+		}
+		return anthropicCredKeyOnly, fmt.Sprintf("apiKey is set (%d bytes) but credentialsJson is empty", len(apiKey))
+	}
+
+	// UseNumber so a millisecond epoch never round-trips through float64 and
+	// loses its low digits — 1_750_000_000_000 is well inside float64's exact
+	// integer range today, but the parse should not depend on that holding.
+	dec := json.NewDecoder(strings.NewReader(credentialsJSON))
+	dec.UseNumber()
+	var root map[string]any
+	if err := dec.Decode(&root); err != nil {
+		return anthropicCredMalformed, fmt.Sprintf("credentialsJson (%d bytes) is not JSON", len(credentialsJSON))
+	}
+	oauth, ok := root["claudeAiOauth"].(map[string]any)
+	if !ok {
+		return anthropicCredMalformed, fmt.Sprintf("credentialsJson (%d bytes) has no claudeAiOauth object", len(credentialsJSON))
+	}
+	if token, _ := oauth["accessToken"].(string); strings.TrimSpace(token) == "" {
+		return anthropicCredMalformed, fmt.Sprintf("credentialsJson (%d bytes) has no claudeAiOauth.accessToken", len(credentialsJSON))
+	}
+
+	expiresAtMillis, present := anthropicExpiresAtMillis(oauth["expiresAt"])
+	if !present || expiresAtMillis <= 0 {
+		// Mirrors the init container's NOEXP arm: no expiresAt is treated as a
+		// non-expiring credential, not as a defect.
+		return anthropicCredValid, "claudeAiOauth blob with no expiresAt — treated as non-expiring"
+	}
+	nowMillis := time.Now().UnixMilli()
+	if expiresAtMillis <= nowMillis {
+		return anthropicCredExpired, fmt.Sprintf("claudeAiOauth accessToken expired ~%dh ago", (nowMillis-expiresAtMillis)/3600000)
+	}
+	return anthropicCredValid, fmt.Sprintf("claudeAiOauth accessToken valid ~%dh longer", (expiresAtMillis-nowMillis)/3600000)
+}
+
+// anthropicExpiresAtMillis normalises the expiresAt field, which real blobs
+// carry as a JSON number and some hand-written ones as a string. Returns
+// (millis, present).
+func anthropicExpiresAtMillis(v any) (int64, bool) {
+	switch t := v.(type) {
+	case json.Number:
+		if n, err := t.Int64(); err == nil {
+			return n, true
+		}
+		if f, err := t.Float64(); err == nil {
+			return int64(f), true
+		}
+	case float64:
+		return int64(t), true
+	case string:
+		if n, err := strconv.ParseInt(strings.TrimSpace(t), 10, 64); err == nil {
+			return n, true
+		}
+	}
+	return 0, false
+}
+
+// anthropicStoredCredentialUsable is the seed reconciler's health predicate for
+// `secret/catalyst/anthropic/token`.
+//
+// It exists because presence is not health here. The reconciler's generic check
+// asks whether a named property is non-empty, and by that measure a path
+// carrying an apiKey and an empty credentialsJson — or a credentialsJson that
+// expired six hours ago — reads HEALTHY and the loop goes quiet, while every
+// Agenity workspace on the Sovereign refuses to start. Health is whether the
+// STORED value can authenticate an agent, which is precisely what the workspace
+// pod asks of the same bytes one layer down.
+func anthropicStoredCredentialUsable(data map[string]any) bool {
+	apiKey, _ := data["apiKey"].(string)
+	credentialsJSON, _ := data["credentialsJson"].(string)
+	class, _ := classifyAnthropicCredential(apiKey, credentialsJSON)
+	return class.usable()
+}
+
+// storedAnthropicCredentialClass reads `secret/catalyst/anthropic/token` and
+// classifies what is actually stored there.
+//
+// The second return is OBSERVED, and callers must honour it: a NotFound is
+// positive evidence of absence, but a transport error is evidence of NOTHING
+// and must never be rendered as "the stored credential is absent, go ahead and
+// overwrite it". Reporting a verdict from absent evidence is how a blip would
+// get to clobber a working credential.
+func (h *Handler) storedAnthropicCredentialClass(ctx context.Context) (anthropicCredentialClass, bool) {
+	if h == nil || h.openbao == nil {
+		return anthropicCredAbsent, false
+	}
+	data, err := h.openbao.GetKVv2(ctx, anthropicSeedMountPath, anthropicSeedSecretPath)
+	if err != nil {
+		if errors.Is(err, openbao.ErrSecretNotFound) {
+			return anthropicCredAbsent, true
+		}
+		return anthropicCredAbsent, false
+	}
+	apiKey, _ := data["apiKey"].(string)
+	credentialsJSON, _ := data["credentialsJson"].(string)
+	class, _ := classifyAnthropicCredential(apiKey, credentialsJSON)
+	return class, true
+}

--- a/products/catalyst/bootstrap/api/internal/handler/anthropic_credential_class_6250_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/anthropic_credential_class_6250_test.go
@@ -1,0 +1,437 @@
+package handler
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+)
+
+// #6250 — the Org-create → workspace-pod credential seam owes its operator
+// THREE distinguishable answers, and shipped two: ABSENT and VALID were
+// distinct, INVALID took VALID's verdict.
+//
+// Everything here drives a REAL CALL SITE — seedAnthropicToken (the producer
+// runOrganizationPipeline fires) and runSeedReconcilePass (the ten-minute loop)
+// — never the classifier in isolation. A classifier that returns the right
+// enum while the producer still writes "seeded" over it is the exact defect
+// being fixed, and a helper-only test cannot see it.
+//
+// CONTROLS are load-bearing throughout: every "unusable credential is refused"
+// case is paired with a valid credential that must still seed. Without them
+// "refuses an expired credential" is indistinguishable from "refuses every
+// credential", which would be a worse bug than the one being fixed.
+//
+// No real credential appears in this file. Every token is an obvious
+// FAKE-prefixed placeholder.
+
+// fakeAnthropicCredentialsJSON builds a claudeAiOauth blob whose accessToken
+// expires `until` from now — negative for an already-expired one. Shaped like
+// the real seeded document (the fields anthropic_credential_class.go parses),
+// with placeholder values that are not credentials.
+func fakeAnthropicCredentialsJSON(until time.Duration) string {
+	return fmt.Sprintf(
+		`{"claudeAiOauth":{"accessToken":"FAKE-not-a-real-access-token","refreshToken":"FAKE-not-a-real-refresh-token","expiresAt":%d,"scopes":["user:inference"]}}`,
+		time.Now().Add(until).UnixMilli())
+}
+
+// validAnthropicCredentialsJSON / expiredAnthropicCredentialsJSON — the two
+// fixtures every case in this package builds on. 6h ahead and 45h behind; the
+// 45h mirrors the live omantel.biz precedent recorded in the bp-agenity
+// statefulset template.
+func validAnthropicCredentialsJSON() string   { return fakeAnthropicCredentialsJSON(6 * time.Hour) }
+func expiredAnthropicCredentialsJSON() string { return fakeAnthropicCredentialsJSON(-45 * time.Hour) }
+
+// ── Producer: a credential that cannot authenticate is never "seeded" ───────
+
+func Test_seedAnthropicToken_UnusableCredentialIsNotReportedAsSeeded(t *testing.T) {
+	cases := []struct {
+		name        string
+		apiKey      string
+		credsJSON   string
+		wantClass   string
+		wantInError string
+	}{
+		{
+			// The shape that stranded R19: an apiKey is set, credentialsJson is
+			// empty, the path is written and read back as healthy — while
+			// claude-code, which authenticates from the OAuth blob, cannot spawn
+			// at all and the init container exits non-zero (#6163 FREEZE 2).
+			name:        "key-only",
+			apiKey:      "FAKE-not-a-real-api-key",
+			credsJSON:   "",
+			wantClass:   "key-only",
+			wantInError: "credentialsJson field is EMPTY",
+		},
+		{
+			// #4111 records this exact operator error: the bare OAuth token
+			// pasted into the credentialsJson field instead of the document.
+			name:        "malformed-bare-token",
+			apiKey:      "",
+			credsJSON:   "FAKE-not-a-real-oauth-token",
+			wantClass:   "malformed",
+			wantInError: "not a claudeAiOauth document",
+		},
+		{
+			name:        "malformed-json-without-accessToken",
+			apiKey:      "",
+			credsJSON:   `{"claudeAiOauth":{"refreshToken":"FAKE-not-a-real-refresh-token"}}`,
+			wantClass:   "malformed",
+			wantInError: "not a claudeAiOauth document",
+		},
+		{
+			// The steady state of a credential nobody rotated: the accessToken
+			// lives hours and nothing in this platform refreshes it.
+			name:        "expired",
+			apiKey:      "FAKE-not-a-real-api-key",
+			credsJSON:   expiredAnthropicCredentialsJSON(),
+			wantClass:   "expired",
+			wantInError: "ROTATE",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := newRWKVServer(t)
+			lg, read := capturingLogger()
+			h := &Handler{log: lg}
+			h.openbao = srv.client()
+			t.Setenv(anthropicSeedAPIKeyEnv, tc.apiKey)
+			t.Setenv(anthropicSeedCredentialsJSONEnv, tc.credsJSON)
+
+			got := h.seedAnthropicToken(context.Background())
+
+			if got == AnthropicSeedOutcomeSeeded {
+				t.Fatalf("a %s credential was reported as %q — INVALID took VALID's verdict, which is the whole defect (#6250)",
+					tc.wantClass, got)
+			}
+			if got != AnthropicSeedOutcomeUnusableSeeded {
+				t.Fatalf("outcome = %q, want %q", got, AnthropicSeedOutcomeUnusableSeeded)
+			}
+
+			// The value IS written (so the per-Org ExternalSecret syncs and the
+			// workspace init container can render the precise verdict from the
+			// real bytes) — but never under a green label.
+			if w := srv.writes(); len(w) != 1 || w[0] != anthropicSeedSecretPath {
+				t.Fatalf("expected exactly one write to %q, got %v", anthropicSeedSecretPath, w)
+			}
+
+			errs := recordsAtLevel(read(), "ERROR")
+			if len(errs) == 0 {
+				t.Fatalf("a credential that cannot authenticate produced no ERROR record — the Sovereign-level signal stays green while every workspace refuses to start")
+			}
+			// The class must be NAMED. "something is wrong" costs the operator
+			// the whole diagnosis; the three causes have three remediations.
+			if !anyRecordContains(errs, tc.wantClass) {
+				t.Errorf("no ERROR record names the credential class %q. records=%v", tc.wantClass, errs)
+			}
+			if !anyRecordContains(errs, tc.wantInError) {
+				t.Errorf("no ERROR record carries the %s remediation (%q). records=%v", tc.wantClass, tc.wantInError, errs)
+			}
+		})
+	}
+}
+
+// Test_seedAnthropicToken_ValidCredentialStillSeeds is THE CONTROL for the test
+// above, and it shares the suspect property exactly: same producer, same absent
+// OpenBao path at entry, same write. The ONLY difference is that the credential
+// can actually authenticate.
+//
+// Its job is to fail if the new refusal fires on "a credential is configured"
+// rather than on "the configured credential cannot work". A guard that refused
+// everything would pass every case above and fail here.
+func Test_seedAnthropicToken_ValidCredentialStillSeeds(t *testing.T) {
+	srv := newRWKVServer(t)
+	lg, read := capturingLogger()
+	h := &Handler{log: lg}
+	h.openbao = srv.client()
+	t.Setenv(anthropicSeedAPIKeyEnv, "FAKE-not-a-real-api-key")
+	t.Setenv(anthropicSeedCredentialsJSONEnv, validAnthropicCredentialsJSON())
+
+	if got := h.seedAnthropicToken(context.Background()); got != AnthropicSeedOutcomeSeeded {
+		t.Fatalf("outcome = %q, want %q — a usable credential must still seed", got, AnthropicSeedOutcomeSeeded)
+	}
+	if errs := recordsAtLevel(read(), "ERROR"); len(errs) != 0 {
+		t.Errorf("a usable credential emitted ERROR records — the refusal cannot discriminate valid from invalid: %v", errs)
+	}
+	if w := srv.writes(); len(w) != 1 || w[0] != anthropicSeedSecretPath {
+		t.Fatalf("expected exactly one write to %q, got %v", anthropicSeedSecretPath, w)
+	}
+}
+
+// Test_seedAnthropicToken_NoExpiresAtIsValid is the second control: a blob with
+// no expiresAt is a non-expiring credential, not a defect. It mirrors the
+// bp-agenity init container's NOEXP arm, so the two layers cannot disagree
+// about the same bytes.
+func Test_seedAnthropicToken_NoExpiresAtIsValid(t *testing.T) {
+	srv := newRWKVServer(t)
+	h := &Handler{log: silentLogger()}
+	h.openbao = srv.client()
+	t.Setenv(anthropicSeedAPIKeyEnv, "")
+	t.Setenv(anthropicSeedCredentialsJSONEnv, `{"claudeAiOauth":{"accessToken":"FAKE-not-a-real-access-token"}}`)
+
+	if got := h.seedAnthropicToken(context.Background()); got != AnthropicSeedOutcomeSeeded {
+		t.Fatalf("outcome = %q, want %q — no expiresAt means non-expiring, not broken", got, AnthropicSeedOutcomeSeeded)
+	}
+}
+
+// Test_seedAnthropicToken_AbsentStaysDistinctFromUnusable pins the third leg of
+// the three-way split. Absence has its own outcome and its own remediation
+// ("supply one"), and adding the unusable class must not swallow it.
+func Test_seedAnthropicToken_AbsentStaysDistinctFromUnusable(t *testing.T) {
+	srv := newRWKVServer(t)
+	h := &Handler{log: silentLogger()}
+	h.openbao = srv.client()
+	t.Setenv(anthropicSeedAPIKeyEnv, "")
+	t.Setenv(anthropicSeedCredentialsJSONEnv, "")
+
+	got := h.seedAnthropicToken(context.Background())
+	if got != AnthropicSeedOutcomeSkippedNoEnv {
+		t.Fatalf("outcome = %q, want %q — absent must not be folded into unusable", got, AnthropicSeedOutcomeSkippedNoEnv)
+	}
+	if w := srv.writes(); len(w) != 0 {
+		t.Fatalf("an absent credential must write NOTHING (the ESO empty-seed trap), got %v", w)
+	}
+}
+
+// ── Producer: a bad rotation must not demote a Sovereign that works ─────────
+
+func Test_seedAnthropicToken_UnusableSourceDoesNotClobberUsableStored(t *testing.T) {
+	srv := newRWKVServer(t)
+	// The Sovereign works today: the stored path holds a usable credential.
+	srv.seedPresent(anthropicSeedSecretPath, map[string]any{
+		"apiKey":          "FAKE-not-a-real-api-key",
+		"credentialsJson": validAnthropicCredentialsJSON(),
+	})
+	lg, read := capturingLogger()
+	h := &Handler{log: lg}
+	h.openbao = srv.client()
+	// …and the operator fat-fingers the rotation.
+	t.Setenv(anthropicSeedAPIKeyEnv, "")
+	t.Setenv(anthropicSeedCredentialsJSONEnv, "FAKE-not-a-real-oauth-token")
+
+	got := h.seedAnthropicToken(context.Background())
+	if got != AnthropicSeedOutcomeUnusableWithheld {
+		t.Fatalf("outcome = %q, want %q", got, AnthropicSeedOutcomeUnusableWithheld)
+	}
+	if w := srv.writes(); len(w) != 0 {
+		t.Fatalf("a working credential was overwritten with an unusable one: writes=%v", w)
+	}
+	if errs := recordsAtLevel(read(), "ERROR"); len(errs) == 0 || !anyRecordContains(errs, "WITHHELD") {
+		t.Errorf("withholding the write was not reported. records=%v", errs)
+	}
+}
+
+// Test_seedAnthropicToken_UsableSourceOverwritesUsableStored is the control for
+// the withhold: rotation of a GOOD credential onto a good one must still land,
+// otherwise the guard has frozen the path instead of protecting it.
+func Test_seedAnthropicToken_UsableSourceOverwritesUsableStored(t *testing.T) {
+	srv := newRWKVServer(t)
+	srv.seedPresent(anthropicSeedSecretPath, map[string]any{
+		"apiKey":          "FAKE-not-a-real-api-key",
+		"credentialsJson": validAnthropicCredentialsJSON(),
+	})
+	h := &Handler{log: silentLogger()}
+	h.openbao = srv.client()
+	t.Setenv(anthropicSeedAPIKeyEnv, "")
+	t.Setenv(anthropicSeedCredentialsJSONEnv, validAnthropicCredentialsJSON())
+
+	if got := h.seedAnthropicToken(context.Background()); got != AnthropicSeedOutcomeSeeded {
+		t.Fatalf("outcome = %q, want %q — a good rotation must still write", got, AnthropicSeedOutcomeSeeded)
+	}
+	if w := srv.writes(); len(w) != 1 {
+		t.Fatalf("expected the rotation to write once, got %v", w)
+	}
+}
+
+// Test_seedAnthropicToken_UnusableSourceOverwritesUnusableStored is the second
+// control on the withhold: there is nothing to protect, so the write proceeds
+// and the workspace pod gets the real bytes to diagnose from.
+func Test_seedAnthropicToken_UnusableSourceOverwritesUnusableStored(t *testing.T) {
+	srv := newRWKVServer(t)
+	srv.seedPresent(anthropicSeedSecretPath, map[string]any{
+		"apiKey":          "FAKE-not-a-real-api-key",
+		"credentialsJson": expiredAnthropicCredentialsJSON(),
+	})
+	h := &Handler{log: silentLogger()}
+	h.openbao = srv.client()
+	t.Setenv(anthropicSeedAPIKeyEnv, "")
+	t.Setenv(anthropicSeedCredentialsJSONEnv, expiredAnthropicCredentialsJSON())
+
+	if got := h.seedAnthropicToken(context.Background()); got != AnthropicSeedOutcomeUnusableSeeded {
+		t.Fatalf("outcome = %q, want %q — nothing usable was at risk, so the write proceeds", got, AnthropicSeedOutcomeUnusableSeeded)
+	}
+	if w := srv.writes(); len(w) != 1 {
+		t.Fatalf("expected one write, got %v", w)
+	}
+}
+
+// ── Call site: the ten-minute loop's HEALTH verdict, not a presence check ───
+
+// Test_runSeedReconcilePass_StoredCredentialThatCannotWorkIsNotHealthy drives
+// runSeedReconcilePass — the production call site, with the production props
+// and predicate — rather than reconcileGlobalSeed with hand-passed arguments.
+// That distinction matters here: the defect WAS the argument list at this call
+// site (props were {"apiKey","credentialsJson"} and the presence check is an
+// OR, so an apiKey with an empty credentialsJson read healthy), and a test that
+// passes its own props could never have seen it.
+func Test_runSeedReconcilePass_StoredCredentialThatCannotWorkIsNotHealthy(t *testing.T) {
+	cases := []struct {
+		name   string
+		stored map[string]any
+	}{
+		{
+			name:   "key-only",
+			stored: map[string]any{"apiKey": "FAKE-not-a-real-api-key", "credentialsJson": ""},
+		},
+		{
+			name:   "expired",
+			stored: map[string]any{"apiKey": "", "credentialsJson": expiredAnthropicCredentialsJSON()},
+		},
+		{
+			name:   "malformed",
+			stored: map[string]any{"apiKey": "", "credentialsJson": "FAKE-not-a-real-oauth-token"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := newRWKVServer(t)
+			// newapi present so its leg no-ops and cannot reach the cluster.
+			srv.seedPresent("catalyst/newapi/admin-token", map[string]any{"ADMIN_API_TOKEN": "FAKE-not-a-real-token"})
+			srv.seedPresent(anthropicSeedSecretPath, tc.stored)
+
+			h := &Handler{log: silentLogger()}
+			h.openbao = srv.client()
+			// A usable credential IS available to heal with.
+			t.Setenv(anthropicSeedAPIKeyEnv, "")
+			t.Setenv(anthropicSeedCredentialsJSONEnv, validAnthropicCredentialsJSON())
+
+			h.runSeedReconcilePass(context.Background())
+
+			healed := false
+			for _, p := range srv.writes() {
+				if p == anthropicSeedSecretPath {
+					healed = true
+				}
+			}
+			if !healed {
+				t.Fatalf("a stored %s credential read as HEALTHY — the loop went silent over a Sovereign whose every Agenity workspace refuses to start (#6250). writes=%v",
+					tc.name, srv.writes())
+			}
+		})
+	}
+}
+
+// Test_runSeedReconcilePass_UsableStoredCredentialIsSilent is THE CONTROL for
+// the call-site test: same pass, same predicate, same props — the only
+// difference is that the stored credential works. It must produce ZERO writes.
+//
+// Without it, "re-seeds a stored credential that cannot work" is
+// indistinguishable from "re-seeds on every tick", which would churn the
+// OpenBao value → ExternalSecret → per-Org Secret chain the no-churn rule in
+// sovereign_seed_reconciler.go exists to prevent.
+func Test_runSeedReconcilePass_UsableStoredCredentialIsSilent(t *testing.T) {
+	srv := newRWKVServer(t)
+	srv.seedPresent("catalyst/newapi/admin-token", map[string]any{"ADMIN_API_TOKEN": "FAKE-not-a-real-token"})
+	srv.seedPresent(anthropicSeedSecretPath, map[string]any{
+		"apiKey":          "FAKE-not-a-real-api-key",
+		"credentialsJson": validAnthropicCredentialsJSON(),
+	})
+
+	lg, read := capturingLogger()
+	h := &Handler{log: lg}
+	h.openbao = srv.client()
+	t.Setenv(anthropicSeedAPIKeyEnv, "")
+	t.Setenv(anthropicSeedCredentialsJSONEnv, validAnthropicCredentialsJSON())
+
+	h.runSeedReconcilePass(context.Background())
+
+	for _, p := range srv.writes() {
+		if p == anthropicSeedSecretPath {
+			t.Fatalf("a HEALTHY anthropic path was re-written (churn) — the health predicate cannot tell usable from unusable. writes=%v", srv.writes())
+		}
+	}
+	if anyRecordContains(recordsAtLevel(read(), "ERROR"), "anthropic") {
+		t.Errorf("a healthy anthropic path produced an ERROR record — the loud line fires on the leg rather than on the verdict")
+	}
+}
+
+// Test_runSeedReconcilePass_UnhealableStoredCredentialStaysLoud closes the
+// loop the operator actually reads: a stored credential that cannot work AND
+// no usable source to heal it with must keep reporting unhealed every tick,
+// carrying the rotation remediation. Silence here is what let hw295 sit red.
+func Test_runSeedReconcilePass_UnhealableStoredCredentialStaysLoud(t *testing.T) {
+	srv := newRWKVServer(t)
+	srv.seedPresent("catalyst/newapi/admin-token", map[string]any{"ADMIN_API_TOKEN": "FAKE-not-a-real-token"})
+	srv.seedPresent(anthropicSeedSecretPath, map[string]any{
+		"apiKey":          "",
+		"credentialsJson": expiredAnthropicCredentialsJSON(),
+	})
+
+	lg, read := capturingLogger()
+	h := &Handler{log: lg}
+	h.openbao = srv.client()
+	// The source is the same expired blob — rotation never happened.
+	t.Setenv(anthropicSeedAPIKeyEnv, "")
+	t.Setenv(anthropicSeedCredentialsJSONEnv, expiredAnthropicCredentialsJSON())
+
+	h.runSeedReconcilePass(context.Background())
+
+	errs := recordsAtLevel(read(), "ERROR")
+	if !anyRecordContains(errs, "self-heal did NOT take") {
+		t.Errorf("an unhealable anthropic path was not reported as unhealed. records=%v", errs)
+	}
+	if !anyRecordContains(errs, "ROTATE") {
+		t.Errorf("the unhealed report never names ROTATE, so the operator is told to CREATE a Secret that already exists. records=%v", errs)
+	}
+}
+
+// ── The classifier's own boundary cases, on top of the call-site coverage ───
+
+// Test_classifyAnthropicCredential_Boundaries pins the parses that the call
+// site cannot vary cheaply: expiresAt carried as a JSON string, and the exact
+// now/expiry boundary. These supplement the call-site tests above; they do not
+// replace them.
+func Test_classifyAnthropicCredential_Boundaries(t *testing.T) {
+	future := time.Now().Add(6 * time.Hour).UnixMilli()
+	cases := []struct {
+		name      string
+		apiKey    string
+		credsJSON string
+		want      anthropicCredentialClass
+	}{
+		{"expiresAt-as-string", "", fmt.Sprintf(`{"claudeAiOauth":{"accessToken":"FAKE-not-a-real-access-token","expiresAt":"%d"}}`, future), anthropicCredValid},
+		{"expiresAt-zero-is-non-expiring", "", `{"claudeAiOauth":{"accessToken":"FAKE-not-a-real-access-token","expiresAt":0}}`, anthropicCredValid},
+		{"epoch-seconds-mistaken-for-millis-reads-expired", "", `{"claudeAiOauth":{"accessToken":"FAKE-not-a-real-access-token","expiresAt":1750000000}}`, anthropicCredExpired},
+		{"whitespace-only-credentialsJson-is-key-only", "FAKE-not-a-real-api-key", "   ", anthropicCredKeyOnly},
+		{"empty-object", "", `{}`, anthropicCredMalformed},
+		{"oauth-under-wrong-key", "", `{"anthropicOauth":{"accessToken":"FAKE-not-a-real-access-token"}}`, anthropicCredMalformed},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, detail := classifyAnthropicCredential(tc.apiKey, tc.credsJSON)
+			if got != tc.want {
+				t.Fatalf("class = %q, want %q (detail=%q)", got, tc.want, detail)
+			}
+			// Credential hygiene (docs/PRINCIPLES.md #10): the detail rides on a
+			// log line, so it must never carry the material.
+			if detail != "" && (containsAny(detail, "FAKE-not-a-real-access-token", "FAKE-not-a-real-api-key")) {
+				t.Errorf("detail leaks credential material: %q", detail)
+			}
+		})
+	}
+}
+
+func containsAny(s string, needles ...string) bool {
+	for _, n := range needles {
+		if len(n) > 0 && len(s) >= len(n) {
+			for i := 0; i+len(n) <= len(s); i++ {
+				if s[i:i+len(n)] == n {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}

--- a/products/catalyst/bootstrap/api/internal/handler/anthropic_seed_unhealed_4277_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/anthropic_seed_unhealed_4277_test.go
@@ -215,8 +215,10 @@ func Test_reconcileGlobalSeed_SuccessfulHealNeverErrors(t *testing.T) {
 	h.openbao = srv.client()
 
 	// The only difference: a platform credential exists, so the seed writes.
+	// #6250: an apiKey alone cannot authenticate an agent, so it is no longer a
+	// credential that "exists" for the purposes of a successful seed.
 	t.Setenv(anthropicSeedAPIKeyEnv, "test-only-not-a-real-credential")
-	t.Setenv(anthropicSeedCredentialsJSONEnv, "")
+	t.Setenv(anthropicSeedCredentialsJSONEnv, validAnthropicCredentialsJSON())
 
 	h.reconcileGlobalSeed(context.Background(),
 		"anthropic", anthropicSeedMountPath, anthropicSeedSecretPath,
@@ -244,8 +246,10 @@ func Test_reconcileGlobalSeed_HealedGapIsVerifiedAndQuiet(t *testing.T) {
 	h.openbao = srv.client()
 
 	// The only difference: a platform credential exists, so the seed writes.
+	// #6250: an apiKey alone cannot authenticate an agent, so it is no longer a
+	// credential that "exists" for the purposes of a successful seed.
 	t.Setenv(anthropicSeedAPIKeyEnv, "test-only-not-a-real-credential")
-	t.Setenv(anthropicSeedCredentialsJSONEnv, "")
+	t.Setenv(anthropicSeedCredentialsJSONEnv, validAnthropicCredentialsJSON())
 
 	got := h.reconcileGlobalSeed(context.Background(),
 		"anthropic", anthropicSeedMountPath, anthropicSeedSecretPath,
@@ -355,8 +359,10 @@ func Test_seedAnthropicToken_SeededPathIsNotAnError(t *testing.T) {
 	lg, read := capturingLogger()
 	h := &Handler{log: lg}
 	h.openbao = srv.client()
+	// #6250: an apiKey alone cannot authenticate an agent, so it is no longer a
+	// credential that "exists" for the purposes of a successful seed.
 	t.Setenv(anthropicSeedAPIKeyEnv, "test-only-not-a-real-credential")
-	t.Setenv(anthropicSeedCredentialsJSONEnv, "")
+	t.Setenv(anthropicSeedCredentialsJSONEnv, validAnthropicCredentialsJSON())
 
 	if out := h.seedAnthropicToken(context.Background()); out != AnthropicSeedOutcomeSeeded {
 		t.Fatalf("outcome = %q, want %q", out, AnthropicSeedOutcomeSeeded)

--- a/products/catalyst/bootstrap/api/internal/handler/sovereign_anthropic_seed.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sovereign_anthropic_seed.go
@@ -109,6 +109,25 @@ const (
 	AnthropicSeedOutcomeSkippedNoEnv AnthropicSeedOutcome = "skipped-no-env"
 	AnthropicSeedOutcomeSkippedNoBao AnthropicSeedOutcome = "skipped-no-openbao"
 	AnthropicSeedOutcomeWriteFailure AnthropicSeedOutcome = "write-failure"
+
+	// AnthropicSeedOutcomeUnusableSeeded — a credential IS configured and
+	// CANNOT authenticate an agent (key-only / malformed / expired), and the
+	// stored path held nothing usable to protect, so the value was written
+	// anyway and reported as what it is.
+	//
+	// Written, deliberately: withholding it would leave the per-Org
+	// ExternalSecret unsynced, and the workspace pod would then report the
+	// generic "credential never arrived" instead of the exact
+	// "EXPIRED ~45h ago" its init container can render from the real bytes
+	// (#6163 FREEZE 3). The operator gets the precise diagnosis at BOTH
+	// layers. What must never happen is calling this seeded.
+	AnthropicSeedOutcomeUnusableSeeded AnthropicSeedOutcome = "unusable-credential-seeded"
+
+	// AnthropicSeedOutcomeUnusableWithheld — the configured credential cannot
+	// work AND the OpenBao path already holds one that can (or could not be
+	// read, so we do not know). The write is withheld: a fat-fingered rotation
+	// must not demote a Sovereign whose workspaces authenticate today.
+	AnthropicSeedOutcomeUnusableWithheld AnthropicSeedOutcome = "unusable-credential-withheld"
 )
 
 // seedAnthropicToken writes the Sovereign's OpenBao
@@ -161,7 +180,14 @@ func (h *Handler) seedAnthropicToken(ctx context.Context) AnthropicSeedOutcome {
 	if credsJSON == "" {
 		credsJSON = strings.TrimSpace(os.Getenv(anthropicSeedCredentialsJSONEnv))
 	}
-	if apiKey == "" && credsJSON == "" {
+	// Three outcomes, not two (#4277/#4111/#4482). ABSENT and VALID were always
+	// distinguishable here; INVALID — a credential that IS configured and
+	// CANNOT authenticate — took VALID's verdict, was written, and was logged
+	// as "wrote OpenBao path so every Org's agenity ExternalSecret resolves".
+	// See anthropic_credential_class.go for the full account.
+	class, detail := classifyAnthropicCredential(apiKey, credsJSON)
+
+	if class == anthropicCredAbsent {
 		// 🛑 FOUNDER-SUPPLIED-SECRET GAP: the platform holds no Anthropic
 		// credential. Surface loud + skip rather than seed an empty path
 		// that pretends to work (the reflector/ESO empty-seed trap the
@@ -189,13 +215,55 @@ func (h *Handler) seedAnthropicToken(ctx context.Context) AnthropicSeedOutcome {
 		return AnthropicSeedOutcomeSkippedNoEnv
 	}
 
+	// 🛑 CONFIGURED-BUT-UNUSABLE. A credential exists and cannot authenticate
+	// an agent: key-only, malformed, or expired. Before #6250 this fell
+	// straight through to the write below and returned "seeded".
+	if !class.usable() {
+		// Never demote a Sovereign that works today. If the stored path holds
+		// a usable credential — or could not be read, so we do not know —
+		// withhold the write and say why. A rotation typo must not cost a
+		// working install its agents.
+		if stored, observed := h.storedAnthropicCredentialClass(ctx); !observed || stored.usable() {
+			if h.log != nil {
+				h.log.Error("🛑 anthropic seed WITHHELD — the configured credential cannot authenticate an agent, and the OpenBao path already holds one that can (or could not be read). Not overwriting (#4277)",
+					"credentialClass", string(class),
+					"detail", detail,
+					"storedClass", string(stored),
+					"storedObserved", observed,
+					"openbaoPath", anthropicSeedMountPath+"/"+anthropicSeedSecretPath,
+					"remediation", anthropicCredentialRemediation(class),
+				)
+			}
+			return AnthropicSeedOutcomeUnusableWithheld
+		}
+		if h.log != nil {
+			h.log.Error("🛑 anthropic seed wrote a credential that CANNOT authenticate an agent — every Organization's Agenity workspace will refuse to start (#4111/#4482). This is NOT a seeded Sovereign",
+				"credentialClass", string(class),
+				"detail", detail,
+				"openbaoPath", anthropicSeedMountPath+"/"+anthropicSeedSecretPath,
+				"remediation", anthropicCredentialRemediation(class),
+			)
+		}
+		if err := h.openbao.PutKVv2(ctx, anthropicSeedMountPath, anthropicSeedSecretPath, map[string]any{
+			"apiKey":          apiKey,
+			"credentialsJson": credsJSON,
+		}); err != nil {
+			if h.log != nil {
+				h.log.Error("anthropic seed: OpenBao write failed",
+					"openbaoPath", anthropicSeedMountPath+"/"+anthropicSeedSecretPath,
+					"err", err,
+				)
+			}
+			return AnthropicSeedOutcomeWriteFailure
+		}
+		return AnthropicSeedOutcomeUnusableSeeded
+	}
+
 	// KV-v2 payload. Field names MUST match the agenity ExternalSecret's
 	// remoteRef.property values: `apiKey` (anthropic.externalSecret
 	// .remoteProperty) + `credentialsJson` (remoteCredentialsProperty).
 	// Both keys are always present so the ExternalSecret's optional
-	// credentialsJson property resolves cleanly; an empty value for a
-	// missing env var is fine (the chart's seed-claude-creds init
-	// container treats a 0-byte credentialsJson as key-only mode).
+	// credentialsJson property resolves cleanly.
 	data := map[string]any{
 		"apiKey":          apiKey,
 		"credentialsJson": credsJSON,
@@ -215,6 +283,8 @@ func (h *Handler) seedAnthropicToken(ctx context.Context) AnthropicSeedOutcome {
 		// Per docs/PRINCIPLES.md #10: byte lengths only, never plaintext.
 		h.log.Info("anthropic seed: wrote OpenBao path so every Org's agenity ExternalSecret resolves",
 			"openbaoPath", anthropicSeedMountPath+"/"+anthropicSeedSecretPath,
+			"credentialClass", string(class),
+			"detail", detail,
 			"apiKeyBytes", len(apiKey),
 			"credentialsJsonBytes", len(credsJSON),
 		)

--- a/products/catalyst/bootstrap/api/internal/handler/sovereign_anthropic_seed_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sovereign_anthropic_seed_test.go
@@ -67,7 +67,10 @@ func Test_seedAnthropicToken_SeedsExpectedPathAndFields(t *testing.T) {
 	h.openbao = &openbao.Client{Addr: srv.srv.URL, Token: "test-token", HTTP: srv.srv.Client()}
 
 	t.Setenv(anthropicSeedAPIKeyEnv, "sk-ant-test-key")
-	t.Setenv(anthropicSeedCredentialsJSONEnv, `{"claudeAiOauth":{"accessToken":"oat-x","refreshToken":"r","expiresAt":1,"scopes":["user:inference"]}}`)
+	// #6250: this fixture used to carry `"expiresAt":1` — epoch-millisecond 1,
+	// i.e. an already-expired credential asserted as a successful seed. The
+	// happy path now needs a credential that can actually authenticate.
+	t.Setenv(anthropicSeedCredentialsJSONEnv, validAnthropicCredentialsJSON())
 
 	outcome := h.seedAnthropicToken(context.Background())
 	if outcome != AnthropicSeedOutcomeSeeded {

--- a/products/catalyst/bootstrap/api/internal/handler/sovereign_seed_reconciler.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sovereign_seed_reconciler.go
@@ -172,15 +172,33 @@ func (h *Handler) runSeedReconcilePass(ctx context.Context) {
 		func() { _ = h.seedNewapiAdminToken(ctx) },
 	)
 
-	// (2) anthropic token — Sovereign-GLOBAL. Seed only when the path lacks a
-	// non-empty apiKey AND credentialsJson. seedAnthropicToken loud-skips when
-	// the founder cred env is unset, so on a credless Sovereign the path stays
+	// (2) anthropic token — Sovereign-GLOBAL. seedAnthropicToken loud-skips
+	// when the founder cred is unset, so on a credless Sovereign the path stays
 	// absent and the loop keeps (usefully) surfacing that gap.
+	//
+	// #6250 — TWO corrections to what this leg calls healthy, because the old
+	// check could not see the failure mode that actually strands UAT R19/G8/G9:
+	//
+	//   props was []string{"apiKey", "credentialsJson"} and the presence check
+	//   is an OR, so a path holding an apiKey and an EMPTY credentialsJson read
+	//   HEALTHY. claude-code authenticates from the OAuth blob; an apiKey-only
+	//   path cannot spawn an agent, and the bp-agenity init container waits out
+	//   credentialWait and exits non-zero (#6163 FREEZE 2). The loop meanwhile
+	//   said nothing, forever. credentialsJson is the load-bearing property, so
+	//   it is the only one named.
+	//
+	//   Presence is still not health: a credentialsJson that expired six hours
+	//   ago is non-empty and useless. The seeded blob is a claudeAiOauth pair
+	//   whose accessToken lives HOURS and nothing refreshes it, so an unrotated
+	//   credential spends most of its life in exactly that state. The usable
+	//   predicate asks of the stored bytes the same question the workspace pod
+	//   asks of them one layer down.
 	h.reconcileGlobalSeed(ctx,
 		"anthropic",
 		anthropicSeedMountPath, anthropicSeedSecretPath,
-		[]string{"apiKey", "credentialsJson"},
+		[]string{"credentialsJson"},
 		func() { _ = h.seedAnthropicToken(ctx) },
+		anthropicStoredCredentialUsable,
 	)
 
 	// (3) per-Org mcp-bearer. Enumerate every Organization CR (the single
@@ -262,7 +280,10 @@ const (
 var seedRemediation = map[string]string{
 	"anthropic": "set CATALYST_ANTHROPIC_CREDENTIALS_JSON (and optionally CATALYST_ANTHROPIC_API_KEY) on catalyst-api " +
 		"— chart values sovereign.anthropic.*, or the operator-rotatable Secret catalyst-system/sovereign-anthropic-credentials (#4277). " +
-		"Until then every Organization's agenity-anthropic-token ExternalSecret stays SecretSyncedError and no Agenity workspace agent can authenticate.",
+		"Until then every Organization's agenity-anthropic-token ExternalSecret stays SecretSyncedError and no Agenity workspace agent can authenticate. " +
+		"If a credential IS already set, this leg also reports unhealed when the stored credentialsJson cannot authenticate — empty, " +
+		"not a claudeAiOauth document, or EXPIRED — in which case the action is to ROTATE that Secret, not to create it (#6250). " +
+		"The preceding 'anthropic seed' line names which of the two it is.",
 	"newapi-admin-token": "NewAPI's bridge Secret has not rendered its ADMIN_SECRET yet — check the bp-newapi HelmRelease (#4477). " +
 		"Until then the catalyst-newapi-admin-token ExternalSecret stays SecretSyncedError and unified-rbac's admin-API calls 401.",
 }
@@ -292,8 +313,17 @@ var seedRemediation = map[string]string{
 //
 // Returns the outcome so a caller/test can assert on a value instead of on log
 // text. Callers may ignore it — the loud line is the operator-facing surface.
-func (h *Handler) reconcileGlobalSeed(ctx context.Context, label, mount, path string, props []string, seed func()) SeedHealOutcome {
-	present, err := h.openbaoPathHasProperty(ctx, mount, path, props...)
+// The optional trailing `usable` predicate (#6250) upgrades the check from
+// PRESENCE to HEALTH for seams where a non-empty value can still be unusable —
+// the anthropic leg, whose stored OAuth blob expires in hours. Omit it and the
+// behaviour is exactly the pre-#6250 presence semantics, which is what the
+// newapi leg and every existing test still get.
+func (h *Handler) reconcileGlobalSeed(ctx context.Context, label, mount, path string, props []string, seed func(), usable ...func(map[string]any) bool) SeedHealOutcome {
+	var healthy func(map[string]any) bool
+	if len(usable) > 0 {
+		healthy = usable[0]
+	}
+	present, err := h.openbaoPathIsHealthy(ctx, mount, path, props, healthy)
 	if err != nil {
 		if h.log != nil {
 			h.log.Warn("[SEED-RECONCILE] presence check failed; skipping this pass — retry next tick",
@@ -312,7 +342,7 @@ func (h *Handler) reconcileGlobalSeed(ctx context.Context, label, mount, path st
 	}
 	seed()
 
-	healed, verr := h.openbaoPathHasProperty(ctx, mount, path, props...)
+	healed, verr := h.openbaoPathIsHealthy(ctx, mount, path, props, healthy)
 	if verr != nil {
 		if h.log != nil {
 			h.log.Warn("[SEED-RECONCILE] self-heal verification read failed — outcome UNKNOWN this pass, retry next tick",
@@ -349,6 +379,20 @@ func (h *Handler) reconcileGlobalSeed(ctx context.Context, label, mount, path st
 //   - transport error           → (false, err): the caller skips this pass and
 //     retries next tick (a write would fail against the same blip).
 func (h *Handler) openbaoPathHasProperty(ctx context.Context, mount, path string, props ...string) (bool, error) {
+	return h.openbaoPathIsHealthy(ctx, mount, path, props, nil)
+}
+
+// openbaoPathIsHealthy is openbaoPathHasProperty plus, when `usable` is
+// supplied, a verdict on the VALUE rather than only on its emptiness (#6250).
+//
+// A nil predicate is the presence-only semantics documented above, unchanged.
+// A non-nil one runs ONLY after presence passes, so an absent or hollow path is
+// still reported as the #4877 gap and never handed to a predicate that has
+// nothing to judge. The predicate answering false means "present but cannot do
+// its job" — same verdict as absent, because the consumer cannot tell the two
+// apart either: an Agenity workspace given an expired blob and an Agenity
+// workspace given no blob both fail to start an agent.
+func (h *Handler) openbaoPathIsHealthy(ctx context.Context, mount, path string, props []string, usable func(map[string]any) bool) (bool, error) {
 	data, err := h.openbao.GetKVv2(ctx, mount, path)
 	if err != nil {
 		if errors.Is(err, openbao.ErrSecretNotFound) {
@@ -356,10 +400,18 @@ func (h *Handler) openbaoPathHasProperty(ctx context.Context, mount, path string
 		}
 		return false, err
 	}
+	found := false
 	for _, p := range props {
 		if s, ok := data[p].(string); ok && strings.TrimSpace(s) != "" {
-			return true, nil
+			found = true
+			break
 		}
 	}
-	return false, nil
+	if !found {
+		return false, nil
+	}
+	if usable != nil && !usable(data) {
+		return false, nil
+	}
+	return true, nil
 }

--- a/products/catalyst/bootstrap/api/internal/handler/sovereign_seed_reconciler_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sovereign_seed_reconciler_test.go
@@ -94,7 +94,10 @@ func (s *rwKVServer) client() *openbao.Client {
 // absent path → false, present-with-value → true, present-but-empty → false.
 func Test_openbaoPathHasProperty(t *testing.T) {
 	srv := newRWKVServer(t)
-	srv.seedPresent("catalyst/anthropic/token", map[string]any{"apiKey": "sk-ant-x", "credentialsJson": ""})
+	// #6250: an apiKey with an EMPTY credentialsJson is NOT a healthy path —
+	// claude-code authenticates from the OAuth blob. A genuinely all-present
+	// pass needs a credential that can authenticate.
+	srv.seedPresent("catalyst/anthropic/token", map[string]any{"apiKey": "FAKE-not-a-real-api-key", "credentialsJson": validAnthropicCredentialsJSON()})
 	srv.seedPresent("catalyst/agenity/hollow/mcp-bearer", map[string]any{"bearer": "  "})
 
 	h := &Handler{log: silentLogger()}
@@ -123,7 +126,10 @@ func Test_openbaoPathHasProperty(t *testing.T) {
 func Test_runSeedReconcilePass_NoChurnWhenAllPresent(t *testing.T) {
 	srv := newRWKVServer(t)
 	srv.seedPresent("catalyst/newapi/admin-token", map[string]any{"ADMIN_API_TOKEN": "bridge-secret"})
-	srv.seedPresent("catalyst/anthropic/token", map[string]any{"apiKey": "sk-ant-x", "credentialsJson": ""})
+	// #6250: an apiKey with an EMPTY credentialsJson is NOT a healthy path —
+	// claude-code authenticates from the OAuth blob. A genuinely all-present
+	// pass needs a credential that can authenticate.
+	srv.seedPresent("catalyst/anthropic/token", map[string]any{"apiKey": "FAKE-not-a-real-api-key", "credentialsJson": validAnthropicCredentialsJSON()})
 
 	h := &Handler{log: silentLogger()}
 	h.openbao = srv.client()
@@ -147,8 +153,8 @@ func Test_runSeedReconcilePass_SelfHealsAbsentGlobalSeed(t *testing.T) {
 
 	h := &Handler{log: silentLogger()}
 	h.openbao = srv.client()
-	t.Setenv(anthropicSeedAPIKeyEnv, "sk-ant-selfheal")
-	t.Setenv(anthropicSeedCredentialsJSONEnv, "")
+	t.Setenv(anthropicSeedAPIKeyEnv, "FAKE-not-a-real-api-key")
+	t.Setenv(anthropicSeedCredentialsJSONEnv, validAnthropicCredentialsJSON())
 
 	h.runSeedReconcilePass(context.Background())
 
@@ -212,5 +218,5 @@ func Test_StartSovereignSeedReconciler_DormantWhenNoOpenBao(t *testing.T) {
 	h := &Handler{log: silentLogger()}
 	// h.openbao deliberately nil.
 	h.StartSovereignSeedReconciler(context.Background()) // must return immediately, no panic.
-	h.runSeedReconcilePass(context.Background())          // must no-op, no panic.
+	h.runSeedReconcilePass(context.Background())         // must no-op, no panic.
 }


### PR DESCRIPTION
## What this fixes

The seam between Org-create and the per-Org Agenity workspace pod owes its
operator **three** distinguishable answers and shipped **two**. `ABSENT` and
`VALID` were distinct. `INVALID` — a credential that IS configured and CANNOT
authenticate — took `VALID`'s verdict, at both layers that could have caught it:

- `seedAnthropicToken` wrote whatever it was handed and logged *"wrote OpenBao
  path so every Org's agenity ExternalSecret resolves"*
  (`sovereign_anthropic_seed.go:199-223` on main).
- the ten-minute self-heal loop then asked whether `apiKey` **OR**
  `credentialsJson` was non-empty (`sovereign_seed_reconciler.go:179-184` +
  `openbaoPathHasProperty:359-364` on main — the presence check is an OR), so a
  path holding an `apiKey` and an **empty** `credentialsJson` read **HEALTHY**
  and the loop went silent for the life of the cluster.

Meanwhile every per-Org Agenity workspace waits out `credentialWait` and exits
`Init:Error`, because `claude-code` authenticates from the OAuth blob and not
from `apiKey`. Sovereign-level signal green, per-Org reality red, nothing in
between reconciling the two.

Expiry is the same shape and is not a rare edge: the seeded blob is a
`claudeAiOauth` pair whose `accessToken` lives **hours** and nothing in this repo
refreshes it, so an unrotated credential spends most of its life in the unusable
class while the producer keeps calling it seeded.

## Per-row findings

| Row | Clause | Class | Evidence | What this PR does |
|---|---|---|---|---|
| **R19** (#4482) | per-Org Agenity StatefulSet Running **with its Anthropic credential**; init container validates and exits 0 | **(b) written but defective** — credential half. **(c)** — workspace half. **(d)** — issue link | Producer: `sovereign_anthropic_seed.go:199-223` writes + returns `seeded` for any input. Reconciler: `sovereign_seed_reconciler.go:182` props `{"apiKey","credentialsJson"}` against an OR-check at `:359-364`. Workspace half: the emitter DOES author `bp-agenity.yaml` unconditionally for every Org (`organization_gitops.go:977` + `:1003`), so "no StatefulSet on hw295" is an env with no customer Organization, not a missing producer | Ships the (b) fix. (c) needs a live walk. (d) noted below |
| **G8** (#4277) | credential seeded into the agentic runtime — chat works end to end | **(b) written but defective**, on top of a real founder input gap | Same two sites. The gap itself (no credential supplied) was already reported honestly; what was NOT reported is a credential that IS supplied and cannot work | Ships the (b) fix: `key-only` / `malformed` / `expired` each get their own outcome, log and remediation |
| **G9** (#4111) | agenity solo agent chats **and** drives `create_application` | **(c) correct in code, needs a live walk** | `create_application` proven present (UAT 221). The per-Org bp-agenity HelmRelease + `agenity-anthropic-token` ExternalSecret + mcp-bearer producers all exist. No code defect found on this row's own path beyond the shared credential seam | Unblocked by the G8/R19 fix; no separate change |

**No row was class (a).** Every producer this cluster needs exists; the failure
was verdict honesty, not a missing writer.

### (d) — one adjudication, reported not acted on

R19 links **#4482**, whose whole body is `bp-sandbox` / `sandbox-controller`
CrashLoop on `CATALYST_GITEA_TOKEN`. Sandbox was removed 2026-06-30 and
superseded by `agenity/` + `openova-mcp/`, so the row's Agenity clause and its
linked issue are about different components. Not corrected here because
`docs/ledger/UAT.md` is not touched by this PR; recorded on the issue instead.

## The fix

One classifier (`anthropic_credential_class.go`), used by **both** halves of the
seam so they cannot drift, reaching the verdict the bp-agenity init container
reaches for the same bytes: `absent` / `key-only` / `malformed` / `expired` /
`valid`.

- **Producer** returns `unusable-credential-seeded`, never `seeded`, and names
  the class plus its own remediation (supply one / fix the shape / **ROTATE**).
- The unusable value **is still written**, deliberately, so the per-Org
  ExternalSecret syncs and the workspace pod can diagnose from the real bytes
  rather than reporting a generic "credential never arrived" — **unless** the
  stored path already holds a credential that works, in which case the write is
  **withheld** (`unusable-credential-withheld`) so a fat-fingered rotation
  cannot demote a Sovereign whose workspaces authenticate today. An unreadable
  stored path counts as "do not know" and also withholds — a verdict is never
  reported from absent evidence.
- **Reconciler** anthropic leg checks `credentialsJson` present **and usable**.
  A stored credential that cannot work re-seeds when a usable source exists, and
  otherwise keeps reporting `[SEED-RECONCILE] 🛑 self-heal did NOT take` with the
  rotation remediation attached. `reconcileGlobalSeed` gained an optional
  trailing predicate; omitted, its behaviour is byte-for-byte the previous
  presence semantics, which is what the newapi leg and all four existing tests
  still exercise.

## Vacuity proof — every guard watched failing on a mutant that still compiles

Each mutant was applied, the suite run, then reverted.

**Mutant 1** — revert the reconciler call site to the old argument list
(`props` back to `{"apiKey","credentialsJson"}`, predicate dropped):

```
--- FAIL: Test_runSeedReconcilePass_StoredCredentialThatCannotWorkIsNotHealthy/key-only
--- FAIL: Test_runSeedReconcilePass_StoredCredentialThatCannotWorkIsNotHealthy/expired
--- FAIL: Test_runSeedReconcilePass_StoredCredentialThatCannotWorkIsNotHealthy/malformed
--- FAIL: Test_runSeedReconcilePass_UnhealableStoredCredentialStaysLoud
```

**Mutant 2** — `if false && !class.usable()` in the producer, i.e. INVALID falls
through to the seeded path again:

```
--- FAIL: Test_seedAnthropicToken_UnusableCredentialIsNotReportedAsSeeded/key-only
      a key-only credential was reported as "seeded" — INVALID took VALID's verdict, which is the whole defect
--- FAIL: .../malformed-bare-token
--- FAIL: .../malformed-json-without-accessToken
--- FAIL: .../expired
--- FAIL: Test_seedAnthropicToken_UnusableSourceDoesNotClobberUsableStored
--- FAIL: Test_seedAnthropicToken_UnusableSourceOverwritesUnusableStored
```

**Mutant 3 — the CONTROL proof.** `if true || expiresAtMillis <= nowMillis`, so
the classifier refuses **every** credential. This is the mutant that separates
"refuses an expired credential" from "refuses everything", and the controls are
the things that must break:

```
--- FAIL: Test_seedAnthropicToken_ValidCredentialStillSeeds
--- FAIL: Test_seedAnthropicToken_UsableSourceOverwritesUsableStored
--- FAIL: Test_runSeedReconcilePass_UsableStoredCredentialIsSilent
--- FAIL: Test_seedAnthropicToken_SeedsExpectedPathAndFields   (pre-existing test)
--- FAIL: Test_seedAnthropicToken_SeededPathIsNotAnError       (pre-existing test)
```

Under mutants 1 and 2 those same controls stayed **green**, which is what makes
them controls rather than a second assertion of the fix.

## The pre-existing fixtures asserted the collapse as correct

Worth flagging for review, because it explains why no existing test caught this:

- `anthropic_seed_unhealed_4277_test.go` × 3 — *"a platform credential exists, so
  the seed writes"* was modelled as `apiKey` set, `credentialsJson` empty.
- `sovereign_anthropic_seed_test.go:70` — the successful-seed fixture carried
  `"expiresAt":1`, epoch-millisecond 1, i.e. an **already-expired** credential
  asserted as `seeded`.
- `sovereign_seed_reconciler_test.go:126` — the no-churn case pinned an
  apiKey-only path as **healthy**, which is the defect stated as a requirement.

All four now carry a credential that can authenticate. The tests keep their
original intent; only the fixture changes.

## Tests drive the call site, not the helper

`runSeedReconcilePass` is exercised with the **production** props and predicate
rather than `reconcileGlobalSeed` with hand-passed arguments — the defect *was*
the argument list at that call site, so a test supplying its own props could
never have seen it. `seedAnthropicToken` is driven directly for every class.
The classifier's own boundary cases (`expiresAt` as a JSON string, the zero
value, epoch-seconds mistaken for millis) supplement that coverage; they do not
replace it. A hygiene assertion checks the log detail never carries credential
material. Every fixture token in this PR is an obvious `FAKE-` placeholder.

## How this avoids colliding with #6234

**Zero file overlap.** #6234 (`fix/6163-freeze3-expired-credential-verdict`)
touches `products/agenity/chart/*`, `products/agenity/blueprint.yaml`, the
catalog-seed pin, the umbrella chart and the two generated catalog files. This
PR touches `products/catalyst/bootstrap/api/internal/handler/*.go` and a **new**
section of `products/agenity/README.md` — no chart, no version pin, no
lockstep site, nothing #6234 claims. bp-agenity stays at the 0.5.27 #6234 owns.

The two are complementary halves of the same three-way split, deliberately:
#6234 makes the **consumer** (the workspace init container) refuse an expired
credential instead of exiting 0 over it; this PR makes the **producer and the
Sovereign-level reconciler** stop calling that same credential seeded and
healthy. #6234 alone would leave a Sovereign whose catalyst-api logs read green
while every workspace `Init:Error`s. The classifier here reaches the same
verdict as #6234's `EXPIRED` / `OK` / `NOEXP` parse on the same bytes, so the
two layers agree by construction. The existing `README.md` paragraph describing
the init container as diagnostic-only is left untouched — that line is #6234's
to update.

## Not finished, with the reason

- **R19 / G8 / G9 stay ❌.** All three need a live walk on a fresh Sovereign that
  has (1) a customer Organization and (2) a real Anthropic credential supplied
  by the founder. This PR removes the false-green that hid which of the two was
  missing; it cannot supply either. `docs/ledger/UAT.md` is deliberately not
  touched — source proof is not walk evidence.
- **Auto-refresh of the OAuth `accessToken`** is still absent, so rotation
  remains a recurring per-Sovereign operator action. That is the same follow-up
  #4277 already records; this PR only makes the moment it becomes necessary
  loud instead of silent.
- One pre-existing test in this package,
  `TestWipeDeployment_NoS3CredsAnywhereSurfacesError`, fails in this sandbox on
  **pristine `origin/main`** as well (10.01s, blocked egress). Verified by
  checking the module out at `origin/main` and running it there. Unrelated to
  this change.

Refs #4277 #4111 #4482
