### PR TITLE
fix(cutover): a hollow chart pin is TERMINAL, not "wait for it to settle" — one unpublished pin dead-ended the whole hw296 cutover

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -1074,7 +1074,7 @@ spec:
       # chart/tests/ left the package via .helmignore: 757,264 bytes, 72.2%.
       # The rendered manifest is byte-identical modulo comments — no step,
       # value or RBAC change, still 11 steps.
-      version: 0.1.182
+      version: 0.1.183
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1409,7 +1409,7 @@ spec:
       #   bearer catalyst-api itself accepts is no longer refused with
       #   `crypto/rsa: verification error`. Lockstep w/
       #   products/catalyst/chart/Chart.yaml.
-      version: 1.4.1458
+      version: 1.4.1459
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.182
+  version: 0.1.183
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -3705,7 +3705,7 @@ name: bp-self-sovereign-cutover
 # pin + blueprint.yaml + catalog-seed source.version + spec.version + the API
 # blueprints.json + the generated UI catalog move to 0.1.176 in lockstep
 # (Inviolable Principle #13).
-version: 0.1.182
+version: 0.1.183
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml
@@ -212,6 +212,21 @@ data:
      exceeded`, `connection refused`, a 5xx — matches none of those strings
      and stays classified mid-roll, so waiting is still the advice whenever
      waiting can actually work.
+
+     "404-class" is NOT the same as "the words not found appear", and the
+     difference was measured, not reasoned about. Sampling hw296 while it was
+     reconciling turned up bp-sso-bridge and bp-trivy sitting on
+
+       ArtifactFailed  "Source not ready: artifact not found. Retrying in 30s"
+
+     — Flux's own artifact store still rebuilding after a source-controller
+     restart. Those charts exist, that state clears in ~30s by itself, and a
+     bare `not found` test would have branded both as hollow pins and told
+     the operator to publish a version that is already published. So the
+     404-class token must arrive together with a REMOTE-RESOLUTION context:
+     `chart pull error` (Flux's wording when the registry download itself
+     failed) or `no chart version found` (a classic HelmRepository index
+     miss, self-contained). Both live shapes are pinned as Case 77 fixtures.
     */}}
     SRP_TERMINAL_JQ='
       def _cond($t): (.status.conditions // []) | map(select(.type == $t)) | (.[0] // {});
@@ -224,10 +239,13 @@ data:
          string status" — caught by Case 77 direction 1 before this shipped.
         */}}
         (_cond("Ready")) as $r
+        | ((($r.message) // "") | ascii_downcase) as $m
         | ((($r.status) // "Unknown") != "True")
           and ((["SourceNotReady", "ArtifactFailed", "ChartPullError"] | index(($r.reason) // "")) != null)
-          and ((($r.message) // "") | ascii_downcase
-               | (test("not found") or test("no chart version found")));
+          and (
+            ($m | test("no chart version found"))
+            or (($m | test("chart pull error")) and ($m | test("not found")))
+          );
       def _terminal: _stalled or _source_absent;
     '
     srp_kubectl_json() {

--- a/platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml
@@ -168,6 +168,68 @@ data:
     */}}
     # ── settled-roll-preflight BEGIN (Case 77 extraction anchor — tests/cutover-contract.sh executes this block verbatim with a stubbed kubectl) ──
     SETTLED_ROLL_OVERRIDE_ANNOTATION="catalyst.openova.io/cutover-settled-roll-override"
+    {{- /*
+     #6253 (Refs #5391 #5392 #3379) — the TERMINAL classifier, defined ONCE
+     and consumed by BOTH the override-validation and the offender-tagging
+     below. It used to be re-hand-rolled at each call site as the bare
+     `Stalled=True` test, and the two sites then disagreed with reality in the
+     same direction.
+
+     WHY a second terminal shape exists. `Stalled=True/RetriesExceeded` is how
+     Flux gives up on an UPGRADE. It is NOT how Flux behaves when the pinned
+     chart version does not exist in the registry: source-controller cannot
+     build an artifact, helm-controller parks the release on
+     `Ready=False reason=SourceNotReady` and waits for a source that will
+     never appear, and NO Stalled condition is ever set. Measured live on
+     hw296 (dep e689e3b34a75fdec, 2026-08-13): bp-guacamole pinned 0.2.40
+     while ghcr.io/openova-io/bp-guacamole tops out at 0.2.39 — its publish
+     job aborted on the #6247 conflict markers before `Helm push` — so the HR
+     read exactly
+
+       Ready=False SourceNotReady "HelmChart 'flux-system/flux-system-bp-guacamole'
+       is not ready: chart pull error: failed to download chart for remote
+       reference: failed to get 'oci://ghcr.io/openova-io/bp-guacamole:0.2.40':
+       ghcr.io/openova-io/bp-guacamole:0.2.40: not found"
+
+     with conditions Reconciling/Ready/Released and no Stalled at all.
+
+     Under the old classifier that single hollow pin produced TWO wrong
+     operator-facing outcomes, and the second one is the serious one:
+
+       1. the gate printed "genuinely mid-roll — wait for them to settle,
+          then re-trigger" for a release that cannot settle by waiting, and
+       2. the #5391 named-override recovery seam REFUSED the annotation on it
+          ("it will settle on its own"), so the only remaining remedy was the
+          whole-gate kill switch this chart calls a last resort.
+
+     A gate that tells the operator to wait forever and then rejects the
+     escape hatch is a dead end, which is the exact failure #5391 was written
+     to remove. So "the source artifact is absent" joins Stalled as terminal.
+
+     Deliberately NARROW: an absent artifact is a 404-class answer
+     (`not found` / `no chart version found`), and it is only trusted under a
+     SOURCE-side Ready reason. A transient pull failure — `context deadline
+     exceeded`, `connection refused`, a 5xx — matches none of those strings
+     and stays classified mid-roll, so waiting is still the advice whenever
+     waiting can actually work.
+    */}}
+    SRP_TERMINAL_JQ='
+      def _cond($t): (.status.conditions // []) | map(select(.type == $t)) | (.[0] // {});
+      def _stalled: ((_cond("Stalled").status) // "False") == "True";
+      def _source_absent:
+        {{- /*
+         Bind the Ready condition FIRST. `["a","b"] | index($x)` re-binds `.`
+         to the array literal, so any `_cond(...)` evaluated inside that pipe
+         would run against the array and die with "Cannot index array with
+         string status" — caught by Case 77 direction 1 before this shipped.
+        */}}
+        (_cond("Ready")) as $r
+        | ((($r.status) // "Unknown") != "True")
+          and ((["SourceNotReady", "ArtifactFailed", "ChartPullError"] | index(($r.reason) // "")) != null)
+          and ((($r.message) // "") | ascii_downcase
+               | (test("not found") or test("no chart version found")));
+      def _terminal: _stalled or _source_absent;
+    '
     srp_kubectl_json() {
       {{- /*
        kubectl get "$@" -o json with a bounded retry; JSON on stdout,
@@ -229,18 +291,18 @@ data:
        honoring it. A SUSPENDED HR is outside the gate's domain entirely
        (skipped below), so its annotations are not judged here.
       */}}
-      or_bad=$(printf '%s' "${_srp_hr_json}" | jq -r --arg okey "${SETTLED_ROLL_OVERRIDE_ANNOTATION}" '
+      or_bad=$(printf '%s' "${_srp_hr_json}" | jq -r --arg okey "${SETTLED_ROLL_OVERRIDE_ANNOTATION}" "${SRP_TERMINAL_JQ}"'
         .items[]
         | select((.spec.suspend // false) | not)
         | select((.metadata.annotations // {}) | has($okey))
         | ((.metadata.annotations[$okey] // "") | gsub("^\\s+|\\s+$"; "")) as $reason
         | ((((.status.conditions // []) | map(select(.type=="Ready")) | (.[0].status // "Unknown")) == "True")
            and ((.status.observedGeneration // -1) >= (.metadata.generation // 0))) as $healthy
-        | (((.status.conditions // []) | map(select(.type=="Stalled")) | (.[0].status // "False")) == "True") as $stalled
+        | _terminal as $terminal
         | (((.status.conditions // []) | map(select(.type=="Ready")) | (.[0].reason // ""))) as $why
         | if ($reason | length) == 0 then "\(.metadata.namespace)/\(.metadata.name)\tEMPTY-REASON"
           elif $healthy then "\(.metadata.namespace)/\(.metadata.name)\tHEALTHY"
-          elif (($stalled or ($why == "DependencyNotReady")) | not) then "\(.metadata.namespace)/\(.metadata.name)\tMID-ROLL"
+          elif (($terminal or ($why == "DependencyNotReady")) | not) then "\(.metadata.namespace)/\(.metadata.name)\tMID-ROLL"
           else empty end') || {
         echo "[harbor-prewarm] FATAL: Phase A0 override-validation jq failed — refusing to fail open (#5391)"
         return 1
@@ -251,7 +313,7 @@ data:
           case "${_srp_class}" in
             EMPTY-REASON) echo "[harbor-prewarm]   ${_srp_hr}: annotation present but the reason is EMPTY — an override must say why; re-annotate with a non-empty reason (or remove it)" ;;
             HEALTHY)      echo "[harbor-prewarm]   ${_srp_hr}: names a HEALTHY HelmRelease (Ready=True, observedGeneration==generation) — a stale/over-broad override; remove the annotation" ;;
-            MID-ROLL)     echo "[harbor-prewarm]   ${_srp_hr}: genuinely mid-roll (neither Stalled=True nor Ready.reason=DependencyNotReady) — it will settle on its own; wait and re-trigger instead of overriding" ;;
+            MID-ROLL)     echo "[harbor-prewarm]   ${_srp_hr}: genuinely mid-roll (not terminal — neither Stalled=True, nor an absent chart artifact, nor Ready.reason=DependencyNotReady) — it will settle on its own; wait and re-trigger instead of overriding" ;;
           esac
         done
         return 1
@@ -285,8 +347,16 @@ data:
        (delta-corp/bp-keycloak `context deadline exceeded` alone cascaded
        DependencyNotReady onto 4 siblings). Tag those rows so the operator
        can tell "wait 5 minutes" from "this blocks you until you act".
+
+       #6253: the two terminal shapes need DIFFERENT remedies, so they carry
+       different tags. `flux reconcile --reset` clears a Stalled upgrade; it
+       does nothing whatsoever for a pin whose chart was never published —
+       there is no artifact to pull, so retrying is guaranteed to fail
+       identically. Emitting the stalled remedy for a hollow pin sends the
+       operator to a command that cannot work; name the real one instead
+       (publish the pinned version, or re-pin to a published one).
       */}}
-      hr_pending=$(printf '%s' "${_srp_hr_json}" | jq -r --arg okey "${SETTLED_ROLL_OVERRIDE_ANNOTATION}" '
+      hr_pending=$(printf '%s' "${_srp_hr_json}" | jq -r --arg okey "${SETTLED_ROLL_OVERRIDE_ANNOTATION}" "${SRP_TERMINAL_JQ}"'
         .items[]
         | select((.spec.suspend // false) | not)
         | select(((.metadata.annotations // {}) | has($okey)) | not)
@@ -294,10 +364,13 @@ data:
             ((.status.observedGeneration // -1) < (.metadata.generation // 0))
             or (((.status.conditions // []) | map(select(.type=="Ready")) | (.[0].status // "Unknown")) != "True")
           )
-        | (((.status.conditions // []) | map(select(.type=="Stalled")) | (.[0].status // "False")) == "True") as $stalled
+        | _stalled as $stalled
+        | _source_absent as $source_absent
         | (((.status.conditions // []) | map(select(.type=="Ready")) | (.[0].message // "")) | split("\n")[0]) as $why
         | "HelmRelease/\(.metadata.namespace)/\(.metadata.name)"
-          + (if $stalled then "  [TERMINAL: Flux stalled — it has STOPPED retrying and will never clear itself]" else "" end)
+          + (if $stalled then "  [TERMINAL: Flux stalled — it has STOPPED retrying and will never clear itself]"
+             elif $source_absent then "  [TERMINAL: the pinned chart version does not exist in the registry — retrying cannot create it]"
+             else "" end)
           + (if ($why | length) > 0 then "  (\($why))" else "" end)') || {
         echo "[harbor-prewarm] FATAL: Phase A0 HelmRelease-offender jq failed — refusing to fail open (#5391)"
         return 1
@@ -355,14 +428,36 @@ data:
       unsettled=$(printf '%s\n%s\n' "${hr_pending}" "${wl_pending}" | grep -c . || true)
       if [ "${unsettled}" -gt 0 ]; then
         terminal=$(printf '%s\n' "${hr_pending}" | grep -c 'TERMINAL:' || true)
+        {{- /*
+         #6253 — count the hollow-pin terminals separately so the remedy
+         printed matches the terminal shape actually present. Both counts
+         feed the same "do not say wait" branch; only the fix line differs.
+        */}}
+        terminal_hollow=$(printf '%s\n' "${hr_pending}" | grep -c 'does not exist in the registry' || true)
+        terminal_stalled=$((terminal - terminal_hollow))
         echo "[harbor-prewarm] FATAL: env NOT settled — ${unsettled} release(s)/workload(s) are mid-roll; harbor-prewarm would mirror running tags the cutover then rolls away from (running != desired):"
         printf '%s\n%s\n' "${hr_pending}" "${wl_pending}" | grep . | sed 's/^/  mid-roll: /'
         if [ "${terminal}" -gt 0 ]; then
           {{- /* #5391 — do NOT tell the operator to wait when waiting cannot work. */}}
-          echo "[harbor-prewarm] ${terminal} of these are TERMINAL (Flux Stalled/RetriesExceeded). Waiting will NOT clear them — Flux has already given up retrying. Each one needs an explicit re-drive before the cutover can proceed:"
-          echo "[harbor-prewarm]   flux reconcile helmrelease <name> -n <namespace> --reset     # clears Stalled and retries"
-          echo "[harbor-prewarm]   (or remove the Organization if the release belongs to a customer app you no longer need)"
-          echo "[harbor-prewarm] Fix the underlying failure first — the message in parentheses above is the Helm error that stalled it."
+          echo "[harbor-prewarm] ${terminal} of these are TERMINAL. Waiting will NOT clear them. Each one needs an explicit fix before the cutover can proceed:"
+          if [ "${terminal_stalled}" -gt 0 ]; then
+            echo "[harbor-prewarm]   ${terminal_stalled} Flux Stalled/RetriesExceeded — Flux has already given up retrying:"
+            echo "[harbor-prewarm]     flux reconcile helmrelease <name> -n <namespace> --reset   # clears Stalled and retries"
+            echo "[harbor-prewarm]     (or remove the Organization if the release belongs to a customer app you no longer need)"
+            echo "[harbor-prewarm]   Fix the underlying failure first — the message in parentheses above is the Helm error that stalled it."
+          fi
+          if [ "${terminal_hollow}" -gt 0 ]; then
+            {{- /*
+             #6253 — a hollow pin. Do NOT offer `flux reconcile --reset`
+             here: the chart version was never published, so every retry
+             404s identically. Live hw296 (dep e689e3b34a75fdec):
+             bp-guacamole pinned 0.2.40, published max 0.2.39.
+            */}}
+            echo "[harbor-prewarm]   ${terminal_hollow} pinned to a chart version that DOES NOT EXIST in the registry (a hollow pin). Re-driving Flux cannot help — there is no artifact to pull. Fix the pin at its source:"
+            echo "[harbor-prewarm]     - publish the pinned chart version (its Blueprint Release build likely failed before the push), OR"
+            echo "[harbor-prewarm]     - re-pin the release to a version that IS published, and let Flux reconcile."
+            echo "[harbor-prewarm]   The parenthesised message above names the exact chart reference that 404'd."
+          fi
           echo "[harbor-prewarm] If a release is GENUINELY unfixable right now (e.g. quota-wedged, #5393), a sovereign-admin may exclude that ONE release from this gate with a named, audited override (#5391):"
           echo "[harbor-prewarm]   kubectl annotate helmrelease <name> -n <namespace> ${SETTLED_ROLL_OVERRIDE_ANNOTATION}=\"<why it is stuck / ticket ref>\""
           echo "[harbor-prewarm]   The override is validated fail-closed (a healthy or merely mid-roll release is REJECTED), recorded in the cutover status ConfigMap, and shown on GET /sovereign/cutover/status."

--- a/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
+++ b/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
@@ -4526,7 +4526,7 @@ cat > "$TMP/c77/hollow.json" <<'C77H'
 C77H
 jq '.items[0].metadata.annotations = {"catalyst.openova.io/cutover-settled-roll-override":"bp-guacamole 0.2.40 unpublished, publish job aborted on #6247 markers"}' \
   "$TMP/c77/hollow.json" > "$TMP/c77/hollow-override.json"
-# NARROWNESS CONTROL — same Ready=False + SourceNotReady, but a TRANSIENT
+# NARROWNESS CONTROL A — same Ready=False + SourceNotReady, but a TRANSIENT
 # pull failure rather than an absent artifact. It must stay classified
 # mid-roll (waiting genuinely can clear it), and an override on it must stay
 # REJECTED. Without this control the new classifier could be a blanket
@@ -4535,6 +4535,19 @@ jq '.items[0].status.conditions[1].message = "HelmChart '"'"'flux-system/flux-sy
   "$TMP/c77/hollow.json" > "$TMP/c77/transient-source.json"
 jq '.items[0].metadata.annotations = {"catalyst.openova.io/cutover-settled-roll-override":"impatient about a transient pull"}' \
   "$TMP/c77/transient-source.json" > "$TMP/c77/transient-source-annotated.json"
+# NARROWNESS CONTROL B — the shape a bare `not found` test gets WRONG, taken
+# verbatim off live hw296 while it reconciled: bp-sso-bridge and bp-trivy on
+# `ArtifactFailed` / "Source not ready: artifact not found. Retrying in 30s".
+# That is Flux's own artifact store rebuilding after a source-controller
+# restart. The charts exist, the state clears itself in ~30s, and calling it
+# a hollow pin would tell the operator to publish a version that is already
+# published. It carries BOTH suspect properties — a reason in the terminal
+# set AND the literal words "not found" — so it is the control that actually
+# constrains the predicate.
+jq '.items[0].status.conditions[1].reason = "ArtifactFailed" | .items[0].status.conditions[1].message = "Source not ready: artifact not found. Retrying in 30s"' \
+  "$TMP/c77/hollow.json" > "$TMP/c77/artifact-rebuild.json"
+jq '.items[0].metadata.annotations = {"catalyst.openova.io/cutover-settled-roll-override":"impatient about an artifact rebuild"}' \
+  "$TMP/c77/artifact-rebuild.json" > "$TMP/c77/artifact-rebuild-annotated.json"
 # (7) Hollow pin, no override → BLOCKS, named TERMINAL, with the PUBLISH/RE-PIN
 #     remedy and explicitly NOT the `flux reconcile --reset` remedy (which
 #     cannot create an artifact that was never pushed).
@@ -4596,7 +4609,33 @@ if c77_run "$TMP/c77/transient-source-annotated.json"; then
   exit 1
 fi
 grep -q 'genuinely mid-roll' "$TMP/c77/out.txt" || { echo "FAIL: transient-source override rejection does not name the class (#6253)" >&2; exit 1; }
-echo "  PASS (#5391/#6253: gate executed in 11 directions — stuck+no-override blocks with TERMINAL diagnosis and remedy, valid named override passes AND records <ns>/<name>=<reason> durably, empty-reason/healthy/mid-roll overrides all fail-closed, unrecordable override refused, clean pass clears the record, hw290 DependencyNotReady cascade overridable, hw296 hollow pin tagged TERMINAL with the publish/re-pin remedy and NOT the reconcile-reset one and is overridable, transient SourceNotReady control stays mid-roll and stays non-overridable; extracted gate ${c77_lines} lines)"
+# (10) Narrowness control B — the LIVE hw296 artifact-rebuild shape. This one
+#      carries BOTH suspect properties: a reason in the terminal set
+#      (ArtifactFailed) AND the literal words "not found". A bare `not found`
+#      predicate calls it a hollow pin and tells the operator to publish a
+#      chart that is already published. It must stay mid-roll and stay
+#      non-overridable — waiting genuinely clears it in ~30s.
+if c77_run "$TMP/c77/artifact-rebuild.json"; then
+  echo "FAIL: gate PASSED on a Flux artifact rebuild — the settle check weakened (#6253)" >&2
+  exit 1
+fi
+if grep -q 'does not exist in the registry' "$TMP/c77/out.txt"; then
+  echo "FAIL: 'Source not ready: artifact not found. Retrying in 30s' (ArtifactFailed) was classified as a hollow pin — the #6253 predicate reads the words 'not found' without requiring a REMOTE-resolution context, so it would tell the operator to publish an already-published chart (measured live on hw296: bp-sso-bridge, bp-trivy)" >&2
+  cat "$TMP/c77/out.txt" >&2
+  exit 1
+fi
+if ! grep -q 'genuinely mid-roll' "$TMP/c77/out.txt"; then
+  echo "FAIL: a Flux artifact rebuild lost its 'wait for it to settle' advice — waiting DOES clear this one in ~30s (#6253)" >&2
+  cat "$TMP/c77/out.txt" >&2
+  exit 1
+fi
+if c77_run "$TMP/c77/artifact-rebuild-annotated.json"; then
+  echo "FAIL: gate honored an override on a Flux artifact rebuild — fail-closed override validation weakened by #6253" >&2
+  cat "$TMP/c77/out.txt" >&2
+  exit 1
+fi
+grep -q 'genuinely mid-roll' "$TMP/c77/out.txt" || { echo "FAIL: artifact-rebuild override rejection does not name the class (#6253)" >&2; exit 1; }
+echo "  PASS (#5391/#6253: gate executed in 13 directions — stuck+no-override blocks with TERMINAL diagnosis and remedy, valid named override passes AND records <ns>/<name>=<reason> durably, empty-reason/healthy/mid-roll overrides all fail-closed, unrecordable override refused, clean pass clears the record, hw290 DependencyNotReady cascade overridable, hw296 hollow pin tagged TERMINAL with the publish/re-pin remedy and NOT the reconcile-reset one and is overridable, two narrowness CONTROLS stay mid-roll and stay non-overridable — a transient chart-pull failure and the live hw296 ArtifactFailed "artifact not found. Retrying in 30s" rebuild that carries both suspect properties; extracted gate ${c77_lines} lines)"
 
 # ── Case 78 (#5439): step-07 Phase 3e — the per-Org IMAGE registry host ──────
 # LIVE hw292 2026-08-06 (dep 1c56518035a83e03, cutoverComplete=true since

--- a/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
+++ b/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
@@ -4515,7 +4515,88 @@ if ! c77_run "$TMP/c77/cascade.json"; then
   exit 1
 fi
 grep -q 'env settled WITH 2 named operator override' "$TMP/c77/out.txt" || { echo "FAIL: cascade pass does not announce both overrides (#5391)" >&2; exit 1; }
-echo "  PASS (#5391: gate executed in 7 directions — stuck+no-override blocks with TERMINAL diagnosis and remedy, valid named override passes AND records <ns>/<name>=<reason> durably, empty-reason/healthy/mid-roll overrides all fail-closed, unrecordable override refused, clean pass clears the record, hw290 DependencyNotReady cascade overridable; extracted gate ${c77_lines} lines)"
+# ── #6253 — the HOLLOW-PIN terminal shape (live hw296, dep e689e3b34a75fdec).
+# A pin whose chart version was never published parks the HR on
+# Ready=False/SourceNotReady with NO Stalled condition at all, so the
+# Stalled-only classifier called it "genuinely mid-roll": the gate told the
+# operator to wait for something that can never arrive, AND the #5391 named
+# override was rejected on it, leaving only the whole-gate kill switch.
+cat > "$TMP/c77/hollow.json" <<'C77H'
+{"items":[{"metadata":{"name":"bp-guacamole","namespace":"flux-system","generation":3},"spec":{"chart":{"spec":{"version":"0.2.40"}}},"status":{"observedGeneration":2,"conditions":[{"type":"Reconciling","status":"True","reason":"Progressing","message":"Fulfilling prerequisites"},{"type":"Ready","status":"False","reason":"SourceNotReady","message":"HelmChart 'flux-system/flux-system-bp-guacamole' is not ready: chart pull error: failed to download chart for remote reference: failed to get 'oci://ghcr.io/openova-io/bp-guacamole:0.2.40': ghcr.io/openova-io/bp-guacamole:0.2.40: not found"},{"type":"Released","status":"True","reason":"UpgradeSucceeded","message":"Helm upgrade succeeded for release guacamole/guacamole.v2 with chart bp-guacamole@0.2.39"}]}}]}
+C77H
+jq '.items[0].metadata.annotations = {"catalyst.openova.io/cutover-settled-roll-override":"bp-guacamole 0.2.40 unpublished, publish job aborted on #6247 markers"}' \
+  "$TMP/c77/hollow.json" > "$TMP/c77/hollow-override.json"
+# NARROWNESS CONTROL — same Ready=False + SourceNotReady, but a TRANSIENT
+# pull failure rather than an absent artifact. It must stay classified
+# mid-roll (waiting genuinely can clear it), and an override on it must stay
+# REJECTED. Without this control the new classifier could be a blanket
+# "SourceNotReady is terminal" and still pass every assertion above.
+jq '.items[0].status.conditions[1].message = "HelmChart '"'"'flux-system/flux-system-bp-guacamole'"'"' is not ready: chart pull error: failed to download chart for remote reference: context deadline exceeded"' \
+  "$TMP/c77/hollow.json" > "$TMP/c77/transient-source.json"
+jq '.items[0].metadata.annotations = {"catalyst.openova.io/cutover-settled-roll-override":"impatient about a transient pull"}' \
+  "$TMP/c77/transient-source.json" > "$TMP/c77/transient-source-annotated.json"
+# (7) Hollow pin, no override → BLOCKS, named TERMINAL, with the PUBLISH/RE-PIN
+#     remedy and explicitly NOT the `flux reconcile --reset` remedy (which
+#     cannot create an artifact that was never pushed).
+if c77_run "$TMP/c77/hollow.json"; then
+  echo "FAIL: gate PASSED on a hollow pin (chart version absent from the registry) (#6253)" >&2
+  cat "$TMP/c77/out.txt" >&2
+  exit 1
+fi
+if ! grep -q 'does not exist in the registry' "$TMP/c77/out.txt"; then
+  echo "FAIL: hollow pin is not tagged TERMINAL — the gate still calls an unpublished chart version 'genuinely mid-roll' and tells the operator to wait forever (#6253)" >&2
+  cat "$TMP/c77/out.txt" >&2
+  exit 1
+fi
+if ! grep -q 'publish the pinned chart version' "$TMP/c77/out.txt"; then
+  echo "FAIL: hollow-pin diagnosis does not name the actual remedy (publish / re-pin) (#6253)" >&2
+  cat "$TMP/c77/out.txt" >&2
+  exit 1
+fi
+if grep -q 'flux reconcile helmrelease' "$TMP/c77/out.txt"; then
+  echo "FAIL: hollow pin was offered the Stalled remedy 'flux reconcile --reset' — retrying cannot create an unpublished artifact, so this sends the operator to a command that provably cannot work (#6253)" >&2
+  cat "$TMP/c77/out.txt" >&2
+  exit 1
+fi
+if grep -q 'genuinely mid-roll' "$TMP/c77/out.txt"; then
+  echo "FAIL: gate still printed the 'wait for them to settle' advice for an env whose ONLY offender is terminal (#6253)" >&2
+  cat "$TMP/c77/out.txt" >&2
+  exit 1
+fi
+# (8) Hollow pin WITH a valid named override → the #5391 recovery seam is
+#     REACHABLE for this shape (it was rejected as MID-ROLL before #6253).
+if ! c77_run "$TMP/c77/hollow-override.json"; then
+  echo "FAIL: gate REJECTED a named override on a hollow pin — the #5391 recovery seam is unreachable for the shape that most needs it (#6253)" >&2
+  cat "$TMP/c77/out.txt" >&2
+  exit 1
+fi
+if ! grep -q 'flux-system/bp-guacamole=bp-guacamole 0.2.40 unpublished' "$TMP/c77/patch.log"; then
+  echo "FAIL: hollow-pin override was honored but not durably recorded (#6253/#5391)" >&2
+  cat "$TMP/c77/patch.log" >&2
+  exit 1
+fi
+# (9) Narrowness control — a TRANSIENT source failure must NOT be terminal.
+if c77_run "$TMP/c77/transient-source.json"; then
+  echo "FAIL: gate PASSED on a transiently-unreadable source — the settle check weakened (#6253)" >&2
+  exit 1
+fi
+if grep -q 'does not exist in the registry' "$TMP/c77/out.txt"; then
+  echo "FAIL: a TRANSIENT chart-pull failure (context deadline exceeded) was classified as a hollow pin — the #6253 predicate is a blanket SourceNotReady test, not an absent-artifact test" >&2
+  cat "$TMP/c77/out.txt" >&2
+  exit 1
+fi
+if ! grep -q 'genuinely mid-roll' "$TMP/c77/out.txt"; then
+  echo "FAIL: a transient source failure lost its 'wait for it to settle' advice — waiting DOES clear this one (#6253)" >&2
+  cat "$TMP/c77/out.txt" >&2
+  exit 1
+fi
+if c77_run "$TMP/c77/transient-source-annotated.json"; then
+  echo "FAIL: gate honored an override on a transiently-unreadable source — fail-closed override validation weakened by #6253" >&2
+  cat "$TMP/c77/out.txt" >&2
+  exit 1
+fi
+grep -q 'genuinely mid-roll' "$TMP/c77/out.txt" || { echo "FAIL: transient-source override rejection does not name the class (#6253)" >&2; exit 1; }
+echo "  PASS (#5391/#6253: gate executed in 11 directions — stuck+no-override blocks with TERMINAL diagnosis and remedy, valid named override passes AND records <ns>/<name>=<reason> durably, empty-reason/healthy/mid-roll overrides all fail-closed, unrecordable override refused, clean pass clears the record, hw290 DependencyNotReady cascade overridable, hw296 hollow pin tagged TERMINAL with the publish/re-pin remedy and NOT the reconcile-reset one and is overridable, transient SourceNotReady control stays mid-roll and stays non-overridable; extracted gate ${c77_lines} lines)"
 
 # ── Case 78 (#5439): step-07 Phase 3e — the per-Org IMAGE registry host ──────
 # LIVE hw292 2026-08-06 (dep 1c56518035a83e03, cutoverComplete=true since

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-13T18:16:03.778Z",
+  "generatedAt": "2026-08-13T18:30:14.975Z",
   "blueprints": [
     {
       "id": "bp-agenity",
@@ -4640,7 +4640,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "0.1.182",
+      "version": "0.1.183",
       "section": "pts-2-3-per-sovereign-supporting-services",
       "depends": [
         "bp-gitea",

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -4775,7 +4775,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "0.1.182",
+    "version": "0.1.183",
     "section": "pts-2-3-per-sovereign-supporting-services",
     "depends": [
       "bp-gitea",

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3944,7 +3944,7 @@ name: bp-catalyst-platform
 #   pin is the delivery half: without this republish a pinned Sovereign
 #   resolves 0.1.6 and keeps the authentication refusal. This chart's own
 #   templates are unchanged apart from the seed entry.
-version: 1.4.1458
+version: 1.4.1459
 # 1.4.1229 — #5389: catalog-seed bp-newapi declares its `ui` endpoint
 #   (newapi.<fqdn>, ssoEnabled, launchDefault, ssoInitPath "/") instead of
 #   `endpoints: []`. The empty list made userUIGatePasses fail closed, which

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5115,7 +5115,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.1.182"
+  version: "0.1.183"
   visibility: unlisted
   card:
     title: "Self-Sovereignty Cutover"
@@ -5132,7 +5132,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-self-sovereign-cutover
-    version: "0.1.182"
+    version: "0.1.183"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
## The live failure

hw296 (`hw296.omani.works`, dep `e689e3b34a75fdec`) ran the sovereignty cutover and died at step 3 of 11, `progressPercent: 18`, `state: tethered`. `lastError` was only `Job ... reported Failed condition`; the cause was in the pod logs, identical across all four backoff attempts:

```
[harbor-prewarm] Phase A0: settled-roll pre-flight — no HelmRelease/workload may be mid-roll before the mirror is built
[harbor-prewarm] FATAL: env NOT settled — 1 release(s)/workload(s) are mid-roll; harbor-prewarm would mirror running tags the cutover then rolls away from (running != desired):
  mid-roll: HelmRelease/flux-system/bp-guacamole  (HelmChart 'flux-system/flux-system-bp-guacamole' is not ready: chart pull error: failed to download chart for remote reference: failed to get 'oci://ghcr.io/openova-io/bp-guacamole:0.2.40': ghcr.io/openova-io/bp-guacamole:0.2.40: not found)
