### PR TITLE
fix(sovereign-api): the /apps estate is Application-keyed, not HelmRelease-keyed (UAT rows 19/15)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/sovereign.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sovereign.go
@@ -772,7 +772,20 @@ func (h *Handler) HandleSovereignApps(w http.ResponseWriter, r *http.Request) {
 		// Application CR pass — separate List so a missing CRD or
 		// RBAC denial on apps.openova.io doesn't break the HR pass
 		// above (which is the load-bearing one for status).
-		if appList, err := deps.dyn.Resource(applicationGVR).Namespace("").List(ctx, metav1.ListOptions{}); err == nil {
+		//
+		// #6249 (UAT rows 19/15) — the OUTCOME of this List, not just its
+		// contents, is load-bearing. When it succeeds we hold the
+		// authoritative answer to "what Applications exist on this
+		// Sovereign", and the estate is exactly that set. When it fails
+		// (CRD not yet registered during first bootstrap, or an RBAC
+		// denial) we hold no answer at all, and the HelmRelease fallback
+		// below is the only thing standing between the operator and a
+		// blank estate. Those are different situations and the old code
+		// could not tell them apart: it discarded `err` at the `if`, so
+		// "zero Applications" and "could not ask" were the same state.
+		appList, appListErr := deps.dyn.Resource(applicationGVR).Namespace("").List(ctx, metav1.ListOptions{})
+		applicationEstateAuthoritative := appListErr == nil
+		if appListErr == nil {
 			for _, app := range appList.Items {
 				// #3370 — every Application CR is one RUNNING INSTANCE
 				// and projects as its OWN card row (the canonical G117
@@ -932,6 +945,44 @@ func (h *Handler) HandleSovereignApps(w http.ResponseWriter, r *http.Request) {
 				// Also suppress any bootstrap SLOT row for this HR below —
 				// the Application CR's card is its one card.
 				adoptedHRs[hrName] = true
+				continue
+			}
+			// #6249 (UAT rows 19/15) — THE ESTATE IS APPLICATION-KEYED.
+			//
+			// Measured on hw296 2026-08-13: the grid drew 11 estate cards
+			// against 10 Application CRs, and the console's own
+			// reconciliation lens counted `Application 10/10` on the same
+			// page load. The surplus card was `valkey` — a HelmRelease
+			// (flux-system/bp-valkey) and a Pod, with no Application CR
+			// anywhere. It is this pass that drew it, and the card it drew
+			// was not merely extra: it carried environment "dev" (the
+			// resolveAppEnvironment fallback) while the only Environments on
+			// that Sovereign were hw296-omani-works-cp and -prod. An
+			// operator counting the estate got a number no other surface
+			// agreed with, and a chip naming an Environment that does not
+			// exist.
+			//
+			// A HelmRelease is how an Application is INSTALLED, not what an
+			// Application IS. Once the Application list has answered, the
+			// estate is exactly that answer, so an HR with no CR is not an
+			// estate card here.
+			//
+			// NOTHING VANISHES. Suppression is of the INSTANCE row only, and
+			// deliberately leaves `adoptedHRs` unset so the blueprint's
+			// bootstrap/catalog slot row still renders below, still badged
+			// INSTALLED off the `installed` map this same loop's HR pass
+			// built. bp-valkey keeps its card; it stops claiming to be an
+			// Application. That is the whole change.
+			//
+			// The gate is readability, NOT per-CR presence — the distinction
+			// the fallback's own rationale draws. During first bootstrap the
+			// Application CRD is not yet registered (the self-registering
+			// chart template is gated on
+			// `.Capabilities.APIVersions.Has "apps.openova.io/v1"`, so the CR
+			// materialises only on the first post-CRD upgrade), the List
+			// errors, and this pass still runs — which is exactly the
+			// zero-touch-prov window it was written for.
+			if applicationEstateAuthoritative {
 				continue
 			}
 			chart, _, _ := unstructured.NestedString(hr.Object, "spec", "chart", "spec", "chart")

--- a/products/catalyst/bootstrap/api/internal/handler/sovereign_apps_estate_is_application_keyed_6249_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sovereign_apps_estate_is_application_keyed_6249_test.go
@@ -1,0 +1,288 @@
+// #6249 (UAT rows 19 + 15, #3687) — the /apps estate is Application-keyed.
+//
+// THE MEASUREMENT, hw296 2026-08-13. The sovereign-admin /apps grid drew
+// ELEVEN estate cards ([data-card-kind="instance"] inside sov-apps-grid)
+// while the cluster held TEN Application CRs. The console contradicted
+// itself on a single page load: /cloud?view=graph&lens=reconciliation
+// counted `Application 10/10` from the same cluster at the same moment.
+//
+// The surplus card was `sov-app-card-valkey`. There is no valkey
+// Application CR on hw296 — valkey exists as HelmRelease
+// flux-system/bp-valkey plus pod valkey/valkey-primary-0, which is exactly
+// the HelmRelease/pod keying row 19 forbids. The card also displayed
+// environment "dev" (resolveAppEnvironment's fallback) while the only
+// Environments on that Sovereign were hw296-omani-works-cp and
+// hw296-omani-works-prod, so it named an Environment that does not exist.
+//
+// WHICH OF THE TWO PRODUCERS WAS WRONG. Both derivations are in this repo
+// and only one can be right:
+//
+//   - TEN — helmwatch/declarative_reconcilers.go:126 lists ApplicationGVR
+//     and is what the reconciliation lens counts; handler/applications.go
+//     HandleApplicationList likewise lists ApplicationGVR() and nothing
+//     else. Both read Application CRs and only Application CRs.
+//   - ELEVEN — handler/sovereign.go, the HelmRelease fallback pass inside
+//     HandleSovereignApps, which projects any shareable HR with no matching
+//     Application CR as `Instance: true`. That is the one that invented
+//     valkey, and it is the one this file pins.
+//
+// The front end is faithful and was NOT the defect: AppsPage.tsx:234 keys
+// the estate card purely on `a.instance === true`, so a row the BFF marks
+// as an instance is drawn as one. Fixing this in the FE would have hidden
+// a lying wire response instead of correcting it.
+//
+// WHAT THE FIX PRESERVES. The fallback exists for the first-bootstrap
+// window, when the Application CRD is not yet registered and the
+// self-registering chart template (gated on `.Capabilities.APIVersions.Has
+// "apps.openova.io/v1"`) has not yet emitted the CR. The gate is therefore
+// READABILITY of the Application list, not presence of a particular CR:
+// TestSovereignApps_EstateFallsBackWhenApplicationCRDUnreadable below holds
+// that window open, and it is the case #3537 actually cares about.
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	fakek8s "k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+// newSovereignHandlerApplicationsUnreadable builds the handler with the
+// Application list FAILING, which is what "the CRD has not landed yet"
+// looks like on the wire. The dynamic fake is otherwise identical to
+// newSovereignHandler; only the applications list verb is intercepted, so
+// the HelmRelease / HTTPRoute passes behave exactly as they do everywhere
+// else and the difference under test is the one variable.
+func newSovereignHandlerApplicationsUnreadable(t *testing.T, dynObjs []runtime.Object) *Handler {
+	t.Helper()
+	core := fakek8s.NewSimpleClientset()
+	scheme := runtime.NewScheme()
+	gvrToList := map[schema.GroupVersionResource]string{
+		helmReleaseGVR:       "HelmReleaseList",
+		httpRouteGVR:         "HTTPRouteList",
+		applicationGVR:       "ApplicationList",
+		fluxKustomizationGVR: "KustomizationList",
+	}
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToList, dynObjs...)
+	dyn.PrependReactor("list", "applications", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewNotFound(
+			schema.GroupResource{Group: "apps.openova.io", Resource: "applications"}, "")
+	})
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	h.SetSovereignDepsFactory(func() (*sovereignDeps, error) {
+		return &sovereignDeps{core: core, dyn: dyn}, nil
+	})
+	return h
+}
+
+// makeKeyspaceHR builds the hw296 bp-valkey HelmRelease: a SHAREABLE chart
+// (bp-valkey declares contextSchema kind=keyspace valuesKey=keyspaces in
+// the embedded catalog, which is what makes the fallback pass eligible to
+// project it) whose release name is `valkey` and which has no companion
+// Application CR. Without the shareable chart + populated valuesKey this
+// fixture would never reach the projection branch at all and the test
+// would be vacuous.
+func makeKeyspaceHR(hrName, releaseName, ready string, keyspaces []map[string]interface{}) *unstructured.Unstructured {
+	u := makeHR(hrName, "flux-system", ready)
+	_ = unstructured.SetNestedField(u.Object, "bp-valkey", "spec", "chart", "spec", "chart")
+	_ = unstructured.SetNestedField(u.Object, releaseName, "spec", "releaseName")
+	ksAny := make([]interface{}, len(keyspaces))
+	for i, k := range keyspaces {
+		ksAny[i] = k
+	}
+	_ = unstructured.SetNestedSlice(u.Object, ksAny, "spec", "values", "keyspaces")
+	return u
+}
+
+// makeBlueprintApplication builds an Application CR carrying a
+// blueprintRef, deliberately WITHOUT spec.helmRelease and with no
+// catalyst.openova.io/app label on its HelmRelease. That matters: it means
+// neither pre-existing suppression path (adoptedHRs, which keys off
+// spec.helmRelease.name, nor the #5429 label path) can be what keeps the
+// count honest in the control below.
+func makeBlueprintApplication(name, ns, env, blueprint string) *unstructured.Unstructured {
+	u := makeApplication(name, ns, env)
+	_ = unstructured.SetNestedField(u.Object, blueprint, "spec", "blueprintRef", "name")
+	_ = unstructured.SetNestedField(u.Object, "Ready", "status", "phase")
+	return u
+}
+
+// hw296Estate returns the measured hw296 shape, reduced to its smallest
+// discriminating form.
+//
+// THE CONTROL SHARES THE SUSPECT PROPERTY. shared-pg and shared-pg-b are
+// bp-postgres HelmReleases — shareable charts with a populated
+// contextSchema valuesKey, the identical property that makes bp-valkey
+// eligible for the fallback — but each HAS a matching Application CR. They
+// must render exactly one card each, before and after the fix. Without
+// them a handler that projected NO instance cards at all (or dropped every
+// shareable HR) would pass the valkey assertion, and the test would be
+// evidence of nothing.
+//
+// bp-cilium is the non-shareable control: it must never be an estate card
+// under any of these conditions.
+func hw296Estate() []runtime.Object {
+	return []runtime.Object{
+		makeBlueprintApplication("shared-pg", "flux-system", "hw296-omani-works-prod", "bp-postgres"),
+		makeBlueprintApplication("shared-pg-b", "flux-system", "hw296-omani-works-prod", "bp-postgres"),
+		makeShareableHR("bp-postgres-shared", "shared-pg", "True", []map[string]interface{}{
+			{"name": "gitea", "owner": "gitea"},
+			{"name": "keycloak", "owner": "keycloak"},
+		}),
+		makeShareableHR("bp-postgres-shared-b", "shared-pg-b", "True", []map[string]interface{}{
+			{"name": "newapi", "owner": "newapi"},
+		}),
+		// The surplus card measured on hw296: a shareable HelmRelease and a
+		// running pod, with no Application CR anywhere.
+		makeKeyspaceHR("bp-valkey", "valkey", "True", []map[string]interface{}{
+			{"name": "newapi", "index": int64(1)},
+		}),
+		makeHR("bp-cilium", "flux-system", "True"),
+	}
+}
+
+func sovereignAppsOf(t *testing.T, h *Handler) []sovereignAppItem {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/sovereign/apps", nil)
+	w := httptest.NewRecorder()
+	h.HandleSovereignApps(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: %d body=%s", w.Code, w.Body.String())
+	}
+	var got sovereignAppsResponse
+	if err := json.NewDecoder(w.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	return got.Apps
+}
+
+func estateIDs(apps []sovereignAppItem) []string {
+	out := []string{}
+	for _, a := range apps {
+		if a.Instance {
+			out = append(out, a.ID)
+		}
+	}
+	return out
+}
+
+// TestSovereignApps_EstateCountEqualsApplicationCRCount is the row-19
+// assertion stated the way the walker settles it: by COUNTING. Two
+// Application CRs on the cluster, two estate cards on the wire.
+func TestSovereignApps_EstateCountEqualsApplicationCRCount(t *testing.T) {
+	const applicationCRCount = 2 // shared-pg, shared-pg-b
+
+	apps := sovereignAppsOf(t, newSovereignHandler(t, nil, hw296Estate()))
+	ids := estateIDs(apps)
+
+	// Shape first. Every assertion below is a count, and a count is
+	// satisfied by an empty response, so if this fails nothing after it
+	// means anything.
+	if len(apps) == 0 {
+		t.Fatalf("no app rows at all — the fixture never reached the handler")
+	}
+	if len(ids) != applicationCRCount {
+		t.Fatalf("estate = %d cards %v; want %d, one per Application CR "+
+			"(row 19: one card per Application, NOT one per HelmRelease/pod). "+
+			"This is the hw296 11-vs-10 defect: a shareable HelmRelease with no "+
+			"Application CR was projected as an estate card.", len(ids), ids, applicationCRCount)
+	}
+}
+
+// TestSovereignApps_HelmReleaseWithoutApplicationCRIsNotAnEstateCard names
+// the surplus card directly, so a future regression reports `valkey` rather
+// than an off-by-one.
+func TestSovereignApps_HelmReleaseWithoutApplicationCRIsNotAnEstateCard(t *testing.T) {
+	apps := sovereignAppsOf(t, newSovereignHandler(t, nil, hw296Estate()))
+
+	for _, a := range apps {
+		if a.Instance && a.ID == "valkey" {
+			t.Fatalf("valkey projected as an estate card (environment=%q, bootstrapKit=%v) "+
+				"but has NO Application CR — only HelmRelease flux-system/bp-valkey. "+
+				"A HelmRelease is how an Application is installed, not what an Application is.",
+				a.Environment, a.BootstrapKit)
+		}
+		if a.Instance && a.ID == "cilium" {
+			t.Errorf("non-shareable bp-cilium projected as an estate card")
+		}
+	}
+
+	// THE CONTROL. Both shareable HRs that DO have an Application CR must
+	// still render, exactly once each. A fix that suppressed every shareable
+	// HelmRelease — or every instance card — would pass the loop above and
+	// fail here.
+	for _, want := range []string{"shared-pg", "shared-pg-b"} {
+		n := 0
+		for _, a := range apps {
+			if a.Instance && a.ID == want {
+				n++
+			}
+		}
+		if n != 1 {
+			t.Errorf("Application %s rendered %d estate cards; want exactly 1", want, n)
+		}
+	}
+}
+
+// TestSovereignApps_SuppressedHelmReleaseStillRendersAsCatalogRow — nothing
+// vanishes from the page. bp-valkey is a bootstrap-kit blueprint, so once
+// it stops claiming to be an Application it must still appear as its
+// bootstrap/catalog row, still marked installed off the HelmRelease. The
+// operator loses a false Application, not a component.
+func TestSovereignApps_SuppressedHelmReleaseStillRendersAsCatalogRow(t *testing.T) {
+	apps := sovereignAppsOf(t, newSovereignHandler(t, nil, hw296Estate()))
+
+	var row *sovereignAppItem
+	for i := range apps {
+		if apps[i].ID == "bp-valkey" {
+			row = &apps[i]
+			break
+		}
+	}
+	if row == nil {
+		t.Fatalf("bp-valkey disappeared from /apps entirely; suppression must drop the "+
+			"ESTATE row only, leaving the bootstrap/catalog row intact. got %d rows", len(apps))
+	}
+	if row.Instance {
+		t.Errorf("bp-valkey row still marked instance=true")
+	}
+	if row.Status != "bootstrap" && row.Status != "installed" {
+		t.Errorf("bp-valkey status = %q; want bootstrap/installed — the HelmRelease is Ready "+
+			"and that must still reach the card", row.Status)
+	}
+}
+
+// TestSovereignApps_EstateFallsBackWhenApplicationCRDUnreadable holds open
+// the window the fallback was written for, and is the reason the gate is
+// readability rather than per-CR presence. During first bootstrap the
+// Application CRD is not registered, the list errors, and the HelmReleases
+// are the only surviving description of what is running — suppressing them
+// there would trade a phantom card for a blank estate.
+func TestSovereignApps_EstateFallsBackWhenApplicationCRDUnreadable(t *testing.T) {
+	apps := sovereignAppsOf(t, newSovereignHandlerApplicationsUnreadable(t, hw296Estate()))
+	ids := estateIDs(apps)
+
+	found := map[string]bool{}
+	for _, id := range ids {
+		found[id] = true
+	}
+	// All three shareable instances project here — including valkey, which
+	// is correct when nothing authoritative can be consulted.
+	for _, want := range []string{"shared-pg", "shared-pg-b", "valkey"} {
+		if !found[want] {
+			t.Errorf("with the Application CRD unreadable, %s projected no estate card %v; "+
+				"the HelmRelease fallback must still run in the pre-CRD bootstrap window", want, ids)
+		}
+	}
+	if found["cilium"] {
+		t.Errorf("non-shareable bp-cilium projected an estate card even in fallback mode")
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/sovereign_apps_one_card_per_cr_5429_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sovereign_apps_one_card_per_cr_5429_test.go
@@ -144,18 +144,29 @@ func TestSovereignApps_OneCardPerApplicationCR_NoFanoutPhantom(t *testing.T) {
 }
 
 // TestSovereignApps_FanoutSuppressionScopedToPresentCRs proves the
-// suppression is not a blanket "drop every labelled HR". When the parent
-// Application CR is absent (deleted, or its CRD/RBAC unreadable — the
-// handler lists Applications in a separate best-effort call), the
-// HelmRelease is the only surviving representation of a real running
+// suppression is not a blanket "drop every labelled HR". When the
+// Application list cannot be READ (CRD not yet registered, or an RBAC
+// denial — the handler lists Applications in a separate best-effort call),
+// the HelmRelease is the only surviving representation of a real running
 // install and MUST still project a card. Without this the fix would trade
 // a duplicate card for a vanished one.
+//
+// #6249 — RE-POINTED, not weakened. This test previously ran against a
+// readable, EMPTY Application list and asserted that an orphan HR still
+// rendered an estate card. That is the condition UAT row 19 forbids: with
+// the Application list answering, an HR with no CR is not an Application,
+// and projecting it is exactly the hw296 11-vs-10 defect (see
+// sovereign_apps_estate_is_application_keyed_6249_test.go). The unreadable
+// case above is the one this test's own rationale names, and it is the one
+// that carries the real risk of a blank estate, so that is what it now
+// drives. The formerly-asserted case is covered with the opposite verdict
+// by TestSovereignApps_HelmReleaseWithoutApplicationCRIsNotAnEstateCard.
 func TestSovereignApps_FanoutSuppressionScopedToPresentCRs(t *testing.T) {
 	dynObjs := []runtime.Object{
-		// Labelled HR whose parent Application CR does NOT exist.
+		// Labelled HR whose parent Application CR cannot be looked up.
 		makeFannedOutHR("orphan-app", "hw290-rtz-a", "True"),
 	}
-	h := newSovereignHandler(t, nil, dynObjs)
+	h := newSovereignHandlerApplicationsUnreadable(t, dynObjs)
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/sovereign/apps", nil)
 	w := httptest.NewRecorder()
 	h.HandleSovereignApps(w, req)

--- a/products/catalyst/bootstrap/api/internal/handler/sovereign_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sovereign_test.go
@@ -401,14 +401,26 @@ func makeShareableHR(hrName, releaseName string, ready string, dbs []map[string]
 }
 
 // TestSovereignApps_BootstrapHRShareableInstanceCards is the #3537
-// regression: on a zero-touch converged prov the shared-pg / -b / -c
-// instances exist ONLY as bootstrap Flux HelmReleases (0 Application
-// CRs). The /api/v1/sovereign/apps handler must still project them as
-// instance:true cards WITH the ⛓ Contexts count — the exact gap the
-// founder hit live on hw138 (instance rows = 0, contextCount = 0) while
-// /catalyst/v1/catalog/postgres/instances correctly rendered them.
+// regression: during the first-bootstrap window the shared-pg / -b / -c
+// instances exist ONLY as bootstrap Flux HelmReleases, because the
+// Application CRD is not yet registered and the self-registering chart
+// template (gated on `.Capabilities.APIVersions.Has "apps.openova.io/v1"`)
+// has not emitted a CR yet. The /api/v1/sovereign/apps handler must still
+// project them as instance:true cards WITH the ⛓ Contexts count — the exact
+// gap the founder hit live on hw138 (instance rows = 0, contextCount = 0)
+// while /catalyst/v1/catalog/postgres/instances correctly rendered them.
+//
+// #6249 — RE-POINTED, not weakened. Every assertion below is unchanged;
+// only the precondition is now stated on the wire the way it actually
+// occurs. "No Application CRs yet" during bootstrap means the CRD is
+// UNREADABLE, not that an empty list came back: once the list answers, the
+// estate is Application-keyed and a shareable HR with no CR must not be an
+// estate card (UAT row 19 — the hw296 11-vs-10 defect, pinned in
+// sovereign_apps_estate_is_application_keyed_6249_test.go). Keeping this
+// test on a readable-but-empty list would have required the handler to
+// contradict that row.
 func TestSovereignApps_BootstrapHRShareableInstanceCards(t *testing.T) {
-	// THREE shareable HRs, ZERO Application CRs — the hw138 shape.
+	// THREE shareable HRs, Application CRD not yet registered — the hw138 shape.
 	dynObjs := []runtime.Object{
 		makeShareableHR("bp-postgres-shared", "shared-pg", "True", []map[string]interface{}{
 			{"name": "registry", "owner": "harbor", "consumer": map[string]interface{}{"blueprint": "bp-harbor"}},
@@ -422,7 +434,7 @@ func TestSovereignApps_BootstrapHRShareableInstanceCards(t *testing.T) {
 		// A non-shareable bootstrap HR must NOT become an instance card.
 		makeHR("bp-cilium", "flux-system", "True"),
 	}
-	h := newSovereignHandler(t, nil, dynObjs)
+	h := newSovereignHandlerApplicationsUnreadable(t, dynObjs)
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/sovereign/apps", nil)
 	w := httptest.NewRecorder()
 	h.HandleSovereignApps(w, req)


### PR DESCRIPTION
## The measurement (live walk, hw296, 2026-08-13)

The sovereign-admin `/apps` estate grid renders MORE cards than there are Application CRs.

- `[data-card-kind="instance"]` inside `sov-apps-grid` = **11**
- `kubectl get applications -A` = **10**
- Surplus card = `sov-app-card-valkey`, backed by **no Application CR** — only HelmRelease `flux-system/bp-valkey` and pod `valkey/valkey-primary-0`
- That card also displayed environment `dev`, while the only Environments were `hw296-omani-works-cp` and `hw296-omani-works-prod`
- On the same page load, `/cloud?view=graph&lens=reconciliation` counted `Application 10/10`

The page contradicted itself, which is what UAT rows **19** and **15** forbid: one estate card per `Application` CR, NOT one per HelmRelease/pod.

## The two derivations

| Count | `file:line` | Reads |
|---|---|---|
| **10** — correct | `products/catalyst/bootstrap/api/internal/helmwatch/declarative_reconcilers.go:126` — `{gvr: ApplicationGVR, kind: "Application"}` | Application CRs. Feeds the reconciliation lens. |
| **10** — correct | `products/catalyst/bootstrap/api/internal/handler/applications.go:2644` — `HandleApplicationList` | `ApplicationGVR()` and nothing else. |
| **11** — wrong | `products/catalyst/bootstrap/api/internal/handler/sovereign.go` — the HelmRelease fallback pass in `HandleSovereignApps`, projecting at `sovereign.go:1020` | Any *shareable* HelmRelease with no matching Application CR, emitted as `Instance: true`. |

**Why the third one is the wrong one.** A HelmRelease is how an Application is *installed*, not what an Application *is*. `bp-valkey` is a shareable chart (`contextSchema` kind=keyspace, valuesKey=keyspaces), so it satisfied the fallback's eligibility test, and the pass emitted an estate row whose `ID` came from `spec.releaseName` (`valkey`) and whose environment came from `resolveAppEnvironment`'s `"dev"` fallback. Both the surplus card and its phantom Environment come from that one branch.

**The front end was faithful and is unchanged.** `products/catalyst/bootstrap/ui/src/pages/sovereign/AppsPage.tsx:234` keys the estate card purely on `a.instance === true`. Fixing this in the FE would have hidden a lying wire response rather than correcting it.

### Trees grepped

All four, as required:

| Tree | Result |
|---|---|
| `products/catalyst/bootstrap/ui/` (`ui`, sovereign-admin) | **The grid lives here** — `AppsPage.tsx`. Faithful; not the defect. |
| `core/console/` (`org-console`) | No estate-grid derivation. |
| `core/marketplace/` (`org-marketplace`) | Customer funnel only. |
| `products/catalyst/console/` (`catalyst-console`) | No estate-grid derivation. |

Backend: `handler/sovereign.go`, `handler/applications.go`, `handler/reconciliation_dag.go`, `helmwatch/declarative_reconcilers.go`.

## The fix

Gate the HelmRelease→estate fallback on whether the Application list was **readable** (`sovereign.go:787` `applicationEstateAuthoritative`, consumed at `sovereign.go:985`), not on whether a particular CR exists. The old code discarded `err` at the `if`, so "zero Applications" and "could not ask" were the same state.

- **List answers** → the estate is exactly that set; an HR with no CR is not an estate card.
- **List errors** (CRD not yet registered during first bootstrap — the self-registering chart template is gated on `.Capabilities.APIVersions.Has "apps.openova.io/v1"` — or an RBAC denial) → the fallback still runs. That is the window it was written for (#3537).

**Nothing disappears.** Suppression drops the *estate* row only and deliberately leaves `adoptedHRs` unset, so `bp-valkey` still renders its bootstrap/catalog row, still badged INSTALLED off the HelmRelease. It stops claiming to be an Application. Pinned by `TestSovereignApps_SuppressedHelmReleaseStillRendersAsCatalogRow`.

## Vacuity proof

The gate was mutated to `if false && applicationEstateAuthoritative` — still compiles, still renders. Observed failures:

```
--- FAIL: TestSovereignApps_EstateCountEqualsApplicationCRCount
    estate = 3 cards [shared-pg shared-pg-b valkey]; want 2, one per Application CR
    (row 19: one card per Application, NOT one per HelmRelease/pod). This is the
    hw296 11-vs-10 defect: a shareable HelmRelease with no Application CR was
    projected as an estate card.
--- FAIL: TestSovereignApps_HelmReleaseWithoutApplicationCRIsNotAnEstateCard
    valkey projected as an estate card (environment="dev", bootstrapKit=true) but
    has NO Application CR — only HelmRelease flux-system/bp-valkey.
--- FAIL: TestSovereignApps_SuppressedHelmReleaseStillRendersAsCatalogRow
    bp-valkey disappeared from /apps entirely; ... got 66 rows
```

The mutant reproduces the live defect including `environment="dev"` — the walk's own corroborating detail — so the fixture is exercising the real branch, not a lookalike.

`TestSovereignApps_EstateFallsBackWhenApplicationCRDUnreadable` **passes on the mutant**, by design: it is a control on the fix's blast radius, not on the defect.

## The control fixture

`hw296Estate()` drives the real handler (`HandleSovereignApps`), not a predicate:

- **Control** — `shared-pg` and `shared-pg-b`: `bp-postgres` HelmReleases, shareable with a populated `contextSchema` valuesKey — *the identical property that made `bp-valkey` eligible* — but each **has** a matching Application CR. Each must render exactly one card, before and after. Without them, a handler that projected no estate cards at all would pass the valkey assertion.
- **Subject** — `bp-valkey`: shareable HR, `releaseName: valkey`, no Application CR.
- **Second control** — `bp-cilium`: non-shareable, must never be an estate card under any condition.

The controls' Application CRs carry no `spec.helmRelease` and their HelmReleases no `catalyst.openova.io/app` label, so neither pre-existing suppression path (`adoptedHRs`, the #5429 label path) is what keeps their count honest.

## Two existing tests re-pointed, not weakened

Each now drives the condition its **own rationale already named** — Application list unreadable — instead of a readable-but-empty list, which is the state row 19 forbids. Every assertion is retained.

- `TestSovereignApps_FanoutSuppressionScopedToPresentCRs` (#5429) — its comment named "CRD/RBAC unreadable" while testing "CR deleted".
- `TestSovereignApps_BootstrapHRShareableInstanceCards` (#3537) — "no Application CRs yet" during bootstrap means the CRD is unreadable, not that an empty list came back. contextCount 3/2, blueprint, status and the non-shareable exclusion all unchanged.

## Verification

- `go build ./...`, `go vet ./internal/handler/` clean
- `go test ./internal/...` — **26 packages ok, 0 FAIL** (handler package 291s)
- FE `AppsPage.one-card-per-application-19.test.tsx` — 8/8 pass, unchanged
- `scripts/check-no-conflict-markers.sh` (self-test PASS: 2 fixtures caught), `scripts/check-no-banned-words.sh`, `gofmt -l` on all four touched files
- No live-cluster writes; no chart touched; no NodePorts

## Follow-up observed, not fixed here

`clusters/_template/bootstrap-kit/17-valkey.yaml:114` sets `bootstrapOwned.enabled: true`, so valkey *should* self-register an Application CR. On hw296 it has not, and this PR does not investigate why — it makes the console stop misreporting it. Worth a separate look.

Refs #6249, #3687, #3537, #5429, #3370. UAT rows 19 + 15 (ledger untouched — those flip only on a live walk).
