### PR TITLE
fix(cilium): the Gateway-API controller must survive a slow apiserver — a 30s ceiling upstream leaves region B's operator alive, healthy, and permanently deaf (#6255)

### DIFF
--- a/.github/workflows/test-bootstrap-kit.yaml
+++ b/.github/workflows/test-bootstrap-kit.yaml
@@ -169,6 +169,26 @@ jobs:
           pip install pyyaml --quiet 2>/dev/null || true
           bash platform/newapi/chart/tests/5612-slot80-session-carrier-render.sh
 
+      - name: cilium Gateway-API controller survives a slow apiserver (#6255)
+        # cilium-operator decides ONCE, at process start, whether to run its
+        # Gateway-API controller, and gives up after a HARDCODED 30s (upstream
+        # v1.19.3 operator/pkg/gateway-api/cell.go:135 — no flag widens it),
+        # returning a NIL error so the operator stays alive and healthy with the
+        # controller permanently off. On hw296 region me-east-215-b-1 that cost 4
+        # of the console Gateway's 10 listeners and, because the console EIP pool
+        # spans both regions, put every per-Org customer door at exactly 50%
+        # reachability. Region A, same chart and version, returned in 16.84s.
+        #
+        # This is a TIMING defect, so the guard holds a fake apiserver REFUSED
+        # for 35s — longer than the 30s ceiling — and asserts the controller ends
+        # up running anyway. It carries its own vacuity cases (no watchdog, and a
+        # 30s-bounded variant, both of which must FAIL the case-A assertions) and
+        # a fast-path control that forbids spurious restarts.
+        #
+        # It runs HERE and not only in blueprint-release.yaml because that job
+        # fires on push to main — a regression would already be merged.
+        run: bash platform/cilium/chart/tests/6255-gateway-api-controller-watchdog-slow-apiserver.sh
+
   pin-sync-audit:
     # TBD-A6 regression test. Asserts every Chart.yaml in platform/* or
     # products/* whose chart is pinned in clusters/_template/bootstrap-

--- a/clusters/_template/bootstrap-kit/01-cilium.yaml
+++ b/clusters/_template/bootstrap-kit/01-cilium.yaml
@@ -150,7 +150,25 @@ spec:
       # empty"), which the SPA paints as a permanent "Idle / Data streams are
       # reconnecting…". crossRegion below anchors the singleton in the primary
       # region; the secondary keeps only a zero-backend mesh stub. Refs #5602.
-      version: 1.4.19
+      # 1.4.20 (#6255, 2026-08-14): gateway-api-controller-watchdog. This slot's
+      # `dependsOn: bp-gateway-api` edge above (#2614) orders the FIRST install
+      # and stays correct — but cilium-operator decides ONCE, at process start,
+      # whether to run its Gateway-API controller, and gives up after a HARDCODED
+      # 30s (upstream v1.19.3 operator/pkg/gateway-api/cell.go:135; no flag
+      # widens it), returning a NIL error so the operator stays alive and healthy
+      # with the controller permanently off. Ordering cannot help an operator Pod
+      # that RESTARTS into a cold local apiserver — node reboot, eviction, OOM,
+      # or region-kill recovery. hw296 (dep e689e3b34a75fdec): region
+      # me-east-215-b-1 `Invoked duration=30.024306733s` after
+      # `dial tcp 10.179.1.83:6443: connect: connection refused` and published 6
+      # of the console Gateway's 10 listeners, while region me-east-215-a on the
+      # SAME chart and version returned in 16.84s and published 10/10. The shared
+      # console EIP pool spans both regions, so every per-Org customer door
+      # answered on exactly 50% of fresh TCP connections. The chart now ships a
+      # region-local watchdog running the UNBOUNDED CRD retry the operator lacks,
+      # which restarts the local operator when the controller is provably not
+      # reconciling. Refs #6255 #5511.
+      version: 1.4.20
       sourceRef:
         kind: HelmRepository
         name: bp-cilium

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1416,7 +1416,15 @@ spec:
       #   runner's yq (0.1.183 was never published). Catches the pin up past
       #   1.4.1463, whose Chart.yaml-only bump left this slot behind. Lockstep
       #   w/ products/catalyst/chart/Chart.yaml.
-      version: 1.4.1467
+      # 1.4.1468 — #6255 (UAT rows R16/87/90/95): catalog-seed advances
+      #   bp-cilium 1.4.19 -> 1.4.20, the release that stops region B's
+      #   cilium-operator from losing the Gateway-API CRD race against its
+      #   OWN apiserver at boot (upstream v1.19.3
+      #   operator/pkg/gateway-api/cell.go:135 bounds CRD discovery at a
+      #   hardcoded 30s and returns `{Enabled:false}, nil` on expiry, so the
+      #   operator stays alive and healthy with the controller permanently
+      #   off). Lockstep w/ products/catalyst/chart/Chart.yaml.
+      version: 1.4.1468
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/docs/ledger/PATH-TO-100.md
+++ b/docs/ledger/PATH-TO-100.md
@@ -221,6 +221,47 @@ the object on a pre-cutover Sovereign, then region B's
 `curl --no-keepalive --http1.1` x12 against `console.<slug>.<pool>` returns 12/12
 200 (fresh-TCP; HTTP/2 pins one backend and hides a 50% split).
 
+> 🟢 **MOVED ON 2026-08-14 — on hw296 the fan-out WORKED and the failure is now
+> one hop downstream (#6255, R16/87/90/95). Read this before re-deriving the
+> producer analysis above.** The listeners reached region B's `.spec` — all ten
+> of them — so `consoleRegionTargets`, the materializer and the disk kubeconfig
+> are no longer the failing leg on that environment. What fails is that region B
+> never *published* them: its `cilium-operator` lost the Gateway-API CRD race
+> against its OWN apiserver at boot and disabled the controller for the process
+> lifetime.
+>
+> Upstream cilium v1.19.3 `operator/pkg/gateway-api/cell.go:135` wraps CRD
+> discovery in a hardcoded `context.WithTimeout(context.Background(),
+> 30*time.Second)`. No pflag reaches it (cell.go:182-192), `isTransientError`
+> (cell.go:323-346) does not classify the resulting `context deadline exceeded`
+> as transient, and the give-up at cell.go:148-155 returns
+> `{Enabled:false}, **nil**` — so the hive cell SUCCEEDS, `/healthz` stays green,
+> and `initGatewayAPIController` (cell.go:210-213) returns without registering
+> the controller. The A/B is same-chart / same-version / same-boot on hw296
+> (dep `e689e3b34a75fdec`): region `me-east-215-a` `Invoked
+> duration=16.84419141s`, Gateway 10/10; region `me-east-215-b-1` `Invoked
+> duration=30.024306733s`, Gateway 10 spec / **6** status. Because the console
+> EIP pool spans both regions, every per-Org door answered on exactly 50% of
+> fresh TCP connections (15/30, against a 27/30 control on the SAME EIP).
+>
+> **Fix:** PR #6259, `bp-cilium 1.4.20` — a region-local
+> `gateway-api-controller-watchdog` that runs the unbounded CRD retry outside
+> the operator process and restarts the local operator once the CRDs are
+> Established. The ceiling is upstream Go; there is no flag to set.
+>
+> **Diagnose in this order on any 2-region Sovereign** — the three legs are
+> distinguishable in one command each, and confusing them has already cost
+> cycles: (1) listeners absent from region B's `.spec` → the producer chain
+> above; (2) present in `.spec`, missing from `.status` → #6255, confirm with
+> `kubectl -n kube-system logs deploy/cilium-operator | grep gateway-api` and
+> look for `Invoked duration=30.0…s`; (3) present in both and still 50% → a
+> genuine edge/datapath split. Note `Programmed=False / AddressNotAssigned` is
+> NORMAL in both regions under the §854 hostPort model and is not a signal.
+>
+> **Superseded here too:** #5511's wildcard/SNI-collision hypothesis. Region A
+> admits TWO per-Org wildcards simultaneously and reports 10/10 — #5511's own
+> proposed regression check, passing.
+
 ### Cluster C — Organization delete cascade (R17): **CLOSED 2026-08-11, walked green**
 
 `97dc33d3e` (#6051) is in `85e2eaf` and `581e042c6` (#6097) is in the running

--- a/platform/cilium/README.md
+++ b/platform/cilium/README.md
@@ -274,6 +274,49 @@ spec:
         backoff: 100ms
 ```
 
+### `gateway-api-controller-watchdog` (#6255)
+
+`cilium-operator` decides **once, at process start**, whether to run its
+Gateway-API controller. Upstream v1.19.3
+(`operator/pkg/gateway-api/cell.go:135`) bounds CRD discovery at a hardcoded
+`30*time.Second`; there is no flag behind it, so `operator.extraArgs` cannot
+widen it. On expiry it logs `Required GatewayAPI resources are not found` and
+returns `{Enabled: false}, nil` — a **nil error** — so the hive cell succeeds,
+the operator stays alive and healthy on `/healthz`, and the controller is never
+registered for the process lifetime.
+
+Measured on hw296: region `me-east-215-b-1` returned `Invoked
+duration=30.024306733s` after `dial tcp 10.179.1.83:6443: connect: connection
+refused`, while region `me-east-215-a` on the **same chart and version** returned
+in `16.84419141s` and worked. Region B then published 6 of the console Gateway's
+10 listeners and stopped reconciling it; because the console EIP pool spans both
+regions, every per-Org customer door answered on exactly 50% of fresh TCP
+connections.
+
+The slot-01 `dependsOn: bp-gateway-api` edge (#2614) is still correct but only
+orders the **first** install — it cannot help an operator Pod restarting into a
+cold apiserver on node reboot, eviction, OOM or region-kill recovery. So this
+chart ships a region-local `gateway-api-controller-watchdog` Deployment that:
+
+- waits **unbounded**, with capped backoff, for the local apiserver to answer and
+  the `gateway.networking.k8s.io` CRDs to reach `Established`;
+- then compares, live, `metadata.generation` against the Accepted condition's
+  `observedGeneration` on `GatewayClass/cilium` and on every Gateway of that
+  class, plus `len(spec.listeners)` against `len(status.listeners)` — stale
+  status written by a dead operator instance cannot satisfy either;
+- deletes the local `cilium-operator` Pod after `failureThreshold` consecutive
+  failing passes, subject to `restartCooldownSeconds`;
+- scores an unreachable apiserver as `UNKNOWN`, never counting it toward the
+  threshold — restarting during an outage would only re-run the race.
+
+`Programmed` is deliberately **not** asserted: under the §854 hostPort /
+Local-ETP model both regions legitimately report
+`Programmed=False / AddressNotAssigned`.
+
+Knobs live under `catalystOverlay.gatewayApiWatchdog` (default **on**; renders
+only when `cilium.gatewayAPI.enabled` is true). Guard:
+`chart/tests/6255-gateway-api-controller-watchdog-slow-apiserver.sh`.
+
 ---
 
 ## Resilience Patterns

--- a/platform/cilium/blueprint.yaml
+++ b/platform/cilium/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: per-host-cluster-infrastructure
     catalyst.openova.io/section: pts-3-1-networking-and-service-mesh
 spec:
-  version: 1.4.19
+  version: 1.4.20
   card:
     title: Cilium
     summary: Unified CNI + Service Mesh (eBPF). mTLS via WireGuard, Hubble observability, Gateway API.

--- a/platform/cilium/chart/Chart.yaml
+++ b/platform/cilium/chart/Chart.yaml
@@ -370,7 +370,49 @@ name: bp-cilium
 #   auth=none the HTTPRoute targets the UPSTREAM hubble-ui Service, which this
 #   chart does not own, so crossRegion is a documented no-op there.
 #   Refs #5602 #5358 #5406.
-version: 1.4.19
+#
+# 1.4.20 (#6255, 2026-08-14): gateway-api-controller-watchdog — cilium-operator
+#   loses the Gateway-API CRD race against its OWN apiserver at boot and never
+#   recovers. Upstream v1.19.3 `operator/pkg/gateway-api/cell.go:135` opens a
+#   HARDCODED `context.WithTimeout(context.Background(), 30*time.Second)` around
+#   CRD discovery. It is not a flag — `gatewayApiConfig.Flags()` (cell.go:182-192)
+#   exposes secrets-sync / xff-hops / hostnetwork and nothing that widens it, so
+#   `operator.extraArgs` cannot reach it. On expiry `isTransientError`
+#   (cell.go:323-346) does not treat the `context deadline exceeded` as
+#   transient, so cell.go:148-155 logs "Required GatewayAPI resources are not
+#   found" and returns `{Enabled:false}, nil` — a NIL error. The hive cell
+#   SUCCEEDS, the operator stays alive and healthy on /healthz, and
+#   `initGatewayAPIController` (cell.go:210-213) returns immediately without
+#   registering the controller. Nothing re-invokes it for the process lifetime.
+#   Live A/B on hw296 (dep e689e3b34a75fdec), SAME chart, SAME version, SAME
+#   boot: region me-east-215-a `Invoked duration=16.84419141s`, controller
+#   running, Gateway 10 spec / 10 status; region me-east-215-b-1
+#   `Invoked duration=30.024306733s` after `dial tcp 10.179.1.83:6443: connect:
+#   connection refused`, controller never started, Gateway 10 spec / 6 status
+#   with the four per-Org listeners silently dropped. The console EIP pool spans
+#   both regions, so every per-Org customer door answered on exactly 50% of
+#   fresh TCP connections (15/30 served, vs a 27/30 control on the SAME EIP).
+#   The bootstrap-kit `dependsOn: bp-gateway-api` edge (#2614) stays correct but
+#   only orders the FIRST install — it cannot help an operator Pod restarting
+#   into a cold apiserver on node reboot, eviction, OOM or region-kill recovery.
+#   FIX (deployment-level, because the ceiling is upstream Go): a region-local
+#   `gateway-api-controller-watchdog` Deployment that runs the UNBOUNDED retry
+#   the operator lacks — no attempt cap, no deadline — then deletes the local
+#   cilium-operator Pod when the controller is provably not reconciling while
+#   the CRDs ARE Established. Liveness is a live generation-vs-observedGeneration
+#   and spec-vs-status-listener comparison, never a trust of written status (region
+#   B's stale 6 listeners were written by an earlier instance); `Programmed` is
+#   deliberately not asserted since `AddressNotAssigned` is normal under the §854
+#   hostPort model on BOTH regions. Apiserver-unreachable passes score UNKNOWN and
+#   never trigger a restart. Guarded by
+#   chart/tests/6255-gateway-api-controller-watchdog-slow-apiserver.sh, which
+#   holds a fake apiserver refused for 35s (longer than the 30s ceiling) and
+#   fails against both a no-watchdog world and a 30s-bounded variant.
+#   This supersedes the wildcard/SNI-collision hypothesis #5511 closed on:
+#   region A admits TWO per-Org wildcards simultaneously and reports 10/10,
+#   which is #5511's own proposed regression check, passing. Refs #6255 #5511
+#   #3376 #4290.
+version: 1.4.20
 description: |
   Catalyst-curated Blueprint umbrella chart for Cilium. Depends on the
   upstream `cilium` chart as a Helm subchart so `helm dependency build`

--- a/platform/cilium/chart/files/gateway-api-controller-watchdog.sh
+++ b/platform/cilium/chart/files/gateway-api-controller-watchdog.sh
@@ -246,13 +246,20 @@ while true; do
       # the very race being fixed.
       log "pass verdict=UNKNOWN detail=${detail} — not counted toward the failure threshold"
       ;;
-    *)
+    DEAD)
       consecutive=$((consecutive + 1))
       log "pass verdict=DEAD consecutive=${consecutive}/${THRESHOLD} detail=${detail}"
       if [ "$consecutive" -ge "$THRESHOLD" ]; then
         restart_operator
         consecutive=0
       fi
+      ;;
+    *)
+      # DEAD is the only verdict that may restart anything, so it must be named
+      # explicitly. A catch-all `*)` that fell through to DEAD would turn any
+      # future unrecognised verdict — or an empty line from a truncated
+      # controller_verdict — into a Pod deletion. Unrecognised is UNKNOWN.
+      log "pass verdict=UNRECOGNISED line='${verdict_line}' — treated as UNKNOWN, not counted"
       ;;
   esac
   sleep "$INTERVAL"