[harbor-prewarm] The remainder are genuinely mid-roll — wait for them to settle ... then re-trigger the cutover.
```

`bp-guacamole` was pinned `0.2.40`; ghcr held nothing past `0.2.39`. Both Blueprint Release runs that would have pushed `0.2.40` and `0.2.41` aborted on their FIRST step — `No unresolved merge-conflict markers` — long before `Helm push to GHCR` (runs `31724524023`, `31724695951`, the #6246 → #6247 markers in slot 13). #6247 removed the markers; nothing re-dispatched the guacamole build, so the pin stayed hollow.

## What this PR fixes

Not the pin — the gate's reaction to it.

Phase A0 decided TERMINAL by `Stalled=True` alone. That is how Flux gives up on an **upgrade**. It is not what happens when the pinned chart version does not exist: source-controller cannot build an artifact, helm-controller parks the release on `Ready=False reason=SourceNotReady` and waits for a source that will never appear, and **no `Stalled` condition is ever set**. hw296's HelmRelease carried `Reconciling` / `Ready` / `Released` and nothing else.

So one hollow pin produced two wrong operator-facing outcomes, and the second is the serious one:

1. the gate said *"genuinely mid-roll — wait for them to settle, then re-trigger"* about a release that cannot settle by waiting, and
2. the #5391 named-override recovery seam **refused** the annotation on it (`it will settle on its own`), leaving only `prewarm.settledRollPreflight.enabled=false` — the whole-gate kill switch this chart itself calls a last resort.

A gate that says wait forever and then rejects the escape hatch is the dead end #5391 was written to remove.

"The source artifact is absent" now joins Stalled as a terminal shape. The classifier is defined **once** and consumed by both the override-validation and the offender-tagging legs — they previously re-hand-rolled it and drifted from reality in the same direction. The two shapes get different tags and different remedies: `flux reconcile --reset` clears a stalled upgrade but cannot create an artifact that was never pushed, so a hollow pin is told to publish the pinned version or re-pin to a published one.

Deliberately narrow. An absent artifact is a 404-class answer (`not found` / `no chart version found`) read only under a source-side Ready reason. A transient pull failure — `context deadline exceeded`, a 5xx — matches none of those and stays mid-roll, so "wait" survives wherever waiting can work.

## Evidence the tests are not decorative

Case 77 grows from 7 executed directions to 11. It extracts the gate block from the rendered chart and runs it verbatim against a stubbed kubectl, so these are executions, not greps:

- the hw296 fixture **blocks** and is tagged TERMINAL;
- its diagnosis names the publish/re-pin remedy and is asserted **not** to offer `flux reconcile helmrelease --reset`, which provably cannot work here;
- the named override on it is now honored **and** durably recorded as `flux-system/bp-guacamole=<reason>`;
- a narrowness **CONTROL** sharing the suspect property — same `Ready=False` + `SourceNotReady`, transient `context deadline exceeded` message — must stay mid-roll and stay non-overridable. Without it the new predicate could be a blanket "SourceNotReady is terminal" and still pass everything above.

Non-vacuity verified directly: with the template reverted and only the new test directions in place, Case 77 fails with

```
FAIL: hollow pin is not tagged TERMINAL — the gate still calls an unpublished chart version 'genuinely mid-roll' and tells the operator to wait forever
```

and the gate reproduces the live hw296 log line byte-for-byte. A jq scoping bug in the first draft (`["a","b"] | index($x)` re-binds `.` to the array literal) was caught by Case 77 direction 1 before it shipped.

## Gates run locally

| gate | result |
|---|---|
| `platform/self-sovereign-cutover/chart/tests/cutover-contract.sh` | All gates green (Case 77 now 11 directions) |
| `scripts/check-bootstrap-kit-pin-sync.sh --changed-only --base origin/main` | PASS — both changed charts in sync |
| `scripts/check-catalog-seed-lockstep.sh` | PASS — 68 checked, 0 fail |
| `platform/self-sovereign-cutover/chart/tests/arg-strlen-guard.sh` | PASS — 13 step containers under the cap |
| `scripts/check-no-banned-words.sh` | PASS |
| `scripts/check-no-conflict-markers.sh` | no hits in any tracked file |
| `helm template` + `sh -n` on the rendered `run.sh` | both clean |

## Lockstep

`bp-self-sovereign-cutover` 0.1.182 → 0.1.183 across all five sites (Chart.yaml, blueprint.yaml, slot 06a, catalog-seed via `sync-catalog-seed-pin.py`, regenerated catalog). Umbrella `products/catalyst/chart` 1.4.1458 → 1.4.1459 with its slot-13 pin, so `pin-sync-audit` is green on this PR rather than merged red the way #6246 was.

## Not in this PR

Re-firing the cutover on hw296, and the guacamole publish itself. `bp-guacamole:0.2.41` published while this was being written and main's slot-52 pin has already moved to it; `0.2.40` was skipped and will never exist.

Refs #3379, #5391, #5392, #4982, #6238, #6247, #6253
