### PR TITLE
fix(cutover): the settled-roll gate blocked on the cutover's OWN hollow pin, and Case 40 could only fail on the release runner's yq

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -1074,7 +1074,7 @@ spec:
       # chart/tests/ left the package via .helmignore: 757,264 bytes, 72.2%.
       # The rendered manifest is byte-identical modulo comments — no step,
       # value or RBAC change, still 11 steps.
-      version: 0.1.183
+      version: 0.1.184
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1409,7 +1409,14 @@ spec:
       #   bearer catalyst-api itself accepts is no longer refused with
       #   `crypto/rsa: verification error`. Lockstep w/
       #   products/catalyst/chart/Chart.yaml.
-      version: 1.4.1462
+      # 1.4.1464 — #6262: catalog-seed advances bp-self-sovereign-cutover
+      #   0.1.183 -> 0.1.184, the release that stops harbor-prewarm's Phase A0
+      #   settled-roll gate from blocking on the cutover's OWN HelmRelease and
+      #   repairs the Case 40 predicate that failed only on the release
+      #   runner's yq (0.1.183 was never published). Catches the pin up past
+      #   1.4.1463, whose Chart.yaml-only bump left this slot behind. Lockstep
+      #   w/ products/catalyst/chart/Chart.yaml.
+      version: 1.4.1464
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.183
+  version: 0.1.184
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -3705,7 +3705,7 @@ name: bp-self-sovereign-cutover
 # pin + blueprint.yaml + catalog-seed source.version + spec.version + the API
 # blueprints.json + the generated UI catalog move to 0.1.176 in lockstep
 # (Inviolable Principle #13).
-version: 0.1.183
+version: 0.1.184
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml
@@ -247,6 +247,42 @@ data:
             or (($m | test("chart pull error")) and ($m | test("not found")))
           );
       def _terminal: _stalled or _source_absent;
