### PR TITLE
fix(catalyst): four unowned UAT rows — G7 plan door, row 60 topology override, row 222 Org estate, row 234 funnel pin

### DIFF
--- a/core/controllers/application/internal/controller/application_controller.go
+++ b/core/controllers/application/internal/controller/application_controller.go
@@ -869,7 +869,15 @@ func (r *Reconciler) Reconcile(ctx context.Context, app *unstructured.Unstructur
 	// written against `Mode`/`BcpTopology` (§8d).
 	fanoutFromTargets := len(spec.PlacementTargets) > 0
 	if bpTopo != nil || fanoutFromTargets {
-		appTopo := spec.Topology
+		// UAT row 60 (Refs #3375) — the operator's chosen posture lives in
+		// `spec.placement(.mode)`, NOT `spec.topology`. The latter is an
+		// OBJECT in the CRD, so parseSpec's NestedString read of it can only
+		// ever be "" and ResolveTopology's operator-override branch was
+		// unreachable from here: every Application resolved the Blueprint's
+		// region-count default, which is how an explicitly hot-standby app
+		// reached buildContinuumPlan as `singleton` and never armed a
+		// Switchover. See topology_override.go for the full derivation.
+		appTopo := topologyOverrideFromPlacement(spec.Placement, bpTopo)
 		sovRegions := len(envSpec.Regions)
 		var (
 			choice  bpv1alpha1.BcpTopology
@@ -3317,16 +3325,6 @@ type appSpec struct {
 	Regions          []string
 	Parameters       map[string]interface{}
 
-	// Topology — G117.6 (Refs #2745). When non-empty, the operator
-	// has explicitly chosen a BCP topology (one of "active-active",
-	// "active-hot-standby", "active-passive", "singleton"). The
-	// reconciler validates that the choice is in
-	// Blueprint.spec.topology.supported[]; on mismatch the
-	// Application moves to Ready=False, reason=InvalidTopology.
-	// When empty, the reconciler picks the Blueprint's default
-	// keyed on Sovereign-region-count (locked decision #7).
-	Topology string
-
 	// ── #3373 instance-level placement (object form of
 	// `spec.placement`) ──────────────────────────────────────────
 	//
@@ -3509,10 +3507,15 @@ func parseSpec(app *unstructured.Unstructured) (appSpec, error) {
 	params, _, _ := unstructured.NestedMap(app.Object, "spec", "parameters")
 	out.Parameters = params
 
-	// G117.6 (Refs #2745) — optional Application.spec.topology operator
-	// override. Empty string is the default-derived path.
-	tp, _, _ := unstructured.NestedString(app.Object, "spec", "topology")
-	out.Topology = tp
+	// UAT row 60 (Refs #3375) — the G117.6 `spec.topology` STRING read that
+	// used to live here is gone, and no `Topology` field replaces it. The CRD
+	// types `spec.topology` as an OBJECT (application.yaml:221 — autoFailover /
+	// rto / rpo / minReplicas), so NestedString could only ever return "" and
+	// the apiserver rejects a string there regardless. The field it fed was
+	// therefore a permanently-empty "operator override" that silently disabled
+	// ResolveTopology's override branch. The operator's posture is read from
+	// `spec.placement(.mode)` above (out.Placement) and reaches the fan-out via
+	// topologyOverrideFromPlacement.
 
 	// #3370 — optional spec.dependsOn[] backing-service wiring.
 	depsRaw, _, _ := unstructured.NestedSlice(app.Object, "spec", "dependsOn")

--- a/core/controllers/application/internal/controller/topology_override.go
+++ b/core/controllers/application/internal/controller/topology_override.go
@@ -1,0 +1,88 @@
+package controller
+
+import (
+	"strings"
+
+	"github.com/openova-io/openova/core/controllers/internal/placement"
+	bpv1alpha1 "github.com/openova-io/openova/core/controllers/pkg/apis/blueprint/v1alpha1"
+)
+
+// topologyOverrideFromPlacement answers ONE question for the legacy
+// (no-`targets[]`) fan-out branch of Reconcile: which BCP posture did the
+// OPERATOR actually choose for this Application?
+//
+// # The defect this replaces (UAT row 60, Refs #3375)
+//
+// That branch used to read `spec.Topology`, parsed by parseSpec as
+//
+//	unstructured.NestedString(app.Object, "spec", "topology")
+//
+// but `spec.topology` is declared in the Application CRD as an OBJECT —
+// `products/catalyst/chart/crds/application.yaml:221` opens
+// `topology: {type: object}` carrying autoFailover / rto / rpo /
+// minReplicas. A string read of an object field returns "" (NestedString
+// reports a type error the call site discarded), and the apiserver would
+// reject a string there anyway. So `spec.Topology` was not merely unset in
+// practice — it was STRUCTURALLY incapable of being non-empty, which made
+// ResolveTopology's "operator override wins" branch
+// (internal/render/topology.go:137) dead code on this path. Every
+// Application resolved the Blueprint's region-count default instead
+// (topology.go:150-153).
+//
+// The operator's choice does exist on the CR: since #3373 `spec.placement`
+// is dual-form and its `mode` lands in `spec.Placement` (parseSpec
+// application_controller.go:3426). The create-instance door writes exactly
+// that — `newApplicationCRFromSeed` stamps
+// `spec.placement.mode = canonicalizeTopology(seed.Topology)`
+// (endpoint_handler.go:2339) and never writes `spec.topology`. The
+// bootstrap-adoption producer already resolves off the right field
+// (`reconcileBootstrapContinuum`, application_controller.go:3161); this
+// helper closes the divergence for the main path.
+//
+// # Why row 60 turned red on it
+//
+// `placement.Resolve(spec.Placement, spec.Regions)` — the per-region
+// primary/standby roles the Topology tab paints — always read the operator's
+// posture, while the (choice, variant) pair feeding the per-app Continuum
+// producer (`buildContinuumPlan`, continuum.go:141) read the Blueprint
+// default. When those two disagree the Application renders a 2-region pair
+// whose Switchover is never armed: buildContinuumPlan's first gate is
+// `choice != BcpActiveHotStandby && choice != BcpActivePassive`, so a
+// Blueprint defaulting to `singleton` on a single-region Sovereign silently
+// drops the DR contract for an app the operator explicitly placed
+// hot-standby across two regions.
+//
+// # The contract
+//
+// Returns the Blueprint's OWN spelling of the operator's posture when the
+// Blueprint declares it in `spec.topology.supported[]`, else "" — which
+// hands ResolveTopology the pre-existing region-count default.
+//
+//   - The Blueprint's own spelling (not the canonical token) is returned so
+//     both `isSupported` and `lookupVariant` match: a Blueprint that still
+//     declares the legacy `active-hotstandby` keeps resolving its own
+//     perTopology entry. Comparison is canonical on BOTH sides via
+//     placement.Canonicalize, so spelling never decides support.
+//   - An unsupported posture falls back rather than failing. `spec.Placement`
+//     is validated upstream against `placementSchema.modes[]`
+//     (application_controller.go:765) — a DIFFERENT list from
+//     `topology.supported[]`. Failing here would newly break Applications
+//     whose Blueprint declares the two inconsistently, which is a Blueprint-
+//     authoring problem and not this row's. Falling back preserves exactly
+//     today's behaviour for that case and changes behaviour ONLY where the
+//     Blueprint can honour what the operator picked.
+func topologyOverrideFromPlacement(mode string, bpTopo *bpv1alpha1.Topology) string {
+	if bpTopo == nil {
+		return ""
+	}
+	canon := placement.Canonicalize(strings.TrimSpace(mode))
+	if canon == "" {
+		return ""
+	}
+	for _, s := range bpTopo.Supported {
+		if placement.Canonicalize(string(s)) == canon {
+			return string(s)
+		}
+	}
+	return ""
+}

--- a/core/controllers/application/internal/controller/topology_override_row60_test.go
+++ b/core/controllers/application/internal/controller/topology_override_row60_test.go
@@ -1,0 +1,373 @@
+// topology_override_row60_test.go — UAT row 60 (Refs #3375).
+//
+// Clause: "Catalog → New instance → pick `active-hot-standby` → Provision →
+// that app's Topology tab shows a 2-region pair (region-a primary + region-b
+// replica + armed Switchover)."
+//
+// # What was actually broken
+//
+// The `armed Switchover` half. The per-app Continuum CR — the object that ARMS
+// a hot standby for promotion — is minted by buildContinuumPlan, whose first
+// gate is the resolved topology CHOICE. Reconcile resolved that choice by
+// handing ResolveTopology `spec.Topology`, read by parseSpec as
+// `unstructured.NestedString(app.Object, "spec", "topology")`. But the
+// Application CRD types `spec.topology` as an OBJECT
+// (products/catalyst/chart/crds/application.yaml:221 — autoFailover / rto /
+// rpo / minReplicas), so that read could only ever return "": the operator-
+// override branch of ResolveTopology was unreachable and every Application
+// resolved the Blueprint's region-count DEFAULT instead of the posture the
+// operator picked.
+//
+// Meanwhile placement.Resolve — the source of the per-region primary/standby
+// roles the Topology tab paints — always read the operator's real posture
+// (`spec.placement(.mode)`). So the two halves of the same clause were driven
+// by two different fields, and a Blueprint that supports active-hot-standby but
+// DEFAULTS to singleton produced exactly the reported symptom: a 2-region pair
+// with nothing armed.
+//
+// # Why the pre-existing Continuum tests could not catch it
+//
+// TestReconcile_PerAppContinuumCR_Produced (continuum_test.go:308) uses a
+// Blueprint whose `defaults.multi-region` IS `active-hot-standby` on a
+// multi-region Environment. The operator's choice and the Blueprint default
+// AGREE there, so the test passes identically whichever field is read — it
+// cannot discriminate. Every fixture below makes them DISAGREE, which is the
+// only way this seam is observable.
+//
+// The Blueprint shape used here is not contrived: bp-openclaw and
+// bp-stalwart-tenant both ship `defaults.multi-region: singleton` in the
+// catalog seed while supporting more than one posture.
+package controller
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// makeBlueprintSingletonDefaultDRCapable builds a Blueprint that SUPPORTS
+// active-hot-standby (with a switchover mechanism, so the Continuum producer
+// can arm it) but whose region-count DEFAULTS are singleton on both shapes.
+//
+// That gap is the whole point: `choice` comes out singleton if the resolver
+// reads the Blueprint default, and active-hot-standby only if it reads what
+// the operator chose.
+func makeBlueprintSingletonDefaultDRCapable(name, version string) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{}
+	u.SetAPIVersion("catalyst.openova.io/v1")
+	u.SetKind("Blueprint")
+	u.SetName(name)
+	u.SetGeneration(1)
+	u.Object["spec"] = map[string]interface{}{
+		"version": version,
+		"card":    map[string]interface{}{"title": name},
+		"placementSchema": map[string]interface{}{
+			// The mode gate Reconcile applies BEFORE topology resolution. It is
+			// deliberately a different list from topology.supported below —
+			// mirroring the real Blueprints, and the reason the fix falls back
+			// rather than failing when the two disagree.
+			"modes": []interface{}{"singleton", "active-hot-standby", "active-active"},
+		},
+		"manifests": map[string]interface{}{
+			"chart": name,
+			"source": map[string]interface{}{
+				"kind": "HelmRepository",
+				"ref":  "openova-catalog",
+			},
+		},
+		"topology": map[string]interface{}{
+			"supported": []interface{}{"active-hot-standby", "singleton"},
+			"defaults": map[string]interface{}{
+				// BOTH default to singleton — so a resolver reading the default
+				// can never reach the DR variant, whatever the region count.
+				"multi-region":  "singleton",
+				"single-region": "singleton",
+			},
+			"perTopology": map[string]interface{}{
+				"active-hot-standby": map[string]interface{}{
+					"placement": map[string]interface{}{
+						"tier":     "",
+						"clusters": []interface{}{"rtz-A", "rtz-B"},
+						"roles": map[string]interface{}{
+							"rtz-A": "active",
+							"rtz-B": "passive",
+						},
+					},
+					"switchover": map[string]interface{}{
+						"mechanism":  "bp-continuum",
+						"rtoSeconds": int64(60),
+						"rpoSeconds": int64(0),
+					},
+				},
+				"singleton": map[string]interface{}{
+					"placement": map[string]interface{}{
+						"tier":     "",
+						"clusters": []interface{}{"rtz-A"},
+						"roles":    map[string]interface{}{"rtz-A": "singleton"},
+					},
+				},
+			},
+		},
+	}
+	u.Object["status"] = map[string]interface{}{"ociDigest": "sha256:row60-fixture"}
+	return u
+}
+
+// makeAppObjectPlacement builds the Application EXACTLY as the "Catalog → +
+// New instance" door writes it: `spec.placement` in its OBJECT form carrying
+// the chosen `mode` + `regions`, and NO `spec.topology`.
+//
+// This is the shape newApplicationCRFromSeed produces
+// (products/catalyst/bootstrap/api/internal/handler/endpoint_handler.go:2335-2360)
+// and it is what makes this a call-site test rather than a helper test: the
+// fixture is the wire object the create door actually commits, not a
+// hand-tuned appSpec.
+func makeAppObjectPlacement(namespace, name, env, bpName, bpVer, mode string, regions []string) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{}
+	u.SetAPIVersion("apps.openova.io/v1")
+	u.SetKind("Application")
+	u.SetNamespace(namespace)
+	u.SetName(name)
+	u.SetGeneration(1)
+	regionsAny := make([]interface{}, len(regions))
+	for i, r := range regions {
+		regionsAny[i] = r
+	}
+	u.Object["spec"] = map[string]interface{}{
+		"environmentRef": env,
+		"blueprintRef": map[string]interface{}{
+			"name":    bpName,
+			"version": bpVer,
+		},
+		"placement": map[string]interface{}{
+			"mode":    mode,
+			"regions": regionsAny,
+		},
+		"regions":    regionsAny,
+		"parameters": map[string]interface{}{},
+	}
+	return u
+}
+
+const (
+	row60RegionA = "hetzner-fsn-rtz-prod"
+	row60RegionB = "hetzner-nbg-rtz-prod"
+)
+
+func row60ContinuumExists(t *testing.T, r *Reconciler, ns, app string) bool {
+	t.Helper()
+	_, err := r.Dynamic.Resource(ContinuumGVR).Namespace(ns).
+		Get(context.Background(), ContinuumNameFor(app), metav1.GetOptions{})
+	return err == nil
+}
+
+// TestRow60_OperatorHotStandbyArmsSwitchover_DespiteSingletonBlueprintDefault
+// is the row's acceptance in source: the posture the operator chose at create
+// time reaches the Continuum producer, so the Switchover is armed even though
+// the Blueprint's own default for this Sovereign shape is singleton.
+//
+// Before the fix this failed — `choice` came back `singleton`, buildContinuumPlan
+// returned (zero, false) at its first gate, and no `dr-<app>` CR was ever
+// written while the HelmReleases still fanned out across two regions.
+func TestRow60_OperatorHotStandbyArmsSwitchover_DespiteSingletonBlueprintDefault(t *testing.T) {
+	bp := makeBlueprintSingletonDefaultDRCapable("bp-row60", "1.0.0")
+	env := makeMultiRegionEnv("acme-prod", "acme", "prod")
+	org := makeOrg("acme")
+	app := makeAppObjectPlacement("acme", "shop", "acme-prod", "bp-row60", "1.0.0",
+		"active-hot-standby", []string{row60RegionA, row60RegionB})
+
+	fg := newFakeGitea()
+	fg.orgsExist["acme"] = true
+	r := newReconciler(t, fg, app, env, org, bp)
+
+	reconcileFromCluster(t, r, "acme", "shop")
+
+	got := readApp(t, r, "acme", "shop")
+	if phase, reason, msg := readPhaseAndReason(t, got); phase == PhaseFailed {
+		t.Fatalf("unexpected Failed phase: reason=%q msg=%q", reason, msg)
+	}
+
+	cr, err := r.Dynamic.Resource(ContinuumGVR).Namespace("acme").
+		Get(context.Background(), ContinuumNameFor("shop"), metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("no Continuum CR for an app the operator placed active-hot-standby "+
+			"across %s + %s: the Switchover half of row 60 is unarmed (%v)",
+			row60RegionA, row60RegionB, err)
+	}
+
+	// The armed contract must name the operator's OWN regions, in their order —
+	// a CR that armed the Blueprint's cluster list instead would be a different
+	// (and wrong) answer that still satisfies "a CR exists".
+	primary, _, _ := unstructured.NestedString(cr.Object, "spec", "primaryRegion")
+	if primary != row60RegionA {
+		t.Errorf("primaryRegion = %q, want %q (regions[0] is the operator's primary)",
+			primary, row60RegionA)
+	}
+	standbys, _, _ := unstructured.NestedStringSlice(cr.Object, "spec", "hotStandbyRegions")
+	if len(standbys) != 1 || standbys[0] != row60RegionB {
+		t.Errorf("hotStandbyRegions = %v, want [%s]", standbys, row60RegionB)
+	}
+	if mech, _, _ := unstructured.NestedString(cr.Object, "spec", "switchover", "mechanism"); mech == "" {
+		t.Error("switchover.mechanism is empty — nothing to arm against")
+	}
+}
+
+// TestRow60_SingletonChoiceStillArmsNothing is the CONTROL that shares the
+// suspect property. Same Blueprint, same Environment, same two regions on the
+// CR — only the operator's chosen mode differs. If the fix had simply started
+// arming everything (or begun trusting spec.regions instead of the posture),
+// this would mint a CR too and the test above would prove nothing.
+func TestRow60_SingletonChoiceStillArmsNothing(t *testing.T) {
+	bp := makeBlueprintSingletonDefaultDRCapable("bp-row60", "1.0.0")
+	env := makeMultiRegionEnv("acme-prod", "acme", "prod")
+	org := makeOrg("acme")
+	app := makeAppObjectPlacement("acme", "blog", "acme-prod", "bp-row60", "1.0.0",
+		"singleton", []string{row60RegionA, row60RegionB})
+
+	fg := newFakeGitea()
+	fg.orgsExist["acme"] = true
+	r := newReconciler(t, fg, app, env, org, bp)
+
+	reconcileFromCluster(t, r, "acme", "blog")
+
+	if row60ContinuumExists(t, r, "acme", "blog") {
+		t.Fatal("a singleton Application minted a Continuum CR — the producer is now " +
+			"arming on region count rather than on the operator's chosen posture")
+	}
+}
+
+// TestRow60_UnsupportedPostureFallsBackAndDoesNotFail pins the deliberate
+// non-regression in topologyOverrideFromPlacement.
+//
+// `active-active` passes the placementSchema.modes gate but is absent from this
+// Blueprint's topology.supported — a Blueprint-authoring inconsistency that
+// exists in the catalog today. Handing it to ResolveTopology verbatim would
+// return ErrInvalidTopology and move the Application to Failed, which would be
+// a NEW failure this row never asked for. The override therefore yields "" for
+// an unsupported posture and the pre-existing region-count default stands.
+func TestRow60_UnsupportedPostureFallsBackAndDoesNotFail(t *testing.T) {
+	bp := makeBlueprintSingletonDefaultDRCapable("bp-row60", "1.0.0")
+	env := makeMultiRegionEnv("acme-prod", "acme", "prod")
+	org := makeOrg("acme")
+	app := makeAppObjectPlacement("acme", "mesh", "acme-prod", "bp-row60", "1.0.0",
+		"active-active", []string{row60RegionA, row60RegionB})
+
+	fg := newFakeGitea()
+	fg.orgsExist["acme"] = true
+	r := newReconciler(t, fg, app, env, org, bp)
+
+	reconcileFromCluster(t, r, "acme", "mesh")
+
+	got := readApp(t, r, "acme", "mesh")
+	if phase, reason, msg := readPhaseAndReason(t, got); phase == PhaseFailed {
+		t.Fatalf("a posture the Blueprint's topology block omits must fall back to the "+
+			"Blueprint default, not fail the Application: reason=%q msg=%q", reason, msg)
+	}
+	// active-active is multi-master — no primary/standby flip to drive — so the
+	// producer must stay silent regardless of which branch resolved the variant.
+	if row60ContinuumExists(t, r, "acme", "mesh") {
+		t.Error("active-active minted a Continuum CR; there is no switchover to arm")
+	}
+}
+
+// TestRow60_LegacyPostureSpellingStillArms — the operator's posture is compared
+// CANONICALLY on both sides, so a CR carrying the legacy `active-hotstandby`
+// spelling resolves the Blueprint's canonical `active-hot-standby` variant.
+// Without canonicalisation this fix would have silently re-created #6200's
+// spelling defect one layer down.
+func TestRow60_LegacyPostureSpellingStillArms(t *testing.T) {
+	bp := makeBlueprintSingletonDefaultDRCapable("bp-row60", "1.0.0")
+	env := makeMultiRegionEnv("acme-prod", "acme", "prod")
+	org := makeOrg("acme")
+	app := makeAppObjectPlacement("acme", "legacy", "acme-prod", "bp-row60", "1.0.0",
+		"active-hotstandby", []string{row60RegionA, row60RegionB})
+
+	fg := newFakeGitea()
+	fg.orgsExist["acme"] = true
+	r := newReconciler(t, fg, app, env, org, bp)
+
+	reconcileFromCluster(t, r, "acme", "legacy")
+
+	if !row60ContinuumExists(t, r, "acme", "legacy") {
+		t.Fatal("the legacy `active-hotstandby` spelling did not arm the Switchover — " +
+			"the override is comparing raw strings instead of canonical postures")
+	}
+}
+
+// TestRow60_SpecTopologyObjectIsNotAnOverride locks the CRD-shape half so the
+// removed read cannot return as a "fix".
+//
+// `spec.topology` is an OBJECT (autoFailover / rto / rpo / minReplicas). An
+// Application may legitimately carry it, and it must have NO influence on which
+// posture is resolved. If someone re-adds a string read of this field it stays
+// "" (as it always did) — but if someone "improves" it into a map read that
+// treats the block as a posture selector, this fails.
+func TestRow60_SpecTopologyObjectIsNotAnOverride(t *testing.T) {
+	bp := makeBlueprintSingletonDefaultDRCapable("bp-row60", "1.0.0")
+	env := makeMultiRegionEnv("acme-prod", "acme", "prod")
+	org := makeOrg("acme")
+	app := makeAppObjectPlacement("acme", "knobs", "acme-prod", "bp-row60", "1.0.0",
+		"active-hot-standby", []string{row60RegionA, row60RegionB})
+	// The CRD-legal object form, carrying a DR knob block.
+	_ = unstructured.SetNestedMap(app.Object, map[string]interface{}{
+		"autoFailover": true,
+		"rto":          "60s",
+		"rpo":          "5s",
+	}, "spec", "topology")
+
+	fg := newFakeGitea()
+	fg.orgsExist["acme"] = true
+	r := newReconciler(t, fg, app, env, org, bp)
+
+	reconcileFromCluster(t, r, "acme", "knobs")
+
+	got := readApp(t, r, "acme", "knobs")
+	if phase, reason, msg := readPhaseAndReason(t, got); phase == PhaseFailed {
+		t.Fatalf("a CRD-legal spec.topology knob block must not fail the reconcile: "+
+			"reason=%q msg=%q", reason, msg)
+	}
+	if !row60ContinuumExists(t, r, "acme", "knobs") {
+		t.Fatal("the posture must still come from spec.placement.mode when spec.topology " +
+			"carries its DR knobs")
+	}
+}
+
+// TestRow60_TopologyOverrideFromPlacement_Table pins the predicate itself.
+// The reconcile tests above are the load-bearing ones — this only documents the
+// mapping and guards the Blueprint's-own-spelling return, which is what lets
+// lookupVariant find a legacy-spelled perTopology entry.
+func TestRow60_TopologyOverrideFromPlacement_Table(t *testing.T) {
+	bpTopo := parseBlueprintTopology(makeBlueprintSingletonDefaultDRCapable("bp-x", "1.0.0"))
+	if bpTopo == nil {
+		t.Fatal("fixture Blueprint parsed to a nil topology — every case below would be vacuous")
+	}
+
+	cases := []struct {
+		name string
+		mode string
+		want string
+	}{
+		{"canonical supported posture wins", "active-hot-standby", "active-hot-standby"},
+		{"legacy spelling folds onto the supported one", "active-hotstandby", "active-hot-standby"},
+		{"singleton is supported and wins", "singleton", "singleton"},
+		{"legacy single-region folds onto singleton", "single-region", "singleton"},
+		{"unsupported posture yields the default fallback", "active-active", ""},
+		{"empty posture yields the default fallback", "", ""},
+		{"unknown token yields the default fallback", "not-a-posture", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := topologyOverrideFromPlacement(tc.mode, bpTopo); got != tc.want {
+				t.Errorf("topologyOverrideFromPlacement(%q) = %q, want %q", tc.mode, got, tc.want)
+			}
+		})
+	}
+
+	// A nil Blueprint topology can never yield an override — the caller's
+	// `bpTopo != nil` guard and this must agree.
+	if got := topologyOverrideFromPlacement("active-hot-standby", nil); got != "" {
+		t.Errorf("nil Blueprint topology returned %q, want \"\"", got)
+	}
+}

--- a/core/services/provisioning/gitops/helmrelease_apps.go
+++ b/core/services/provisioning/gitops/helmrelease_apps.go
@@ -665,6 +665,32 @@ spec:
 }
 
 
+// DefaultHRAppChartVersions is the built-in CATALYST_HR_APP_CHART_VERSIONS
+// value — the chart version every HelmRelease-shaped funnel app installs at
+// when the operator sets no env override, which on every Sovereign we run is
+// ALWAYS (nothing in this repo sets that env).
+//
+// # The invariant (UAT row 234, Refs #4307)
+//
+// It MUST equal the catalog-seed delivery pin for the same chart. That was
+// already the stated contract at the call site in main.go ("Defaults = the
+// current catalog-seed pins") and nothing enforced it, so it silently rotted:
+// the funnel installed bp-stalwart-tenant 0.1.13 while the seed served 0.1.15,
+// and the intervening 0.1.14 is the §854 nodePort fix WITHOUT WHICH KYVERNO
+// DENIES THE HELMRELEASE AT ADMISSION — no pod, no HTTPRoute, and
+// `mail.<slug>.<pool-tld>` answers nothing. bp-openclaw was five versions
+// behind (0.2.13 vs 0.2.18) for the same reason.
+//
+// A stale pin here is invisible in every other gate: the chart renders, the
+// seed renders, the bootstrap-kit renders, and the two numbers simply differ.
+// hrAppPinSeedDrift in helmrelease_apps_pin_seed_drift_test.go is the guard
+// that makes the drift fail a PR instead of a walk.
+//
+// Living here rather than as a literal in main.go is what makes the guard test
+// the value main.go actually ships — a copy in the test would pass while the
+// binary shipped something else.
+const DefaultHRAppChartVersions = "openclaw=0.2.18,stalwart-mail=0.1.15,newapi=1.4.153"
+
 // ParseHRAppVersions parses the CATALYST_HR_APP_CHART_VERSIONS wire format
 // ("slug=version,slug=version") into the HelmReleaseAppVersions map (#4706).
 // Malformed entries are skipped rather than fatal — a typo in one pin must

--- a/core/services/provisioning/gitops/helmrelease_apps_pin_seed_drift_test.go
+++ b/core/services/provisioning/gitops/helmrelease_apps_pin_seed_drift_test.go
@@ -1,0 +1,173 @@
+// helmrelease_apps_pin_seed_drift_test.go — UAT row 234 (Refs #4307).
+//
+// The gap this closes: the funnel's built-in chart pins
+// (gitops.DefaultHRAppChartVersions, consumed by services/provisioning/main.go)
+// and the catalog-seed delivery pins
+// (products/catalyst/chart/templates/catalog-seed/blueprints.yaml `source.version`)
+// are two independent numbers describing the same install, and only the first
+// one decides what a funnel Org actually gets. Nothing compared them, so they
+// drifted: stalwart-mail sat at 0.1.13 against a seed of 0.1.15, straddling
+// 0.1.14 — the §854 nodePort fix, without which Kyverno DENIES the HelmRelease
+// at admission and `mail.<slug>.<pool-tld>` has no pod and no HTTPRoute to
+// serve. openclaw was five behind. newapi carried no pin at all and rendered
+// the floating `version: "*"` that #4706 exists to forbid.
+//
+// Both halves are read from their REAL sources — the exported constant the
+// binary ships, and the seed file parsed by the repo's own canonical parser
+// (scripts/lib/parse-catalog-seed-pins.awk, the same one
+// tests/e2e/bootstrap-kit and sync-catalog-seed-pin.py mirror). Neither number
+// is retyped here, so the guard cannot pass against a value the platform does
+// not use.
+package gitops
+
+import (
+	"bufio"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// repoRoot resolves the monorepo root from this package's directory
+// (core/services/provisioning/gitops → ../../../..).
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	abs, err := filepath.Abs(filepath.Join("..", "..", "..", ".."))
+	if err != nil {
+		t.Fatalf("resolve repo root: %v", err)
+	}
+	return abs
+}
+
+// catalogSeedPins returns chart-name → source.version for every seeded
+// Blueprint, by shelling out to the repo's canonical seed parser rather than
+// re-implementing its line-scan here. Re-typing that predicate is exactly how
+// two "equivalent" parsers come to disagree, and the awk one is already the
+// shared source for the bootstrap-kit e2e gate and the bump writer.
+func catalogSeedPins(t *testing.T) map[string]string {
+	t.Helper()
+	root := repoRoot(t)
+	awkScript := filepath.Join(root, "scripts", "lib", "parse-catalog-seed-pins.awk")
+	seed := filepath.Join(root, "products", "catalyst", "chart", "templates",
+		"catalog-seed", "blueprints.yaml")
+
+	out, err := exec.Command("awk", "-f", awkScript, seed).Output()
+	if err != nil {
+		t.Fatalf("parse catalog seed via %s: %v", awkScript, err)
+	}
+
+	pins := map[string]string{}
+	sc := bufio.NewScanner(strings.NewReader(string(out)))
+	for sc.Scan() {
+		// name|visibility|source.chart|source.version
+		f := strings.Split(sc.Text(), "|")
+		if len(f) != 4 {
+			continue
+		}
+		chart, version := strings.TrimSpace(f[2]), strings.TrimSpace(f[3])
+		if chart == "" || version == "" {
+			continue
+		}
+		pins[chart] = version
+	}
+	if len(pins) == 0 {
+		t.Fatalf("catalog seed parsed to ZERO pins — the parser or the seed path is wrong, "+
+			"and a guard reading nothing would pass on everything (awk=%s seed=%s)", awkScript, seed)
+	}
+	return pins
+}
+
+// chartRE pulls the bp-* chart name out of a rendered HelmRelease so the
+// slug→chart mapping comes from the GENERATOR's own output, never from a table
+// retyped in this file. `stalwart-mail` renders `bp-stalwart-tenant`; a guard
+// that hardcoded that pairing would keep passing if the generator changed it.
+var chartRE = regexp.MustCompile(`(?m)^\s+chart:\s*"?(bp-[a-z0-9-]+)"?\s*$`)
+
+// TestDefaultHRAppPins_MatchCatalogSeed — the funnel's default chart pin for
+// every HelmRelease-shaped app equals the catalog-seed delivery pin for the
+// chart that app's generator actually emits.
+func TestDefaultHRAppPins_MatchCatalogSeed(t *testing.T) {
+	seedPins := catalogSeedPins(t)
+	funnelPins := ParseHRAppVersions(DefaultHRAppChartVersions)
+
+	if len(helmReleaseAppSlugs) == 0 {
+		t.Fatal("helmReleaseAppSlugs is empty — this guard would assert nothing")
+	}
+
+	for slug := range helmReleaseAppSlugs {
+		slug := slug
+		t.Run(slug, func(t *testing.T) {
+			// (1) Every HR-shaped app MUST carry a pin. An absent one leaves the
+			// template's floating `version: "*"`, which resolves to the highest
+			// semver tag on the OCI repo — the exact failure #4706 was written
+			// to stop, and how newapi shipped unpinned.
+			funnelVersion, pinned := funnelPins[slug]
+			if !pinned {
+				t.Fatalf("slug %q is a HelmRelease-shaped funnel app but carries no pin in "+
+					"DefaultHRAppChartVersions — it will render the floating version \"*\"", slug)
+			}
+
+			// (2) Ask the REAL generator which chart this slug installs, then
+			// compare against that chart's seed pin.
+			rendered := generateHelmReleaseApp(slug, helmReleaseAppOpts{
+				slug:         "acme",
+				parentDomain: "omani.trade",
+				chartVersion: funnelVersion,
+			})
+			if strings.TrimSpace(rendered) == "" {
+				t.Fatalf("generateHelmReleaseApp(%q) rendered nothing — the slug registry and "+
+					"the generator switch disagree", slug)
+			}
+			m := chartRE.FindStringSubmatch(rendered)
+			if m == nil {
+				t.Fatalf("no bp-* chart name in the HelmRelease %q renders; "+
+					"cannot resolve its catalog-seed pin", slug)
+			}
+			chart := m[1]
+
+			seedVersion, seeded := seedPins[chart]
+			if !seeded {
+				t.Fatalf("chart %q (funnel slug %q) has no catalog-seed entry — the funnel "+
+					"installs a chart the Sovereign's own catalog does not deliver", chart, slug)
+			}
+			if funnelVersion != seedVersion {
+				t.Errorf("PIN DRIFT for %q: the funnel installs %s@%s but the catalog seed "+
+					"delivers %s@%s. A funnel Org gets the older chart, and every fix "+
+					"published between those two versions is absent from the purchase path "+
+					"while the seed says it shipped.",
+					slug, chart, funnelVersion, chart, seedVersion)
+			}
+		})
+	}
+}
+
+// TestDefaultHRAppPins_GuardIsNotVacuous — the VACUITY control.
+//
+// The test above compares two values read from real sources; if either read
+// silently yielded nothing it would pass on everything. This pins the guard's
+// own machinery: the seed parse must produce the charts we look up, and a
+// deliberately WRONG pin must be detected by the same comparison the guard
+// makes. Without this, a broken awk path or a renamed constant turns the drift
+// guard into decoration that reports green forever.
+func TestDefaultHRAppPins_GuardIsNotVacuous(t *testing.T) {
+	seedPins := catalogSeedPins(t)
+
+	// The seed parse really resolves the charts this guard is about.
+	for _, chart := range []string{"bp-stalwart-tenant", "bp-openclaw", "bp-newapi"} {
+		if seedPins[chart] == "" {
+			t.Fatalf("seed parse produced no version for %q — the drift guard above would "+
+				"fail-open on a chart it is supposed to police", chart)
+		}
+	}
+
+	// A mutant pin set that still parses must be REJECTED by the same equality
+	// the guard applies. This is the "watched it fail" half: it reproduces the
+	// exact 0.1.13-vs-0.1.15 shape that shipped.
+	mutant := ParseHRAppVersions("stalwart-mail=0.1.13")
+	if mutant["stalwart-mail"] == seedPins["bp-stalwart-tenant"] {
+		t.Fatalf("the historical stale pin 0.1.13 equals the current seed pin %q — this "+
+			"control no longer discriminates and must be re-pointed at a version the "+
+			"seed does not carry", seedPins["bp-stalwart-tenant"])
+	}
+}

--- a/core/services/provisioning/main.go
+++ b/core/services/provisioning/main.go
@@ -185,11 +185,14 @@ func main() {
 	// ghcr artifact broke every Org install; majors could jump ungated).
 	// Defaults = the current catalog-seed pins; operators override via env.
 	// A missing/malformed entry falls back to "*" (never fatal).
-	// stalwart-mail 0.1.13 (#4833): CPU right-sized 1->500m so bp-openclaw's
-	// controller fits the S-plan 2-vCPU plan-quota on a co-tenant funnel Org
-	// (0.1.12's guaranteed full core starved openclaw → UAT 224/232 red).
+	// UAT row 234 (Refs #4307) — the default now lives in the gitops package as
+	// gitops.DefaultHRAppChartVersions, guarded in lockstep with the
+	// catalog-seed delivery pins. It used to be an inline literal that fell two
+	// versions behind bp-stalwart-tenant (0.1.13 vs the seed's 0.1.15, missing
+	// the 0.1.14 §854 nodePort fix that Kyverno denies the install without) and
+	// five behind bp-openclaw, with nothing able to notice.
 	generator.HelmReleaseAppVersions = gitops.ParseHRAppVersions(getEnv(
-		"CATALYST_HR_APP_CHART_VERSIONS", "openclaw=0.2.13,stalwart-mail=0.1.13"))
+		"CATALYST_HR_APP_CHART_VERSIONS", gitops.DefaultHRAppChartVersions))
 
 	// #4282/#4275 CROSS-REGION STANDBY: the flux-system Secret name holding
 	// region-B's (the STANDBY region's) host-cluster kubeconfig. The per-Org