--- a/platform/cilium/chart/files/gateway-api-controller-watchdog.sh
+++ b/platform/cilium/chart/files/gateway-api-controller-watchdog.sh
@@ -1,0 +1,259 @@
+#!/usr/bin/env bash
+# bp-cilium — gateway-api-controller-watchdog (#6255)
+#
+# ─── THE DEFECT THIS EXISTS FOR ────────────────────────────────────────────────
+#
+# cilium-operator decides ONCE, at process start, whether to run its Gateway-API
+# controller. Upstream cilium v1.19.3,
+# `operator/pkg/gateway-api/cell.go:135`:
+#
+#     ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+#
+# That 30 seconds is a hardcoded literal. It is not a flag — `gatewayApiConfig.
+# Flags()` (cell.go:182-192) registers `enable-gateway-api-secrets-sync`,
+# `gateway-api-xff-num-trusted-hops`, `gateway-api-hostnetwork-enabled` and
+# friends, and NOTHING that widens this budget — so no value in
+# `operator.extraArgs` can reach it. When the budget expires, `isTransientError`
+# (cell.go:323-346) does not classify the resulting `context deadline exceeded`
+# as transient, so control falls into cell.go:148-155:
+#
+#     params.Logger.Error("Required GatewayAPI resources are not found, ...")
+#     return &gatewayAPIPreconditions{Enabled: false}, nil
+#
+# …which returns **nil error**. The hive cell therefore SUCCEEDS. The operator
+# stays alive and reports healthy on /healthz, and `initGatewayAPIController`
+# (cell.go:210-213) returns immediately on `!Preconditions.Enabled` without ever
+# registering the controller. There is no re-entry for the process lifetime.
+#
+# Measured on Sovereign hw296 (dep e689e3b34a75fdec, 2-region me-east-215-a/-b),
+# 2026-08-13. Region B, at boot:
+#
+#     18:32:05 warn  Failed to check GatewayAPI CRDs due to transient error, will retry
+#                    error="... dial tcp 10.179.1.83:6443: connect: connection refused"
+#     18:32:35 error Required GatewayAPI resources are not found, ...
+#     18:32:35 info  Invoked duration=30.024306733s function="gateway-api.initGatewayAPIController"
+#
+# Region A, same chart, same version, same boot: `Invoked duration=16.84419141s`,
+# no error, controller running. 16.8s vs 30.0s is the ENTIRE difference. Region
+# B's own apiserver was simply slower to answer, which on a fresh 2-region prov
+# — and on every region-kill recovery, where the apiserver comes back cold — is
+# a NORMAL condition, not an error.
+#
+# Downstream, region B published 6 of the console Gateway's 10 listeners and
+# stopped reconciling it. The console EIP pool spans both regions, so every
+# per-Org customer door answered on exactly 50% of fresh TCP connections
+# (measured 15/30 served, against a 27/30 control on the same EIP). That is what
+# holds UAT rows R16 / 87 / 90 / 95 red.
+#
+# ─── WHY THIS IS A DEPLOYMENT-LEVEL FIX ───────────────────────────────────────
+#
+# The bounded retry is upstream Go we do not own, and it is not reachable from
+# any chart value or operator flag. So our fix is at the deployment level: keep
+# an unbounded retry OUTSIDE the operator process, and re-invoke the operator
+# when the precondition it gave up on is finally satisfiable. That is a watch,
+# not a one-shot poll — exactly what cell.go lacks.
+#
+# The bootstrap-kit already orders `bp-cilium dependsOn bp-gateway-api` (#2614),
+# and that is still correct and still necessary — but ordering only constrains
+# the FIRST install. It does nothing for the case this watchdog exists for: the
+# operator pod restarting (node reboot, eviction, OOM, region-kill recovery)
+# while its own apiserver is still cold.
+#
+# ─── WHAT IT DOES ─────────────────────────────────────────────────────────────
+#
+#   1. Waits — UNBOUNDED, with capped exponential backoff — for the local
+#      apiserver to answer AND the gateway.networking.k8s.io CRDs to be
+#      Established. No attempt ceiling, no deadline. This is the retry the
+#      operator does not have.
+#   2. Then evaluates, on every pass, whether THIS cluster's Gateway-API
+#      controller is actually reconciling.
+#   3. If it is not, for `WATCHDOG_FAILURE_THRESHOLD` consecutive passes, it
+#      deletes the local cilium-operator Pod. The replacement boots with the
+#      CRDs already Established, so cell.go's 30s budget is satisfied on the
+#      first poll — region A's fast path.
+#   4. Loops forever, so a later apiserver flap that restarts the operator into
+#      the same race is healed too.
+#
+# ─── HOW LIVENESS IS DETECTED WITHOUT TRUSTING STALE STATUS ───────────────────
+#
+# Region B's Gateway carried 6 status listeners written by an EARLIER operator
+# instance and kept them after the controller died — a bare `Accepted=True` or a
+# non-empty `.status.listeners` proves nothing. Every check here is a LIVE
+# COMPARISON that a stale write cannot satisfy:
+#
+#   * GatewayClass/cilium — `Accepted=True` AND
+#     `observedGeneration == metadata.generation`.
+#   * every Gateway on that class — `len(status.listeners) == len(spec.listeners)`
+#     AND the Accepted condition's `observedGeneration == metadata.generation`.
+#
+# `Programmed` is deliberately NOT asserted. Under the §854 hostPort / Local-ETP
+# model BOTH regions legitimately report `Programmed=False / AddressNotAssigned`
+# — #5511 already recorded that, and asserting on it would fire on every healthy
+# Sovereign.
+#
+# A pass that cannot reach the apiserver returns UNKNOWN and is NOT counted
+# toward the failure threshold. Restarting the operator during an apiserver
+# outage would only re-run the exact race this fixes.
+
+set -uo pipefail
+
+INTERVAL="${WATCHDOG_INTERVAL_SECONDS:-30}"
+CRD_BACKOFF_MIN="${WATCHDOG_CRD_BACKOFF_MIN_SECONDS:-1}"
+CRD_BACKOFF_MAX="${WATCHDOG_CRD_BACKOFF_MAX_SECONDS:-30}"
+THRESHOLD="${WATCHDOG_FAILURE_THRESHOLD:-3}"
+RESTART_COOLDOWN="${WATCHDOG_RESTART_COOLDOWN_SECONDS:-300}"
+GWC="${WATCHDOG_GATEWAY_CLASS:-cilium}"
+OPERATOR_NS="${WATCHDOG_OPERATOR_NAMESPACE:-kube-system}"
+OPERATOR_SELECTOR="${WATCHDOG_OPERATOR_SELECTOR:-io.cilium/app=operator,name=cilium-operator}"
+
+# The three kinds cell.go's `requiredGVKs` insists on. If any is not Established
+# the operator's own check would fail, so there is nothing to restart it into.
+REQUIRED_CRDS="${WATCHDOG_REQUIRED_CRDS:-gatewayclasses.gateway.networking.k8s.io gateways.gateway.networking.k8s.io httproutes.gateway.networking.k8s.io}"
+
+LAST_RESTART=0
+
+log() { printf '[gw-api-watchdog] %s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*"; }
+
+# echoes exactly one of: established | missing | unreachable
+crd_probe() {
+  local c out rc
+  for c in $REQUIRED_CRDS; do
+    out="$(kubectl get crd "$c" -o jsonpath='{.status.conditions[?(@.type=="Established")].status}' 2>&1)"
+    rc=$?
+    if [ "$rc" -ne 0 ]; then
+      case "$out" in
+        *"not found"*|*NotFound*|*"the server doesn't have a resource type"*) echo missing; return 0 ;;
+        *) echo unreachable; return 0 ;;
+      esac
+    fi
+    [ "$out" = "True" ] || { echo missing; return 0; }
+  done
+  echo established
+}
+
+# UNBOUNDED. There is deliberately no attempt cap and no deadline here — that
+# ceiling IS the defect (cell.go:135). A slow apiserver at operator boot is a
+# normal condition on a fresh 2-region prov and on every region-kill recovery.
+wait_for_crds() {
+  local attempt=0 backoff="$CRD_BACKOFF_MIN" state
+  while true; do
+    attempt=$((attempt + 1))
+    state="$(crd_probe)"
+    if [ "$state" = established ]; then
+      log "crd-wait satisfied attempt=${attempt} (gateway.networking.k8s.io CRDs Established)"
+      return 0
+    fi
+    log "crd-wait attempt=${attempt} state=${state} — retrying in ${backoff}s (no ceiling)"
+    sleep "$backoff"
+    backoff=$((backoff * 2))
+    [ "$backoff" -gt "$CRD_BACKOFF_MAX" ] && backoff="$CRD_BACKOFF_MAX"
+  done
+}
+
+# echoes "<LIVE|DEAD|UNKNOWN> <detail>"
+controller_verdict() {
+  local gc_out rc gen obs st gws_out drift
+
+  gc_out="$(kubectl get gatewayclass "$GWC" -o json 2>&1)"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    case "$gc_out" in
+      *"not found"*|*NotFound*|*"the server doesn't have a resource type"*)
+        # gatewayClass.create=false, or Gateway API simply unused here. Nothing
+        # to assert — never restart the operator on this.
+        echo "LIVE gatewayclass/${GWC}-absent"; return 0 ;;
+      *) echo "UNKNOWN gatewayclass-read-failed"; return 0 ;;
+    esac
+  fi
+
+  gen="$(jq -r '.metadata.generation // 0' <<<"$gc_out" 2>/dev/null)"
+  st="$(jq -r  '[.status.conditions[]? | select(.type=="Accepted")][0].status // "Missing"' <<<"$gc_out" 2>/dev/null)"
+  obs="$(jq -r '[.status.conditions[]? | select(.type=="Accepted")][0].observedGeneration // -1' <<<"$gc_out" 2>/dev/null)"
+  if [ -z "$gen" ] || [ -z "$st" ]; then
+    echo "UNKNOWN gatewayclass-unparseable"; return 0
+  fi
+  if [ "$st" != "True" ] || [ "$obs" != "$gen" ]; then
+    # `Accepted: Missing` with observedGeneration -1 is the exact signature of a
+    # controller that never started: the chart created the GatewayClass
+    # (gatewayClass.create="true", #503) and nothing ever wrote its status.
+    echo "DEAD gatewayclass/${GWC} accepted=${st} observedGeneration=${obs} generation=${gen}"
+    return 0
+  fi
+
+  gws_out="$(kubectl get gateways.gateway.networking.k8s.io --all-namespaces -o json 2>&1)"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    echo "UNKNOWN gateway-list-failed"; return 0
+  fi
+
+  drift="$(jq -r --arg gwc "$GWC" '
+    [ .items[]?
+      | select(.spec.gatewayClassName == $gwc)
+      | { ns: .metadata.namespace,
+          name: .metadata.name,
+          gen: (.metadata.generation // 0),
+          spec_listeners:   ((.spec.listeners   // []) | length),
+          status_listeners: ((.status.listeners // []) | length),
+          obs: ([ .status.conditions[]? | select(.type=="Accepted") | (.observedGeneration // -1) ][0] // -1) }
+      | select( .spec_listeners != .status_listeners or .obs != .gen )
+      | "\(.ns)/\(.name) spec=\(.spec_listeners) status=\(.status_listeners) generation=\(.gen) observedGeneration=\(.obs)"
+    ] | join("; ")' <<<"$gws_out" 2>/dev/null)"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    echo "UNKNOWN gateway-list-unparseable"; return 0
+  fi
+  if [ -n "$drift" ]; then
+    echo "DEAD $drift"; return 0
+  fi
+
+  echo "LIVE all-current"
+}
+
+restart_operator() {
+  local now
+  now="$(date +%s)"
+  if [ "$LAST_RESTART" -ne 0 ] && [ "$((now - LAST_RESTART))" -lt "$RESTART_COOLDOWN" ]; then
+    log "restart SUPPRESSED — last restart was $((now - LAST_RESTART))s ago, cooldown is ${RESTART_COOLDOWN}s. A controller that stays dead across a restart is a different fault; restart-storming it would only hide that."
+    return 0
+  fi
+  log "restarting cilium-operator (-n ${OPERATOR_NS} -l ${OPERATOR_SELECTOR}) — the Gateway-API controller is not reconciling and the CRDs ARE Established, so the replacement will satisfy cell.go's 30s budget on its first poll"
+  if kubectl -n "$OPERATOR_NS" delete pod -l "$OPERATOR_SELECTOR" --ignore-not-found >/dev/null 2>&1; then
+    LAST_RESTART="$now"
+    log "restart issued"
+  else
+    log "restart FAILED — could not delete cilium-operator Pod(s); will retry on the next threshold breach"
+  fi
+}
+
+log "starting — #6255 unbounded Gateway-API CRD gate for cilium-operator (interval=${INTERVAL}s threshold=${THRESHOLD} cooldown=${RESTART_COOLDOWN}s class=${GWC})"
+wait_for_crds
+
+consecutive=0
+while true; do
+  verdict_line="$(controller_verdict)"
+  verdict="${verdict_line%% *}"
+  detail="${verdict_line#* }"
+  case "$verdict" in
+    LIVE)
+      if [ "$consecutive" -ne 0 ]; then
+        log "recovered after ${consecutive} consecutive DEAD pass(es)"
+      fi
+      consecutive=0
+      log "pass verdict=LIVE detail=${detail}"
+      ;;
+    UNKNOWN)
+      # Explicitly NOT counted. Restarting during an apiserver outage re-runs
+      # the very race being fixed.
+      log "pass verdict=UNKNOWN detail=${detail} — not counted toward the failure threshold"
+      ;;
+    *)
+      consecutive=$((consecutive + 1))
+      log "pass verdict=DEAD consecutive=${consecutive}/${THRESHOLD} detail=${detail}"
+      if [ "$consecutive" -ge "$THRESHOLD" ]; then
+        restart_operator
+        consecutive=0
+      fi
+      ;;
+  esac
+  sleep "$INTERVAL"
+done

--- a/platform/cilium/chart/templates/gateway-api-controller-watchdog.yaml
+++ b/platform/cilium/chart/templates/gateway-api-controller-watchdog.yaml
@@ -219,10 +219,19 @@ spec:
               value: {{ (default 300 $wd.restartCooldownSeconds) | quote }}
             - name: WATCHDOG_GATEWAY_CLASS
               value: {{ (default "cilium" $wd.gatewayClass) | quote }}
+            # readOnlyRootFilesystem is on, so give kubectl a writable HOME for
+            # its discovery cache ($HOME/.kube/cache). Cache writes are
+            # best-effort in client-go, but without this every 30s pass pays a
+            # full discovery round-trip against the apiserver this component
+            # exists to be gentle with.
+            - name: HOME
+              value: /tmp
           volumeMounts:
             - name: script
               mountPath: /opt/watchdog
               readOnly: true
+            - name: tmp
+              mountPath: /tmp
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
@@ -238,4 +247,6 @@ spec:
         - name: script
           configMap:
             name: gateway-api-controller-watchdog-script
+        - name: tmp
+          emptyDir: {}
 {{- end }}

--- a/platform/cilium/chart/templates/gateway-api-controller-watchdog.yaml
+++ b/platform/cilium/chart/templates/gateway-api-controller-watchdog.yaml
@@ -1,0 +1,241 @@
+{{/*
+#6255 — gateway-api-controller-watchdog.
+
+WHAT IS BROKEN (upstream, and not reachable from any chart value)
+
+  cilium-operator decides ONCE, at process start, whether to run its Gateway-API
+  controller. Upstream cilium v1.19.3, `operator/pkg/gateway-api/cell.go:135`:
+
+      ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+
+  A hardcoded literal, with no pflag behind it — `gatewayApiConfig.Flags()`
+  (cell.go:182-192) exposes the secrets-sync / xff-hops / hostnetwork knobs and
+  nothing that widens this budget, so `operator.extraArgs` cannot reach it. On
+  expiry, `isTransientError` (cell.go:323-346) does not treat the resulting
+  `context deadline exceeded` as transient, so cell.go:148-155 logs
+  "Required GatewayAPI resources are not found" and returns
+  `&gatewayAPIPreconditions{Enabled: false}, nil` — a NIL ERROR. The hive cell
+  succeeds, the operator stays alive and healthy on /healthz, and
+  `initGatewayAPIController` (cell.go:210-213) returns immediately without ever
+  registering the controller. Nothing re-invokes it for the process lifetime.
+
+  Measured on hw296 (dep e689e3b34a75fdec, me-east-215-a / -b-1), 2026-08-13:
+  region B `Invoked duration=30.024306733s` + the error line; region A, same
+  chart, same version, same boot, `Invoked duration=16.84419141s` and no error.
+  Region B's own apiserver was `connection refused` for the first seconds of the
+  window — which on a fresh 2-region prov, and on every region-kill recovery
+  where the apiserver comes back cold, is a NORMAL condition and not an error.
+
+  Consequence: region B published 6 of the console Gateway's 10 listeners and
+  stopped reconciling the object. The console EIP pool spans both regions, so
+  every per-Org customer door answered on exactly 50% of fresh TCP connections
+  (15/30 served, against a 27/30 control on the same EIP). UAT rows R16/87/90/95.
+
+WHY A WATCHDOG AND NOT ORDERING
+
+  The bootstrap-kit already orders `bp-cilium dependsOn bp-gateway-api` (#2614,
+  clusters/_template/bootstrap-kit/01-cilium.yaml) and that stays correct — but
+  ordering only constrains the FIRST install. It does nothing for the case this
+  exists for: the operator Pod restarting (node reboot, eviction, OOM,
+  region-kill recovery) into a cold local apiserver. The fix has to be an
+  UNBOUNDED retry that lives OUTSIDE the operator process and re-invokes it once
+  the precondition it gave up on is satisfiable — a watch, not a one-shot poll.
+
+WHY AN INIT CONTAINER WAS REJECTED
+
+  Blocking inside the operator Pod would be the tighter fix, but upstream's
+  operator Deployment template (cilium/templates/cilium-operator/deployment.yaml)
+  exposes `extraVolumes` / `extraVolumeMounts` / `extraEnv` / `extraArgs` and NO
+  initContainers hook, so it would have to be injected by a Flux postRenderer —
+  and that would make cilium-operator, at bootstrap slot 01, unable to start
+  until it pulled a SECOND image. A pull failure there wedges the CNI itself.
+  A separate Deployment can be degraded (ImagePullBackOff, unscheduled) without
+  ever holding cilium back, which is why the same shape was chosen for
+  vpc-podcidr-route-reconciler (#5339).
+
+WHY A Deployment AND NOT A CronJob
+
+  Same reason as #5339 / #5157: a CronJob leaves a gap exactly at region-reboot,
+  which is precisely when the apiserver is coldest and this race is most likely.
+  replicas: 1 — a single evaluator; N racing instances would each restart the
+  same operator Pod.
+
+DEFAULT-ON, deliberately. This is a correctness fix for a defect that holds four
+acceptance rows red on every 2-region Sovereign, not an observability toggle;
+shipping it `enabled: false` would leave the defect live everywhere. It renders
+only when Gateway API is actually enabled, and `catalystOverlay
+.gatewayApiWatchdog.enabled=false` is the escape hatch.
+*/}}
+{{- $wd := dig "gatewayApiWatchdog" (dict) (.Values.catalystOverlay | default dict) }}
+{{- $gwapi := dig "gatewayAPI" (dict) (.Values.cilium | default dict) }}
+{{- if and (ne $wd.enabled false) (dig "enabled" false $gwapi) }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: gateway-api-controller-watchdog
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: bp-cilium
+    app.kubernetes.io/component: gateway-api-controller-watchdog
+    catalyst.openova.io/blueprint: bp-cilium
+    catalyst.openova.io/blueprint-version: {{ .Chart.Version | quote }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: gateway-api-controller-watchdog
+  labels:
+    app.kubernetes.io/name: bp-cilium
+    app.kubernetes.io/component: gateway-api-controller-watchdog
+rules:
+  # Read-only. The CRD Established condition is the unbounded gate's input; the
+  # GatewayClass/Gateway generations vs observedGenerations are the liveness
+  # comparison. The watchdog never writes a Gateway-API object.
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["get", "list"]
+  - apiGroups: ["gateway.networking.k8s.io"]
+    resources: ["gatewayclasses", "gateways"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: gateway-api-controller-watchdog
+  labels:
+    app.kubernetes.io/name: bp-cilium
+    app.kubernetes.io/component: gateway-api-controller-watchdog
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: gateway-api-controller-watchdog
+subjects:
+  - kind: ServiceAccount
+    name: gateway-api-controller-watchdog
+    namespace: kube-system
+---
+# The ONLY mutation this component performs, scoped to kube-system by a Role
+# (not a ClusterRole): delete the local cilium-operator Pod so it re-executes
+# its start-time Gateway-API precondition. `resourceNames` is deliberately
+# absent — operator Pod names carry a random ReplicaSet suffix, so a name pin
+# would silently stop matching on the first roll (docs/PRINCIPLES.md
+# anti-pattern: an RBAC rule that cannot fire).
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: gateway-api-controller-watchdog
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: bp-cilium
+    app.kubernetes.io/component: gateway-api-controller-watchdog
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: gateway-api-controller-watchdog
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: bp-cilium
+    app.kubernetes.io/component: gateway-api-controller-watchdog
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: gateway-api-controller-watchdog
+subjects:
+  - kind: ServiceAccount
+    name: gateway-api-controller-watchdog
+    namespace: kube-system
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: gateway-api-controller-watchdog-script
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: bp-cilium
+    app.kubernetes.io/component: gateway-api-controller-watchdog
+    catalyst.openova.io/blueprint: bp-cilium
+    catalyst.openova.io/blueprint-version: {{ .Chart.Version | quote }}
+data:
+  # Sourced from chart/files/ via .Files.Get rather than inlined, so
+  # chart/tests/6255-gateway-api-controller-watchdog-slow-apiserver.sh executes
+  # the EXACT bytes that get mounted into the Pod. An inlined heredoc would let
+  # the tested script and the shipped script drift apart silently; the guard's
+  # render case re-asserts that this ConfigMap still carries the file.
+  # trimSuffix "\n" keeps the rendered block byte-identical to the file (helm's
+  # `indent` would otherwise emit a trailing 4-space line), so the guard's diff
+  # is exact rather than whitespace-tolerant.
+  watchdog.sh: |
+{{ .Files.Get "files/gateway-api-controller-watchdog.sh" | trimSuffix "\n" | indent 4 }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gateway-api-controller-watchdog
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: bp-cilium
+    app.kubernetes.io/component: gateway-api-controller-watchdog
+    catalyst.openova.io/blueprint: bp-cilium
+    catalyst.openova.io/blueprint-version: {{ .Chart.Version | quote }}
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: bp-cilium
+      app.kubernetes.io/component: gateway-api-controller-watchdog
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: bp-cilium
+        app.kubernetes.io/component: gateway-api-controller-watchdog
+      annotations:
+        # Roll the Pod whenever the script changes, so a chart bump that edits
+        # the watchdog actually takes effect without a manual delete.
+        checksum/script: {{ .Files.Get "files/gateway-api-controller-watchdog.sh" | sha256sum | trunc 16 | quote }}
+    spec:
+      serviceAccountName: gateway-api-controller-watchdog
+      containers:
+        - name: watchdog
+          # alpine/k8s toolbox (bash + kubectl + jq), dockerhub-proxied per
+          # MIRROR-EVERYTHING — the same image and tag the sibling
+          # vpc-podcidr-route-reconciler already ships in this chart.
+          image: {{ (default "harbor.openova.io/proxy-dockerhub/alpine/k8s:1.30.0" $wd.image) | quote }}
+          command: ["bash", "/opt/watchdog/watchdog.sh"]
+          env:
+            - name: WATCHDOG_INTERVAL_SECONDS
+              value: {{ (default 30 $wd.intervalSeconds) | quote }}
+            - name: WATCHDOG_CRD_BACKOFF_MAX_SECONDS
+              value: {{ (default 30 $wd.crdBackoffMaxSeconds) | quote }}
+            - name: WATCHDOG_FAILURE_THRESHOLD
+              value: {{ (default 3 $wd.failureThreshold) | quote }}
+            - name: WATCHDOG_RESTART_COOLDOWN_SECONDS
+              value: {{ (default 300 $wd.restartCooldownSeconds) | quote }}
+            - name: WATCHDOG_GATEWAY_CLASS
+              value: {{ (default "cilium" $wd.gatewayClass) | quote }}
+          volumeMounts:
+            - name: script
+              mountPath: /opt/watchdog
+              readOnly: true
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 128Mi
+      volumes:
+        - name: script
+          configMap:
+            name: gateway-api-controller-watchdog-script
+{{- end }}

--- a/platform/cilium/chart/tests/6255-gateway-api-controller-watchdog-slow-apiserver.sh
+++ b/platform/cilium/chart/tests/6255-gateway-api-controller-watchdog-slow-apiserver.sh
@@ -1,0 +1,552 @@
+#!/usr/bin/env bash
+# bp-cilium — #6255 gateway-api-controller-watchdog guard.
+#
+# WHAT THIS PROTECTS
+#
+# cilium-operator decides ONCE, at process start, whether to run its Gateway-API
+# controller, and gives up after a HARDCODED 30 seconds (upstream cilium v1.19.3
+# `operator/pkg/gateway-api/cell.go:135`). On expiry it returns
+# `{Enabled:false}, nil` — a NIL error — so the operator stays alive and healthy
+# with the controller permanently disabled, and nothing re-invokes it.
+#
+# On hw296 (2026-08-13) region B's own apiserver was `connection refused` at
+# operator boot; `Invoked duration=30.024306733s` and the controller never
+# started. Region A, same chart and version, same boot: `16.84419141s`, running.
+# Region B then published 6 of the console Gateway's 10 listeners and stopped
+# reconciling it, so every per-Org customer door answered on exactly 50% of
+# fresh TCP connections across the shared EIP pool. UAT rows R16/87/90/95.
+#
+# THIS IS A TIMING DEFECT, so a test that starts everything in the right order
+# proves nothing. The harness below drives the SHIPPED watchdog script against a
+# fake kubectl whose apiserver is REFUSED for longer than the 30s budget that
+# broke region B, and asserts the controller ends up running anyway.
+#
+# CASES
+#   A  SLOW APISERVER (the reproduction) — apiserver refused for
+#      GUARD_APISERVER_DOWN_SECONDS (default 35s, deliberately > the 30s ceiling
+#      at cell.go:135), then up with the CRDs Established and a GatewayClass
+#      that has NO status at all (the never-started-controller signature).
+#      The watchdog must keep polling past 30s, detect the dead controller, and
+#      restart cilium-operator exactly once, after which the fixture converges.
+#
+#   B1 VACUITY — no watchdog (main's world: render with the component disabled
+#      produces no script at all). Case A's assertions are re-run and MUST FAIL.
+#
+#   B2 VACUITY, isolating the UNBOUNDED RETRY — the shipped script with the
+#      upstream ceiling re-injected into wait_for_crds. Case A's assertions MUST
+#      FAIL. This is what proves the fix is the unbounded wait and not merely
+#      "a Deployment exists". The sed is verified to have actually changed the
+#      script, so this case cannot itself go vacuous.
+#
+#   C  FAST-PATH CONTROL — CRDs already Established and the controller already
+#      current (region A's 16.84s path). The CRD wait must be satisfied on
+#      attempt 1, a LIVE verdict must appear promptly, and ZERO restarts may be
+#      issued. A fix that traded a bounded retry for an unbounded hang, or that
+#      restarts healthy operators, fails here.
+#
+#   D  STALE-STATUS CONTROL, sharing the suspect property — the Gateway HAS a
+#      non-empty `.status.listeners` (6 of them, written by an earlier operator
+#      instance, exactly as region B did) and the GatewayClass says
+#      `Accepted=True`. A naive "status is non-empty" or "Accepted is True"
+#      check passes on this. The watchdog must still call it DEAD, because
+#      observedGeneration is behind and 6 != 10. The same fixture reports
+#      `Programmed=False / AddressNotAssigned`, which under the §854 hostPort /
+#      Local-ETP model is normal on BOTH regions — case C's healthy fixture
+#      carries it too, so the guard proves we never assert on it (#5511 warned
+#      about exactly that trap).
+#
+#   E  APISERVER-OUTAGE CONTROL — CRDs Established, then the apiserver goes
+#      away. Verdicts must be UNKNOWN and ZERO restarts may be issued.
+#      Restarting the operator during an outage re-runs the very race.
+#
+#   F  RENDER BINDING — the rendered ConfigMap's `watchdog.sh` must byte-match
+#      chart/files/gateway-api-controller-watchdog.sh (so cases A-E exercise the
+#      bytes that actually reach the Pod), the Deployment must mount it, and the
+#      RBAC that lets it restart the operator must be present.
+
+set -uo pipefail
+
+chart_dir="$(cd "$(dirname "$0")/.." && pwd)"
+helm="${HELM_BIN:-helm}"
+script_src="${chart_dir}/files/gateway-api-controller-watchdog.sh"
+
+# Deliberately LONGER than the 30s ceiling at cell.go:135 — that gap IS the
+# proof. Shortening this below 31 makes case A pass on a bounded implementation
+# and destroys the guard.
+DOWN_SECONDS="${GUARD_APISERVER_DOWN_SECONDS:-35}"
+
+fails=0
+pass() { printf '  PASS  %s\n' "$*"; }
+fail() { printf '  FAIL  %s\n' "$*"; fails=$((fails + 1)); }
+
+command -v jq >/dev/null 2>&1 || { echo "FATAL: jq is required by this guard"; exit 1; }
+[ -f "$script_src" ] || { echo "FATAL: missing $script_src"; exit 1; }
+
+# The upstream cilium subchart must be present or every `helm template` below
+# dies with "found in Chart.yaml, but missing in charts/" — on a fresh CI
+# checkout charts/ is gitignored.
+"$helm" dependency build "$chart_dir" >/dev/null 2>&1 || true
+
+work="$(mktemp -d)"
+cleanup() { pkill -P $$ >/dev/null 2>&1 || true; rm -rf "$work"; }
+trap cleanup EXIT
+
+# ── fixtures ─────────────────────────────────────────────────────────────────
+# Ten listeners in spec (six pre-existing + the four per-Org entries region B
+# dropped: console-{https,http}-walk{one,two}).
+listeners_10='[{"name":"console-https"},{"name":"console-http"},{"name":"wildcard-https"},{"name":"wildcard-http"},{"name":"api-https"},{"name":"api-http"},{"name":"console-https-walkone"},{"name":"console-http-walkone"},{"name":"console-https-walktwo"},{"name":"console-http-walktwo"}]'
+listeners_6='[{"name":"console-https"},{"name":"console-http"},{"name":"wildcard-https"},{"name":"wildcard-http"},{"name":"api-https"},{"name":"api-http"}]'
+
+# Both regions legitimately report Programmed=False/AddressNotAssigned under the
+# §854 hostPort / Local-ETP model. It appears in BOTH the dead and the healthy
+# fixture so no case can accidentally key off it.
+programmed_false='{"type":"Programmed","status":"False","reason":"AddressNotAssigned","observedGeneration":7}'
+
+gwc_no_status='{"apiVersion":"gateway.networking.k8s.io/v1","kind":"GatewayClass","metadata":{"name":"cilium","generation":1},"spec":{"controllerName":"io.cilium/gateway-controller"}}'
+gwc_current='{"apiVersion":"gateway.networking.k8s.io/v1","kind":"GatewayClass","metadata":{"name":"cilium","generation":1},"spec":{"controllerName":"io.cilium/gateway-controller"},"status":{"conditions":[{"type":"Accepted","status":"True","observedGeneration":1}]}}'
+# Stale but superficially healthy: Accepted=True at the CURRENT generation, so
+# the GatewayClass alone looks fine — only the Gateway exposes the fault.
+gwc_stale_ok="$gwc_current"
+
+gw_dead="$(jq -cn --argjson spec "$listeners_10" --argjson status "$listeners_6" --argjson prog "$programmed_false" \
+  '{items:[{metadata:{namespace:"kube-system",name:"cilium-gateway-console",generation:7},
+            spec:{gatewayClassName:"cilium",listeners:$spec},
+            status:{listeners:$status,conditions:[{type:"Accepted",status:"True",observedGeneration:3},$prog]}}]}')"
+gw_healthy="$(jq -cn --argjson spec "$listeners_10" --argjson prog "$programmed_false" \
+  '{items:[{metadata:{namespace:"kube-system",name:"cilium-gateway-console",generation:7},
+            spec:{gatewayClassName:"cilium",listeners:$spec},
+            status:{listeners:$spec,conditions:[{type:"Accepted",status:"True",observedGeneration:7},$prog]}}]}')"
+
+# ── fake kubectl ─────────────────────────────────────────────────────────────
+# State is a directory of plain files so the fake and the harness share it
+# without any IPC:
+#   up_at      epoch after which the apiserver answers ("" = never)
+#   down_from  epoch after which the apiserver stops answering again ("" = never)
+#   gwc        GatewayClass JSON served now
+#   gw         Gateway list JSON served now
+#   gwc_after / gw_after   what to serve after a restart is observed
+#   restarts   restart counter
+make_fake_kubectl() {
+  local dir="$1"
+  mkdir -p "$dir/bin"
+  cat >"$dir/bin/kubectl" <<'FAKE'
+#!/usr/bin/env bash
+S="$FAKE_STATE"
+now="$(date +%s)"
+echo "$now $*" >>"$S/calls.log"
+
+up_at="$(cat "$S/up_at" 2>/dev/null || true)"
+down_from="$(cat "$S/down_from" 2>/dev/null || true)"
+reachable=1
+[ -n "$up_at" ] && [ "$now" -lt "$up_at" ] && reachable=0
+[ -n "$down_from" ] && [ "$now" -ge "$down_from" ] && reachable=0
+
+if [ "$reachable" -eq 0 ]; then
+  echo "The connection to the server 10.179.1.83:6443 was refused - did you specify the right host or port?" >&2
+  exit 1
+fi
+
+args="$*"
+case "$args" in
+  *"delete pod"*)
+    n="$(cat "$S/restarts" 2>/dev/null || echo 0)"
+    echo $((n + 1)) >"$S/restarts"
+    # The replacement operator Pod boots with the CRDs already Established, so
+    # cell.go's 30s budget is satisfied on its first poll and the controller
+    # comes up — model that by swapping in the post-restart fixtures.
+    [ -f "$S/gwc_after" ] && cp "$S/gwc_after" "$S/gwc"
+    [ -f "$S/gw_after" ]  && cp "$S/gw_after"  "$S/gw"
+    echo 'pod "cilium-operator-abc123" deleted'
+    exit 0
+    ;;
+  *"get crd"*)
+    # Established only once the CRDs are installed, which is what up_at models.
+    echo "True"
+    exit 0
+    ;;
+  *"get gatewayclass"*)
+    cat "$S/gwc"
+    exit 0
+    ;;
+  *"get gateways"*)
+    cat "$S/gw"
+    exit 0
+    ;;
+esac
+echo "fake kubectl: unhandled args: $args" >&2
+exit 1
+FAKE
+  chmod +x "$dir/bin/kubectl"
+}
+
+# ── harness ──────────────────────────────────────────────────────────────────
+# Runs a watchdog script in the background against a fake-kubectl state dir.
+# Returns the PID via $RUN_PID and the log path via $RUN_LOG.
+RUN_PID=""
+RUN_LOG=""
+start_watchdog() {
+  local name="$1" script="$2" state="$3"
+  RUN_LOG="$work/$name.log"
+  : >"$RUN_LOG"
+  (
+    export PATH="$work/fakebin:$PATH"
+    export FAKE_STATE="$state"
+    export WATCHDOG_INTERVAL_SECONDS=1
+    export WATCHDOG_CRD_BACKOFF_MIN_SECONDS=1
+    export WATCHDOG_CRD_BACKOFF_MAX_SECONDS=2
+    export WATCHDOG_FAILURE_THRESHOLD=3
+    export WATCHDOG_RESTART_COOLDOWN_SECONDS=300
+    exec bash "$script"
+  ) >"$RUN_LOG" 2>&1 &
+  RUN_PID=$!
+}
+
+stop_watchdog() {
+  [ -n "$RUN_PID" ] || return 0
+  kill "$RUN_PID" >/dev/null 2>&1 || true
+  wait "$RUN_PID" >/dev/null 2>&1 || true
+  RUN_PID=""
+}
+
+# Waits up to $2 seconds for regex $1 to appear in $RUN_LOG.
+wait_for_log() {
+  local re="$1" limit="$2" waited=0
+  while [ "$waited" -lt "$limit" ]; do
+    grep -Eq "$re" "$RUN_LOG" 2>/dev/null && return 0
+    sleep 1
+    waited=$((waited + 1))
+  done
+  return 1
+}
+
+new_state() {
+  local dir="$work/state-$1"
+  mkdir -p "$dir"
+  : >"$dir/calls.log"
+  echo 0 >"$dir/restarts"
+  echo "$dir"
+}
+
+restarts_of() { cat "$1/restarts" 2>/dev/null || echo 0; }
+
+# ── the case-A assertion set, factored out so the vacuity cases can re-run it ─
+#
+# THIS is the assertion the vacuity cases must fail. It is deliberately the
+# whole outcome — survived past the 30s ceiling, restarted the operator, and the
+# Gateway converged to 10/10 — not a log-string spot check.
+assert_case_a_outcome() {
+  local state="$1" log="$2"
+  local up first served gap
+
+  # 1. it outlasted the refused-apiserver window. Timing is read from the fake's
+  #    own call ledger (epoch per call), not from log mtimes: the gap between
+  #    the FIRST call it made and the first call the fake actually SERVED is
+  #    exactly how long it endured `connection refused`.
+  up="$(cat "$state/up_at" 2>/dev/null || echo 0)"
+  [ -n "$up" ] || up=0
+  first="$(head -n1 "$state/calls.log" 2>/dev/null | awk '{print $1}')"
+  served="$(awk -v u="$up" '$1>=u{print $1; exit}' "$state/calls.log" 2>/dev/null || true)"
+  [ -n "${first:-}" ] && [ -n "${served:-}" ] || return 1
+  gap=$((served - first))
+  [ "$gap" -ge 30 ] || return 1
+  # 2. it restarted the operator exactly once
+  [ "$(restarts_of "$state")" -eq 1 ] || return 1
+  # 3. the Gateway converged: 10 spec listeners, 10 in status
+  [ "$(jq -r '.items[0].status.listeners | length' "$state/gw" 2>/dev/null)" = "10" ] || return 1
+  # 4. and the watchdog itself saw the controller come back
+  grep -q "verdict=LIVE" "$log" 2>/dev/null || return 1
+  return 0
+}
+
+mkdir -p "$work/fakebin"
+make_fake_kubectl "$work"
+cp "$work/bin/kubectl" "$work/fakebin/kubectl"
+
+echo "=============================================================="
+echo "#6255 gateway-api-controller-watchdog — slow-apiserver guard"
+echo "  apiserver-down window: ${DOWN_SECONDS}s (cell.go:135 gives up at 30s)"
+echo "=============================================================="
+
+# ── CASE A — SLOW APISERVER (the reproduction) ───────────────────────────────
+echo
+echo "CASE A — apiserver refused for ${DOWN_SECONDS}s, CRDs appear late, controller never started"
+state_a="$(new_state a)"
+start_epoch="$(date +%s)"
+echo "$((start_epoch + DOWN_SECONDS))" >"$state_a/up_at"
+printf '%s' "$gwc_no_status" >"$state_a/gwc"
+printf '%s' "$gw_dead"       >"$state_a/gw"
+printf '%s' "$gwc_current"   >"$state_a/gwc_after"
+printf '%s' "$gw_healthy"    >"$state_a/gw_after"
+
+start_watchdog a "$script_src" "$state_a"
+if wait_for_log "restart issued" $((DOWN_SECONDS + 40)); then
+  wait_for_log "verdict=LIVE" 20 || true
+fi
+sleep 2
+log_a="$RUN_LOG"
+stop_watchdog
+
+crd_attempts="$(grep -c 'crd-wait attempt=' "$log_a" 2>/dev/null || echo 0)"
+last_refusal_gap=0
+first_call="$(head -n1 "$state_a/calls.log" 2>/dev/null | awk '{print $1}')"
+if [ -n "${first_call:-}" ]; then
+  # epoch of the first call the fake actually SERVED (i.e. apiserver back up)
+  served="$(awk -v u="$(cat "$state_a/up_at")" '$1>=u{print $1; exit}' "$state_a/calls.log" 2>/dev/null || true)"
+  [ -n "${served:-}" ] && last_refusal_gap=$((served - first_call))
+fi
+
+if [ "$crd_attempts" -ge 10 ]; then
+  pass "kept polling for the CRDs across ${crd_attempts} attempts (no attempt ceiling)"
+else
+  fail "only ${crd_attempts} crd-wait attempts — the wait looks bounded"
+fi
+if [ "$last_refusal_gap" -ge 30 ]; then
+  pass "survived ${last_refusal_gap}s of a refused apiserver — past the 30s budget at cell.go:135"
+elif [ "$last_refusal_gap" -eq 0 ]; then
+  fail "never made a call after the apiserver came back — it stopped polling inside the ${DOWN_SECONDS}s window, exactly like cell.go:135"
+else
+  fail "gave up after ${last_refusal_gap}s — did not outlast the 30s budget that broke region B"
+fi
+if [ "$(restarts_of "$state_a")" -eq 1 ]; then
+  pass "restarted cilium-operator exactly once"
+else
+  fail "expected exactly 1 operator restart, got $(restarts_of "$state_a")"
+fi
+if [ "$(jq -r '.items[0].status.listeners | length' "$state_a/gw" 2>/dev/null)" = "10" ]; then
+  pass "console Gateway converged 10 spec / 10 status (region B published 6)"
+else
+  fail "Gateway did not converge: $(jq -r '.items[0].status.listeners | length' "$state_a/gw" 2>/dev/null) in status"
+fi
+if grep -q "verdict=LIVE" "$log_a" 2>/dev/null; then
+  pass "watchdog observed the Gateway-API controller running after the restart"
+else
+  fail "watchdog never reported a LIVE verdict"
+fi
+
+# ── CASE B1 — VACUITY: no watchdog at all (main's world) ─────────────────────
+echo
+echo "CASE B1 — VACUITY: the component disabled renders no script; case A's outcome must NOT be reachable"
+disabled_render="$("$helm" template smoke "$chart_dir" \
+  --set catalystOverlay.gatewayApiWatchdog.enabled=false 2>/dev/null \
+  | grep -c 'gateway-api-controller-watchdog' || true)"
+if [ "${disabled_render:-0}" -eq 0 ]; then
+  pass "enabled=false renders nothing (this is exactly the pre-fix world)"
+else
+  fail "enabled=false still rendered ${disabled_render} watchdog line(s)"
+fi
+
+state_b1="$(new_state b1)"
+b1_start="$(date +%s)"
+echo "$((b1_start + DOWN_SECONDS))" >"$state_b1/up_at"
+printf '%s' "$gwc_no_status" >"$state_b1/gwc"
+printf '%s' "$gw_dead"       >"$state_b1/gw"
+printf '%s' "$gwc_current"   >"$state_b1/gwc_after"
+printf '%s' "$gw_healthy"    >"$state_b1/gw_after"
+: >"$work/b1.log"
+# No watchdog runs. Let the same wall-clock window elapse.
+sleep 3
+if assert_case_a_outcome "$state_b1" "$work/b1.log"; then
+  fail "case-A assertions PASSED with no watchdog — the guard is vacuous"
+else
+  pass "case-A assertions FAIL with no watchdog (restarts=$(restarts_of "$state_b1"), status listeners=$(jq -r '.items[0].status.listeners | length' "$state_b1/gw"))"
+fi
+
+# ── CASE B2 — VACUITY: the unbounded retry is the load-bearing part ──────────
+echo
+echo "CASE B2 — VACUITY: re-inject cell.go's 30s ceiling into wait_for_crds; case A's outcome must NOT be reachable"
+bounded="$work/bounded-watchdog.sh"
+sed 's|^    attempt=\$((attempt + 1))$|    attempt=$((attempt + 1)); if [ "$SECONDS" -ge 30 ]; then log "BOUNDED VARIANT: giving up at 30s, exactly like cell.go:135"; exit 0; fi|' \
+  "$script_src" >"$bounded"
+if cmp -s "$script_src" "$bounded"; then
+  fail "the bounded-variant sed matched nothing — case B2 would itself be vacuous"
+else
+  pass "bounded variant differs from the shipped script (the ceiling was really injected)"
+
+  state_b2="$(new_state b2)"
+  b2_start="$(date +%s)"
+  echo "$((b2_start + DOWN_SECONDS))" >"$state_b2/up_at"
+  printf '%s' "$gwc_no_status" >"$state_b2/gwc"
+  printf '%s' "$gw_dead"       >"$state_b2/gw"
+  printf '%s' "$gwc_current"   >"$state_b2/gwc_after"
+  printf '%s' "$gw_healthy"    >"$state_b2/gw_after"
+
+  start_watchdog b2 "$bounded" "$state_b2"
+  wait_for_log "BOUNDED VARIANT" $((DOWN_SECONDS + 10)) || true
+  sleep 2
+  log_b2="$RUN_LOG"
+  stop_watchdog
+
+  if assert_case_a_outcome "$state_b2" "$log_b2"; then
+    fail "case-A assertions PASSED against a 30s-bounded wait — the guard does not test the unbounded retry"
+  else
+    pass "case-A assertions FAIL with the 30s ceiling restored (restarts=$(restarts_of "$state_b2"), status listeners=$(jq -r '.items[0].status.listeners | length' "$state_b2/gw"))"
+  fi
+fi
+
+# ── CASE C — FAST-PATH CONTROL (region A's 16.84s path) ─────────────────────
+echo
+echo "CASE C — CONTROL: CRDs already Established and controller current; must start clean, fast, and restart nothing"
+state_c="$(new_state c)"
+: >"$state_c/up_at"
+printf '%s' "$gwc_current" >"$state_c/gwc"
+printf '%s' "$gw_healthy"  >"$state_c/gw"
+c_start="$(date +%s)"
+start_watchdog c "$script_src" "$state_c"
+wait_for_log "verdict=LIVE" 15 || true
+sleep 3
+log_c="$RUN_LOG"
+c_live="$(date +%s)"
+stop_watchdog
+
+if grep -q "crd-wait satisfied attempt=1" "$log_c" 2>/dev/null; then
+  pass "CRD wait satisfied on the FIRST attempt — no added latency on the fast path"
+else
+  fail "fast path did not satisfy the CRD wait on attempt 1: $(grep -m1 'crd-wait' "$log_c" 2>/dev/null)"
+fi
+if grep -q "verdict=LIVE" "$log_c" 2>/dev/null && [ "$((c_live - c_start))" -lt 20 ]; then
+  pass "reached a LIVE verdict in $((c_live - c_start))s — a bounded retry was not traded for an unbounded hang"
+else
+  fail "fast path did not reach a LIVE verdict promptly"
+fi
+if [ "$(restarts_of "$state_c")" -eq 0 ]; then
+  pass "zero restarts against a healthy controller"
+else
+  fail "restarted a HEALTHY operator $(restarts_of "$state_c") time(s)"
+fi
+if grep -q "verdict=DEAD" "$log_c" 2>/dev/null; then
+  fail "a healthy fixture with Programmed=False/AddressNotAssigned was called DEAD — the guard is asserting on Programmed (#5511's trap)"
+else
+  pass "Programmed=False/AddressNotAssigned did not make a healthy Gateway look dead (§854 model)"
+fi
+
+# ── CASE D — STALE-STATUS CONTROL (shares the suspect property) ─────────────
+echo
+echo "CASE D — CONTROL: non-empty stale status + Accepted=True must still read DEAD"
+state_d="$(new_state d)"
+: >"$state_d/up_at"
+printf '%s' "$gwc_stale_ok" >"$state_d/gwc"
+printf '%s' "$gw_dead"      >"$state_d/gw"
+# No *_after fixtures: the fault persists across the restart, which also
+# exercises the cooldown.
+start_watchdog d "$script_src" "$state_d"
+wait_for_log "verdict=DEAD" 20 || true
+sleep 2
+log_d="$RUN_LOG"
+stop_watchdog
+
+if grep -q "verdict=DEAD" "$log_d" 2>/dev/null; then
+  pass "6 stale listeners in status + GatewayClass Accepted=True still reads DEAD (spec=10, observedGeneration behind)"
+else
+  fail "a stale non-empty status was accepted as healthy — the exact hw296 mis-read"
+fi
+if grep -Eq 'spec=10 status=6' "$log_d" 2>/dev/null; then
+  pass "detail names the drift the operator-side reporter also names (spec=10 status=6)"
+else
+  fail "DEAD verdict did not name the listener drift"
+fi
+
+# ── CASE E — APISERVER-OUTAGE CONTROL ───────────────────────────────────────
+echo
+echo "CASE E — CONTROL: apiserver disappears after the CRDs were Established; must go UNKNOWN, never restart"
+state_e="$(new_state e)"
+: >"$state_e/up_at"
+printf '%s' "$gwc_current" >"$state_e/gwc"
+printf '%s' "$gw_healthy"  >"$state_e/gw"
+start_watchdog e "$script_src" "$state_e"
+wait_for_log "verdict=LIVE" 15 || true
+echo "$(date +%s)" >"$state_e/down_from"
+wait_for_log "verdict=UNKNOWN" 20 || true
+sleep 6
+log_e="$RUN_LOG"
+stop_watchdog
+
+if grep -q "verdict=UNKNOWN" "$log_e" 2>/dev/null; then
+  pass "an unreachable apiserver produces UNKNOWN, not DEAD"
+else
+  fail "an unreachable apiserver did not produce an UNKNOWN verdict"
+fi
+if grep -q "not counted toward the failure threshold" "$log_e" 2>/dev/null; then
+  pass "UNKNOWN passes are excluded from the failure threshold"
+else
+  fail "UNKNOWN passes are not documented as excluded in the log"
+fi
+if [ "$(restarts_of "$state_e")" -eq 0 ]; then
+  pass "zero restarts during an apiserver outage — the race is never re-run on purpose"
+else
+  fail "restarted the operator $(restarts_of "$state_e") time(s) during an apiserver outage"
+fi
+
+# ── CASE F — RENDER BINDING ─────────────────────────────────────────────────
+echo
+echo "CASE F — the tested script is the shipped script, and the RBAC to restart the operator exists"
+render="$work/render.yaml"
+"$helm" template smoke "$chart_dir" --show-only templates/gateway-api-controller-watchdog.yaml >"$render" 2>/dev/null
+
+extracted="$work/extracted.sh"
+awk '
+  /^  watchdog\.sh: \|/ { grab=1; next }
+  grab {
+    if ($0 ~ /^    /) { sub(/^    /, ""); print; next }
+    if ($0 == "") { print; next }
+    grab=0
+  }
+' "$render" >"$extracted"
+
+if [ -s "$extracted" ] && diff -q <(sed -e 's/[[:space:]]*$//' "$script_src") <(sed -e 's/[[:space:]]*$//' "$extracted") >/dev/null 2>&1; then
+  pass "ConfigMap watchdog.sh matches chart/files/gateway-api-controller-watchdog.sh"
+else
+  fail "rendered watchdog.sh drifted from chart/files/ — cases A-E would be testing bytes that never reach the Pod"
+fi
+for want in \
+  'kind: Deployment' \
+  'name: gateway-api-controller-watchdog-script' \
+  'command: \["bash", "/opt/watchdog/watchdog.sh"\]' \
+  'checksum/script:' ; do
+  if grep -Eq "$want" "$render"; then
+    pass "render carries: ${want}"
+  else
+    fail "render is MISSING: ${want}"
+  fi
+done
+if grep -A6 'kind: Role$' "$render" | grep -q 'namespace: kube-system' \
+   && grep -q '"delete"' "$render"; then
+  pass "namespaced Role grants pods delete in kube-system (the only mutation)"
+else
+  fail "the operator-restart RBAC is missing or not namespaced"
+fi
+if grep -Eq 'resources: \["gatewayclasses", "gateways"\]' "$render"; then
+  pass "ClusterRole can read gatewayclasses + gateways"
+else
+  fail "ClusterRole cannot read the objects the liveness comparison needs"
+fi
+# The Pod runs the PACKAGED chart, not the working tree. If a future .helmignore
+# ever excluded files/, `.Files.Get` would return "" and the ConfigMap would ship
+# an EMPTY watchdog.sh — a render that still looks structurally correct.
+mkdir -p "$work/pkg"
+# NOTE: `tar … | grep -q` is deliberately NOT used — grep -q exits on the first
+# match, tar takes SIGPIPE, and `set -o pipefail` then reports the whole pipeline
+# as failed. That reads as "the file is missing" when it is present.
+"$helm" package "$chart_dir" -d "$work/pkg" >/dev/null 2>&1
+tar tzf "$work"/pkg/bp-cilium-*.tgz >"$work/pkg.list" 2>/dev/null
+if grep -q 'bp-cilium/files/gateway-api-controller-watchdog.sh' "$work/pkg.list"; then
+  pass "the packaged chart carries files/gateway-api-controller-watchdog.sh"
+else
+  fail "the packaged chart does NOT carry the watchdog script — .Files.Get would render an empty ConfigMap"
+fi
+# A watchdog that also renders when Gateway API is off would restart-loop on a
+# cluster that legitimately has no controller.
+gwoff="$("$helm" template smoke "$chart_dir" --set cilium.gatewayAPI.enabled=false 2>/dev/null | grep -c 'gateway-api-controller-watchdog' || true)"
+if [ "${gwoff:-0}" -eq 0 ]; then
+  pass "renders nothing when cilium.gatewayAPI.enabled=false"
+else
+  fail "still renders with Gateway API disabled (${gwoff} line(s)) — would restart-loop"
+fi
+
+echo
+echo "=============================================================="
+if [ "$fails" -eq 0 ]; then
+  echo "#6255 watchdog guard: ALL CASES PASS"
+  exit 0
+fi
+echo "#6255 watchdog guard: ${fails} FAILURE(S)"
+exit 1