+      {{- /*
+       #6262 — THIS CHART'S OWN HELMRELEASE IS EXCLUDED, for exactly the
+       circularity #6198 already recognised one paragraph down for this
+       chart's own WORKLOADS. The gate's premise is "running != desired":
+       an offender would be mirrored at its RUNNING tag and then rolled by
+       step-04/step-07 to a DESIRED tag that was never mirrored. That
+       premise cannot apply to the release that is RUNNING THIS GATE. The
+       script executing right now was rendered from the INSTALLED revision,
+       so it is self-consistent by construction, and the cutover never rolls
+       itself to a new tag mid-run.
+
+       Left in scope it is not merely noisy, it is a dead end with no
+       in-chart remedy: the only way to deliver a fix for the deadlock is a
+       new version of the very chart that cannot install. Measured live on
+       hw296 (dep e689e3b34a75fdec), fourth cutover attempt, step 3 of 11,
+       progressPercent 18:
+
+         mid-roll: HelmRelease/flux-system/bp-self-sovereign-cutover
+           (chart pull error: failed to get
+            'oci://ghcr.io/openova-io/bp-self-sovereign-cutover:0.1.183':
+            not found)
+
+       — 67 HelmReleases on that cluster, exactly ONE not Ready (this one),
+       zero pending Deployments/StatefulSets. The env was settled; the gate
+       was blocking on its own hollow pin, shipped when #6254's chart build
+       failed on Case 40 while the umbrella that seeds the pin published in
+       the same run.
+
+       Deliberately narrow, and matched by the Case 94 CONTROL: it keys on
+       the chart this HR installs (`.spec.chart.spec.chart`) and on the
+       bootstrap-kit slot-06a release name, both of which equal .Chart.Name.
+       Every OTHER HelmRelease — including a foreign one that is byte-
+       identically stuck — stays gated and stays named.
+      */}}
+      def _is_own_release($own):
+        ((.spec.chart.spec.chart // "") == $own) or ((.metadata.name // "") == $own);
     '
     srp_kubectl_json() {
       {{- /*
@@ -307,11 +343,15 @@ data:
        #5391 override validation FIRST, before ANY exclusion — the gate
        fail-closes on a malformed or over-broad override rather than
        honoring it. A SUSPENDED HR is outside the gate's domain entirely
-       (skipped below), so its annotations are not judged here.
+       (skipped below), so its annotations are not judged here. #6262: so is
+       this chart's OWN release — judging an override on a release the gate
+       does not gate would reject it as "names a HEALTHY HelmRelease" and
+       fail the whole gate closed on an annotation that was never needed.
       */}}
-      or_bad=$(printf '%s' "${_srp_hr_json}" | jq -r --arg okey "${SETTLED_ROLL_OVERRIDE_ANNOTATION}" "${SRP_TERMINAL_JQ}"'
+      or_bad=$(printf '%s' "${_srp_hr_json}" | jq -r --arg okey "${SETTLED_ROLL_OVERRIDE_ANNOTATION}" --arg own {{ .Chart.Name | quote }} "${SRP_TERMINAL_JQ}"'
         .items[]
         | select((.spec.suspend // false) | not)
+        | select(_is_own_release($own) | not)
         | select((.metadata.annotations // {}) | has($okey))
         | ((.metadata.annotations[$okey] // "") | gsub("^\\s+|\\s+$"; "")) as $reason
         | ((((.status.conditions // []) | map(select(.type=="Ready")) | (.[0].status // "Unknown")) == "True")
@@ -374,9 +414,10 @@ data:
        operator to a command that cannot work; name the real one instead
        (publish the pinned version, or re-pin to a published one).
       */}}
-      hr_pending=$(printf '%s' "${_srp_hr_json}" | jq -r --arg okey "${SETTLED_ROLL_OVERRIDE_ANNOTATION}" "${SRP_TERMINAL_JQ}"'
+      hr_pending=$(printf '%s' "${_srp_hr_json}" | jq -r --arg okey "${SETTLED_ROLL_OVERRIDE_ANNOTATION}" --arg own {{ .Chart.Name | quote }} "${SRP_TERMINAL_JQ}"'
         .items[]
         | select((.spec.suspend // false) | not)
+        | select(_is_own_release($own) | not)
         | select(((.metadata.annotations // {}) | has($okey)) | not)
         | select(
             ((.status.observedGeneration // -1) < (.metadata.generation // 0))
@@ -393,6 +434,29 @@ data:
         echo "[harbor-prewarm] FATAL: Phase A0 HelmRelease-offender jq failed — refusing to fail open (#5391)"
         return 1
       }
+      {{- /*
+       #6262 — the own-release exclusion must not be SILENT. Skipping the
+       gate is the right call (the deadlock above), but an unsettled own
+       release still means the next chart fix will not reach this Sovereign,
+       and the operator has to learn that from somewhere. Report it as a
+       NOTE that never blocks: same evidence, no exit.
+      */}}
+      own_hr=$(printf '%s' "${_srp_hr_json}" | jq -r --arg own {{ .Chart.Name | quote }} "${SRP_TERMINAL_JQ}"'
+        .items[]
+        | select(_is_own_release($own))
+        | select(
+            ((.status.observedGeneration // -1) < (.metadata.generation // 0))
+            or (((.status.conditions // []) | map(select(.type=="Ready")) | (.[0].status // "Unknown")) != "True")
+          )
+        | "HelmRelease/\(.metadata.namespace)/\(.metadata.name)"
+          + (if _terminal then "  [TERMINAL]" else "" end)
+          + ((((.status.conditions // []) | map(select(.type=="Ready")) | (.[0].message // "")) | split("\n")[0]) as $why
+             | if ($why | length) > 0 then "  (\($why))" else "" end)') || own_hr=""
+      if [ -n "${own_hr}" ]; then
+        echo "[harbor-prewarm] NOTE: this chart's OWN HelmRelease is not settled. It is EXCLUDED from the settled-roll gate on purpose (#6262/#6198 circularity — the cutover does not roll itself, and this script was rendered from the INSTALLED revision), so the cutover proceeds:"
+        printf '%s\n' "${own_hr}" | sed 's/^/  own (not gated): /'
+        echo "[harbor-prewarm]   It does mean a NEWER cutover chart is not reaching this Sovereign — if the message above is a 404 on the pinned version, that version was never published and the pin needs fixing at its source before any future cutover fix can land here."
+      fi
       {{- /*
        Deployments + StatefulSets: a pending rollout — observedGeneration
        behind the spec, or updated/ready replicas short of desired. Skip

--- a/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
+++ b/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
@@ -1636,11 +1636,44 @@ echo "[cutover-contract] Case 40: cutover step + resolver ConfigMaps re-render o
 # check, the positive half AND the control, so the control cannot drift from
 # what the gate actually runs.
 #
+# #6262 — AND THEN THE REPAIR ITSELF WAS VERSION-DEPENDENT, which cost a
+# published chart. The #6235 form was
+#
+#   yq 'select(.kind == "ConfigMap" and .metadata.name == "<n>")
+#       | .metadata.annotations."helm.sh/resource-policy" // "none"' render.yaml
+#
+# run against a MULTI-DOCUMENT render. In plain (non-`ea`) mode yq evaluates the
+# expression once per document, and on yq v4.44.3 — the version
+# blueprint-release.yaml pins and installs on the runner — the `// "none"`
+# alternative is ALSO applied to every document `select` filtered out. The status
+# CM therefore answers
+#
+#   none\nnone\n…(18x)…\n---\nkeep
+#
+# not `keep`, so `[ "$(c40_keep_policy …)" != keep ]` fired and Case 40 failed the
+# release build for platform/self-sovereign-cutover on merge commit 129f40f33
+# (run 31734398570). 0.1.183 was never pushed; the umbrella in the SAME run
+# published carrying the 0.1.183 seed pin; hw296 repinned to it and parked on
+# `Ready=False SourceNotReady`, which the Phase A0 gate then read as an offender.
+# Cutover dead at step 3 of 11, fourth attempt. On yq v4.53.2 the identical
+# command prints one line, `keep` — so the defect is invisible on a current
+# workstation and fatal on the release runner.
+#
+# The loop half degraded the other way and that is the worse half: for a step CM
+# the same call returns `none…---…none`, which never equals `keep`, so the 12-CM
+# scan Case 40 exists to run was FAIL-OPEN on the release runner.
+#
+# `ea` (eval-all) is the fix: it loads the whole stream as one sequence, so
+# `select` REMOVES the non-matching documents rather than leaving a per-document
+# result for `//` to fill in. Collect the survivors and read `[0]`. Verified
+# byte-identical on yq v4.44.3 and v4.53.2 for all three cases (annotated CM →
+# `keep`; CM present without the annotation → `none`; name absent → `none`).
+#
 # c40_keep_policy <configmap-name> <rendered-yaml> — echoes "keep" or "none".
 c40_keep_policy() {
   local _name="$1" _file="$2" _meta
   if command -v yq >/dev/null 2>&1; then
-    yq "select(.kind == \"ConfigMap\" and .metadata.name == \"${_name}\") | .metadata.annotations.\"helm.sh/resource-policy\" // \"none\"" "$_file"
+    yq ea "[select(.kind == \"ConfigMap\" and .metadata.name == \"${_name}\") | .metadata.annotations.\"helm.sh/resource-policy\"] | .[0] // \"none\"" "$_file"
     return 0
   fi
   # No yq: slice ONLY the metadata block (name -> the `data:` key at column 0,
@@ -1671,6 +1704,12 @@ for cm in cutover-offline-mirror-resolver \
 done
 # Positive half of the invariant: the status CM MUST keep (mirror of Case 6, kept
 # here so Case 40 fully specifies the keep policy across ALL cutover ConfigMaps).
+# Presence first, so "the CM vanished from the render" can never be reported as a
+# keep-policy verdict — c40_keep_policy answers "none" for an absent name.
+if ! grep -q '^  name: self-sovereign-cutover-status$' "$TMP/render.yaml"; then
+  echo "FAIL: the self-sovereign-cutover-status ConfigMap is not in the render at all — mid-cutover progress would not survive a chart uninstall (#4982 Finding A / Case 6)" >&2
+  exit 1
+fi
 if [ "$(c40_keep_policy self-sovereign-cutover-status "$TMP/render.yaml")" != keep ]; then
   echo "FAIL: self-sovereign-cutover-status ConfigMap must carry helm.sh/resource-policy: keep to preserve mid-cutover progress (#4982 Finding A / Case 6)" >&2
   exit 1
@@ -1680,7 +1719,23 @@ fi
 # carrying a REAL metadata.annotations keep, run through the SAME function the
 # loop above calls, must come back "keep". Without it the repair could have
 # swapped a flaky false positive for a permanently dead gate and looked greener.
+#
+# #6262 — THE CONTROL FIXTURE IS MULTI-DOCUMENT, and that is the whole point of
+# it. The #6235 control was a SINGLE-document file, and every yq-version defect
+# in this predicate lives in multi-document streaming: with one document there is
+# nothing for `select` to filter out, so `// "none"` has no spurious document to
+# fire on and v4.44.3 and v4.53.2 agree. The control therefore passed on the exact
+# runner where the real check was both false-failing (status CM) and fail-open
+# (the 12-CM loop). A control that cannot reproduce the shape the real check runs
+# against proves nothing — keep decoy documents on BOTH sides of the annotated one.
 cat > "$TMP/c40-control.yaml" <<'C40CTL'
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cutover-step-97-decoy-before
+data:
+  stepName: decoy
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -1689,11 +1744,28 @@ metadata:
     helm.sh/resource-policy: keep
 data:
   stepName: control
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cutover-step-98-decoy-after
+data:
+  stepName: decoy
 C40CTL
 if [ "$(c40_keep_policy cutover-step-99-control "$TMP/c40-control.yaml")" != keep ]; then
-  echo "FAIL: CONTROL — the annotation-anchored keep check did NOT detect a genuine metadata.annotations keep on a step CM; Case 40 is fail-open again (#6235, #4982 Finding A)" >&2
+  echo "FAIL: CONTROL — the annotation-anchored keep check did NOT detect a genuine metadata.annotations keep on a step CM inside a MULTI-DOCUMENT stream; Case 40's positive half is dead again (#6262, #6235, #4982 Finding A)" >&2
   exit 1
 fi
+# CONTROL 1b — the fail-open half. A CM with NO keep annotation, sitting in the
+# SAME multi-document stream as one that has it, must read "none". On yq v4.44.3
+# the pre-#6262 predicate answered `none…---…none` here: never equal to "keep",
+# so the loop above could not have caught a real keep on any step CM.
+for _decoy in cutover-step-97-decoy-before cutover-step-98-decoy-after; do
+  if [ "$(c40_keep_policy "$_decoy" "$TMP/c40-control.yaml")" != none ]; then
+    echo "FAIL: CONTROL — an UNannotated CM in a multi-document stream did not read \"none\" (got \"$(c40_keep_policy "$_decoy" "$TMP/c40-control.yaml")\"); the 12-CM loop above cannot detect a real keep and Case 40 is fail-open (#6262)" >&2
+    exit 1
+  fi
+done
 # CONTROL 2 — the comment in _helpers.tpl:222 that used to trip this gate is
 # still in the render. Prove the new predicate does NOT read it as a keep: pick
 # a step CM whose script body contains the phrase and assert it reads "none".
@@ -1705,7 +1777,7 @@ if [ "$(c40_keep_policy cutover-step-09-gitea-token-mint "$TMP/render.yaml")" !=
   echo "FAIL: CONTROL 2 — a step CM whose SCRIPT BODY mentions helm.sh/resource-policy: keep was read as carrying the annotation; the #6235 body/metadata confusion is back" >&2
   exit 1
 fi
-echo "  PASS (resolver + 11 step CMs re-render on upgrade; only the status CM keeps; CONTROL proves a real metadata keep is caught, CONTROL 2 proves the _helpers.tpl comment is not)"
+echo "  PASS (resolver + 11 step CMs re-render on upgrade; only the status CM keeps; CONTROL proves a real metadata keep is caught AND an unannotated sibling reads none inside a multi-document stream, CONTROL 2 proves the _helpers.tpl comment is not read as the annotation)"
 
 echo "[cutover-contract] Case 41: Step-03 harbor-prewarm has a settled-roll pre-flight (Phase A0) that fail-closes on a mid-roll env BEFORE building the mirror (#4982 Finding B, Refs #3379)"
 # #4982 Finding B: harbor-prewarm mirrors the RUNNING / declared-template image
@@ -4833,6 +4905,75 @@ if ! grep -q 'acme/some-tenant-app' "$TMP/c90/out.txt"; then
   exit 1
 fi
 echo "  PASS (#6198: the chart's own workloads are excluded from its own settled-roll gate, and the CONTROL proves a foreign unsettled Deployment is still caught and named)"
+
+echo "[cutover-contract] Case 94: Step-03 Phase A0 must NOT gate on the cutover chart's OWN HelmRelease (#6262) — EXECUTED, with controls proving the exclusion does not leak and is not name-only"
+# WHY: #6198 removed the chart's own WORKLOADS from this gate for circularity and
+# stopped there. The HelmRelease selection kept filtering only on spec.suspend and
+# the #5391 override annotation — so the release that IS RUNNING THE GATE was
+# judged by the gate. The script executing Phase A0 was rendered from the
+# INSTALLED revision, so it is self-consistent by construction and the cutover
+# never rolls itself mid-run; a pending upgrade of it cannot invalidate the mirror
+# this step builds. Left in scope it is a dead end with no in-chart remedy: the
+# only vehicle for a fix is a new version of the chart that cannot install.
+#
+# Live hw296 (dep e689e3b34a75fdec), fourth attempt, step 3 of 11: 67
+# HelmReleases, exactly ONE not Ready — flux-system/bp-self-sovereign-cutover,
+# 404 on its own pinned 0.1.183 — and zero pending workloads. The env was
+# settled and the gate blocked on its own hollow pin.
+c93_run() {
+  # $1 = HR fixture. Reuses the Case 77 extracted gate + stub layout, whose
+  # kubectl stub already answers deployments,statefulsets with an empty set.
+  c77_run "$1"
+}
+mkdir -p "$TMP/c93"
+# The live hw296 shape: own release, own chart, 404 on the pinned version.
+cat > "$TMP/c93/own-chart.json" <<'C93F'
+{"items":[{"metadata":{"name":"bp-self-sovereign-cutover","namespace":"flux-system","generation":7},"spec":{"chart":{"spec":{"chart":"bp-self-sovereign-cutover","version":"0.1.183"}}},"status":{"observedGeneration":7,"conditions":[{"type":"Ready","status":"False","reason":"SourceNotReady","message":"HelmChart 'flux-system/flux-system-bp-self-sovereign-cutover' is not ready: chart pull error: failed to download chart for remote reference: failed to get 'oci://ghcr.io/openova-io/bp-self-sovereign-cutover:0.1.183': ghcr.io/openova-io/bp-self-sovereign-cutover:0.1.183: not found"}]}}]}
+C93F
+# Same release expressed the OTHER supported way — .spec.chartRef (an
+# OCIRepository), where .spec.chart.spec.chart does not exist at all. Without the
+# metadata.name leg of _is_own_release this fixture would sail straight back into
+# the deadlock, and nothing else in this file would notice.
+jq 'del(.items[0].spec.chart) | .items[0].spec.chartRef = {"kind":"OCIRepository","name":"bp-self-sovereign-cutover"}' \
+  "$TMP/c93/own-chart.json" > "$TMP/c93/own-chartref.json"
+# CONTROL: byte-identical failure shape, FOREIGN chart and name. Must still block.
+jq '.items[0].metadata.name = "bp-guacamole"
+    | .items[0].spec.chart.spec.chart = "bp-guacamole"
+    | .items[0].status.conditions[0].message = "HelmChart '\''flux-system/flux-system-bp-guacamole'\'' is not ready: chart pull error: failed to download chart for remote reference: failed to get '\''oci://ghcr.io/openova-io/bp-guacamole:0.2.40'\'': ghcr.io/openova-io/bp-guacamole:0.2.40: not found"' \
+  "$TMP/c93/own-chart.json" > "$TMP/c93/foreign.json"
+
+for _fx in own-chart own-chartref; do
+  if ! c93_run "$TMP/c93/${_fx}.json"; then
+    echo "FAIL: the gate REFUSED an env whose only unsettled HelmRelease is the cutover's OWN (${_fx}) — that is the #6262 deadlock: the fix can only ship as a new version of the chart that cannot install" >&2
+    sed -n '1,20p' "$TMP/c77/out.txt" >&2
+    exit 1
+  fi
+  if grep -q 'mid-roll: HelmRelease/flux-system/bp-self-sovereign-cutover' "$TMP/c77/out.txt"; then
+    echo "FAIL: the gate named its OWN HelmRelease as a blocking offender (${_fx}) (#6262)" >&2
+    exit 1
+  fi
+  # The exclusion must not be SILENT — an unsettled own release still means no
+  # newer cutover chart is reaching this Sovereign, and only this line says so.
+  if ! grep -q 'own (not gated): HelmRelease/flux-system/bp-self-sovereign-cutover' "$TMP/c77/out.txt"; then
+    echo "FAIL: the gate skipped its own unsettled HelmRelease (${_fx}) WITHOUT reporting it — a silent exclusion hides that future cutover chart fixes cannot land on this Sovereign (#6262)" >&2
+    exit 1
+  fi
+done
+# CONTROL — without this the exclusion could match every HelmRelease and still "pass".
+if c93_run "$TMP/c93/foreign.json"; then
+  echo "FAIL: CONTROL — a FOREIGN HelmRelease with a byte-identical hollow-pin failure (bp-guacamole) was NOT caught; the #6262 exclusion leaked and the settled-roll gate is now fail-open" >&2
+  exit 1
+fi
+if ! grep -q 'HelmRelease/flux-system/bp-guacamole' "$TMP/c77/out.txt"; then
+  echo "FAIL: CONTROL — the foreign HelmRelease was refused but never NAMED; the operator cannot act on an unnamed offender" >&2
+  exit 1
+fi
+# ...and it must still carry the #6253 hollow-pin remedy, not the stalled one.
+if ! grep -q 'does not exist in the registry' "$TMP/c77/out.txt"; then
+  echo "FAIL: CONTROL — the foreign hollow pin lost its TERMINAL hollow-pin classification; #6253's remedy split regressed" >&2
+  exit 1
+fi
+echo "  PASS (#6262: the chart's own HelmRelease is excluded from its own settled-roll gate under BOTH the .spec.chart and .spec.chartRef shapes and is still reported as a non-blocking NOTE; the CONTROL proves a foreign hollow pin is still caught, named, and classified TERMINAL)"
 
 echo "[cutover-contract] Case 92: the cutover-order labels are a CONTIGUOUS 1..N permutation — no duplicate, no gap (#6235, UAT row 166)"
 # UAT row 166 asks the `cutover` group on /jobs to read all-11-green. The order

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -4640,7 +4640,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "0.1.183",
+      "version": "0.1.184",
       "section": "pts-2-3-per-sovereign-supporting-services",
       "depends": [
         "bp-gitea",

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -4775,7 +4775,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "0.1.183",
+    "version": "0.1.184",
     "section": "pts-2-3-per-sovereign-supporting-services",
     "depends": [
       "bp-gitea",

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3944,7 +3944,7 @@ name: bp-catalyst-platform
 #   pin is the delivery half: without this republish a pinned Sovereign
 #   resolves 0.1.6 and keeps the authentication refusal. This chart's own
 #   templates are unchanged apart from the seed entry.
-version: 1.4.1463
+version: 1.4.1464
 # 1.4.1229 — #5389: catalog-seed bp-newapi declares its `ui` endpoint
 #   (newapi.<fqdn>, ssoEnabled, launchDefault, ssoInitPath "/") instead of
 #   `endpoints: []`. The empty list made userUIGatePasses fail closed, which

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5115,7 +5115,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.1.183"
+  version: "0.1.184"
   visibility: unlisted
   card:
     title: "Self-Sovereignty Cutover"
@@ -5132,7 +5132,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-self-sovereign-cutover
-    version: "0.1.183"
+    version: "0.1.184"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
## The quoted failure

hw296 (dep `e689e3b34a75fdec`), fourth cutover attempt, step 3 of 11, `progressPercent: 18`. From `cutover-harbor-prewarm-1786648684-rerun-1786651188`:

```
[harbor-prewarm] Phase A0: settled-roll pre-flight — no HelmRelease/workload may be mid-roll before the mirror is built
[harbor-prewarm] FATAL: env NOT settled — 1 release(s)/workload(s) are mid-roll; harbor-prewarm would mirror running tags the cutover then rolls away from (running != desired):
  mid-roll: HelmRelease/flux-system/bp-self-sovereign-cutover  (HelmChart 'flux-system/flux-system-bp-self-sovereign-cutover' is not ready: chart pull error: failed to download chart for remote reference: failed to get 'oci://ghcr.io/openova-io/bp-self-sovereign-cutover:0.1.183': ghcr.io/openova-io/bp-self-sovereign-cutover:0.1.183: not found)
[harbor-prewarm] The remainder are genuinely mid-roll — wait for them to settle …
```

Read-only on the cluster at the same moment: **67 HelmReleases, exactly one not Ready** — that one — and **zero** pending Deployments/StatefulSets. The env was settled. hw296 runs `0.1.182` (`lastAttemptedRevision` and the installed release both), so attempt 4 ran the pre-#6254 gate, which is why the message says "wait for them to settle" about a 404 that will never settle.

The merge-train churn hypothesis does not explain this failure: the offender is the cutover's own chart.

## Defect 1 — Case 40 could only fail on the release runner

`c40_keep_policy` asked yq for the status ConfigMap's `helm.sh/resource-policy` across a **multi-document** render:

```
yq 'select(.kind == "ConfigMap" and .metadata.name == "<n>")
    | .metadata.annotations."helm.sh/resource-policy" // "none"' render.yaml
```

On yq **v4.53.2** (a current workstation) that prints one line, `keep`. On yq **v4.44.3** — the version `blueprint-release.yaml` pins and installs on the runner — the `// "none"` alternative is *also* applied to every document `select` filtered out, so the same command prints `none` ×18, then `---`, then `keep`. The positive half false-failed and killed the release build:

```
FAIL: self-sovereign-cutover-status ConfigMap must carry helm.sh/resource-policy: keep …
```

`build (platform/self-sovereign-cutover)` in run `31734398570` (merge commit `129f40f33`). `0.1.183` was never pushed — published tags stop at `0.1.182` — while `build (products/catalyst)` in the **same** run succeeded and published the umbrella carrying the `0.1.183` seed pin. hw296 took the new umbrella, repinned, and parked on `Ready=False SourceNotReady`.

The loop half degraded the other way, and that half is worse: a step CM answered `none…---…none`, never equal to `keep`, so **the 12-CM scan Case 40 exists to run was fail-open on the release runner.**

#6236's CONTROL could not catch either direction, because its fixture was a **single-document** file and the entire defect lives in multi-document streaming — with one document there is nothing for `select` to remove, so both yq versions agree. The control passed on the exact runner where the real check was simultaneously false-failing and fail-open.

`yq ea` loads the stream as one sequence, so `select` removes the non-matching documents instead of leaving a per-document result for `//` to fill. Collect the survivors, read `[0]`. Verified byte-identical on v4.44.3 and v4.53.2 for all three cases: annotated → `keep`, present-but-unannotated → `none`, absent → `none`. The control is now multi-document with decoys on both sides of the annotated CM and asserts both directions.

**Provenance:** the broken predicate is #6236's, not #6254's. #6236 changed only `chart/tests/` — not a rendered surface — so `check-chart-version-bumped` correctly required no version bump, and no release build ever exercised it. #6254's bump to `0.1.183` was simply the first build to carry it. A chart-test regression is therefore invisible until the next unrelated version bump.

## Defect 2 — Phase A0 gated on the cutover's own HelmRelease

#6198 removed this chart's own **workloads** from the settled-roll offender set for circularity, and stopped at workloads. The HelmRelease selection still filtered only on `spec.suspend` and the #5391 override annotation — so the release *running the gate* was judged by the gate.

The premise cannot apply to it. The script executing Phase A0 was rendered from the **installed** revision, so it is self-consistent by construction, and the cutover never rolls itself mid-run; a pending upgrade of it cannot invalidate the mirror this step builds. Left in scope it is a dead end with no in-chart remedy: the only vehicle for a fix is a new version of the chart that cannot install.

`_is_own_release` now excludes it at both jq sites, under the `.spec.chart` and the `.spec.chartRef` shapes. The exclusion is **not silent** — an unsettled own release is still reported as a non-blocking `NOTE` naming the pin, because it does mean no newer cutover chart is reaching that Sovereign.

#6254's terminal classifier tags this offender correctly; it improves the message but does not stop the deadlock, and was itself stuck behind Defect 1.

## Proof

Case 94 EXECUTES the extracted gate against the live hw296 fixture in both HelmRelease shapes, asserts the NOTE, and the CONTROL proves a byte-identical **foreign** hollow pin (`bp-guacamole:0.2.40`) is still caught, named and classified TERMINAL.

Vacuity, both directions, run against CI's exact yq v4.44.3:

| mutant | result |
|---|---|
| revert `c40_keep_policy` to the #6236 form | Case 40 fails, reproducing the release failure verbatim — and **passes** on v4.53.2 |
| drop `_is_own_release` from `hr_pending` | Case 94 fails with the deadlock message |

Full suite green on **both** yq v4.44.3 and v4.53.2 (`All gates green`).

## Delivery

Five lockstep sites move to `0.1.184` with the umbrella at `1.4.1464` in the same commit. `ghcr-pin-existence` will be red for `bp-self-sovereign-cutover:0.1.184` until this merges and publishes — the known structural race, and the pin named here is this PR's own bump. `check-bootstrap-kit-pin-sync` flags `bp-catalyst-platform` (chart `1.4.1464`, pin `1.4.1462`); that drift is inherited from main (`1.4.1463` vs `1.4.1462`) and belongs to the release writer's post-publish hook.

Refs #3379 #6262 #6253 #6198 #6236 #4982 #5391