--- a/products/catalyst/bootstrap/api/internal/handler/org_applications.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_applications.go
@@ -340,7 +340,41 @@ func (h *Handler) HandleOrgApplications(w http.ResponseWriter, r *http.Request) 
 	adopted := map[string]bool{} // HR names already projected via an Application CR
 
 	// Application CR pass — each CR in the Org namespace is one card.
-	if appList, err := deps.dyn.Resource(applicationGVR).Namespace(orgNS).List(ctx, metav1.ListOptions{}); err == nil {
+	//
+	// UAT row 222 (Refs #3988) — the OUTCOME of this List is load-bearing, not
+	// just its contents. This is the estate a chat-created Application has to
+	// appear in: `create_application` POSTs to catalyst-api, which writes an
+	// Application CR into `orgNS` (applications.go:547), and THIS pass is the
+	// only one that can see it — the HelmRelease and funnel-HTTPRoute passes
+	// below are keyed on other objects entirely.
+	//
+	// The `err` used to be discarded at the `if`, so a failed List (Application
+	// CRD unregistered, RBAC denial on apps.openova.io, apiserver timeout) fell
+	// through to a 200 whose `apps` was built from HelmReleases and HTTPRoutes
+	// alone. The grid then looked populated and merely lacked the agent's app —
+	// indistinguishable from "the agent's app never converged", which is the
+	// one conclusion this row exists to adjudicate. #6249/#6251 drew exactly
+	// this distinction on the Sovereign estate (sovereign.go:786); the
+	// Org-scoped estate — the surface this row's clause names — was never
+	// enrolled.
+	//
+	// The ACTION deliberately differs from the Sovereign path's. There the
+	// remedy was to SKIP the HelmRelease fallback once the Application estate
+	// is authoritative; here that would be wrong, because an Org legitimately
+	// owns HR-only apps with no Application CR (agenity-demo, per the pass
+	// below) and funnel purchases that deploy neither. Suppressing them would
+	// blank a correct estate. So the failure is REPORTED, not compensated:
+	// every pass still runs, and the response says plainly that the
+	// Application-keyed half is missing.
+	appList, appListErr := deps.dyn.Resource(applicationGVR).Namespace(orgNS).List(ctx, metav1.ListOptions{})
+	if appListErr != nil {
+		resp.ApplicationEstateUnreadable = true
+		if h.log != nil {
+			h.log.Warn("org apps: Application CR list failed; estate omits every Application",
+				"orgNamespace", orgNS, "err", appListErr)
+		}
+	}
+	if appListErr == nil {
 		for i := range appList.Items {
 			app := &appList.Items[i]
 			bpFull, _, _ := unstructured.NestedString(app.Object, "spec", "blueprintRef", "name")

--- a/products/catalyst/bootstrap/api/internal/handler/org_applications_estate_row222_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_applications_estate_row222_test.go
@@ -1,0 +1,252 @@
+// org_applications_estate_row222_test.go — UAT row 222 (Refs #3988).
+//
+// Clause: "The agent-created application converges and appears in the user's
+// Org (chat-driven app creation works end-to-end)."
+//
+// The Org-scoped estate this exercises is the surface that clause names.
+// `create_application` (products/openova-mcp/internal/tools/catalogue.go:373)
+// POSTs to catalyst-api, which writes an Application CR into the Org namespace
+// (applications.go:547) — and GET /api/v1/org/applications is the ONLY reader
+// that can see it. Its two sibling passes are keyed on HelmReleases and on
+// per-org-app HTTPRoutes; neither can ever surface an Application CR.
+//
+// # The defect
+//
+// That pass discarded the List error at the `if`, so a failed List (Application
+// CRD unregistered, RBAC denial on apps.openova.io, apiserver timeout) produced
+// a 200 whose `apps` was assembled from the other two passes alone. The grid
+// rendered plausibly and merely lacked the agent's Application — which is
+// byte-identical, on the wire and on screen, to "the agent's app never
+// converged". That is the exact conflation #6249/#6251 named and fixed on the
+// Sovereign estate (sovereign.go:786); the Org-scoped handler was never
+// enrolled, and it is the one this row walks.
+//
+// # Why the remedy differs from the Sovereign path's
+//
+// There, the fix SUPPRESSES the HelmRelease fallback once the Application
+// estate is authoritative. Here that would be wrong: an Org legitimately owns
+// HR-only apps with no Application CR (agenity-demo) and funnel purchases that
+// deploy neither a CR nor an HR. Suppressing those would blank a correct
+// estate. So the failure is REPORTED rather than compensated — every pass still
+// runs, and the response states plainly that the Application-keyed half is
+// missing.
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	k8stesting "k8s.io/client-go/testing"
+
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/store"
+)
+
+var errForbiddenRow222 = errors.New(
+	"applications.apps.openova.io is forbidden: User cannot list resource in the namespace")
+
+const (
+	row222Host  = "console.demo.omani.homes"
+	row222OrgNS = "org-7283eb4a-19e5-4e86-9066-d4aa26762064"
+)
+
+// row222AgentApp is the Application CR an agent-driven create_application
+// leaves behind: written into the Org namespace, blueprintRef + environmentRef
+// set, phase Ready once the application-controller has converged it.
+func row222AgentApp(name string) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{}
+	u.SetAPIVersion("apps.openova.io/v1")
+	u.SetKind("Application")
+	u.SetNamespace(row222OrgNS)
+	u.SetName(name)
+	u.Object["spec"] = map[string]interface{}{
+		"environmentRef": "demo-prod",
+		"blueprintRef": map[string]interface{}{
+			"name":    "bp-wordpress",
+			"version": "0.4.23",
+		},
+	}
+	u.Object["status"] = map[string]interface{}{"phase": "Ready"}
+	return u
+}
+
+// row222Handler wires the Org-applications handler onto a fake dynamic client.
+// `breakApplicationList` installs a reactor that fails the Application LIST the
+// same way an unregistered CRD or an RBAC denial would.
+func row222Handler(t *testing.T, breakApplicationList bool, objs ...*unstructured.Unstructured) *Handler {
+	t.Helper()
+	h := &Handler{log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+
+	reg, err := store.NewTenantRegistry(t.TempDir())
+	if err != nil {
+		t.Fatalf("registry: %v", err)
+	}
+	if err := reg.Put(store.TenantRegistration{
+		Host:                  row222Host,
+		TenantID:              "7283eb4a-19e5-4e86-9066-d4aa26762064",
+		TenantKind:            store.TenantKindOrg,
+		KeycloakRealmURL:      "https://keycloak.demo.omani.homes/realms/org-demo",
+		KeycloakClientID:      "catalyst-ui",
+		OrganizationNamespace: row222OrgNS,
+		OrgKeycloakRealmName:  "org-demo",
+	}); err != nil {
+		t.Fatalf("put demo: %v", err)
+	}
+	h.SetTenantRegistry(reg)
+
+	gvrToList := map[schema.GroupVersionResource]string{
+		applicationGVR:       "ApplicationList",
+		helmReleaseGVR:       "HelmReleaseList",
+		httpRouteGVR:         "HTTPRouteList",
+		fluxKustomizationGVR: "KustomizationList",
+	}
+	runtimeObjs := make([]runtime.Object, 0, len(objs))
+	for _, o := range objs {
+		runtimeObjs = append(runtimeObjs, o)
+	}
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(), gvrToList, runtimeObjs...)
+
+	if breakApplicationList {
+		dyn.PrependReactor("list", "applications",
+			func(k8stesting.Action) (bool, runtime.Object, error) {
+				return true, nil, apierrors.NewForbidden(
+					schema.GroupResource{Group: "apps.openova.io", Resource: "applications"},
+					"", errForbiddenRow222)
+			})
+	}
+	h.SetSovereignDepsFactory(func() (*sovereignDeps, error) {
+		return &sovereignDeps{core: nil, dyn: dyn}, nil
+	})
+	return h
+}
+
+func row222Get(t *testing.T, h *Handler) (int, sovereignAppsResponse) {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/org/applications", nil)
+	req.Header.Set("X-Tenant-Host", row222Host)
+	req = req.WithContext(context.Background())
+	rec := httptest.NewRecorder()
+	h.HandleOrgApplications(rec, req)
+
+	var resp sovereignAppsResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode body %q: %v", rec.Body.String(), err)
+	}
+	return rec.Code, resp
+}
+
+// TestRow222_AgentApplicationAppearsInTheOrgEstate — the positive half: a
+// converged Application CR in the Org namespace IS the Org's estate.
+func TestRow222_AgentApplicationAppearsInTheOrgEstate(t *testing.T) {
+	h := row222Handler(t, false, row222AgentApp("agent-shop"))
+
+	code, resp := row222Get(t, h)
+	if code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", code)
+	}
+	if resp.ApplicationEstateUnreadable {
+		t.Error("applicationEstateUnreadable set on a healthy List — the flag would " +
+			"cry wolf on every normal read")
+	}
+
+	var found *sovereignAppItem
+	for i := range resp.Apps {
+		if resp.Apps[i].ID == "agent-shop" {
+			found = &resp.Apps[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("the agent-created Application is absent from the Org estate: %+v", resp.Apps)
+	}
+	if found.Status != "installed" {
+		t.Errorf("status = %q, want installed for a phase=Ready Application", found.Status)
+	}
+	if found.Blueprint != "bp-wordpress" {
+		t.Errorf("blueprint = %q, want bp-wordpress", found.Blueprint)
+	}
+}
+
+// TestRow222_UnreadableApplicationEstateIsReported — the defect's own shape.
+//
+// The List fails, so `apps` CANNOT contain the agent's Application. Before the
+// fix the response was an unremarkable 200 and the absence read as "the app
+// never converged". Now the response says the Application-keyed half is
+// missing, so the two situations are distinguishable.
+func TestRow222_UnreadableApplicationEstateIsReported(t *testing.T) {
+	h := row222Handler(t, true, row222AgentApp("agent-shop"))
+
+	code, resp := row222Get(t, h)
+	if code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (the other estate passes still serve)", code)
+	}
+	if !resp.ApplicationEstateUnreadable {
+		t.Fatal("the Application CR List FAILED and the response did not say so — " +
+			"an operator reading this estate cannot tell \"this Org has no " +
+			"Applications\" from \"we could not ask\", which is precisely the " +
+			"conclusion UAT row 222 has to adjudicate")
+	}
+	// The absence itself is the premise of the test, not the assertion — state
+	// it so a future reader knows the flag is describing a real omission.
+	for _, a := range resp.Apps {
+		if a.ID == "agent-shop" {
+			t.Fatal("an Application surfaced despite a failed List — the fixture no " +
+				"longer reproduces the situation the flag describes")
+		}
+	}
+}
+
+// TestRow222_UnreadableEstateStillServesTheOtherPasses is the CONTROL that
+// shares the suspect property: the same failed Application List, but the Org
+// also owns an HR-only app.
+//
+// It pins the deliberate divergence from the Sovereign path. Had this been
+// fixed by copying #6251's remedy — skip the HelmRelease pass — an Org whose
+// Agenity workspace is HR-only would have lost its only card at exactly the
+// moment the Application estate was unreadable. That would trade one silent
+// wrong answer for another.
+func TestRow222_UnreadableEstateStillServesTheOtherPasses(t *testing.T) {
+	hr := &unstructured.Unstructured{}
+	hr.SetAPIVersion("helm.toolkit.fluxcd.io/v2")
+	hr.SetKind("HelmRelease")
+	hr.SetNamespace(row222OrgNS)
+	hr.SetName("agenity-demo")
+	hr.Object["spec"] = map[string]interface{}{
+		"releaseName": "agenity-demo",
+		"chart": map[string]interface{}{
+			"spec": map[string]interface{}{"chart": "bp-agenity"},
+		},
+	}
+
+	h := row222Handler(t, true, hr)
+
+	code, resp := row222Get(t, h)
+	if code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", code)
+	}
+	if !resp.ApplicationEstateUnreadable {
+		t.Error("the failed Application List must still be reported")
+	}
+	var sawAgenity bool
+	for _, a := range resp.Apps {
+		if a.ID == "agenity-demo" {
+			sawAgenity = true
+		}
+	}
+	if !sawAgenity {
+		t.Fatal("the HelmRelease-only app vanished when the Application List failed — " +
+			"reporting the gap must not also blank the estate")
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/sovereign.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sovereign.go
@@ -543,6 +543,20 @@ type sovereignAppsResponse struct {
 	Apps         []sovereignAppItem `json:"apps"`
 	GeneratedAt  string             `json:"generatedAt,omitempty"`
 	BootstrapKit []string           `json:"bootstrapKit"`
+
+	// ApplicationEstateUnreadable — the Application-CR List that sources the
+	// Application-keyed half of this estate FAILED (CRD unregistered, RBAC
+	// denial, apiserver timeout), so `apps` cannot contain any Application
+	// and its absence from the grid means NOTHING (UAT row 222, Refs #3988;
+	// same distinction #6249/#6251 drew on the Sovereign estate).
+	//
+	// Omitted on the normal path, so a `false` is never transmitted and no
+	// existing consumer changes shape. Present-and-true is the ONLY honest
+	// way for a caller to tell "this Org has no Applications" apart from
+	// "we could not ask" — the two were byte-identical on the wire, which is
+	// precisely how a chat-created Application that DID converge would read
+	// to an operator as one that never appeared.
+	ApplicationEstateUnreadable bool `json:"applicationEstateUnreadable,omitempty"`
 }
 
 // HandleSovereignApps — GET /api/v1/sovereign/apps.

--- a/products/catalyst/bootstrap/ui/src/lib/organizations.api.ts
+++ b/products/catalyst/bootstrap/ui/src/lib/organizations.api.ts
@@ -105,6 +105,48 @@ export function kindDefaults(kind: OrgKind): {
     : { billingMode: 'real', isolation: 'vcluster' }
 }
 
+/**
+ * ORG_PLAN_SLUGS — the purchasable catalog plans, in tier order (UAT row G7,
+ * Refs #4293/#4292).
+ *
+ * Mirrors `catalogPlanSlugs` in
+ * products/catalyst/bootstrap/api/internal/handler/organization_provisioning.go:361,
+ * the ONE list the create handler normalises against: a `plan_slug` outside it
+ * is silently coerced to `s`. Kept as a single exported constant so the create
+ * form's picker and any future plan surface offer exactly the set the server
+ * accepts — a hand-typed subset would render options that vanish on submit.
+ */
+export const ORG_PLAN_SLUGS = ['s', 'm', 'l', 'xl', 'flexi'] as const
+
+export type OrgPlanSlug = (typeof ORG_PLAN_SLUGS)[number]
+
+/**
+ * isolationForPlan — the #4292 TIER GATE, front-end side.
+ *
+ * The boundary primitive an Organization gets is decided by the plan slug
+ * ALONE, never by `kind`. free/S share the host `<slug>` namespace; every paid
+ * tier from M up gets a dedicated Org-vCluster. This is the exact predicate of
+ * `isolationForTier` (organization_provisioning.go:346) and of the renderer
+ * that actually authors the boundary, `boundaryIsVcluster`
+ * (core/controllers/organization/internal/gitops/manifests.go:151).
+ *
+ * It exists so the create form can show the isolation the CHOSEN PLAN will
+ * deliver. Before UAT row G7 the form showed `kindDefaults(kind).isolation` —
+ * 'vcluster' for every customer Org — while the form had no plan input at all,
+ * so the server normalised the plan to `s` and authored a host namespace. The
+ * page advertised a boundary it could not order.
+ */
+export function isolationForPlan(planSlug: string): OrgIsolation {
+  switch (planSlug.trim().toLowerCase()) {
+    case '':
+    case 's':
+    case 'free':
+      return 'namespace'
+    default:
+      return 'vcluster'
+  }
+}
+
 interface SovereignSelf {
   deploymentId: string
   sovereignFQDN: string

--- a/products/catalyst/bootstrap/ui/src/pages/org/CreateOrganizationPage.plan-g7.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/org/CreateOrganizationPage.plan-g7.test.tsx
@@ -1,0 +1,152 @@
+/**
+ * CreateOrganizationPage.plan-g7.test.tsx — UAT row G7 (Refs #4293).
+ *
+ * Clause: "vcluster dual-door walk — both Org doors land a vcluster-isolation
+ * Org."
+ *
+ * # What was actually missing
+ *
+ * Not a precondition — a FIELD. An Organization's boundary primitive is decided
+ * by `boundaryIsVcluster(planSlug)` alone (#4292, the tier gate at
+ * core/controllers/organization/internal/gitops/manifests.go:151): free/S share
+ * the host `<slug>` namespace, m/l/xl/flexi get a dedicated Org-vCluster. The
+ * server has accepted `plan_slug` on this door since #4292
+ * (organization_provisioning.go:290, normalised against catalogPlanSlugs:361),
+ * and the FUNNEL door has sent one since #4473
+ * (core/services/provisioning/handlers/organization_create.go:140).
+ *
+ * The CONSOLE door never sent it. `OrgCreateRequest` had no such member, so
+ * every Organization created here arrived plan-less, was normalised to `s`, and
+ * was authored onto a host namespace. "Both doors land a vcluster-isolation
+ * Org" was unsatisfiable from this door by construction — and an operator who
+ * opened Advanced and picked `vcluster` got HTTP 422 `isolation-plan-conflict`
+ * from #6135, because the plan could not deliver what the label claimed.
+ *
+ * These tests drive the REAL component and assert on the REAL submit payload
+ * (the mocked `createOrganization` is the module boundary, one layer below the
+ * page), not on a helper.
+ */
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { CreateOrganizationPage } from './CreateOrganizationPage'
+import { createOrganization, type SovereignParentDomain } from './org.api'
+import { ORG_PLAN_SLUGS, isolationForPlan } from '@/lib/organizations.api'
+
+vi.mock('./org.api', async () => {
+  const actual = await vi.importActual<typeof import('./org.api')>('./org.api')
+  return { ...actual, createOrganization: vi.fn() }
+})
+
+const POOL: SovereignParentDomain[] = [
+  { name: 'omani.homes', role: 'org-pool', flipStatus: 'ready' },
+]
+
+/** Fill the required fields and submit; the create is rejected so the page
+ *  stays on the form and the payload is all we read. */
+async function submitWith(mutate: () => void) {
+  vi.mocked(createOrganization).mockClear()
+  vi.mocked(createOrganization).mockRejectedValueOnce(new Error('stop here'))
+  render(<CreateOrganizationPage initialParentDomains={POOL} disableFetch />)
+  mutate()
+  fireEvent.change(screen.getByTestId('org-create-subdomain'), {
+    target: { value: 'acme' },
+  })
+  fireEvent.change(screen.getByTestId('org-create-email'), {
+    target: { value: 'admin@acme.com' },
+  })
+  fireEvent.click(screen.getByTestId('org-create-submit'))
+  await waitFor(() => expect(createOrganization).toHaveBeenCalled())
+  return vi.mocked(createOrganization).mock.calls.at(-1)![0]
+}
+
+describe('UAT row G7 — the console door can order a vcluster-isolation Org', () => {
+  beforeEach(() => {
+    // This suite renders the page in every case; without an explicit unmount
+    // the previous DOM lingers and every getByTestId resolves to two nodes.
+    cleanup()
+    vi.mocked(createOrganization).mockReset()
+  })
+
+  it('offers exactly the plans the server accepts', () => {
+    render(<CreateOrganizationPage initialParentDomains={POOL} disableFetch />)
+    const select = screen.getByTestId('create-org-plan-select') as HTMLSelectElement
+    const offered = Array.from(select.options).map((o) => o.value)
+    // A plan the server does not know is silently coerced to "s" — an option
+    // that quietly becomes a different Org is worse than no option.
+    expect(offered).toEqual([...ORG_PLAN_SLUGS])
+  })
+
+  it('sends the chosen paid plan, which is what makes the Org vcluster-backed', async () => {
+    const body = await submitWith(() => {
+      fireEvent.change(screen.getByTestId('create-org-plan-select'), {
+        target: { value: 'm' },
+      })
+    })
+    expect(
+      body.plan_slug,
+      'the console door dropped the plan again — the server normalises a ' +
+        'plan-less create to "s" and boundaryIsVcluster("s") is false, so the ' +
+        'Org is authored onto the host namespace and G7 cannot pass from this door',
+    ).toBe('m')
+  })
+
+  it('renders the boundary the chosen plan will actually deliver', () => {
+    render(<CreateOrganizationPage initialParentDomains={POOL} disableFetch />)
+    const badge = () =>
+      screen.getByTestId('create-org-isolation').getAttribute('data-isolation')
+
+    // Default plan S — host namespace.
+    expect(badge()).toBe('namespace')
+
+    fireEvent.change(screen.getByTestId('create-org-plan-select'), {
+      target: { value: 'm' },
+    })
+    expect(badge()).toBe('vcluster')
+
+    // CONTROL that shares the suspect property: back down to S on the same
+    // form. A page that simply started printing 'vcluster' once a plan control
+    // existed would pass the assertion above and fail this one.
+    fireEvent.change(screen.getByTestId('create-org-plan-select'), {
+      target: { value: 's' },
+    })
+    expect(badge()).toBe('namespace')
+  })
+
+  it('the default plan is still S, so an operator who ignores the control gets the old behaviour', async () => {
+    const body = await submitWith(() => undefined)
+    expect(body.plan_slug).toBe('s')
+    // Unchanged from #5857: isolation is not sent as a default, so the server
+    // derives it from the tier gate.
+    expect('isolation' in body).toBe(false)
+  })
+
+  it('a paid plan plus an explicit isolation assertion AGREE, so #6135 cannot 422 them', async () => {
+    const body = await submitWith(() => {
+      fireEvent.change(screen.getByTestId('create-org-plan-select'), {
+        target: { value: 'xl' },
+      })
+      fireEvent.click(screen.getByTestId('create-org-advanced-toggle'))
+    })
+    expect(body.plan_slug).toBe('xl')
+    // The advanced panel opens showing the plan-derived value, so submitting it
+    // asserts the boundary the plan delivers rather than contradicting it —
+    // which is the whole contract of #6135's constraint assertion.
+    expect(body.isolation).toBe('vcluster')
+  })
+
+  it('every plan the picker offers maps to a boundary, and the paid ones map to vcluster', () => {
+    // Vacuity control for isolationForPlan: if it ever returned one constant,
+    // the badge assertions above would still pass for one of the two cases and
+    // silently stop discriminating.
+    const mapped = ORG_PLAN_SLUGS.map((p) => isolationForPlan(p))
+    expect(new Set(mapped).size, 'the tier gate collapsed to a single answer').toBe(2)
+    expect(isolationForPlan('s')).toBe('namespace')
+    for (const paid of ['m', 'l', 'xl', 'flexi']) {
+      expect(isolationForPlan(paid), `plan ${paid} must deliver a vCluster`).toBe('vcluster')
+    }
+    // Mirrors the server's `case "", "s", "free"` arm verbatim.
+    expect(isolationForPlan('')).toBe('namespace')
+    expect(isolationForPlan('free')).toBe('namespace')
+    expect(isolationForPlan('M')).toBe('vcluster')
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/org/CreateOrganizationPage.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/org/CreateOrganizationPage.test.tsx
@@ -49,13 +49,34 @@ describe('CreateOrganizationPage', () => {
 
   /* ── Organizations internal door (issue #3378 B1, DoD-4) ── */
 
-  it('defaults to customer kind with real + vcluster derived defaults', () => {
+  /* UAT row G7 — this test USED TO assert `data-isolation === 'vcluster'` on
+   * first render, and it was protecting a defect rather than behaviour.
+   *
+   * The form's own #5857 comment already recorded why 'vcluster' is wrong here:
+   * the boundary is authored by `boundaryIsVcluster(planSlug)` alone, the form
+   * sent no plan, the server normalised it to `s`, and the org-controller
+   * therefore built a host `<slug>` namespace. The badge asserted 'vcluster'
+   * over a namespace-backed Org — "the BACKING was always right, only the label
+   * ignored the tier", which is the exact mislabel isolationForTier was written
+   * to remove. Pinning it kept the page advertising a boundary it could not
+   * order, and made the honest value look like the regression.
+   *
+   * The kind-derived BILLING default is real behaviour and stays pinned.
+   * Isolation now follows the plan, so it is asserted against the default plan
+   * below and re-asserted for a paid tier in CreateOrganizationPage.plan-g7.test.tsx.
+   */
+  it('defaults to customer kind with real billing and the default plan S boundary', () => {
     render(<CreateOrganizationPage initialParentDomains={POOL} disableFetch />)
     expect(
       screen.getByTestId('create-org-kind-customer').getAttribute('aria-pressed'),
     ).toBe('true')
     expect(screen.getByTestId('create-org-billing-mode').getAttribute('data-mode')).toBe('real')
-    expect(screen.getByTestId('create-org-isolation').getAttribute('data-isolation')).toBe('vcluster')
+    // Plan defaults to S, and S shares the host namespace — so this is what the
+    // create will actually deliver.
+    expect(
+      (screen.getByTestId('create-org-plan-select') as HTMLSelectElement).value,
+    ).toBe('s')
+    expect(screen.getByTestId('create-org-isolation').getAttribute('data-isolation')).toBe('namespace')
   })
 
   it('selecting Internal renders showback + namespace defaults', () => {
@@ -185,11 +206,12 @@ describe('CreateOrganizationPage', () => {
     vi.mocked(createOrganization).mockRejectedValueOnce(new Error('stop here'))
     render(<CreateOrganizationPage initialParentDomains={POOL} disableFetch />)
 
-    // Sanity: the badge still SHOWS the kind default, so this is a
-    // wire-payload fix and not a visible-behaviour change.
+    // Sanity: the badge shows the boundary the DEFAULT PLAN delivers. This
+    // line used to assert 'vcluster' — the kind default — which is the mislabel
+    // described above rather than a property worth preserving (UAT row G7).
     expect(
       screen.getByTestId('create-org-isolation').getAttribute('data-isolation'),
-    ).toBe('vcluster')
+    ).toBe('namespace')
 
     fireEvent.change(screen.getByTestId('org-create-subdomain'), {
       target: { value: 'acme' },

--- a/products/catalyst/bootstrap/ui/src/pages/org/CreateOrganizationPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/org/CreateOrganizationPage.tsx
@@ -37,10 +37,13 @@ import {
 // Organizations model (issue #3378 B1) — the kind-derived defaults that
 // drive the internal door's billingMode + isolation rendering.
 import {
+  isolationForPlan,
   kindDefaults,
+  ORG_PLAN_SLUGS,
   type OrgBillingMode,
   type OrgIsolation,
   type OrgKind,
+  type OrgPlanSlug,
 } from '@/lib/organizations.api'
 
 export interface CreateOrganizationPageProps {
@@ -81,17 +84,38 @@ export function CreateOrganizationPage({
   const [advancedOpen, setAdvancedOpen] = useState<boolean>(false)
   const derived = kindDefaults(orgKind)
   const [billingMode, setBillingMode] = useState<OrgBillingMode>(derived.billingMode)
-  const [isolation, setIsolation] = useState<OrgIsolation>(derived.isolation)
 
-  // When kind flips, re-seed billingMode + isolation to the kind default
-  // UNLESS the operator has opened the advanced override (then their
-  // explicit choice sticks). This is what makes "internal → showback +
-  // namespace render" the moment Internal is selected (DoD-4).
+  // ── The PURCHASED plan (UAT row G7, Refs #4293/#4292) ──
+  // The #4292 tier gate decides the Organization's boundary primitive from the
+  // plan slug ALONE — free/S share the host `<slug>` namespace, M+ gets a
+  // dedicated Org-vCluster. This form had no plan input at all, so every
+  // Organization it created was normalised server-side to `s` and could only
+  // ever be namespace-backed. That is why the dual-door clause was unsatisfiable
+  // from this door: not a missing precondition, a missing FIELD.
+  //
+  // Defaults to `s` — the value the server already substituted — so an operator
+  // who ignores this control gets byte-identical behaviour to before.
+  const [planSlug, setPlanSlug] = useState<OrgPlanSlug>('s')
+  const [advancedIsolation, setAdvancedIsolation] = useState<OrgIsolation | null>(null)
+
+  // Isolation is DERIVED from the plan, by the same predicate the server and
+  // the org-controller's renderer apply. It is a PREVIEW of what the chosen
+  // plan will deliver, never an independent choice — a form that let these two
+  // drift is exactly how a create returned 202 saying `vcluster` while a host
+  // namespace was authored (#5857/#6135).
+  const isolation: OrgIsolation = advancedIsolation ?? isolationForPlan(planSlug)
+
+  // When kind flips, re-seed billingMode to the kind default UNLESS the
+  // operator has opened the advanced override (then their explicit choice
+  // sticks). This is what makes "internal → showback render" the moment
+  // Internal is selected (DoD-4). Isolation is no longer re-seeded here: it
+  // follows the plan, and `kind` never selected the boundary primitive — that
+  // conflation is what #4292 removed from the server and what this page kept
+  // rendering afterwards.
   useEffect(() => {
     if (advancedOpen) return
-    const d = kindDefaults(orgKind)
-    setBillingMode(d.billingMode)
-    setIsolation(d.isolation)
+    setBillingMode(kindDefaults(orgKind).billingMode)
+    setAdvancedIsolation(null)
   }, [orgKind, advancedOpen])
 
   const isInternal = orgKind === 'internal'
@@ -175,13 +199,18 @@ export function CreateOrganizationPage({
         // so the advanced override round-trips.
         kind: orgKind,
         billing_mode: billingMode,
+        // UAT row G7 — the purchased plan. The ONLY input that decides whether
+        // this Organization is authored onto a dedicated vCluster or the host
+        // `<slug>` namespace, and the field this door never sent.
+        plan_slug: planSlug,
         // #5857 (UAT row G7) — send `isolation` ONLY as an explicit operator
         // override, never as the form's own default.
         //
-        // This form has no plan input, so the server normalises planSlug to "s"
-        // and the GitOps renderer derives the boundary from planSlug alone
-        // (BoundaryIsVcluster("s") === false → the host `<slug>` namespace). It
-        // never reads the record's Isolation.
+        // The GitOps renderer derives the boundary from planSlug alone
+        // (BoundaryIsVcluster) and never reads the record's Isolation. The
+        // form now SENDS a plan, so the derived value below is the one the
+        // plan will actually deliver rather than a fixed 'vcluster' label over
+        // a server-substituted "s".
         //
         // `resolveOrgShape` USED to let a valid explicit `isolation` bypass the
         // tier gate. Sending the kind default — 'vcluster' for every customer —
@@ -276,6 +305,32 @@ export function CreateOrganizationPage({
               )
             })}
           </div>
+          {/* ── Plan (UAT row G7, Refs #4293/#4292) ──
+              The purchased tier. This is the ONE input that selects the
+              Organization's boundary primitive: free/S share the host `<slug>`
+              namespace, M and above get a dedicated Org-vCluster. Options come
+              from ORG_PLAN_SLUGS — the same list the server normalises against,
+              so nothing offered here can be silently coerced on submit. */}
+          <label className="grid gap-1 text-sm">
+            <span className="text-[var(--color-text-dim)]">Plan</span>
+            <select
+              data-testid="create-org-plan-select"
+              value={planSlug}
+              onChange={(e) => setPlanSlug(e.target.value as OrgPlanSlug)}
+              className="rounded-md border border-[var(--color-border)] bg-[var(--color-input)] px-3 py-2 text-sm"
+            >
+              {ORG_PLAN_SLUGS.map((p) => (
+                <option key={p} value={p}>
+                  {p.toUpperCase()} — {isolationForPlan(p)} isolation
+                </option>
+              ))}
+            </select>
+            <span className="text-xs text-[var(--color-text-dim)]">
+              The plan decides the boundary this organization is built on, and
+              the ResourceQuota and LimitRange that cap it. S shares the host
+              namespace; M and above get a dedicated vCluster.
+            </span>
+          </label>
           {/* Kind-derived defaults — the §2.3 values that render the
               moment Internal/Customer is selected. */}
           <div
@@ -329,7 +384,7 @@ export function CreateOrganizationPage({
                 <select
                   data-testid="create-org-isolation-select"
                   value={isolation}
-                  onChange={(e) => setIsolation(e.target.value as OrgIsolation)}
+                  onChange={(e) => setAdvancedIsolation(e.target.value as OrgIsolation)}
                   className="rounded-md border border-[var(--color-border)] bg-[var(--color-surface)] px-2 py-1.5"
                 >
                   <option value="namespace">namespace</option>

--- a/products/catalyst/bootstrap/ui/src/pages/org/org.api.ts
+++ b/products/catalyst/bootstrap/ui/src/pages/org/org.api.ts
@@ -189,6 +189,22 @@ export interface OrgCreateRequest {
   tier?: 'org' | 'corporate'
   billing_mode?: 'real' | 'chargeback' | 'showback'
   isolation?: 'namespace' | 'vcluster'
+  /** The PURCHASED catalog plan (s|m|l|xl|flexi) — UAT row G7, Refs
+   *  #4293/#4292.
+   *
+   *  This field is what makes the console door capable of ordering a
+   *  vcluster-isolation Organization at all. The server has accepted
+   *  `plan_slug` since #4292 (organization_provisioning.go:290) and derives
+   *  BOTH the boundary primitive (`boundaryIsVcluster`) and the
+   *  ResourceQuota/LimitRange from it — but this request type never carried
+   *  it, so every Organization created through the console arrived with no
+   *  plan, was normalised to `s`, and was authored onto the host `<slug>`
+   *  namespace. The dual-door clause ("both Org doors land a
+   *  vcluster-isolation Org") could not be satisfied from this door by
+   *  construction; the funnel door has carried the slug since #4473.
+   *
+   *  Omitted ⇒ the server's `s` default, i.e. the previous behaviour. */
+  plan_slug?: string
 }
 
 /** Wire shape mirrors the canonical issue #829 endpoint


### PR DESCRIPTION
Root-causes and fixes four UAT rows that were ❌ with no owner and no diagnosis. Three turned out to be **written but defective**; one is a **missing producer**. All four defects are on the exact surface each clause names.

## Per-row verdict

| Row | Class | Evidence (`file:line`) | What I did |
|---|---|---|---|
| **G7** (#4293) | **(a) never written** | `products/catalyst/bootstrap/ui/src/pages/org/CreateOrganizationPage.tsx:181` said it verbatim: *"This form has no plan input, so the server normalises planSlug to `s`"*. The consumer chain is complete and correct — server accepts `plan_slug` (`organization_provisioning.go:290`), normalises against `catalogPlanSlugs` (`:361`), derives isolation via `isolationForTier` (`:346`), and the renderer's tier gate `boundaryIsVcluster` (`core/controllers/organization/internal/gitops/manifests.go:151`) maps `""`/`s`/`free` → host-ns and m/l/xl/flexi → vCluster. `OrgCreateRequest` (`org.api.ts:165`) simply had no such member. The **funnel** door has sent the slug since #4473 (`core/services/provisioning/handlers/organization_create.go:140`). | Implemented the producer: plan picker + `plan_slug` on the wire, and the displayed isolation now derives from the plan. |
| **60** (#3375) | **(b) defective** | `application_controller.go:872` fed `ResolveTopology` the field `spec.Topology`, parsed at `:3514` with `unstructured.NestedString(app.Object, "spec", "topology")` — against a field the CRD types as an **OBJECT** (`products/catalyst/chart/crds/application.yaml:221`: autoFailover/rto/rpo/minReplicas). It could only ever be `""`, so the operator-override branch (`internal/render/topology.go:137`) was dead code. | Read the posture from `spec.placement(.mode)` — the field the create door actually writes (`endpoint_handler.go:2339`) and the one the bootstrap producer already used (`:3161`). Removed the dead field + its dead read. |
| **222** (#3988) | **(b) defective** | `org_applications.go:343` — `if appList, err := …List(…); err == nil {` discarded the error, so a failed List produced a 200 whose `apps` came from the HelmRelease + HTTPRoute passes alone. This is the **only** reader that can surface an agent-created Application CR (`create_application` → `catalogue.go:373` → `applications.go:547`). Same conflation #6249/#6251 fixed on the Sovereign estate (`sovereign.go:786`); this sibling was never enrolled. | Report the gap via `applicationEstateUnreadable` rather than compensate for it. |
| **234** (#4307) | **(b) defective** | `core/services/provisioning/main.go:192` pinned `openclaw=0.2.13,stalwart-mail=0.1.13` under a comment declaring *"Defaults = the current catalog-seed pins"*. Seed says `bp-stalwart-tenant` **0.1.15** (`catalog-seed/blueprints.yaml:2821`) and `bp-openclaw` **0.2.18** (`:2401`). `bp-newapi` is an HR-shaped app (`helmrelease_apps.go:61`) with **no pin at all** → floating `version: "*"`, exactly what #4706 forbids. | Corrected the pins and added the guard that was missing. |

### Why row 60's remaining half was the Switchover

`placement.Resolve(spec.Placement, …)` — the primary/standby roles the Topology tab paints — always read the operator's real posture, while the `(choice, variant)` pair feeding `buildContinuumPlan` (`continuum.go:141`) read the Blueprint's region-count default. Two halves of one clause driven by two different fields. `buildContinuumPlan`'s first gate is `choice != BcpActiveHotStandby && choice != BcpActivePassive`, so a Blueprint that **supports** hot-standby but **defaults** to singleton rendered the 2-region pair and silently dropped the DR contract. That Blueprint shape is not hypothetical — `bp-openclaw` and `bp-stalwart-tenant` both ship `defaults.multi-region: singleton`.

The fix is deliberately non-escalating: an unsupported posture returns `""` and keeps today's default fallback rather than newly failing the Application, because `spec.Placement` is validated upstream (`:765`) against `placementSchema.modes[]` — a **different** list from `topology.supported[]`.

### Why row 234's pin lag is fatal rather than cosmetic

`bp-stalwart-tenant` **0.1.14** is the §854 nodePort fix. Below it Kyverno **denies the HelmRelease at admission** — no pod, no HTTPRoute, and `mail.<slug>.<pool-tld>` answers nothing. The chart half of the clause is already correct and was not touched: the HTTPRoute is real (`platform/stalwart-tenant/chart/templates/ingress-webmail.yaml:28-30`, gateway mode default at `values.yaml:499`), parented at `cilium-gateway-console`, backed by SnappyMail (`webmail-deployment.yaml:27`), and the funnel stamps `mail.<slug>.<parent>` itself (`helmrelease_apps.go:581`).

### Why row 222's remedy differs from #6251's

#6251 **suppresses** the HelmRelease fallback once the Application estate is authoritative. Copying that here would be wrong: an Org legitimately owns HR-only apps (`agenity-demo`) and funnel purchases that deploy neither a CR nor an HR (`org_applications.go:422`). Suppressing them would blank a correct estate — trading one silent wrong answer for another. So every pass still runs and the response states plainly that the Application-keyed half is missing.

## Front-end trees grepped

All four, as required: `products/catalyst/bootstrap/ui/` (sovereign-admin — where rows 60 and G7 live), `core/marketplace/` (customer funnel — row 234's purchase path), `core/console/` (per-Org tenant console), `products/catalyst/console/`. Row 60's create door is `pages/sovereign/AppDetail/InstancesSection.tsx` `NewInstanceDialog` + `pages/sovereign/InstallPage.tsx`; **both already carry the mode and ≥2 regions correctly** — the create path was not the defect, the reconcile-side resolution was.

## Vacuity proofs — every new test watched failing on a mutant that still compiles

| Test | Mutant | Observed failure |
|---|---|---|
| `TestRow60_*` (6 cases) | `topologyOverrideFromPlacement` returns `""` (pre-fix) | Reconcile logged `choice=singleton clusters=[rtz-A]`; the arming, legacy-spelling, CRD-object and table cases all failed |
| `TestDefaultHRAppPins_MatchCatalogSeed` | restored `openclaw=0.2.13,stalwart-mail=0.1.13` | named all three: two drifts + newapi unpinned |
| `TestRow222_*` | dropped `resp.ApplicationEstateUnreadable = true` | both failure-path cases failed |
| `CreateOrganizationPage.plan-g7` | removed `plan_slug` from the submit | `expected undefined to be 'm' / 's' / 'xl'` |

Each also carries a **control sharing the suspect property**: row 60 asserts a `singleton` app on the same Blueprint/Environment/regions still arms nothing; G7 asserts the badge returns to `namespace` when the plan drops back to S; row 222 asserts an HR-only app survives a failed Application List; row 234's `GuardIsNotVacuous` proves the seed parse resolves the charts it polices and that the historical stale pin still discriminates.

## A test that was asserting the bug

`CreateOrganizationPage.test.tsx:58` pinned `data-isolation === 'vcluster'` on first render. The page's own #5857 comment records that exact value as *"the mislabel `isolationForTier` was written to remove"* — the form sent no plan, the server substituted `s`, and the org-controller built a host namespace, so the badge advertised a boundary that was never ordered. It was **protecting a defect, not behaviour**; repointed at the boundary the chosen plan delivers. Two sibling failures were a **cascade**, not independent breaks: the unconsumed `mockRejectedValueOnce('stop here')` from the aborted test leaked into the next one — verified rather than assumed, and both pass once the first is corrected.

## Not finished, with reasons

- **All four rows still need a live walk to go green.** These are source fixes; none is a walk, and `docs/ledger/UAT.md` is deliberately untouched — source proof is not walk evidence and `check-walk-respects-scheduler.sh` correctly rejects it.
- **Row 222 has a second, larger defect I did not guess at**: the discovery surface and the convergence surface are different sets. `list_blueprints` serves the Gitea/embedded catalog (99 ids) while the application-controller resolves **only** Blueprint CRs (81 seeded) — measured delta **25**, including `bp-librechat`, `bp-dragonfly`, `bp-neo4j`, `bp-knative`. An agent that picks one gets **HTTP 201 + `"applied": true`** and a CR that sits at `Pending/BlueprintMissing` forever. Closing that split is a design decision (seed the missing 25, or validate installs against the CR set, or converge the two catalogs) that I cannot settle from evidence, so it is written up on #3988 rather than guessed at here.

## Test runs

`core/controllers` ✅ · `core/services/provisioning` ✅ · `products/catalyst/bootstrap/api` ✅ (full suite, exit 0) · `products/catalyst/bootstrap/ui` ✅ 250 files / 2248 tests · `tsc --noEmit` clean · `check-no-conflict-markers.sh`, `check-no-banned-words.sh`, `check-guards-are-wired.sh` ✅

No chart version moved, so no five-site lockstep or umbrella bump is owed. No live-cluster writes; no NodePorts.

Refs #4293 #3375 #3988 #4307

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HvMZTDx7W6EPZMmjyXmYh1