--- a/platform/cilium/chart/values.yaml
+++ b/platform/cilium/chart/values.yaml
@@ -585,3 +585,47 @@ catalystOverlay:
     huaweiSecretKey: ""
     huaweiProjectId: ""
     huaweiRegion: ""
+
+  # #6255 — gateway-api-controller-watchdog. cilium-operator decides ONCE, at
+  # process start, whether to run its Gateway-API controller, and gives up after
+  # a HARDCODED 30s (upstream v1.19.3 operator/pkg/gateway-api/cell.go:135,
+  # `context.WithTimeout(context.Background(), 30*time.Second)` — no pflag
+  # behind it, so operator.extraArgs cannot widen it). On expiry it logs
+  # "Required GatewayAPI resources are not found" and returns
+  # `{Enabled:false}, nil` — a NIL error, so the operator stays alive and
+  # healthy with the controller permanently off and nothing ever re-invokes it.
+  #
+  # hw296, 2026-08-13: region B `Invoked duration=30.024306733s` (its own
+  # apiserver was `connection refused` at boot) vs region A `16.84419141s` on
+  # the SAME chart and version. Region B then published 6 of the console
+  # Gateway's 10 listeners and stopped reconciling it, so every per-Org customer
+  # door answered on exactly 50% of fresh TCP connections across the shared EIP
+  # pool. UAT rows R16/87/90/95.
+  #
+  # This runs the unbounded retry the operator lacks, OUTSIDE the operator
+  # process, and deletes the local cilium-operator Pod when the Gateway-API
+  # controller is provably not reconciling while the CRDs ARE Established.
+  #
+  # DEFAULT ON — a correctness fix for four red acceptance rows, not an
+  # observability toggle. It renders only when cilium.gatewayAPI.enabled is
+  # true; set enabled:false to opt a Sovereign out.
+  gatewayApiWatchdog:
+    enabled: true
+    # Steady-state evaluation interval, seconds.
+    intervalSeconds: 30
+    # Ceiling of the exponential BACKOFF while waiting for the Gateway-API CRDs
+    # — NOT a ceiling on how long it waits. The wait itself has no bound and no
+    # attempt cap; that bound is the defect being fixed.
+    crdBackoffMaxSeconds: 30
+    # Consecutive DEAD passes before the operator Pod is deleted. 3 × 30s = 90s,
+    # comfortably longer than a healthy reconcile, so normal latency never
+    # triggers a restart. Passes that cannot reach the apiserver are UNKNOWN and
+    # are not counted — restarting during an outage re-runs the very race.
+    failureThreshold: 3
+    # Minimum seconds between operator restarts. A controller that stays dead
+    # across a restart is a DIFFERENT fault; restart-storming would hide it.
+    restartCooldownSeconds: 300
+    gatewayClass: "cilium"
+    # alpine/k8s toolbox (bash + kubectl + jq), proxied — same image/tag as the
+    # sibling vpcPodcidrRouteReconciler above.
+    image: "harbor.openova.io/proxy-dockerhub/alpine/k8s:1.30.0"

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-13T18:30:14.975Z",
+  "generatedAt": "2026-08-13T19:30:36.588Z",
   "blueprints": [
     {
       "id": "bp-agenity",
@@ -590,7 +590,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "1.4.19",
+      "version": "1.4.20",
       "section": "pts-3-1-networking-and-service-mesh",
       "depends": [],
       "shareable": false,

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -725,7 +725,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "1.4.19",
+    "version": "1.4.20",
     "section": "pts-3-1-networking-and-service-mesh",
     "depends": [],
     "shareable": false,

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3944,7 +3944,31 @@ name: bp-catalyst-platform
 #   pin is the delivery half: without this republish a pinned Sovereign
 #   resolves 0.1.6 and keeps the authentication refusal. This chart's own
 #   templates are unchanged apart from the seed entry.
-version: 1.4.1467
+# 1.4.1468 — #6255 (UAT rows R16/87/90/95): catalog-seed advances bp-cilium
+#   1.4.19 -> 1.4.20, the release that stops region B's cilium-operator from
+#   losing the Gateway-API CRD race against its OWN apiserver at boot. Upstream
+#   v1.19.3 operator/pkg/gateway-api/cell.go:135 bounds CRD discovery at a
+#   hardcoded 30s and, on expiry, returns `{Enabled:false}, nil` — a NIL error —
+#   so the operator stays alive and healthy with the Gateway-API controller
+#   permanently off and nothing re-invokes it. On hw296 region me-east-215-b-1
+#   that cost 4 of the console Gateway's 10 listeners and, because the console
+#   EIP pool spans both regions, put every per-Org customer door at exactly 50%
+#   reachability. 1.4.20 ships a region-local watchdog running the unbounded CRD
+#   retry the operator lacks. The seed pin is the delivery half: without this
+#   republish a pinned Sovereign resolves 1.4.19 and keeps the 50% door. This
+#   chart's own templates are unchanged apart from the seed entry.
+#   (Rebase note: this entry was authored against 1.4.1460/1.4.1461 and the
+#   republish number moved three times while the PR waited on CI, because a
+#   version is a claim on a namespace shared by every open branch. 1.4.1464
+#   was taken mid-rebase by #6263 and caught by
+#   scripts/check-chart-version-not-claimed-by-open-pr.py — exactly the race
+#   that check exists for. 1.4.1465 was then overtaken by main itself, which
+#   published 1.4.1466 and 1.4.1467 while the checks ran; landing 1.4.1465 at
+#   that point would have moved `version:` BACKWARD, the same shape this
+#   file's 1.4.1325 entry records as permanently burned. The republish
+#   therefore lands on 1.4.1468 — ahead of main's 1.4.1467, absent from GHCR,
+#   and claimed by no open PR.)
+version: 1.4.1468
 # 1.4.1229 — #5389: catalog-seed bp-newapi declares its `ui` endpoint
 #   (newapi.<fqdn>, ssoEnabled, launchDefault, ssoInitPath "/") instead of
 #   `endpoints: []`. The empty list made userUIGatePasses fail closed, which

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -3864,7 +3864,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "1.4.19"
+  version: "1.4.20"
   visibility: unlisted
   card:
     title: "Cilium"
@@ -3881,7 +3881,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-cilium
-    version: "1.4.19"
+    version: "1.4.20"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
## Where the bounded retry lives — upstream, stated plainly

**Upstream cilium v1.19.3, `operator/pkg/gateway-api/cell.go:135`.** Not our code, and not reachable from any chart value:

```go
// newGatewayAPIPreconditions, cell.go:126-166
bo := backoff.Exponential{Min: 200 * time.Millisecond, Max: 5 * time.Second, ...}
ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)   // <- cell.go:135
```

Three facts make this terminal rather than merely slow:

1. **No flag widens it.** `gatewayApiConfig.Flags()` (cell.go:182-192) registers `enable-gateway-api-secrets-sync`, `gateway-api-xff-num-trusted-hops`, `gateway-api-hostnetwork-enabled` and friends — nothing that touches this budget. `operator.extraArgs` cannot reach a literal.
2. **The deadline expiry is classified as permanent.** `isTransientError` (cell.go:323-346) matches `IsServerTimeout` / `IsServiceUnavailable` / `IsTooManyRequests` / `IsTimeout` and the `ECONNREFUSED`-family errnos. The `context deadline exceeded` the 30s budget produces matches none of them, so control falls into the give-up branch.
3. **The give-up returns `nil`.** cell.go:148-155 logs `Required GatewayAPI resources are not found` and returns `&gatewayAPIPreconditions{Enabled: false}, nil`. The hive cell therefore **succeeds** — the operator stays alive and reports healthy on `/healthz` — and `initGatewayAPIController` (cell.go:210-213) returns immediately on `!Preconditions.Enabled` without ever registering the controller. There is no re-entry for the process lifetime.

The A/B control from #6255 is same chart, same version, same boot, on hw296 (dep `e689e3b34a75fdec`):

| region | init duration | error | Gateway |
|---|---|---|---|
| `me-east-215-a` | `16.84419141s` | none | 10 spec / **10** status |
| `me-east-215-b-1` | `30.024306733s` | `Required GatewayAPI resources are not found` | 10 spec / **6** status |

Region B's own apiserver answered `dial tcp 10.179.1.83:6443: connect: connection refused` for the first seconds of that window. **A slow apiserver at operator boot is a normal condition** on a fresh 2-region prov and on every region-kill recovery where the apiserver comes back cold. Region B then dropped the four per-Org listeners and stopped reconciling the object; because the console EIP pool spans both regions, every per-Org customer door answered on exactly 50% of fresh TCP connections (15/30 served, against a 27/30 control on the **same** EIP). That is what holds UAT rows R16 / 87 / 90 / 95 red.

## What changed

Since the ceiling is upstream Go, **our fix is at the deployment level** — an unbounded retry that lives *outside* the operator process and re-invokes it once the precondition it gave up on is satisfiable. That is a watch, not a one-shot poll.

The slot-01 `dependsOn: bp-gateway-api` edge (#2614) stays correct, but it only orders the **first** install. It does nothing for the case this exists for: an operator Pod **restarting** into a cold apiserver on node reboot, eviction, OOM, or region-kill recovery.

**An init container on the operator Pod was considered and rejected.** Upstream's operator Deployment template exposes `extraVolumes` / `extraVolumeMounts` / `extraEnv` / `extraArgs` and **no** `initContainers` hook, so it would have to be injected by a Flux postRenderer — and it would make `cilium-operator`, at bootstrap slot 01, unable to start until a **second** image pull succeeded. A pull failure there wedges the CNI itself. A separate Deployment can be degraded (ImagePullBackOff, unscheduled) without ever holding cilium back, which is exactly why the sibling `vpc-podcidr-route-reconciler` (#5339) has the same shape.

**bp-cilium 1.4.19 → 1.4.20** ships a region-local `gateway-api-controller-watchdog` Deployment (`replicas: 1`, `Recreate`) that:

- waits **unbounded**, with capped exponential backoff, for the local apiserver to answer *and* the `gateway.networking.k8s.io` CRDs to reach `Established`. **No attempt cap, no deadline** — that ceiling is the defect;
- compares, live, `metadata.generation` against the `Accepted` condition's `observedGeneration` on `GatewayClass/cilium` and on every Gateway of that class, plus `len(spec.listeners)` against `len(status.listeners)`. Region B's 6 status listeners were written by an **earlier** operator instance and survived its death, so a bare `Accepted=True` or a non-empty `.status.listeners` proves nothing — every check here is a comparison a stale write cannot satisfy;
- deletes the local `cilium-operator` Pod after `failureThreshold` consecutive failing passes, rate-limited by `restartCooldownSeconds`. The replacement boots with the CRDs already `Established`, so cell.go's 30s budget is satisfied on its first poll — region A's fast path;
- scores an unreachable apiserver as **UNKNOWN** and never counts it toward the threshold. Restarting during an outage would only re-run the very race.

`Programmed` is deliberately **not** asserted: under the §854 hostPort / Local-ETP model both regions legitimately report `Programmed=False / AddressNotAssigned`, and #5511 already warned that asserting on it fires on every healthy Sovereign.

Default **on**, gated only on `cilium.gatewayAPI.enabled`. Shipping a correctness fix for four red acceptance rows behind `enabled: false` would leave the defect live everywhere.

RBAC is minimal and asymmetric: cluster-wide **read** on `customresourcedefinitions` / `gatewayclasses` / `gateways`, and a **namespaced Role** in `kube-system` for the single mutation (`pods: get,list,delete`). No `resourceNames` pin — operator Pod names carry a random ReplicaSet suffix, so a name pin would silently stop matching on the first roll.

No NodePort is involved anywhere; `scripts/check-no-nodeports.sh` reports `OK — platform/cilium/chart renders zero NodePorts`.

## Proving it — the guard reproduces the timing, not the ordering

`platform/cilium/chart/tests/6255-gateway-api-controller-watchdog-slow-apiserver.sh` drives the **shipped** script (mounted from `chart/files/` via `.Files.Get`) against a fake kubectl whose apiserver is **refused for 35 real seconds — longer than the 30s ceiling that broke region B** — and asserts the controller ends up running anyway. 27 assertions, 6 cases:

```
CASE A — apiserver refused for 35s, CRDs appear late, controller never started
  PASS  kept polling for the CRDs across 18 attempts (no attempt ceiling)
  PASS  survived 36s of a refused apiserver — past the 30s budget at cell.go:135
  PASS  restarted cilium-operator exactly once
  PASS  console Gateway converged 10 spec / 10 status (region B published 6)
  PASS  watchdog observed the Gateway-API controller running after the restart

CASE B1 — VACUITY: the component disabled renders no script
  PASS  enabled=false renders nothing (this is exactly the pre-fix world)
  PASS  case-A assertions FAIL with no watchdog (restarts=0, status listeners=6)

CASE B2 — VACUITY: re-inject cell.go's 30s ceiling into wait_for_crds
  PASS  bounded variant differs from the shipped script (the ceiling was really injected)
  PASS  case-A assertions FAIL with the 30s ceiling restored (restarts=0, status listeners=6)

CASE C — CONTROL: CRDs already Established and controller current
  PASS  CRD wait satisfied on the FIRST attempt — no added latency on the fast path
  PASS  reached a LIVE verdict in 4s — a bounded retry was not traded for an unbounded hang
  PASS  zero restarts against a healthy controller
  PASS  Programmed=False/AddressNotAssigned did not make a healthy Gateway look dead (§854 model)

CASE D — CONTROL: non-empty stale status + Accepted=True must still read DEAD
  PASS  6 stale listeners in status + GatewayClass Accepted=True still reads DEAD
  PASS  detail names the drift the operator-side reporter also names (spec=10 status=6)

CASE E — CONTROL: apiserver disappears after the CRDs were Established
  PASS  an unreachable apiserver produces UNKNOWN, not DEAD
  PASS  UNKNOWN passes are excluded from the failure threshold
  PASS  zero restarts during an apiserver outage — the race is never re-run on purpose

CASE F — the tested script is the shipped script
  PASS  ConfigMap watchdog.sh matches chart/files/gateway-api-controller-watchdog.sh
  PASS  the packaged chart carries files/gateway-api-controller-watchdog.sh
  PASS  namespaced Role grants pods delete in kube-system (the only mutation)
  PASS  renders nothing when cilium.gatewayAPI.enabled=false
  … 4 more render assertions

#6255 watchdog guard: ALL CASES PASS
```

### VACUITY PROOF — the reverted-fix run that FAILED

Cases B1 and B2 are built in, but the fix was also reverted **in place** and the guard re-run. Injecting cell.go's 30s ceiling into `chart/files/gateway-api-controller-watchdog.sh`:

```
$ sed -i '…' platform/cilium/chart/files/gateway-api-controller-watchdog.sh   # 30s ceiling restored
$ bash platform/cilium/chart/tests/6255-gateway-api-controller-watchdog-slow-apiserver.sh
GUARD EXIT CODE: 1

CASE A — apiserver refused for 35s, CRDs appear late, controller never started
  FAIL  never made a call after the apiserver came back — it stopped polling inside the 35s window
  FAIL  expected exactly 1 operator restart, got 0
  FAIL  Gateway did not converge: 6 in status
  FAIL  watchdog never reported a LIVE verdict
CASE B2
  FAIL  the bounded-variant sed matched nothing — case B2 would itself be vacuous

#6255 watchdog guard: 5 FAILURE(S)
```

The reverted run reproduces region B exactly: Gateway stuck at **6** in status, **0** operator restarts, no LIVE verdict. (B2's own no-match failure is a bonus signal — it detected that the shipped script had already been tampered with.) The script was restored and the guard returns `ALL CASES PASS` / exit 0.

### Fast-path control

Case C is the control that shares the suspect property: CRDs already `Established` and the controller already current — region A's 16.84s path. The CRD wait is satisfied on **attempt 1**, a LIVE verdict lands in 4s, and **zero** restarts are issued. A fix that traded a bounded retry for an unbounded hang, or that restarts healthy operators, fails there. Case D is the second control: a Gateway whose `.status.listeners` is **non-empty** (6 stale entries) with `Accepted=True` — a naive "status is populated" or "Accepted is True" check passes on it, and the watchdog must still read it DEAD.

The guard is wired into `test-bootstrap-kit.yaml` so it gates at **PR** time; `blueprint-release.yaml`'s `chart/tests/*.sh` runner fires on push to `main`, by which point a regression would already be merged.

## #5511's wildcard/SNI diagnosis is superseded by evidence

#5511 recorded the identical symptom (declared > published, per-Org door dead, control on the same VIP alive) and closed with wildcard/SNI overlap (#5341 class) as the leading hypothesis. **That is not the cause here, and #5511's own proposed regression check is what disproves it:**

> "Regression check: N per-Org wildcards admitted simultaneously, asserting `len(status.listeners) == len(spec.listeners)`"

Region A admits **two** per-Org wildcards simultaneously — `*.walkone.omani.rest` and `*.walktwo.omani.homes` — alongside the pre-existing exact-hostname set, and reports **10/10**. Same wildcard shapes, same envoy, admitted cleanly. The listeners are not colliding; in region B nothing was reconciling them at all. Also ruled out by measurement rather than assumption: region B **has** the referenced TLS Secret (replicated); `Programmed=False / AddressNotAssigned` is normal in **both** regions under §854; and the per-Org region fan-out from #5957 worked — the listeners reached region B's `.spec`.

The **reporting** half of #5511 (#6107 / #6144 Organization postcondition verifier) already names the region and the exact dropped listeners correctly, and is untouched here.

## Lockstep

| site | from | to |
|---|---|---|
| `platform/cilium/chart/Chart.yaml` | 1.4.19 | **1.4.20** |
| `platform/cilium/blueprint.yaml` | 1.4.19 | **1.4.20** |
| `clusters/_template/bootstrap-kit/01-cilium.yaml` | 1.4.19 | **1.4.20** |
| catalog-seed + generated catalog (`sync-catalog-seed-pin.py`, `build-catalog.mjs`) | 1.4.19 | **1.4.20** |
| `products/catalyst/chart/Chart.yaml` (umbrella republish) | 1.4.1467 | **1.4.1468** |
| `clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml` | 1.4.1467 | **1.4.1468** |

### Rebase, 2026-08-13

Rebased onto `main` after ~49 PRs landed under this branch. Exactly two files conflicted, both the expected umbrella/lockstep pair — `products/catalyst/chart/Chart.yaml` and `clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml` — and both were resolved to **main's** side plus its full comment history, then advanced forward. Every file was staged **by name**; `git add -A` was never used, and `scripts/check-no-conflict-markers.sh` was run to exit 0 (its own self-test passing: `2 conflict fixtures caught`) *before* `git rebase --continue`, so the #6246 shape that put literal conflict markers on `main` earlier today cannot recur here.

The umbrella republish number moved three times, which is the point of the claim check rather than an accident. `main` stood at 1.4.1463 at first resolve, so the republish took 1.4.1464 — and `scripts/check-chart-version-not-claimed-by-open-pr.py` failed it, correctly: **#6263 opened at 20:30:05Z and claimed 1.4.1464 as well**, a minute after the local enumeration ran. That is exactly the shared-namespace race the check exists for, and why its enumeration is authoritative where a hand-rolled one gives false negatives. 1.4.1465 was then overtaken by `main` itself, which published **1.4.1466 and 1.4.1467** to GHCR while these checks ran; landing 1.4.1465 at that point would have moved `version:` **backward**, the same shape this chart's own 1.4.1325 entry records as a permanently burned artifact. The republish therefore lands on **1.4.1468** — ahead of main's 1.4.1467, absent from GHCR, claimed by no open PR — folded into the *same* commit as the catalog-seed pin move, so `check-umbrella-republish-gate.py` (which reads committed history, not the working tree) sees the republish atomically.

`docs/ledger/UAT.md` was not touched by the rebase, and the fix's own diff is byte-unchanged from its pre-rebase state apart from the two version lines. Re-run green after the rebase: the full #6255 watchdog guard (`ALL CASES PASS`, 27 assertions / 6 cases), all six pre-existing `platform/cilium/chart/tests/*.sh`, `check-bootstrap-kit-pin-sync.sh` (67 pairs), `check-umbrella-republish-gate.py` (160 seed pins), `check-catalog-seed-lockstep.sh`, `helm lint` on both charts, `go build ./...` + `go test ./internal/provisioner/ -run Cilium`, and `build-catalog.mjs` regenerated to a **zero-byte diff** — the generator, not a hand edit, satisfies `check-catalog-generated-drift`.

Green locally: `check-bootstrap-kit-pin-sync.sh`, `check-umbrella-republish-gate.py` (`the umbrella (now at 1.4.1468) has been re-bumped at or after every one's last change`), `check-bootstrap-deps.sh`, `check-cutover-version-floor.py`, `check-cloudinit-kustomization-deps.sh`, `render-slot-placement.py check`, `audit-placement-conformance.py rendered`, `check-no-banned-words.sh`, `check-no-banned-object-names.sh`, `check-no-conflict-markers.sh`, `helm lint`, all six pre-existing `platform/cilium/chart/tests/*.sh`, and `go test ./internal/provisioner/ -run Cilium`.

`ghcr-pin-existence` will report `bp-cilium 1.4.20` and `bp-catalyst-platform 1.4.1468` missing until `blueprint-release.yaml` publishes them — that workflow is `on: push → main` only, so the pins named here cannot exist before merge. Those two are the known structural race and nothing else.

## Scope notes

- **No live-cluster writes.** All live evidence quoted here is read-only and comes from #6255's measurement.
- **`docs/ledger/UAT.md` is untouched.** R16 / 87 / 90 / 95 flip only on a live walk against an environment carrying this fix.

Refs #6255 #3376 #4290

