### PR TITLE
fix(cutover): stamp a carried-over step failure with the Job's own times, not the re-read time

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/cutover.go
+++ b/products/catalyst/bootstrap/api/internal/handler/cutover.go
@@ -926,12 +926,28 @@ func findExistingRunningJobForStep(ctx context.Context, deps *cutoverDeps, stepN
 	return nil
 }
 
-// jobCompletionTime returns the Job's completion timestamp in RFC3339,
-// falling back to the latest condition's LastTransitionTime, then to
-// time.Now() if the Job is malformed. The fallbacks are defensive — a
-// terminal condition without timing data is a chart bug, but we'd
-// rather emit a slightly-imprecise audit row than drop the success
-// signal entirely.
+// jobCompletionTime returns the Job's terminal timestamp, falling back to
+// the terminal condition's LastTransitionTime, then to time.Now() if the
+// Job is malformed. The fallbacks are defensive — a terminal condition
+// without timing data is a chart bug, but we'd rather emit a
+// slightly-imprecise audit row than drop the signal entirely.
+//
+// #6262 — this must answer for a FAILED Job, not only a Complete one. The
+// sole caller stamps `step.<name>.finishedAt` on BOTH terminal branches,
+// but the loop below used to match only batchv1.JobComplete, and the
+// kube-apiserver sets Status.CompletionTime only on success. So every
+// carried-over FAILURE fell through to time.Now() and was stamped with the
+// moment it was RE-READ rather than the moment it failed.
+//
+// That is not a cosmetic audit-row defect — it erases the one field that
+// distinguishes a fresh failure from a stale one. Measured on hw296 (dep
+// e689e3b34a75fdec): Job cutover-harbor-prewarm-1786655169 failed
+// 21:08:08Z, and the 22:02:16Z auto-resume re-reported it with
+// finishedAt=22:03:34Z — one second after step-02 succeeded. The status
+// API therefore showed step-03 failing inside the current attempt when the
+// evidence was 56 minutes old and from a prior one, which is exactly the
+// reading that sent three separate investigations after the wrong cause.
+// The JobFailed condition carried the true 21:08:08Z all along.
 func jobCompletionTime(job *batchv1.Job) time.Time {
 	if job == nil {
 		return time.Now().UTC()
@@ -940,7 +956,10 @@ func jobCompletionTime(job *batchv1.Job) time.Time {
 		return job.Status.CompletionTime.Time.UTC()
 	}
 	for _, c := range job.Status.Conditions {
-		if c.Type == batchv1.JobComplete && c.Status == corev1.ConditionTrue && !c.LastTransitionTime.IsZero() {
+		if c.Type != batchv1.JobComplete && c.Type != batchv1.JobFailed {
+			continue
+		}
+		if c.Status == corev1.ConditionTrue && !c.LastTransitionTime.IsZero() {
 			return c.LastTransitionTime.Time.UTC()
 		}
 	}
@@ -1988,14 +2007,53 @@ func (h *Handler) runCutoverStep(ctx context.Context, deps *cutoverDeps, step cu
 				// idempotent PodSpec usually fails the same way; the operator
 				// must address the cause then re-fire /start (which sets
 				// operatorRetry=true and takes the re-run branch above).
+				//
+				// #6262 — this branch halts the engine on EVIDENCE FROM A
+				// PRIOR ATTEMPT, so the durable rows it writes have to make
+				// that legible. Two fields did the opposite:
+				//
+				//   startedAt was never patched at all. The JobComplete
+				//   branch directly above carefully recovers it; this one
+				//   left it "". A step whose row reads result=failed +
+				//   finishedAt=<set> + startedAt="" is a step that finished
+				//   without ever starting, which is precisely the shape of
+				//   "no Job ran this attempt" — the single most useful fact
+				//   here — rendered as though it were missing data.
+				//
+				//   finishedAt was stamped with the re-read time (see
+				//   jobCompletionTime), collapsing a 56-minute-old failure
+				//   onto the current attempt's timeline.
+				//
+				// Stamp both from the Job itself so the row, the status API
+				// and the CTA all say the same thing: this failure predates
+				// the current attempt. Prefer the Job's own StartTime — it is
+				// authoritative for THIS Job, where the durable row may still
+				// carry an even earlier attempt's value.
+				startedAt := ""
+				if job.Status.StartTime != nil && !job.Status.StartTime.IsZero() {
+					startedAt = job.Status.StartTime.UTC().Format(time.RFC3339)
+				} else if priorStatus, readErr := readCutoverStatus(ctx, deps); readErr == nil {
+					startedAt = priorStatus["step."+step.stepName+".startedAt"]
+				}
+				if startedAt == "" && !job.CreationTimestamp.IsZero() {
+					startedAt = job.CreationTimestamp.UTC().Format(time.RFC3339)
+				}
+				if startedAt == "" {
+					startedAt = finishedAt.Format(time.RFC3339)
+				}
 				if err := patchCutoverStatus(ctx, deps, map[string]string{
+					"step." + step.stepName + ".startedAt":  startedAt,
 					"step." + step.stepName + ".finishedAt": finishedAt.Format(time.RFC3339),
 					"step." + step.stepName + ".result":     "failed",
 					"step." + step.stepName + ".jobName":    job.Name,
 				}); err != nil {
 					return fmt.Errorf("status patch (resume-failed): %w", err)
 				}
-				return fmt.Errorf("Job %s/%s reported Failed condition (carried over from prior cutover attempt)", deps.ns, job.Name)
+				// Name the Job's OWN failure time in lastError. The operator
+				// reads this string first; without the timestamp it cannot
+				// tell a fresh failure from one this attempt never re-ran.
+				return fmt.Errorf("Job %s/%s reported Failed condition at %s (carried over from a prior cutover attempt — this attempt did NOT re-run the step; re-fire /cutover/start to delete the prior Job and re-run it)",
+					deps.ns, job.Name, finishedAt.Format(time.RFC3339))
 			}
 		}
 	}

--- a/products/catalyst/bootstrap/api/internal/handler/cutover_carried_over_failure_6262_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/cutover_carried_over_failure_6262_test.go
@@ -1,0 +1,241 @@
+// Regression coverage for the carried-over-failure REPORTING path (#6262).
+//
+// When an unattended resume (operatorRetry=false) finds a Failed Job from a
+// PRIOR cutover attempt, runCutoverStep deliberately does not re-run the
+// step — it surfaces the prior failure and halts. That halt semantic is
+// correct and these tests keep it pinned.
+//
+// What was NOT correct is the evidence it wrote while halting. Two fields
+// actively disguised a stale failure as a fresh one:
+//
+//   - step.<name>.startedAt was never patched, so the durable row read
+//     result=failed + finishedAt=<set> + startedAt="" — a step that
+//     finished without ever starting. That empty cell is the clearest
+//     available signal that NO Job ran this attempt, and it rendered as
+//     missing data instead.
+//   - step.<name>.finishedAt was stamped with the moment of the re-read,
+//     because jobCompletionTime matched only batchv1.JobComplete and the
+//     apiserver sets Status.CompletionTime only on success. A failure from
+//     a prior attempt therefore landed on the CURRENT attempt's timeline.
+//
+// Measured on hw296 (dep e689e3b34a75fdec): Job
+// cutover-harbor-prewarm-1786655169 failed at 21:08:08Z; the 22:02:16Z
+// auto-resume re-reported it with finishedAt=22:03:34Z, one second after
+// step-02 succeeded. Reading that row top-down says "step-03 just failed in
+// this attempt". It had not run in this attempt at all.
+//
+// The assertions below are written against the JOB's OWN timestamps rather
+// than against "not now", so they fail on the pre-fix code for the real
+// reason rather than on a clock race.
+package handler
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	clienttesting "k8s.io/client-go/testing"
+)
+
+// hw296FailedPrewarmJob reproduces the exact live object: a harbor-prewarm
+// Job that exhausted its backoff limit 56 minutes before the resume that
+// re-reads it. BackoffLimitExceeded (NOT DeadlineExceeded) is what makes
+// jobFailedTransiently return false and routes this to the carried-over
+// branch.
+func hw296FailedPrewarmJob(failedAt, startedAt time.Time) *batchv1.Job {
+	return &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cutover-harbor-prewarm-1786655169",
+			Namespace: cutoverTestNS,
+			Labels: map[string]string{
+				cutoverStepPartOfLabel:    cutoverStepPartOfValue,
+				cutoverStepComponentLabel: "cutover-job",
+				cutoverStepLabelKey:       "harbor-prewarm",
+			},
+			CreationTimestamp: metav1.NewTime(startedAt),
+		},
+		Status: batchv1.JobStatus{
+			Failed:    4,
+			StartTime: &metav1.Time{Time: startedAt},
+			Conditions: []batchv1.JobCondition{{
+				Type:               batchv1.JobFailed,
+				Status:             corev1.ConditionTrue,
+				LastTransitionTime: metav1.NewTime(failedAt),
+				Reason:             "BackoffLimitExceeded",
+				Message:            "Job has reached the specified backoff limit",
+			}},
+		},
+	}
+}
+
+// TestJobCompletionTime_UsesFailedConditionTime is the unit-level seam.
+// A Failed Job carries its terminal time ONLY on the JobFailed condition;
+// Status.CompletionTime stays nil. Matching just JobComplete silently
+// yielded time.Now() for every failure.
+func TestJobCompletionTime_UsesFailedConditionTime(t *testing.T) {
+	failedAt := time.Date(2026, 8, 13, 21, 8, 8, 0, time.UTC)
+	job := hw296FailedPrewarmJob(failedAt, failedAt.Add(-77*time.Second))
+
+	got := jobCompletionTime(job)
+	if !got.Equal(failedAt) {
+		t.Errorf("jobCompletionTime(failed job) = %s, want the JobFailed condition time %s\n"+
+			"a Failed Job has no Status.CompletionTime, so falling through to time.Now() "+
+			"stamps the moment of the RE-READ and erases how stale the failure is (#6262)",
+			got.Format(time.RFC3339), failedAt.Format(time.RFC3339))
+	}
+}
+
+// TestJobCompletionTime_CompleteJobUnchanged is the CONTROL. Broadening the
+// condition match must not disturb the success path that already worked:
+// Status.CompletionTime still wins, and a Complete condition still resolves
+// ahead of anything else.
+func TestJobCompletionTime_CompleteJobUnchanged(t *testing.T) {
+	completedAt := time.Date(2026, 8, 13, 22, 3, 28, 0, time.UTC)
+
+	withCompletionTime := &batchv1.Job{
+		Status: batchv1.JobStatus{
+			CompletionTime: &metav1.Time{Time: completedAt},
+			Conditions: []batchv1.JobCondition{{
+				Type:               batchv1.JobComplete,
+				Status:             corev1.ConditionTrue,
+				LastTransitionTime: metav1.NewTime(completedAt.Add(9 * time.Second)),
+			}},
+		},
+	}
+	if got := jobCompletionTime(withCompletionTime); !got.Equal(completedAt) {
+		t.Errorf("jobCompletionTime(complete job) = %s, want Status.CompletionTime %s",
+			got.Format(time.RFC3339), completedAt.Format(time.RFC3339))
+	}
+
+	conditionOnly := &batchv1.Job{
+		Status: batchv1.JobStatus{
+			Conditions: []batchv1.JobCondition{{
+				Type:               batchv1.JobComplete,
+				Status:             corev1.ConditionTrue,
+				LastTransitionTime: metav1.NewTime(completedAt),
+			}},
+		},
+	}
+	if got := jobCompletionTime(conditionOnly); !got.Equal(completedAt) {
+		t.Errorf("jobCompletionTime(condition-only complete job) = %s, want %s",
+			got.Format(time.RFC3339), completedAt.Format(time.RFC3339))
+	}
+}
+
+// TestRunCutoverStep_CarriedOverFailureStampsJobTimes drives the real
+// resume path with operatorRetry=false and asserts the durable row it
+// writes is legible as CARRIED OVER — while keeping the halt + no-re-run
+// semantics that #3379 deliberately chose for unattended resumes.
+func TestRunCutoverStep_CarriedOverFailureStampsJobTimes(t *testing.T) {
+	jobStartedAt := time.Date(2026, 8, 13, 21, 6, 51, 0, time.UTC)
+	jobFailedAt := time.Date(2026, 8, 13, 21, 8, 8, 0, time.UTC)
+
+	preStatus := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cutoverStatusConfigMapName(),
+			Namespace: cutoverTestNS,
+		},
+		Data: map[string]string{
+			"cutoverComplete": "false",
+			// Exactly as observed live: the prior attempt's rows for this
+			// step were reset, so there is no startedAt to recover from the
+			// ConfigMap. The Job itself is the only source of truth.
+			"step.harbor-prewarm.result":     "",
+			"step.harbor-prewarm.startedAt":  "",
+			"step.harbor-prewarm.finishedAt": "",
+			"step.harbor-prewarm.jobName":    "",
+		},
+	}
+	stepCM := makeCutoverStepCM("cutover-step-03-harbor-prewarm", "harbor-prewarm", 3,
+		cutoverModeJob, minimalPodSpecYAML, "")
+	priorJob := hw296FailedPrewarmJob(jobFailedAt, jobStartedAt)
+
+	h, client := fakeHandlerWithCutover(t, []k8sruntime.Object{stepCM, preStatus, priorJob}...)
+
+	// Any Job creation here would mean the unattended path silently
+	// re-ran a genuinely-failed step — the #3379 fail-closed semantic.
+	var muJobs sync.Mutex
+	created := []string{}
+	client.PrependReactor("create", "jobs", func(action clienttesting.Action) (bool, k8sruntime.Object, error) {
+		ca, ok := action.(clienttesting.CreateAction)
+		if !ok {
+			return false, nil, nil
+		}
+		if job, ok := ca.GetObject().(*batchv1.Job); ok {
+			muJobs.Lock()
+			created = append(created, job.Name)
+			muJobs.Unlock()
+		}
+		return false, nil, nil
+	})
+
+	step, err := parseCutoverStep(*stepCM)
+	if err != nil {
+		t.Fatalf("parseCutoverStep: %v", err)
+	}
+	deps := &cutoverDeps{core: client, ns: cutoverTestNS}
+
+	runErr := h.runCutoverStep(context.Background(), deps, step,
+		time.Now().Unix(), false /* operatorRetry */, false /* forceRerun */)
+
+	if runErr == nil {
+		t.Fatalf("runCutoverStep returned nil; a carried-over Failed Job must still halt the engine")
+	}
+
+	muJobs.Lock()
+	nCreated := len(created)
+	muJobs.Unlock()
+	if nCreated != 0 {
+		t.Errorf("runCutoverStep created %d Job(s) %v; an unattended resume must NOT re-run a "+
+			"genuinely-failed step (#3379 fail-closed)", nCreated, created)
+	}
+
+	// The error string is what lands in the status ConfigMap's lastError and
+	// is the first thing an operator reads. It must date the failure.
+	if !strings.Contains(runErr.Error(), jobFailedAt.Format(time.RFC3339)) {
+		t.Errorf("error %q does not name the Job's failure time %s;\n"+
+			"without it, lastError cannot be told apart from a failure that "+
+			"happened in the current attempt (#6262)",
+			runErr.Error(), jobFailedAt.Format(time.RFC3339))
+	}
+
+	got, err := readCutoverStatus(context.Background(), deps)
+	if err != nil {
+		t.Fatalf("readCutoverStatus: %v", err)
+	}
+
+	if got["step.harbor-prewarm.result"] != "failed" {
+		t.Errorf("step.harbor-prewarm.result = %q, want %q",
+			got["step.harbor-prewarm.result"], "failed")
+	}
+	if got["step.harbor-prewarm.jobName"] != priorJob.Name {
+		t.Errorf("step.harbor-prewarm.jobName = %q, want %q",
+			got["step.harbor-prewarm.jobName"], priorJob.Name)
+	}
+
+	// The regression: startedAt was left "" while finishedAt was set,
+	// producing a step that finished without starting.
+	wantStarted := jobStartedAt.Format(time.RFC3339)
+	if got["step.harbor-prewarm.startedAt"] != wantStarted {
+		t.Errorf("step.harbor-prewarm.startedAt = %q, want %q (the prior Job's own StartTime);\n"+
+			"an empty startedAt beside a populated finishedAt reads as missing data when it is "+
+			"in fact the strongest evidence that no Job ran this attempt (#6262)",
+			got["step.harbor-prewarm.startedAt"], wantStarted)
+	}
+
+	// The regression: finishedAt was time.Now(), which relocated a
+	// 56-minute-old failure onto the current attempt.
+	wantFinished := jobFailedAt.Format(time.RFC3339)
+	if got["step.harbor-prewarm.finishedAt"] != wantFinished {
+		t.Errorf("step.harbor-prewarm.finishedAt = %q, want %q (the JobFailed condition time);\n"+
+			"stamping the re-read time makes a carried-over failure indistinguishable from a "+
+			"fresh one on the status API (#6262)",
+			got["step.harbor-prewarm.finishedAt"], wantFinished)
+	}
+}


