### PR TITLE
fix(agenity): the Anthropic credential had no producer, and a retired reconciler's CRs reported pending forever (R19, G8, G9)

### DIFF
--- a/products/agenity/README.md
+++ b/products/agenity/README.md
@@ -134,13 +134,31 @@ zero-touch by construction — no per-Org `bao kv put`.
 > prefix. The path is **cluster-shared** — one seed serves every Org's agenity
 > install on that Sovereign.
 
-**Supplying the platform credential (the one founder action).** Set it once per
-Sovereign via either:
-- the operator-rotatable `catalyst-system/sovereign-anthropic-credentials`
-  Secret (keys `apiKey` / `credentialsJson`) — **source-wins**, so this is also
-  the seam to re-seed the EXPIRING OAuth blob without a chart upgrade; or
-- a per-Sovereign overlay setting `sovereign.anthropic.{apiKey,credentialsJson}`
-  on bp-catalyst-platform.
+**Supplying the platform credential (the one founder action).** Set it **once on
+the mothership** — not once per Sovereign:
+
+- **Mothership (preferred, #4277).** Populate `CATALYST_ANTHROPIC_API_KEY` and
+  `CATALYST_ANTHROPIC_CREDENTIALS_JSON` on the mothership catalyst-api (they
+  arrive via its own `catalyst-openova-kc-credentials` Secret, which
+  `catalyst-system/sovereign-anthropic-credentials` on the MOTHERSHIP
+  source-wins into). Every Sovereign provisioned afterwards is seeded with no
+  human step: the cloud-init kubeconfig postback runs
+  `seedSovereignAnthropicCredentials`
+  (`products/catalyst/bootstrap/api/internal/handler/sovereign_anthropic_seed_mothership.go`,
+  called from `kubeconfig.go`'s `PutKubeconfig`), which creates
+  `catalyst-system/sovereign-anthropic-credentials` on the new cluster — the
+  same rail the #883 SMTP-relay credential rides. It refuses to ship a
+  credential that is absent, key-only, malformed or expired, so a Sovereign is
+  never handed a Secret that inspects as populated and fails at first use.
+- **Per-Sovereign (the escape hatch, and the rotation seam).** Create or edit
+  `catalyst-system/sovereign-anthropic-credentials` (keys `apiKey` /
+  `credentialsJson`) on that Sovereign directly. The mothership seed **never
+  overwrites an existing Secret**, so operator-supplied bytes always win, and
+  this stays the way to re-seed the EXPIRING OAuth blob without a chart
+  upgrade (#6163 reads it live — no catalyst-api roll needed).
+- **Chart floor.** A per-Sovereign overlay setting
+  `sovereign.anthropic.{apiKey,credentialsJson}` on bp-catalyst-platform is the
+  lowest-precedence source; both seams above win over it.
 
 Until it is supplied the dashboard still renders, but the seed **loud-skips**
 (catalyst-api logs `anthropic seed: SKIPPED — platform Anthropic credential

--- a/products/catalyst/bootstrap/api/internal/handler/handler.go
+++ b/products/catalyst/bootstrap/api/internal/handler/handler.go
@@ -574,6 +574,13 @@ type Handler struct {
 	// exercised without standing up a real cluster.
 	sovereignSMTPSeedClientFactory SovereignSMTPSeedClientFactory
 
+	// ── Sovereign Anthropic seed (issues #4277 / #4111) ─────────────────────
+	// sovereignAnthropicSeedClientFactory — same seam as the SMTP one
+	// above, for the mothership→Sovereign write of
+	// catalyst-system/sovereign-anthropic-credentials. See
+	// sovereign_anthropic_seed_mothership.go.
+	sovereignAnthropicSeedClientFactory SovereignAnthropicSeedClientFactory
+
 	// ── NewAPI admin-token OpenBao seed (issue #4477 secondary; ADR-0003) ───
 	// newapiAdminTokenSecretReader — test-only override for reading the
 	// bridge ADMIN_SECRET from the in-cluster

--- a/products/catalyst/bootstrap/api/internal/handler/kubeconfig.go
+++ b/products/catalyst/bootstrap/api/internal/handler/kubeconfig.go
@@ -698,6 +698,24 @@ func (h *Handler) PutKubeconfig(w http.ResponseWriter, r *http.Request) {
 		seedOutcome := h.seedSovereignSMTPCredentials(r.Context(), dep, string(body))
 		h.emitSovereignSMTPSeedEvent(dep, seedOutcome)
 
+		// Issues #4277 / #4111 — seed the Sovereign-side
+		// catalyst-system/sovereign-anthropic-credentials Secret from the
+		// mothership's own Anthropic credential, on the same rail and for
+		// the same reason as the SMTP seed above.
+		//
+		// Before this, that Secret had two readers and NO writer anywhere
+		// in the repo: it came into existence only when a human ran
+		// `kubectl create secret` on that one Sovereign. Every Sovereign
+		// therefore started life with its Agenity workspaces unable to
+		// reach Anthropic, and the gap re-opened on every fresh prov.
+		//
+		// The seed cannot invent a credential the mothership does not
+		// hold — that branch skips loudly and provisioning continues
+		// exactly as before. What it removes is the per-Sovereign manual
+		// step for every Sovereign after the founder's one-time edit.
+		anthropicSeedOutcome := h.seedSovereignAnthropicCredentials(r.Context(), dep, string(body))
+		h.emitSovereignAnthropicSeedEvent(dep, anthropicSeedOutcome)
+
 		// Launch the helmwatch goroutine in the background.
 		//
 		// phase1WatchWG (test-only; nil in production) lets a test

--- a/products/catalyst/bootstrap/api/internal/handler/sandbox_sessions.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sandbox_sessions.go
@@ -1263,7 +1263,116 @@ func unstructuredToSandboxItem(u *unstructured.Unstructured) sandboxItem {
 		}
 	}
 
+	// #6260 — an empty `.status` that has stopped being young is NOT
+	// "the controller has not observed it yet". Since 9ed9619e1 (#5117)
+	// deleted bootstrap-kit slot 19a there is no install site anywhere in
+	// this repo for the reconciler of this CRD, so on every Sovereign
+	// built since 2026-07-15 an empty `.status` is the PERMANENT state.
+	// Reporting it as `pending` held the FE's 6-stage provisioning
+	// checklist open forever. Projected last so a controller-authored
+	// `.status.conditions` list is never displaced by the synthetic one.
+	if age, stale := sandboxUnreconciled(u, rawPhase, time.Now()); stale {
+		item.Status = "failed"
+		item.Conditions = append(item.Conditions, sandboxCondition{
+			Type:    sandboxReconciledConditionType,
+			Status:  "False",
+			Reason:  sandboxNoReconcilerReason,
+			Message: sandboxNoReconcilerMessage(age),
+		})
+	}
+
 	return item
+}
+
+// ── #6260 unreconciled projection ───────────────────────────────────
+//
+// sandboxReconciledConditionType / sandboxNoReconcilerReason are the
+// synthetic condition the projection appends when a Sandbox CR's
+// `.status` never arrives. `status: "False"` plus a non-empty `Reason`
+// is exactly the shape SandboxProvisioningPanel.tsx already treats as
+// actionable (isSandboxFailed + the failureConditions filter), so the
+// honest state needs no front-end change — the back end simply was
+// never telling it.
+const (
+	sandboxReconciledConditionType = "Reconciled"
+	sandboxNoReconcilerReason      = "NoReconciler"
+)
+
+// defaultSandboxUnreconciledAfter — how long a Sandbox CR may carry an
+// EMPTY `.status` before the projection stops calling it pending.
+//
+// Sized against the surface it guards, not a round number: the panel's
+// own contract (mapSandboxStatus' doc comment) is that a reconciled
+// Sandbox transits Pending → Provisioning → Ready in under ten seconds,
+// so two minutes is an order of magnitude of headroom over a live
+// controller's slowest observed first write, while still resolving well
+// inside a walker's attention span.
+const defaultSandboxUnreconciledAfter = 2 * time.Minute
+
+// sandboxUnreconciledAfter reads the grace window from
+// CATALYST_SANDBOX_UNRECONCILED_AFTER (a Go duration, e.g. "90s").
+// Unset / unparseable / non-positive falls back to the default — an
+// operator cannot accidentally disable the honest verdict by setting
+// the knob to garbage. Per Inviolable Principle #4 the value is read
+// from env, never hardcoded at the call site.
+func sandboxUnreconciledAfter() time.Duration {
+	raw := strings.TrimSpace(os.Getenv("CATALYST_SANDBOX_UNRECONCILED_AFTER"))
+	if raw == "" {
+		return defaultSandboxUnreconciledAfter
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil || d <= 0 {
+		return defaultSandboxUnreconciledAfter
+	}
+	return d
+}
+
+// sandboxUnreconciled reports whether a Sandbox CR has carried an empty
+// `.status.phase` for longer than the grace window, and how long.
+//
+// Three cases deliberately do NOT report stale, because each is a state
+// the projection cannot prove is wrong:
+//
+//   - rawPhase is non-empty — a controller HAS written status; whatever
+//     it says is the truth and mapSandboxStatus owns the projection.
+//   - metadata.creationTimestamp is zero — the CR's age is unknown, and
+//     staleness that cannot be measured must not be asserted. (This is
+//     also the shape of the hand-built fixtures in the unit tests.)
+//
+// Clock skew — a creationTimestamp in the FUTURE relative to this
+// process — needs no branch of its own and deliberately does not get
+// one. The window is guaranteed positive by sandboxUnreconciledAfter,
+// so a negative age fails the comparison on its own and reads pending.
+// An explicit `if age < 0` guard was written first and then removed:
+// no mutant of it could be made to fail a test, which meant it was
+// unfalsifiable code asserting a condition already covered. What DOES
+// discriminate is the sign itself, so the skew case is pinned as a
+// test (TestSandboxSessions_FutureCreationTimestampIsPending) against
+// anyone later reaching for an absolute value here.
+func sandboxUnreconciled(u *unstructured.Unstructured, rawPhase string, now time.Time) (time.Duration, bool) {
+	if u == nil || rawPhase != "" {
+		return 0, false
+	}
+	created := u.GetCreationTimestamp()
+	if created.IsZero() {
+		return 0, false
+	}
+	age := now.Sub(created.Time)
+	return age, age >= sandboxUnreconciledAfter()
+}
+
+// sandboxNoReconcilerMessage renders the operator-facing explanation.
+// It names the age measured (so the reader can tell a genuine stall
+// from a misconfigured grace window), the retirement that removed the
+// reconciler, and the surface that replaced it.
+func sandboxNoReconcilerMessage(age time.Duration) string {
+	return fmt.Sprintf(
+		"no controller has written .status in %s. The Sandbox reconciler is not installed on this Sovereign — "+
+			"bootstrap-kit slot 19a was retired on 2026-07-15 (#5114) when the Sandbox concept was removed, "+
+			"so this session cannot provision. The supported agentic surface is the per-Organization Agenity "+
+			"workspace (bp-agenity) with bp-openova-mcp. See issue #6260.",
+		age.Round(time.Second),
+	)
 }
 
 // readSandboxPhase reads `.status.phase` verbatim, trimming
@@ -1283,8 +1392,17 @@ func readSandboxPhase(u *unstructured.Unstructured) string {
 // products/catalyst/bootstrap/ui/src/lib/sandbox.api.ts:normalizeStatus.
 //
 // Empty / unknown phases surface as `pending` so the FE renders the
-// spinner rather than the red-text "unknown" pill — a fresh Sandbox
-// typically transits Pending → Provisioning → Ready in <10s.
+// spinner rather than the red-text "unknown" pill — a RECONCILED
+// Sandbox transits Pending → Provisioning → Ready in <10s.
+//
+// #6260 — that "<10s" is a claim about a Sovereign that HAS a Sandbox
+// reconciler, and since 9ed9619e1 (#5117 retired bootstrap-kit slot
+// 19a) none does. This function still maps the empty phase to
+// `pending` because from a raw phase string alone it cannot tell a
+// two-second-old CR from a two-hour-old one; the AGE-aware verdict
+// lives in sandboxUnreconciled, which unstructuredToSandboxItem
+// applies over this result. Do not push the age check down here —
+// mapSandboxStatus has no access to metadata and would have to guess.
 //
 // Wave 14: signature takes the raw phase string (was: *Unstructured).
 // The caller reads via readSandboxPhase exactly once and reuses the
@@ -1299,8 +1417,9 @@ func mapSandboxStatus(rawPhase string) string {
 	case "failed":
 		return "failed"
 	case "":
-		// No status yet — the controller hasn't observed the CR.
-		// Render as pending so the FE shows the spinner.
+		// No status yet. Pending is only correct while the CR is still
+		// young — sandboxUnreconciled promotes an aged empty status to
+		// `failed` + a NoReconciler condition (#6260).
 		return "pending"
 	default:
 		return "unknown"

--- a/products/catalyst/bootstrap/api/internal/handler/sandbox_unreconciled_6260_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sandbox_unreconciled_6260_test.go
@@ -1,0 +1,320 @@
+package handler
+
+// sandbox_unreconciled_6260_test.go — #6260.
+//
+// The subject under test is the WIRE PAYLOAD of the two read endpoints
+// the Sandbox front end polls, not the projection helper. Every case
+// below drives `GET /api/v1/sandbox/sessions` and
+// `GET /api/v1/sandbox/sessions/{id}` through the real chi router via
+// callSandbox, because the defect being fixed was only ever observable
+// there: `unstructuredToSandboxItem` was returning a status the handler
+// then served to a browser that spun on it forever.
+//
+// Each assertion is paired with a CONTROL that shares the property the
+// verdict keys on, so a change that fires too broadly cannot pass:
+//
+//	AgedEmptyStatus     — aged AND empty  → failed + NoReconciler
+//	  control ReadyIsUntouched      — aged, NOT empty   → running, no condition
+//	  control YoungIsPending        — empty, NOT aged   → pending, no condition
+//	  control NoTimestampIsPending  — empty, age UNKNOWN → pending, no condition
+//
+// The last control is the one that matters most: an unmeasurable age
+// must never be read as a stale one.
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// mkAgedSandboxCR builds a Sandbox CR whose creationTimestamp is
+// exactly `age` in the past. Unlike mkSandboxCR it takes the age
+// explicitly so a test can sit on either side of the grace window.
+func mkAgedSandboxCR(name, ns, agent string, age time.Duration, status map[string]any) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{}
+	u.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "sandbox.openova.io",
+		Version: "v1",
+		Kind:    "Sandbox",
+	})
+	u.SetName(name)
+	u.SetNamespace(ns)
+	u.SetCreationTimestamp(metav1.NewTime(time.Now().Add(-age).UTC().Truncate(time.Second)))
+	_ = unstructured.SetNestedSlice(u.Object, []any{agent}, "spec", "agentCatalogue")
+	if status != nil {
+		u.Object["status"] = status
+	}
+	return u
+}
+
+// getSandboxItem drives the real GET-by-id handler and decodes the
+// wire payload.
+func getSandboxItem(t *testing.T, h *Handler, id string) sandboxItem {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/sandbox/sessions/"+id, nil)
+	req = withSandboxClaims(req, "user-sub-abcdef12", "operator@acme.com", "acme")
+	rec := callSandbox(t, h, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET %s: status = %d, body = %s", id, rec.Code, rec.Body.String())
+	}
+	var item sandboxItem
+	if err := json.Unmarshal(rec.Body.Bytes(), &item); err != nil {
+		t.Fatalf("decode GET body: %v", err)
+	}
+	return item
+}
+
+// findSandboxCondition returns the first condition of the given type, or
+// false when absent.
+func findSandboxCondition(item sandboxItem, condType string) (sandboxCondition, bool) {
+	for _, c := range item.Conditions {
+		if c.Type == condType {
+			return c, true
+		}
+	}
+	return sandboxCondition{}, false
+}
+
+// TestSandboxSessions_AgedEmptyStatusIsNotPending — THE defect.
+//
+// A Sandbox CR that has carried an empty `.status` for half an hour is
+// not "about to be observed". Since 9ed9619e1 retired bootstrap-kit
+// slot 19a there is no reconciler installed to observe it at all, so
+// the wire payload must say so rather than keep the FE spinner alive.
+func TestSandboxSessions_AgedEmptyStatusIsNotPending(t *testing.T) {
+	cr := mkAgedSandboxCR("claude-code-aged", "acme", "claude-code", 30*time.Minute, nil)
+	h := newSandboxHandler(t, cr)
+
+	item := getSandboxItem(t, h, "claude-code-aged")
+
+	if item.Status != "failed" {
+		t.Errorf("Status = %q, want failed — an empty .status 30m after create is terminal, not pending", item.Status)
+	}
+	// The raw phase stays verbatim: the projection reports what it
+	// concluded, it does not fabricate a controller write.
+	if item.Phase != "" {
+		t.Errorf("Phase = %q, want \"\" — the CR genuinely has no .status.phase", item.Phase)
+	}
+
+	c, ok := findSandboxCondition(item, sandboxReconciledConditionType)
+	if !ok {
+		t.Fatalf("no %q condition on the wire payload; conditions = %+v", sandboxReconciledConditionType, item.Conditions)
+	}
+	// SandboxProvisioningPanel.tsx:201-208 renders a condition only
+	// when status is literally "False" AND reason is non-empty. Assert
+	// the exact shape that contract needs, not merely "a condition".
+	if c.Status != "False" {
+		t.Errorf("condition Status = %q, want False — the FE's isSandboxFailed keys on it", c.Status)
+	}
+	if c.Reason != sandboxNoReconcilerReason {
+		t.Errorf("condition Reason = %q, want %q — an empty reason is filtered out by the FE", c.Reason, sandboxNoReconcilerReason)
+	}
+	if c.Message == "" {
+		t.Error("condition Message is empty — the operator is left with a red pill and no explanation")
+	}
+}
+
+// TestSandboxSessions_AgedReadyIsUntouched — CONTROL sharing the AGE
+// property.
+//
+// This CR is just as old as the one above. If the verdict keyed on age
+// alone it would be marked failed here too, which would break every
+// long-lived healthy Sandbox on a Sovereign that DOES run a
+// reconciler. A controller-written phase is the truth and wins.
+func TestSandboxSessions_AgedReadyIsUntouched(t *testing.T) {
+	cr := mkAgedSandboxCR("claude-code-ready", "acme", "claude-code", 30*time.Minute, map[string]any{
+		"phase": "Ready",
+	})
+	h := newSandboxHandler(t, cr)
+
+	item := getSandboxItem(t, h, "claude-code-ready")
+
+	if item.Status != "running" {
+		t.Errorf("Status = %q, want running — a controller wrote Ready, age is irrelevant", item.Status)
+	}
+	if _, ok := findSandboxCondition(item, sandboxReconciledConditionType); ok {
+		t.Errorf("unexpected %q condition on a reconciled Sandbox: %+v", sandboxReconciledConditionType, item.Conditions)
+	}
+}
+
+// TestSandboxSessions_YoungEmptyStatusIsPending — CONTROL sharing the
+// EMPTY-STATUS property.
+//
+// A CR created two seconds ago has an empty `.status` for the same
+// reason it always did, and on a Sovereign with a reconciler it will
+// be observed shortly. Calling that failed would make the create hot
+// path report failure on every single click.
+func TestSandboxSessions_YoungEmptyStatusIsPending(t *testing.T) {
+	cr := mkAgedSandboxCR("claude-code-young", "acme", "claude-code", 2*time.Second, nil)
+	h := newSandboxHandler(t, cr)
+
+	item := getSandboxItem(t, h, "claude-code-young")
+
+	if item.Status != "pending" {
+		t.Errorf("Status = %q, want pending — a 2s-old CR is still inside the grace window", item.Status)
+	}
+	if _, ok := findSandboxCondition(item, sandboxReconciledConditionType); ok {
+		t.Errorf("unexpected %q condition on a young Sandbox: %+v", sandboxReconciledConditionType, item.Conditions)
+	}
+}
+
+// TestSandboxSessions_NoCreationTimestampIsPending — CONTROL for the
+// UNMEASURABLE case.
+//
+// A CR with no creationTimestamp has an age of "unknown", and a zero
+// time is the epoch — trivially older than any grace window. Reading
+// that as stale would assert a fact the payload does not contain. This
+// is also the shape of every hand-built fixture in
+// sandbox_sessions_test.go, so the guard doubles as a regression pin
+// on those.
+func TestSandboxSessions_NoCreationTimestampIsPending(t *testing.T) {
+	u := &unstructured.Unstructured{
+		Object: map[string]any{
+			"metadata": map[string]any{"name": "sandbox-x"},
+			"status":   map[string]any{"phase": ""},
+		},
+	}
+	item := unstructuredToSandboxItem(u)
+
+	if item.Status != "pending" {
+		t.Errorf("Status = %q, want pending — an unmeasurable age must not be reported as a stale one", item.Status)
+	}
+	if _, ok := findSandboxCondition(item, sandboxReconciledConditionType); ok {
+		t.Errorf("unexpected %q condition on a CR with no creationTimestamp: %+v", sandboxReconciledConditionType, item.Conditions)
+	}
+}
+
+// TestSandboxSessions_FutureCreationTimestampIsPending — CONTROL for
+// clock skew between this process and the apiserver. A negative age is
+// not evidence of anything.
+func TestSandboxSessions_FutureCreationTimestampIsPending(t *testing.T) {
+	cr := mkAgedSandboxCR("claude-code-skew", "acme", "claude-code", -10*time.Minute, nil)
+	h := newSandboxHandler(t, cr)
+
+	item := getSandboxItem(t, h, "claude-code-skew")
+
+	if item.Status != "pending" {
+		t.Errorf("Status = %q, want pending — a creationTimestamp in the future is skew, not staleness", item.Status)
+	}
+}
+
+// TestSandboxSessions_ListAgreesWithGet — the landing page polls LIST,
+// the session page polls GET. A verdict that only reached one of them
+// would leave the landing grid showing a healthy-looking row next to a
+// session page reporting failure.
+func TestSandboxSessions_ListAgreesWithGet(t *testing.T) {
+	h := newSandboxHandler(t,
+		mkAgedSandboxCR("claude-code-aged", "acme", "claude-code", 30*time.Minute, nil),
+		mkAgedSandboxCR("claude-code-ready", "acme", "claude-code", 30*time.Minute, map[string]any{"phase": "Ready"}),
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/sandbox/sessions", nil)
+	req = withSandboxClaims(req, "user-sub-abcdef12", "operator@acme.com", "acme")
+	rec := callSandbox(t, h, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("LIST: status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+
+	var resp struct {
+		Sandboxes []sandboxItem `json:"sandboxes"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode LIST body: %v", err)
+	}
+	if len(resp.Sandboxes) != 2 {
+		t.Fatalf("LIST returned %d rows, want 2: %+v", len(resp.Sandboxes), resp.Sandboxes)
+	}
+
+	byID := map[string]sandboxItem{}
+	for _, s := range resp.Sandboxes {
+		byID[s.ID] = s
+	}
+	if got := byID["claude-code-aged"].Status; got != "failed" {
+		t.Errorf("LIST claude-code-aged Status = %q, want failed", got)
+	}
+	if got := byID["claude-code-ready"].Status; got != "running" {
+		t.Errorf("LIST claude-code-ready Status = %q, want running", got)
+	}
+}
+
+// TestSandboxSessions_CreateResponseIsPending — the create hot path.
+//
+// POST projects the object the apiserver just returned. Whatever the
+// fake sets for creationTimestamp, a just-created Sandbox must never
+// come back as failed: that would put a red "cannot provision" pill on
+// screen in the same paint as the click.
+func TestSandboxSessions_CreateResponseIsPending(t *testing.T) {
+	h := newSandboxHandler(t)
+
+	raw, _ := json.Marshal(sandboxCreateRequest{Agent: "claude-code", Name: "fresh"})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sandbox/sessions", bytes.NewReader(raw))
+	req.Header.Set("Content-Type", "application/json")
+	req = withSandboxClaims(req, "user-sub-abcdef12", "operator@acme.com", "acme")
+
+	rec := callSandbox(t, h, req)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("POST: status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	var created sandboxItem
+	if err := json.Unmarshal(rec.Body.Bytes(), &created); err != nil {
+		t.Fatalf("decode POST body: %v", err)
+	}
+	if created.Status != "pending" {
+		t.Errorf("POST Status = %q, want pending on a just-created Sandbox", created.Status)
+	}
+}
+
+// ── grace-window knob ───────────────────────────────────────────────
+
+// TestSandboxUnreconciledAfter_EnvOverride — the window is operator
+// tunable, and garbage cannot silently disable the honest verdict.
+func TestSandboxUnreconciledAfter_EnvOverride(t *testing.T) {
+	cases := []struct {
+		name string
+		env  string
+		want time.Duration
+	}{
+		{"unset", "", defaultSandboxUnreconciledAfter},
+		{"valid", "90s", 90 * time.Second},
+		{"valid-minutes", "10m", 10 * time.Minute},
+		{"unparseable", "soon", defaultSandboxUnreconciledAfter},
+		{"zero", "0s", defaultSandboxUnreconciledAfter},
+		{"negative", "-5m", defaultSandboxUnreconciledAfter},
+		{"whitespace", "   ", defaultSandboxUnreconciledAfter},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("CATALYST_SANDBOX_UNRECONCILED_AFTER", tc.env)
+			if got := sandboxUnreconciledAfter(); got != tc.want {
+				t.Errorf("env=%q → %v, want %v", tc.env, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestSandboxSessions_GraceWindowIsHonouredEndToEnd — the knob must
+// reach the wire payload, not just the helper. A CR aged 30s reads
+// pending under the default window and failed under a 10s one, with
+// nothing else about the CR changing.
+func TestSandboxSessions_GraceWindowIsHonouredEndToEnd(t *testing.T) {
+	t.Run("default-window-30s-old-is-pending", func(t *testing.T) {
+		h := newSandboxHandler(t, mkAgedSandboxCR("cr", "acme", "claude-code", 30*time.Second, nil))
+		if got := getSandboxItem(t, h, "cr").Status; got != "pending" {
+			t.Errorf("Status = %q, want pending under the 2m default", got)
+		}
+	})
+	t.Run("tightened-window-30s-old-is-failed", func(t *testing.T) {
+		t.Setenv("CATALYST_SANDBOX_UNRECONCILED_AFTER", "10s")
+		h := newSandboxHandler(t, mkAgedSandboxCR("cr", "acme", "claude-code", 30*time.Second, nil))
+		if got := getSandboxItem(t, h, "cr").Status; got != "failed" {
+			t.Errorf("Status = %q, want failed under a 10s window", got)
+		}
+	})
+}

--- a/products/catalyst/bootstrap/api/internal/handler/sovereign_anthropic_seed_mothership.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sovereign_anthropic_seed_mothership.go
@@ -1,0 +1,318 @@
+package handler
+
+// sovereign_anthropic_seed_mothership.go — #4277 / #4111.
+//
+// ── The hop that was never written ──────────────────────────────────
+//
+// Every other platform credential a fresh Sovereign needs has a producer
+// with a name and a file. `powerdns_api_key`, `harbor_robot_token`,
+// `ghcr_pull_token` and `hcloud_token` ride the tfvars → terraform →
+// cloud-init rail; the SMTP relay credential rides the mothership-writes-
+// the-Sovereign's-apiserver rail (#883, sovereign_smtp_seed.go, called
+// from PutKubeconfig). The Anthropic credential had CONSUMERS at four
+// layers —
+//
+//	catalyst-openova-kc-credentials-secret.yaml   (helm lookup, source-wins)
+//	sovereign_anthropic_seed_live.go             (live Secret read, #6163)
+//	api-deployment.yaml CATALYST_ANTHROPIC_*      (env, boot snapshot)
+//	sovereign_anthropic_seed.go                   (OpenBao PutKVv2)
+//
+// — and ZERO producers. `catalyst-system/sovereign-anthropic-credentials`
+// was read in two places and written in none, on any Sovereign, by any
+// Go code, Helm template, script, terraform module or cloud-init
+// template. The only way it ever came into existence was a human running
+// `kubectl create secret` on that specific Sovereign, once per Sovereign,
+// forever. The chart comment that anticipated this file
+// (catalyst-openova-kc-credentials-secret.yaml, the `$anthSrc` block:
+// "the operator (or a future mothership seed, mirroring #883 SMTP)")
+// has been carrying the word "future" since it was written.
+//
+// This is that seed. It is deliberately the #883 shape rather than the
+// tfvars shape: no terraform variable in two providers, no cloud-init
+// substitute (Hetzner's user_data is capped at 32256 B and an OAuth blob
+// is not small), and it lands in the exact Secret both existing readers
+// already watch.
+//
+// ── What this does NOT do ───────────────────────────────────────────
+//
+// It does not conjure a credential. If the mothership itself holds none,
+// the seed says so and skips — the same loud no-op posture as the SMTP
+// seed's skipped-no-env branch and as seedAnthropicToken's ABSENT branch.
+// What it changes is the SHAPE of the remaining gap: from "a human must
+// run kubectl on every Sovereign that will ever exist" to "the founder
+// populates one Secret on the mothership, once, and every Sovereign
+// provisioned after that is seeded with no human step". That is the
+// difference between a gate and a chore.
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/helmwatch"
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/provisioner"
+)
+
+// sovereignAnthropicSeedTimeoutEnv bounds the seed's K8s calls. Same
+// budget and the same reasoning as the SMTP seed: generous for first
+// contact with an LB-fronted apiserver right after kubeconfig postback.
+const (
+	sovereignAnthropicSeedTimeoutEnv     = "CATALYST_SOVEREIGN_ANTHROPIC_SEED_TIMEOUT"
+	defaultSovereignAnthropicSeedTimeout = 30 * time.Second
+)
+
+// sovereignAnthropicSeedPhase — SSE phase tag on the deployment event
+// bus, alongside sovereign-smtp-seed.
+const sovereignAnthropicSeedPhase = "sovereign-anthropic-seed"
+
+// SovereignAnthropicSeedOutcome — terminal classification of one attempt.
+//
+// `skipped-unusable` is deliberately distinct from `skipped-no-env`.
+// #6245 established that a credential which is configured and cannot
+// authenticate must not be reported as a seeded one; the same rule has
+// to hold one hop earlier, or the mothership ships an expired OAuth blob
+// to a fresh Sovereign and the Sovereign-side classifier is left to
+// discover it after the fact.
+type SovereignAnthropicSeedOutcome string
+
+const (
+	SovereignAnthropicSeedOutcomeCreated         SovereignAnthropicSeedOutcome = "created"
+	SovereignAnthropicSeedOutcomeAlreadyExists   SovereignAnthropicSeedOutcome = "already-exists"
+	SovereignAnthropicSeedOutcomeSkippedNoEnv    SovereignAnthropicSeedOutcome = "skipped-no-env"
+	SovereignAnthropicSeedOutcomeSkippedUnusable SovereignAnthropicSeedOutcome = "skipped-unusable"
+	SovereignAnthropicSeedOutcomeClientFailure   SovereignAnthropicSeedOutcome = "client-failure"
+	SovereignAnthropicSeedOutcomeAPIFailure      SovereignAnthropicSeedOutcome = "api-failure"
+)
+
+// SovereignAnthropicSeedClientFactory — test-only override, mirroring
+// SovereignSMTPSeedClientFactory.
+type SovereignAnthropicSeedClientFactory func(kubeconfigYAML string) (kubernetes.Interface, error)
+
+// SetSovereignAnthropicSeedClientFactory wires a test-only factory.
+func (h *Handler) SetSovereignAnthropicSeedClientFactory(f SovereignAnthropicSeedClientFactory) {
+	h.sovereignAnthropicSeedClientFactory = f
+}
+
+// seedSovereignAnthropicCredentials creates
+// catalyst-system/sovereign-anthropic-credentials on the freshly
+// provisioned Sovereign from the MOTHERSHIP's own Anthropic credential.
+//
+// Idempotent and non-destructive in the same way as the SMTP seed: an
+// existing Secret short-circuits to AlreadyExists and is never
+// overwritten, so a Sovereign whose operator already rotated the
+// credential by hand keeps their bytes. Rotation of a seeded Sovereign
+// stays the operator's edit + the #6163 live read; this hop only closes
+// the FIRST-write gap.
+func (h *Handler) seedSovereignAnthropicCredentials(ctx context.Context, dep *Deployment, kubeconfigYAML string) SovereignAnthropicSeedOutcome {
+	apiKey := strings.TrimSpace(os.Getenv(anthropicSeedAPIKeyEnv))
+	credsJSON := strings.TrimSpace(os.Getenv(anthropicSeedCredentialsJSONEnv))
+
+	// Classify with the SAME predicate the Sovereign-side seam uses
+	// (#6245) rather than re-deriving "well, one of them is non-empty".
+	// A key-only / malformed / expired credential is not a credential:
+	// claude-code authenticates from the claudeAiOauth blob, so seeding
+	// any of those ships a Secret that looks populated on inspection and
+	// fails at first use — the precise fake-green this seam exists to
+	// refuse.
+	class, detail := classifyAnthropicCredential(apiKey, credsJSON)
+
+	if class == anthropicCredAbsent {
+		// 🛑 FOUNDER-SUPPLIED-SECRET GAP, now visible at PROVISION time on
+		// the mothership rather than only after someone opens an Agenity
+		// workspace on the new Sovereign. Skip loudly; never seed an empty
+		// Secret that pretends to work.
+		h.log.Error("sovereign anthropic seed: the MOTHERSHIP holds no Anthropic credential, so this Sovereign's "+
+			"catalyst-system/sovereign-anthropic-credentials Secret is NOT written and every Organization's "+
+			"agenity workspace on it will start without one",
+			"deploymentID", dep.ID,
+			"sovereignFQDN", dep.Request.SovereignFQDN,
+			"class", string(class),
+			"detail", detail,
+			"remediation", "populate "+anthropicSeedAPIKeyEnv+" + "+anthropicSeedCredentialsJSONEnv+" on the MOTHERSHIP's "+
+				"catalyst-openova-kc-credentials Secret (or catalyst-system/sovereign-anthropic-credentials on the "+
+				"mothership, which source-wins into it). One edit, once — every Sovereign provisioned afterwards is "+
+				"seeded with no per-Sovereign kubectl. Refs #4277.",
+		)
+		return SovereignAnthropicSeedOutcomeSkippedNoEnv
+	}
+
+	if !class.usable() {
+		h.log.Error("sovereign anthropic seed: the mothership's Anthropic credential is present but NOT usable, "+
+			"so it is not propagated to this Sovereign — shipping it would hand the Sovereign a Secret that "+
+			"inspects as populated and fails at first use",
+			"deploymentID", dep.ID,
+			"sovereignFQDN", dep.Request.SovereignFQDN,
+			"class", string(class),
+			"detail", detail,
+			"remediation", anthropicCredentialRemediation(class),
+		)
+		return SovereignAnthropicSeedOutcomeSkippedUnusable
+	}
+
+	factory := h.sovereignAnthropicSeedClientFactory
+	if factory == nil {
+		factory = helmwatch.NewKubernetesClientFromKubeconfig
+	}
+	clientset, err := factory(kubeconfigYAML)
+	if err != nil {
+		h.log.Error("sovereign anthropic seed: build kubernetes client from kubeconfig failed",
+			"deploymentID", dep.ID, "err", err)
+		return SovereignAnthropicSeedOutcomeClientFailure
+	}
+
+	timeout := defaultSovereignAnthropicSeedTimeout
+	if v, _ := time.ParseDuration(os.Getenv(sovereignAnthropicSeedTimeoutEnv)); v > 0 {
+		timeout = v
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	cctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	// Existence check first: an operator-supplied Secret always wins.
+	_, getErr := clientset.CoreV1().Secrets(anthropicCredentialNamespace).
+		Get(cctx, anthropicCredentialSecret, metav1.GetOptions{})
+	if getErr == nil {
+		h.log.Info("sovereign anthropic seed: target Secret already exists; leaving it untouched (idempotent)",
+			"deploymentID", dep.ID,
+			"namespace", anthropicCredentialNamespace,
+			"name", anthropicCredentialSecret,
+		)
+		return SovereignAnthropicSeedOutcomeAlreadyExists
+	}
+	if !apierrors.IsNotFound(getErr) {
+		h.log.Error("sovereign anthropic seed: pre-create Get failed",
+			"deploymentID", dep.ID,
+			"namespace", anthropicCredentialNamespace,
+			"name", anthropicCredentialSecret,
+			"err", getErr,
+		)
+		return SovereignAnthropicSeedOutcomeAPIFailure
+	}
+
+	// catalyst-system may not exist yet — bp-catalyst-platform installs
+	// later in Phase 1. Same pre-create as the SMTP seed.
+	if _, nsErr := clientset.CoreV1().Namespaces().Create(cctx, &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: anthropicCredentialNamespace},
+	}, metav1.CreateOptions{}); nsErr != nil && !apierrors.IsAlreadyExists(nsErr) {
+		h.log.Error("sovereign anthropic seed: pre-create Namespace failed",
+			"deploymentID", dep.ID,
+			"namespace", anthropicCredentialNamespace,
+			"err", nsErr,
+		)
+		return SovereignAnthropicSeedOutcomeAPIFailure
+	}
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      anthropicCredentialSecret,
+			Namespace: anthropicCredentialNamespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/managed-by": "catalyst-api",
+				"app.kubernetes.io/part-of":    "sovereign-bootstrap",
+				"catalyst.openova.io/seed":     "anthropic-credentials",
+			},
+			Annotations: map[string]string{
+				// A UUID, not a credential — safe to log and to read off
+				// the object during incident response.
+				"catalyst.openova.io/seeded-by-deployment-id": dep.ID,
+			},
+		},
+		Type: corev1.SecretTypeOpaque,
+		// Key names are the chart contract, not a choice: the helm lookup
+		// in catalyst-openova-kc-credentials-secret.yaml indexes `apiKey`
+		// and `credentialsJson`, and sovereign_anthropic_seed_live.go
+		// reads the same two. They are shared constants for that reason.
+		Data: map[string][]byte{
+			anthropicCredentialAPIKeyKey: []byte(apiKey),
+			anthropicCredentialJSONKey:   []byte(credsJSON),
+		},
+	}
+
+	if _, createErr := clientset.CoreV1().Secrets(anthropicCredentialNamespace).
+		Create(cctx, secret, metav1.CreateOptions{}); createErr != nil {
+		if apierrors.IsAlreadyExists(createErr) {
+			// Raced another writer between Get and Create. Theirs wins.
+			h.log.Info("sovereign anthropic seed: target Secret appeared during create; leaving it untouched",
+				"deploymentID", dep.ID)
+			return SovereignAnthropicSeedOutcomeAlreadyExists
+		}
+		h.log.Error("sovereign anthropic seed: Secret create failed",
+			"deploymentID", dep.ID,
+			"namespace", anthropicCredentialNamespace,
+			"name", anthropicCredentialSecret,
+			"err", createErr,
+		)
+		return SovereignAnthropicSeedOutcomeAPIFailure
+	}
+
+	// The detail string carries byte lengths and remaining hours only —
+	// classifyAnthropicCredential is explicit that it never includes any
+	// part of the credential. Logging it is what lets an operator tell a
+	// long-lived blob from one that expires this afternoon.
+	h.log.Info("sovereign anthropic seed: wrote catalyst-system/sovereign-anthropic-credentials on the new Sovereign; "+
+		"its Organizations' agenity workspaces resolve their credential with no per-Sovereign kubectl",
+		"deploymentID", dep.ID,
+		"sovereignFQDN", dep.Request.SovereignFQDN,
+		"class", string(class),
+		"detail", detail,
+	)
+	return SovereignAnthropicSeedOutcomeCreated
+}
+
+// emitSovereignAnthropicSeedEvent mirrors emitSovereignSMTPSeedEvent so
+// the provisioning wizard renders this line next to the SMTP one.
+//
+// Every message names the Secret and what the operator loses without it.
+// None of them carries a credential — the outcome and the Secret's
+// coordinates are all that reaches the SSE buffer.
+func (h *Handler) emitSovereignAnthropicSeedEvent(dep *Deployment, outcome SovereignAnthropicSeedOutcome) {
+	target := anthropicCredentialNamespace + "/" + anthropicCredentialSecret
+	level := "info"
+	var msg string
+	switch outcome {
+	case SovereignAnthropicSeedOutcomeCreated:
+		msg = "Sovereign Anthropic seed: created Secret " + target + " on the new Sovereign, so every Organization's " +
+			"Agenity workspace resolves its credential with no per-Sovereign kubectl."
+	case SovereignAnthropicSeedOutcomeAlreadyExists:
+		msg = "Sovereign Anthropic seed: Secret " + target + " already present on the new Sovereign — leaving " +
+			"operator-supplied bytes in place (idempotent)."
+	case SovereignAnthropicSeedOutcomeSkippedNoEnv:
+		level = "warn"
+		msg = "Sovereign Anthropic seed: SKIPPED — the mothership catalyst-api has empty " + anthropicSeedAPIKeyEnv +
+			" / " + anthropicSeedCredentialsJSONEnv + ". Provisioning continues, but Agenity workspaces on this " +
+			"Sovereign cannot reach Anthropic until Secret " + target + " exists (#4277)."
+	case SovereignAnthropicSeedOutcomeSkippedUnusable:
+		level = "warn"
+		msg = "Sovereign Anthropic seed: SKIPPED — the mothership's Anthropic credential is configured but cannot " +
+			"authenticate (key-only, malformed or expired), and shipping it would give this Sovereign a Secret that " +
+			"inspects as populated and fails at first use. Rotate the mothership credential, then create " + target +
+			" here or re-provision (#6245)."
+	case SovereignAnthropicSeedOutcomeClientFailure:
+		level = "warn"
+		msg = "Sovereign Anthropic seed: FAILED to build a Kubernetes client from the cloud-init kubeconfig. " +
+			"Provisioning continues; an operator can create Secret " + target + " on the new cluster."
+	case SovereignAnthropicSeedOutcomeAPIFailure:
+		level = "warn"
+		msg = "Sovereign Anthropic seed: FAILED talking to the new Sovereign's API server (RBAC drift, network blip, " +
+			"or LB still reconciling). Provisioning continues; an operator can create Secret " + target + " on the new cluster."
+	default:
+		level = "warn"
+		msg = fmt.Sprintf("Sovereign Anthropic seed: unknown outcome %q (programming error in catalyst-api).", outcome)
+	}
+
+	h.emitWatchEvent(dep, provisioner.Event{
+		Time:    time.Now().UTC().Format(time.RFC3339),
+		Phase:   sovereignAnthropicSeedPhase,
+		Level:   level,
+		Message: msg,
+	})
+}

--- a/products/catalyst/bootstrap/api/internal/handler/sovereign_anthropic_seed_mothership_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sovereign_anthropic_seed_mothership_test.go
@@ -1,0 +1,308 @@
+package handler
+
+// sovereign_anthropic_seed_mothership_test.go — #4277 / #4111.
+//
+// THE SUBJECT IS THE CALL SITE. seedSovereignAnthropicCredentials is a
+// helper nobody reaches by hand; what has to hold is that a real
+// `PUT /api/v1/deployments/{id}/kubeconfig` — the cloud-init postback
+// that every fresh Sovereign performs exactly once — lands the Secret on
+// the new cluster. So every behavioural case below drives
+// h.PutKubeconfig and then inspects the fake Sovereign's apiserver.
+// A test that called the helper directly would keep passing if the call
+// in kubeconfig.go were deleted, which is precisely the way this seam
+// went missing in the first place.
+//
+// CREDENTIAL SAFETY: every value here is obviously synthetic. This repo
+// is public; no fixture may be a plausible credential.
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+	fakek8s "k8s.io/client-go/kubernetes/fake"
+)
+
+// Obviously-fake fixture values. Never a real key shape that could be
+// mistaken for one during a secret scan.
+const (
+	fakeAnthropicAPIKey = "sk-ant-FAKE-DO-NOT-USE-test-fixture-only"
+	fakeAccessToken     = "FAKE-ACCESS-TOKEN-NOT-A-CREDENTIAL"
+	fakeRefreshToken    = "FAKE-REFRESH-TOKEN-NOT-A-CREDENTIAL"
+)
+
+// fakeClaudeOAuthBlob renders a claudeAiOauth document whose accessToken
+// expires `in` from now. A negative duration yields an EXPIRED blob.
+//
+// expiresAt is computed, never a literal. A hardcoded epoch is how a
+// fixture silently becomes expired and then starts asserting that an
+// expired credential is a good one — the exact defect #6234 fixed.
+func fakeClaudeOAuthBlob(t *testing.T, in time.Duration) string {
+	t.Helper()
+	blob := map[string]any{
+		"claudeAiOauth": map[string]any{
+			"accessToken":  fakeAccessToken,
+			"refreshToken": fakeRefreshToken,
+			"expiresAt":    time.Now().Add(in).UnixMilli(),
+			"scopes":       []string{"user:inference"},
+		},
+	}
+	raw, err := json.Marshal(blob)
+	if err != nil {
+		t.Fatalf("marshal fake oauth blob: %v", err)
+	}
+	return string(raw)
+}
+
+// withMothershipAnthropicEnv sets the mothership-side credential env for
+// one test.
+func withMothershipAnthropicEnv(t *testing.T, apiKey, credsJSON string) {
+	t.Helper()
+	t.Setenv(anthropicSeedAPIKeyEnv, apiKey)
+	t.Setenv(anthropicSeedCredentialsJSONEnv, credsJSON)
+}
+
+// putKubeconfigWithFakeSovereign drives the real PUT handler with a fake
+// Sovereign apiserver injected, and returns that fake so the test can
+// inspect what the seed wrote. `seed` pre-populates the fake (used by
+// the idempotence case).
+func putKubeconfigWithFakeSovereign(t *testing.T, query string, seed ...*corev1.Secret) kubernetes.Interface {
+	t.Helper()
+	h, _, id, bearer := makePutFixture(t, "phase1-watching")
+
+	objs := make([]runtime.Object, 0, len(seed))
+	for _, s := range seed {
+		objs = append(objs, s)
+	}
+	fake := fakek8s.NewSimpleClientset(objs...)
+	h.SetSovereignAnthropicSeedClientFactory(func(string) (kubernetes.Interface, error) {
+		return fake, nil
+	})
+	// The SMTP seed shares this hot path; give it a sink of its own so
+	// its own env-driven behaviour never colours this test's fake.
+	h.SetSovereignSMTPSeedClientFactory(func(string) (kubernetes.Interface, error) {
+		return fakek8s.NewSimpleClientset(), nil
+	})
+
+	r := putReq(t, id, bearer, []byte(validKubeconfigYAML))
+	if query != "" {
+		r.URL.RawQuery = query
+	}
+	w := httptest.NewRecorder()
+	h.PutKubeconfig(w, r)
+	if w.Code < 200 || w.Code > 299 {
+		t.Fatalf("PUT kubeconfig: status = %d, body = %s", w.Code, w.Body.String())
+	}
+	return fake
+}
+
+// getSeededSecret returns the seeded Secret, or (nil, false).
+func getSeededSecret(t *testing.T, cli kubernetes.Interface) (*corev1.Secret, bool) {
+	t.Helper()
+	sec, err := cli.CoreV1().Secrets(anthropicCredentialNamespace).
+		Get(t.Context(), anthropicCredentialSecret, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		return nil, false
+	}
+	if err != nil {
+		t.Fatalf("get seeded Secret: %v", err)
+	}
+	return sec, true
+}
+
+// ── the gap this closes ─────────────────────────────────────────────
+
+// TestPutKubeconfig_SeedsAnthropicCredentialOnTheNewSovereign — THE
+// call-site pin.
+//
+// Before this seam existed, catalyst-system/sovereign-anthropic-
+// credentials had two readers and no writer: it appeared on a Sovereign
+// only when a human ran kubectl there. This asserts the cloud-init
+// postback now creates it, with the two keys the chart lookup and the
+// live reader both index.
+func TestPutKubeconfig_SeedsAnthropicCredentialOnTheNewSovereign(t *testing.T) {
+	withMothershipAnthropicEnv(t, fakeAnthropicAPIKey, fakeClaudeOAuthBlob(t, 12*time.Hour))
+
+	fake := putKubeconfigWithFakeSovereign(t, "")
+
+	sec, ok := getSeededSecret(t, fake)
+	if !ok {
+		t.Fatal("no Secret on the new Sovereign — the kubeconfig postback did not seed the Anthropic credential")
+	}
+	if got := string(sec.Data[anthropicCredentialAPIKeyKey]); got != fakeAnthropicAPIKey {
+		t.Errorf("data[%s] = %q, want the mothership's apiKey", anthropicCredentialAPIKeyKey, got)
+	}
+	// credentialsJson is the load-bearing half — claude-code
+	// authenticates from the OAuth blob, not from apiKey. A seed that
+	// wrote only apiKey would satisfy a careless assertion and leave
+	// every workspace unable to authenticate.
+	if got := string(sec.Data[anthropicCredentialJSONKey]); got == "" {
+		t.Errorf("data[%s] is EMPTY — the OAuth blob is the channel claude-code actually uses", anthropicCredentialJSONKey)
+	}
+	if sec.Labels["catalyst.openova.io/seed"] != "anthropic-credentials" {
+		t.Errorf("seed label = %q, want anthropic-credentials", sec.Labels["catalyst.openova.io/seed"])
+	}
+}
+
+// ── controls ────────────────────────────────────────────────────────
+
+// TestPutKubeconfig_NoMothershipCredentialSeedsNothing — CONTROL
+// sharing the "the postback ran" property.
+//
+// The founder gate is real: when the mothership holds no credential
+// there is nothing to propagate, and the seed must not write an empty
+// Secret that inspects as populated. Provisioning must also continue —
+// the PUT still succeeds (asserted inside the helper).
+func TestPutKubeconfig_NoMothershipCredentialSeedsNothing(t *testing.T) {
+	withMothershipAnthropicEnv(t, "", "")
+
+	fake := putKubeconfigWithFakeSovereign(t, "")
+
+	if sec, ok := getSeededSecret(t, fake); ok {
+		t.Fatalf("a Secret was created with no mothership credential to put in it: keys = %v", anthropicSeedSecretKeys(sec))
+	}
+}
+
+// TestPutKubeconfig_ExpiredMothershipCredentialSeedsNothing — CONTROL
+// sharing the "a credential IS configured" property.
+//
+// This is the control the absent-case cannot provide. An implementation
+// that merely checked "is either env var non-empty" would pass the
+// happy path and the absent path and still ship an expired OAuth blob to
+// every new Sovereign, where it inspects as populated and fails at first
+// use. The seed classifies with the same predicate the Sovereign-side
+// seam uses (#6245), so this must be refused.
+func TestPutKubeconfig_ExpiredMothershipCredentialSeedsNothing(t *testing.T) {
+	withMothershipAnthropicEnv(t, fakeAnthropicAPIKey, fakeClaudeOAuthBlob(t, -3*time.Hour))
+
+	fake := putKubeconfigWithFakeSovereign(t, "")
+
+	if _, ok := getSeededSecret(t, fake); ok {
+		t.Fatal("an EXPIRED credential was seeded onto the new Sovereign — it inspects as populated and fails at first use")
+	}
+}
+
+// TestPutKubeconfig_KeyOnlyMothershipCredentialSeedsNothing — CONTROL
+// for the other unusable class. A bare apiKey with no OAuth blob is the
+// shape claude-code rejects outright.
+func TestPutKubeconfig_KeyOnlyMothershipCredentialSeedsNothing(t *testing.T) {
+	withMothershipAnthropicEnv(t, fakeAnthropicAPIKey, "")
+
+	fake := putKubeconfigWithFakeSovereign(t, "")
+
+	if _, ok := getSeededSecret(t, fake); ok {
+		t.Fatal("a key-only credential was seeded — claude-code authenticates from credentialsJson, not from apiKey")
+	}
+}
+
+// TestPutKubeconfig_ExistingSecretIsNeverOverwritten — an operator who
+// already placed their own credential on this Sovereign keeps their
+// bytes. The seed closes the FIRST-write gap only; rotation stays the
+// operator's edit plus the #6163 live read.
+func TestPutKubeconfig_ExistingSecretIsNeverOverwritten(t *testing.T) {
+	withMothershipAnthropicEnv(t, fakeAnthropicAPIKey, fakeClaudeOAuthBlob(t, 12*time.Hour))
+
+	operatorBytes := "OPERATOR-SUPPLIED-FAKE-VALUE-DO-NOT-REPLACE"
+	existing := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      anthropicCredentialSecret,
+			Namespace: anthropicCredentialNamespace,
+		},
+		Data: map[string][]byte{
+			anthropicCredentialAPIKeyKey: []byte(operatorBytes),
+			anthropicCredentialJSONKey:   []byte(operatorBytes),
+		},
+	}
+
+	fake := putKubeconfigWithFakeSovereign(t, "", existing)
+
+	sec, ok := getSeededSecret(t, fake)
+	if !ok {
+		t.Fatal("the pre-existing Secret disappeared")
+	}
+	if got := string(sec.Data[anthropicCredentialAPIKeyKey]); got != operatorBytes {
+		t.Errorf("data[%s] = %q — the seed overwrote operator-supplied bytes", anthropicCredentialAPIKeyKey, got)
+	}
+}
+
+// TestPutKubeconfig_SecondaryRegionDoesNotSeed — the seed belongs to the
+// primary control plane's postback only, exactly like the SMTP seed it
+// sits beside. A secondary-region PUT just deposits its kubeconfig.
+func TestPutKubeconfig_SecondaryRegionDoesNotSeed(t *testing.T) {
+	withMothershipAnthropicEnv(t, fakeAnthropicAPIKey, fakeClaudeOAuthBlob(t, 12*time.Hour))
+
+	fake := putKubeconfigWithFakeSovereign(t, "region=fsn1")
+
+	if _, ok := getSeededSecret(t, fake); ok {
+		t.Fatal("a secondary-region postback seeded the credential — the seed must fire once, on the primary CP")
+	}
+}
+
+// ── outcome classification ──────────────────────────────────────────
+
+// TestSeedSovereignAnthropicCredentials_OutcomeMatrix pins the outcome
+// each input class produces, since the SSE message the wizard renders is
+// selected from it. Driven through the helper because the outcome value
+// is not observable from the HTTP response.
+func TestSeedSovereignAnthropicCredentials_OutcomeMatrix(t *testing.T) {
+	cases := []struct {
+		name      string
+		apiKey    string
+		credsJSON func(*testing.T) string
+		want      SovereignAnthropicSeedOutcome
+	}{
+		{"absent", "", func(*testing.T) string { return "" }, SovereignAnthropicSeedOutcomeSkippedNoEnv},
+		{"key-only", fakeAnthropicAPIKey, func(*testing.T) string { return "" }, SovereignAnthropicSeedOutcomeSkippedUnusable},
+		{"malformed", fakeAnthropicAPIKey, func(*testing.T) string { return "{\"nope\":true}" }, SovereignAnthropicSeedOutcomeSkippedUnusable},
+		{"expired", fakeAnthropicAPIKey, func(t *testing.T) string { return fakeClaudeOAuthBlob(t, -time.Hour) }, SovereignAnthropicSeedOutcomeSkippedUnusable},
+		{"valid", fakeAnthropicAPIKey, func(t *testing.T) string { return fakeClaudeOAuthBlob(t, 6*time.Hour) }, SovereignAnthropicSeedOutcomeCreated},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			withMothershipAnthropicEnv(t, tc.apiKey, tc.credsJSON(t))
+			h := NewWithPDM(silentLogger(), &fakePDM{})
+			h.SetSovereignAnthropicSeedClientFactory(func(string) (kubernetes.Interface, error) {
+				return fakek8s.NewSimpleClientset(), nil
+			})
+			dep := &Deployment{ID: "dep-" + tc.name}
+
+			got := h.seedSovereignAnthropicCredentials(t.Context(), dep, validKubeconfigYAML)
+			if got != tc.want {
+				t.Errorf("outcome = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestSeedSovereignAnthropicCredentials_ClientFailure — a kubeconfig the
+// factory cannot turn into a client is reported as such, never as a
+// successful seed.
+func TestSeedSovereignAnthropicCredentials_ClientFailure(t *testing.T) {
+	withMothershipAnthropicEnv(t, fakeAnthropicAPIKey, fakeClaudeOAuthBlob(t, 6*time.Hour))
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	h.SetSovereignAnthropicSeedClientFactory(func(string) (kubernetes.Interface, error) {
+		return nil, fmt.Errorf("synthetic kubeconfig parse failure")
+	})
+
+	got := h.seedSovereignAnthropicCredentials(t.Context(), &Deployment{ID: "dep-clientfail"}, "not-a-kubeconfig")
+	if got != SovereignAnthropicSeedOutcomeClientFailure {
+		t.Errorf("outcome = %q, want %q", got, SovereignAnthropicSeedOutcomeClientFailure)
+	}
+}
+
+// anthropicSeedSecretKeys renders a Secret's key set for failure messages. Keys only
+// — a failing test must never print a credential.
+func anthropicSeedSecretKeys(sec *corev1.Secret) []string {
+	out := make([]string, 0, len(sec.Data))
+	for k := range sec.Data {
+		out = append(out, k)
+	}
+	return out
+}


### PR DESCRIPTION
Closes the last unowned ❌ cluster — **R19, G8, G9**, the per-Organization Agenity workspace (Pillar 4). The hw296 walk found two distinct gaps and did not name an issue for the second one, deliberately. Both are named here; one is closed in code, one is closed on the producer side and the remainder is stated precisely.

## Per-row classification

| Row | Clause (verbatim, field 6 = ❌) | Class | `file:line` | What this PR did |
|---|---|---|---|---|
| **R19** | *"The per-Org **Agenity** workspace StatefulSet reaches Running with its Anthropic credential seeded — the init container validates the token and exits 0."* | **(b) written but defective**, plus **(d) obsolete citation** | producer exists: `products/catalyst/bootstrap/api/internal/handler/organization_gitops.go:1939` (`orgTenantBPAgenity`, listed in the overlay map at `:977`) and the install-on-demand door `core/controllers/application/internal/render/fanout.go:342`; StatefulSet at `products/agenity/chart/templates/statefulset.yaml`; credential read-path `products/agenity/chart/values.yaml:168` | The workspace half is not missing. The credential half had no producer at all — closed here. Issue link adjudicated below. |
| **G8** | *"anthropic credential seeded into the agentic runtime — chat works end-to-end."* | **(a) never written** — for the hop that actually blocks it | `catalyst-system/sovereign-anthropic-credentials` had **two readers and zero writers**: `products/catalyst/chart/templates/catalyst-openova-kc-credentials-secret.yaml:287` (helm lookup) and `products/catalyst/bootstrap/api/internal/handler/sovereign_anthropic_seed_live.go:59-68` (live read) | Wrote the missing producer: `sovereign_anthropic_seed_mothership.go`, called from `kubeconfig.go` `PutKubeconfig`. |
| **G9** | *"agentic-run half — the agenity solo agent chats + drives `create_application`."* | **(b) written but defective** — a half-landed retirement | reconciler exists and is installed nowhere: `core/controllers/sandbox/internal/controller/sandbox_controller.go` + `platform/sandbox/chart/templates/deployment.yaml`; its only slot deleted by `9ed9619e1`; the projection that hid it at `sandbox_sessions.go:1301-1304` | The empty `.status` now reports honestly instead of spinning forever. |

The **`sovereign_anthropic_seed.go` producer itself is class (c)** — correct in code, wired, reachable, and it ran. It logged `anthropic seed SKIPPED — the platform holds no Anthropic credential` every 600 s exactly as designed. #6245 is working and was not touched.

## Gap 1 — the credential producer (#4277). Closed on the producer side.

The question was what is *supposed* to seed the OpenBao path, and whether it exists, is wired, and is reachable. Traced end to end, and the answer splits in two:

**The OpenBao writer exists and works.** `seedAnthropicToken` (`sovereign_anthropic_seed.go:272`) is the sole writer of `secret/catalyst/anthropic/token`, invoked from the Org-create pipeline (`organization_provisioning.go:1385`) and the 600 s self-heal loop (`sovereign_seed_reconciler.go:200`). Nothing is wrong with it.

**The thing that supplies it had never been written.** Every other platform credential has a producer with a name and a file:

| Credential | Producer | Rail |
|---|---|---|
| `powerdns_api_key` | `provisioner.go:3069` → `variables.tf:689` → `cloudinit-control-plane.tftpl:1007` | tfvars → terraform → cloud-init |
| `harbor_robot_token` | `deployments.go:1341` → `provisioner.go:3092` → `tftpl:253-264` | same |
| `ghcr_pull_token` | `deployments.go:1331` → `provisioner.go:3085` | same |
| `hcloud_token` | `provisioner.go:2960` → `main.tf:819` | same |
| SMTP relay (#883) | `sovereign_smtp_seed.go:175`, called at `kubeconfig.go:698` | mothership writes the new Sovereign's apiserver |
| **Anthropic** | **— none —** | **a human running `kubectl` on that one Sovereign** |

`grep -rn "sovereign-anthropic-credentials"` returns reads, comments and docs only. `grep -rni anthropic clusters/ infra/ .github/` returns nothing. The deployment-create request cannot carry one either: `provisioner.Request` (`provisioner.go:403-1160`) has zero map fields, `writeTfvars` (`:2792`) builds a fixed literal map, and the cloud-init `postBuild.substitute` blocks are hand-enumerated YAML. The chart comment at `catalyst-openova-kc-credentials-secret.yaml:280` names the missing piece outright — *"the operator (or a future mothership seed, mirroring #883 SMTP)"*.

So this PR writes that seed, in the #883 shape (no terraform variable in two providers, no cloud-init substitute against Hetzner's 32256 B `user_data` cap, and it lands in the exact Secret both readers already watch).

**What is still founder input, stated precisely.** A credential the platform does not have cannot be conjured, and none is faked here. What changed is the shape of the remaining ask: it was *"a human runs `kubectl create secret` on every Sovereign that will ever exist, once each, forever"*. It is now **one edit, once, on the mothership** — populate `CATALYST_ANTHROPIC_API_KEY` + `CATALYST_ANTHROPIC_CREDENTIALS_JSON` there (or `catalyst-system/sovereign-anthropic-credentials` on the mothership, which source-wins into them) and every Sovereign provisioned afterwards is seeded with no human step. Per-Sovereign `kubectl` remains available and always wins: the seed never overwrites an existing Secret. Written up on #4277.

The seed refuses to propagate a credential that is absent, key-only, malformed or expired, reusing `classifyAnthropicCredential` (#6245) rather than re-deriving the predicate — shipping one of those would hand a Sovereign a Secret that inspects as populated and fails at first use.

## Gap 2 — the controller. **Absent from the bootstrap-kit**, of the three candidates.

Not present-but-not-enabled, and not deployed-and-crashing. `clusters/_template/bootstrap-kit/19a-bp-sandbox.yaml` was **deleted** by `9ed9619e1` (PR #5117, 2026-07-15, Refs #5114) and no slot has referenced that chart since. `clusters/_template/bootstrap-kit/kustomization.yaml:185-199` carries the tombstone and says so.

The retirement was correct — the founder removed the Sandbox concept on 2026-06-30 and the replacement is `products/agenity` + `products/openova-mcp`. Nothing here resurrects it. What the retirement missed is the **producer**, which is still the console's headline Pillar-4 affordance:

| Surface | Location |
|---|---|
| Nav entry **labelled "Agenity"**, pointing at `/sandbox` | `products/catalyst/bootstrap/ui/src/pages/sovereign/SovereignSidebar.tsx:119-121` |
| `/sandbox`, `/sandbox/$id`, `/sandbox/settings` | `products/catalyst/bootstrap/ui/src/app/router.tsx:1932-1935` |
| `POST/GET/DELETE /api/v1/sandbox/sessions` | `products/catalyst/bootstrap/api/cmd/api/main.go:1297-1300` |
| Sandbox CR create | `products/catalyst/bootstrap/api/internal/handler/sandbox_sessions.go:613` |

So the console still manufactures CRs for a reconciler that no longer has an install site. Neither the tombstone nor the #5114 follow-up checklist mentions the console door, which is why nothing tracked it. Filed as **#6260**.

## Gap 3 — G9's empty `.status`. The reconciler exists; nothing runs it.

`core/controllers/sandbox/internal/controller/sandbox_controller.go` is the owner of the session CR and it is in-tree and intact — class (b), not (a). It has had no install site since `9ed9619e1`.

The surface defect that made this invisible is `sandbox_sessions.go:1301-1304`:

```go
case "":
    // No status yet — the controller hasn't observed the CR.
    // Render as pending so the FE shows the spinner.
    return "pending"
```

with the doc comment two lines above asserting *"a fresh Sandbox typically transits Pending → Provisioning → Ready in <10s"*. True while slot 19a existed; since 2026-07-15 an empty `.status` is the permanent terminal state, so the projection asserted "not observed **yet**" forever and `SandboxProvisioningPanel.tsx` held its 6-stage checklist open with no timeout. Same class as the two freezes in #6163.

Fixed: an empty `.status` on a CR older than a bounded, env-tunable grace window (`CATALYST_SANDBOX_UNRECONCILED_AFTER`, default 2 m) projects as `failed` with a `Reconciled=False / NoReconciler` condition naming the retirement and pointing at the per-Organization Agenity workspace. `SandboxProvisioningPanel.tsx:201-208` already renders that shape, so **no front-end change was needed** — the back end simply was never telling it.

Three cases keep reporting `pending`, each a state the projection cannot prove wrong: a controller-written phase, a CR inside the grace window, and a CR with no `creationTimestamp`.

## R19 issue-link adjudication

**R19's link to #4482 is wrong.** #4482 is CLOSED (`status/completed`) and its body is entirely about the legacy `bp-sandbox` component's sandbox-controller CrashLooping on an unreflected `CATALYST_GITEA_TOKEN` Secret. It says nothing about an Anthropic credential or an Agenity workspace StatefulSet. A reader checking the warrant lands on a resolved, differently-scoped defect. The correct citations are **#4277** for the credential half and **#6260** for the reconciler half. `docs/ledger/UAT.md` is untouched — these rows flip only on a live walk; the adjudication is recorded here and on #6260.

## Vacuity proof

Every new assertion was watched failing on a mutant that still compiles, then the tree was restored and the package re-run green.

**#6260 status projection** — 6 mutants, each killed by a named test:

| Mutant | Test that failed |
|---|---|
| `sandboxUnreconciled` always returns false (pre-fix behaviour) | `AgedEmptyStatusIsNotPending`, `ListAgreesWithGet`, `GraceWindowIsHonouredEndToEnd` |
| drop the `created.IsZero()` guard | `NoCreationTimestampIsPending`, `CreateResponseIsPending`, `TestSandboxIntegration_PostThenGet` |
| drop the `rawPhase != ""` guard (age alone decides) | `AgedReadyIsUntouched`, `ListAgreesWithGet`, `TestSandboxIntegration_GetReflectsReadyStatus` |
| age comparison takes an absolute value | `FutureCreationTimestampIsPending` |
| `sandboxUnreconciledAfter` ignores the env knob | `EnvOverride`, `GraceWindowIsHonouredEndToEnd` |
| synthetic condition carries no `Reason` | `AgedEmptyStatusIsNotPending` |

**#4277 mothership seed** — 6 mutants, each killed by a named test:

| Mutant | Test that failed |
|---|---|
| remove the call from `PutKubeconfig` | `SeedsAnthropicCredentialOnTheNewSovereign` |
| skip the `usable()` gate | `ExpiredMothershipCredentialSeedsNothing`, `KeyOnlyMothershipCredentialSeedsNothing`, `OutcomeMatrix` |
| skip the absent branch | `NoMothershipCredentialSeedsNothing` + the two above |
| overwrite an existing Secret (both existence guards removed, `Create`→`Update`) | `ExistingSecretIsNeverOverwritten` |
| seed on every postback, not the primary CP's | `SecondaryRegionDoesNotSeed` |
| write `apiKey` without `credentialsJson` | `SeedsAnthropicCredentialOnTheNewSovereign` |

**Controls sharing the suspect property.** The staleness verdict is controlled by an equally-aged CR that *has* a phase (so age alone cannot decide) and by an equally-empty CR that is *young* (so emptiness alone cannot decide). The seed's refusal is controlled by an *expired* and a *key-only* credential — both configured, so an implementation checking only "is either env var non-empty" passes the happy path and the absent path and still fails these.

**A guard that shipped, then did not.** An explicit `if age < 0` clock-skew branch was written first. No mutant of it could be made to fail any test — the grace window is always positive, so a negative age fails the comparison on its own. It was removed rather than shipped as unfalsifiable code; the sign is pinned by a test instead.

**A mutant that was itself wrong, and the correction.** The first overwrite mutant removed only the `getErr == nil` short-circuit. That left the `!apierrors.IsNotFound(getErr)` guard immediately below it to return `api-failure` on a pre-existing Secret, so control never reached the write and `ExistingSecretIsNeverOverwritten` passed — which would have read as a vacuous test. It is not: with **both** existence guards removed and `Create` switched to `Update`, the test fails with `data[apiKey] = "sk-ant-FAKE-DO-NOT-USE-test-fixture-only" — the seed overwrote operator-supplied bytes`. A mutant that a test survives is a claim about the mutant until you have checked which one is at fault.

**Existing tests: protecting behaviour, not enshrining a defect.** `TestUnstructuredToSandboxItem_PhaseProjection`'s `{"", "pending", ""}` case and `TestSandboxIntegration_PostThenGet` both still pass unmodified, because both use CRs with no `creationTimestamp` — the unmeasurable-age case, which correctly stays `pending`. No existing test was rewritten to accommodate this change. Seed fixtures compute `expiresAt` from `time.Now()` rather than a literal, specifically so a fixture cannot silently age into asserting that an expired credential is a good one — the `"expiresAt":1` shape #6234 fixed.

## What is closed and what is not

- **Closed:** the mothership→Sovereign credential producer (gap 1, the missing hop), and the forever-pending session surface (gaps 2/3's user-visible symptom).
- **Not closed:** the platform-level credential VALUE, which is founder input and cannot be code. Written up precisely on #4277 — the ask is now one mothership edit rather than one per Sovereign.
- **Not closed, and deliberately not attempted:** removing the retired `/sandbox` surface (2 566 lines of front end, four API endpoints, `core/controllers/sandbox`, `platform/sandbox`, `products/sandbox`). That is #5114's "LEGACY tree removal is separate scope" item and it needs a product call, since `products/agenity/blueprint.yaml` registers no `consoleUI.sidebarEntry` and deleting the nav entry today would leave the console with no Agenity affordance at all. Recorded on #6260.

## Verification

- `go build ./...` clean; `go vet ./internal/handler/` clean; `gofmt -l` clean on every touched file.
- `go test ./internal/handler/ -count=1` — exit 0, zero `--- FAIL` lines.
- `go test ./... -count=1` across the catalyst-api module — all packages `ok`.
- `scripts/check-no-conflict-markers.sh`, `scripts/check-no-banned-words.sh`, `scripts/check-no-banned-object-names.sh`, `scripts/check-guards-are-wired.sh` — all pass.
- No chart, `blueprint.yaml`, bootstrap-kit slot or catalog-seed pin is touched, so no five-site lockstep applies.
- `docs/ledger/UAT.md` untouched.
- No live-cluster writes were made at any point.

Refs #4277 #4111 #4482 #6260 #5114
