### PR TITLE
fix(guards): the expected bootstrap DAG never learned the two edges #6246 added

### DIFF
--- a/scripts/expected-bootstrap-deps.yaml
+++ b/scripts/expected-bootstrap-deps.yaml
@@ -643,14 +643,23 @@ slots:
   # W2.K4 AI-runtime cohort (slots 36-48) so they never collide.
   #   - bp-k8s-ws-proxy: per-node DaemonSet bridging HMAC-signed
   #     callers onto the local kube-apiserver pods/exec stream.
-  #     Depends on bp-cilium (CNI) + bp-sealed-secrets (HMAC secret).
+  #     Depends on bp-cilium (CNI) + bp-sealed-secrets (HMAC secret)
+  #     + bp-cert-manager + bp-reflector. The last two arrived with
+  #     #5991's mTLS leg (UAT row 115): the chart renders cert-manager
+  #     Certificates for its mTLS listener, and reflector mirrors the
+  #     issued client-certificate Secret into the `guacamole` namespace
+  #     (tls.reflectClientCertTo) so guacd has a credential to present.
+  #     Both edges are load-bearing for ORDERING only — the Certificate
+  #     render is gated on the cert-manager.io/v1 CRD, so a missing edge
+  #     produces a proxy with no TLS listener instead of a failed apply,
+  #     which is the silent shape this DAG exists to make loud.
   #   - bp-guacamole: HTML5 RDP/SSH/exec gateway. Depends on
   #     bp-cilium (Gateway API) + bp-cert-manager (TLS) + bp-keycloak
   #     (OIDC) + bp-sealed-secrets (OIDC client secret) + bp-seaweedfs
   #     (RWX recordings PVC) + bp-k8s-ws-proxy (apiserver tunnel).
   - slot: 51
     name: bp-k8s-ws-proxy
-    depends_on: [bp-cilium, bp-sealed-secrets]
+    depends_on: [bp-cilium, bp-sealed-secrets, bp-cert-manager, bp-reflector]
     wave: present
   - slot: 52
     name: bp-guacamole


### PR DESCRIPTION
fix(guards): the expected bootstrap DAG never learned the two edges #6246 added

dependency-graph-audit has been RED on main since 21e6fad23 (#6246), and it
reddens every open pull request:

  ERROR: HR 'bp-k8s-ws-proxy' (file clusters/_template/bootstrap-kit/51-bp-k8s-ws-proxy.yaml): dependsOn drift
           extra edges   (in HR, NOT declared expected):   bp-cert-manager bp-reflector
  ERROR: 1 drift(s) detected.

The HR is the side that is CORRECT. #5991's mTLS leg gave bp-k8s-ws-proxy a
cert-manager Certificate for its mTLS listener and a reflector mirror that
copies the issued client-certificate Secret into the `guacamole` namespace
(tls.reflectClientCertTo), and #6246 added both edges to
clusters/_template/bootstrap-kit/51-bp-k8s-ws-proxy.yaml with a comment at each
one explaining why. What it did not do is teach the expected DAG in
scripts/expected-bootstrap-deps.yaml the same two names, so the audit read the
new, correct ordering as drift.

Both edges matter for the reason the comment in the HR already records, and it
is the reason this guard exists: the Certificate render is gated on the
cert-manager.io/v1 CRD being registered, so a missing edge does not fail the
apply — it silently produces a proxy with no TLS listener, and the Guacamole
click then fails with nothing to point at. A DAG that cannot see the edge cannot
protect the ordering.

RED -> GREEN, the same command CI runs, exit code read directly:

  before:  bash scripts/check-bootstrap-deps.sh  ->  exit 1
           ERROR: HR 'bp-k8s-ws-proxy': dependsOn drift
                  extra edges: bp-cert-manager bp-reflector
  after:   bash scripts/check-bootstrap-deps.sh  ->  exit 0
           OK: no drift between actual HRs and expected DAG (13 deferred)

Data-only: one `depends_on` list and the comment above it. No HelmRelease, no
chart, no version, no slot ordering is touched — the running bootstrap kit is
byte-identical before and after.

Refs #5991 #6246