### PR DESCRIPTION
## What this fixes

An unattended cutover resume that finds a **Failed Job from a prior attempt**
halts without re-running the step. That halt is deliberate (#3379) and is
**unchanged** by this PR — the test asserts no Job is created.

What was wrong is the **evidence recorded while halting**. Two fields made a
stale failure indistinguishable from a fresh one:

| field | before | after |
|---|---|---|
| `step.<n>.startedAt` | never patched — stayed `""` | the Job's own `Status.StartTime` |
| `step.<n>.finishedAt` | `time.Now()` (the re-read) | the `JobFailed` condition time |
| `lastError` | "reported Failed condition (carried over…)" | names the failure time + that the step was not re-run + how to re-run it |

`jobCompletionTime` matched only `batchv1.JobComplete`, and the apiserver sets
`Status.CompletionTime` only on success — so **every** Failed Job fell through
to `time.Now()`. The `JobFailed` condition carried the true time all along. The
`JobComplete` branch immediately above already recovered `startedAt`; the
failure branch never did.

## Live evidence — hw296 (dep `e689e3b34a75fdec`)

Job `cutover-harbor-prewarm-1786655169` failed at **21:08:08Z**
(`BackoffLimitExceeded`). The **22:02:16Z** auto-resume re-reported it as:

```
step.harbor-prewarm.startedAt:  ""
step.harbor-prewarm.finishedAt: "2026-08-13T22:03:34Z"
step.harbor-prewarm.result:     failed
lastError: Job catalyst/cutover-harbor-prewarm-1786655169 reported Failed
           condition (carried over from prior cutover attempt)
```

`22:03:34Z` is one second after step-02 succeeded. Read top-down, that row says
step-03 just failed inside the current attempt. It had **not run in the current
attempt at all**, and its failure was 56 minutes old and already resolved out of
band. Three separate investigations chased the wrong cause off that row — the
`startedAt: ""` that would have given it away read as missing data instead of as
the finding.

A step that "finished without ever starting" should be the loudest signal on the
status API, not the quietest.

## Tests

- `TestJobCompletionTime_UsesFailedConditionTime` — the unit seam.
- `TestJobCompletionTime_CompleteJobUnchanged` — **CONTROL**: broadening the
  condition match must not disturb the success path. `Status.CompletionTime`
  still wins; a condition-only Complete Job still resolves.
- `TestRunCutoverStep_CarriedOverFailureStampsJobTimes` — drives the real resume
  path with `operatorRetry=false` against the exact live object shape, asserting
  all three row fields, the error text, **and** that zero Jobs were created.

Assertions are written against the Job's own timestamps rather than "not now",
so they fail for the real reason rather than on a clock race.

**Vacuity-checked**: with the fix reverted, all three assertions fail for the
intended reasons —

```
jobCompletionTime(failed job) = 2026-08-13T22:34:25Z, want 2026-08-13T21:08:08Z
error "...(carried over from prior cutover attempt)" does not name the failure time
step.harbor-prewarm.startedAt  = "",                     want "2026-08-13T21:06:51Z"
step.harbor-prewarm.finishedAt = "2026-08-13T22:34:25Z", want "2026-08-13T21:08:08Z"
```

## Not in this PR

The reason hw296's cutover is wedged is that the auto-resume path re-reports
that stale Job forever (until its 24h TTL) instead of re-running the step —
`operatorRetry=false` + `BackoffLimitExceeded` misses both arms of
`if jobFailedTransiently(job) || operatorRetry` at `cutover.go:1948`. Only an
operator-fired `/cutover/start` deletes the prior Job and mints a fresh one.
This PR makes that state **legible**; it does not change the retry policy.

Refs #6262 #3379

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HvMZTDx7W6EPZMmjyXmYh1
