### PR TITLE
fix(bootstrap-kit): slot 13 carries unresolved conflict markers and does not parse (regression from #6246)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1395,9 +1395,6 @@ spec:
       # 1.4.1440 — #5991 (UAT row 115): catalog-seed advances bp-guacamole
       #   0.2.37 -> 0.2.38, the release that writes a Guacamole connection at
       #   all. Lockstep w/ products/catalyst/chart/Chart.yaml.
-<<<<<<< HEAD
-      version: 1.4.1453
-=======
       # 1.4.1454 — #5991 (UAT row 115), the delivery half of the mTLS leg:
       #   catalog-seed advances bp-k8s-ws-proxy 0.1.16 -> 0.1.17 (the proxy
       #   gains a client-certificate credential guacd can actually present)
@@ -1407,7 +1404,6 @@ spec:
       #   proxy mints the certificate the connection presents. Lockstep w/
       #   products/catalyst/chart/Chart.yaml.
       version: 1.4.1454
->>>>>>> ca5b4f1ea (fix(bp-k8s-ws-proxy,bp-guacamole): the seeded Guacamole connection now authenticates when clicked (UAT row 115))
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform


### PR DESCRIPTION
## main does not parse: bootstrap-kit slot 13 carries literal conflict markers

`clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml` on `main` has
`<<<<<<< HEAD` / `=======` / `>>>>>>>` at lines 1398-1410. That file is the
**bp-catalyst-platform HelmRelease** — the Catalyst control-plane umbrella.

```
$ git show origin/main:clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml | python3 -c "import yaml,sys; list(yaml.safe_load_all(sys.stdin))"
MAIN IS UNPARSEABLE: ScannerError while scanning a simple key
```

So Flux cannot reconcile slot 13 on any Sovereign that syncs the kit, and every
guard that YAML-parses the bootstrap kit is reading a broken file rather than a
wrong value.

### This is my regression, from #6246

Recorded plainly because the mechanism generalises:

While rebasing #6246 onto a `main` that had advanced (its deploy bot bumps the
umbrella every few minutes), the rebase produced **two** conflicts. I resolved
the one in `products/catalyst/chart/Chart.yaml`, missed the second one in this
file, then ran **`git add -A`** — which blanket-staged the still-conflicted file
— and `git rebase --continue` accepted it without complaint.

`scripts/check-bootstrap-kit-pin-sync.sh` **did** catch it —
`DRIFT bp-catalyst-platform: chart=1.4.1454 pin=1.4.1453` — and my chained gate
blocked *that* push. But the broken commit had already been pushed one revision
earlier, and #6246 was merged before the repaired force-push landed.

Two things would each have prevented it, and both are cheap:

1. Stage conflicted files **by explicit path**, never `git add -A` during a
   rebase.
2. Scan for markers **before** committing, rather than relying on a guard that
   reports a *symptom* (a drifted pin) instead of the cause:
   ```
   git grep -n '^<<<<<<< ' HEAD -- platform products clusters core infra
   ```

### The fix

Keeps both intended contents: the changelog entry from #6246 **and** a single
`version:` key at `1.4.1454`, which matches `products/catalyst/chart/Chart.yaml`
on main.

**Verified on this branch:**

- the file parses — 3 documents, `HelmRelease` chart version `1.4.1454`;
- `scripts/check-bootstrap-kit-pin-sync.sh` → `PASS: all bootstrap-kit pins are
  in sync with their source charts.`

**Control:** the same file at `origin/main` fails to parse with the
`ScannerError` above, so the assertion is not vacuous.

One file, four lines deleted.

Refs #5991

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HvMZTDx7W6EPZMmjyXmYh1
