### PR TITLE
fix(catalyst-api): the Topology tab drew a Standby with no Primary and called it a placement

### DIFF
--- a/.github/workflows/blueprint-release.yaml
+++ b/.github/workflows/blueprint-release.yaml
@@ -81,6 +81,7 @@ permissions:
   contents: write
   packages: write
   id-token: write              # for cosign keyless signing
+  actions: read                # #6262: read this run's sibling job outcomes
 
 jobs:
   detect:
@@ -501,6 +502,88 @@ jobs:
           python3 scripts/check-helm-release-payload-size.py "${{ matrix.path }}/chart" \
             --release-name "${{ steps.chart.outputs.name }}" \
             --namespace catalyst
+
+      # ──────────────────────────────────────────────────────────────
+      # GATE — the umbrella never publishes a seed pin its sibling
+      #        failed to push in this same run (#6262)
+      # ──────────────────────────────────────────────────────────────
+      # Every changed Blueprint builds as one entry of this matrix, and
+      # `fail-fast: false` makes those entries independent — deliberately,
+      # so one broken chart does not stop the rest. But `products/catalyst`
+      # is not peer to the others: it CARRIES the catalog seed, and the seed
+      # pins every sub-chart by exact version. Independence therefore lets
+      # the umbrella publish a pin to a tag that was never pushed.
+      #
+      # That is the measured cause of hw296's cutover dying at step 3 of 11,
+      # four times (#6262). #6254 moved bp-self-sovereign-cutover to 0.1.183;
+      # in run 31734398570 `build (platform/self-sovereign-cutover)` FAILED,
+      # so 0.1.183 never reached ghcr — while `build (products/catalyst)` in
+      # the SAME run succeeded and shipped the umbrella carrying the pin.
+      # hw296's Flux repinned to 0.1.183 and parked on
+      #   chart pull error: ... 0.1.183: not found
+      # which harbor-prewarm's Phase A0 then read as its own mid-roll and
+      # fail-closed on. The same shape recurred twice more the same night
+      # (bp-guacamole 0.2.40, bp-catalyst-platform 1.4.1464).
+      #
+      # A gate for the resulting STATE already exists —
+      # check-catalog-seed-lockstep.sh --check-ghcr — but it lives in
+      # check-catalog-seed-lockstep.yaml, is continue-on-error on push
+      # (it has to be: it races this very workflow), and only fails loud on
+      # an hourly cron. By the time the cron fires, Sovereigns have already
+      # pulled the umbrella. Closing the race here rather than detecting it
+      # afterwards is what makes the --check-ghcr call below safe to run as a
+      # HARD gate: once every sibling has finished, there is no race left.
+      - name: "Umbrella: no seed pin may outrun its sibling build (#6262)"
+        if: steps.chart.outputs.skip != 'true' && matrix.path == 'products/catalyst'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SELF_JOB_NAME: "build (${{ matrix.path }})"
+        run: |
+          set -euo pipefail
+
+          # Prove every verdict is reachable before trusting one of them.
+          # Without this the gate could report "no sibling failed" from a job
+          # list it never managed to read — the defect class #6262 is filed
+          # under, one layer up.
+          python3 scripts/check-sibling-chart-builds.py --self-test
+
+          deadline=$(( SECONDS + 900 ))
+          while :; do
+            gh api "/repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/jobs" \
+              --paginate --jq '.jobs[]' | jq -s '.' > /tmp/run-jobs.json
+
+            set +e
+            python3 scripts/check-sibling-chart-builds.py \
+              --jobs-file /tmp/run-jobs.json --self-name "${SELF_JOB_NAME}"
+            rc=$?
+            set -e
+
+            case "$rc" in
+              0)  break ;;
+              75)
+                if [ "$SECONDS" -ge "$deadline" ]; then
+                  echo "::error title=Sibling builds did not finish::Waited 15 min for sibling chart builds in this run; refusing to publish the umbrella on an unknown sibling outcome (#6262)."
+                  exit 1
+                fi
+                sleep 20
+                ;;
+              1)
+                echo "::error title=Umbrella would ship a hollow pin::A sibling chart build in this run failed, so the seed pin it owns points at a tag that was never pushed. See the offender named above (#6262)."
+                exit 1
+                ;;
+              *)
+                echo "::error title=Sibling-build gate could not read this run::The gate refused to report a verdict. This is an input error, never a pass (#6262)."
+                exit "$rc"
+                ;;
+            esac
+          done
+
+          # Siblings are all done and green, so this is no longer racing any
+          # publish and can block. Catches the residual class the wait cannot:
+          # a seed pin to a chart that was NOT part of this run and was never
+          # published at all. Measured on main 2026-08-14: 75/75 pins resolve,
+          # 5 declared known-gaps, 0 failures.
+          bash scripts/check-catalog-seed-lockstep.sh --check-ghcr
 
       - name: Helm push to GHCR
         if: steps.chart.outputs.skip != 'true'

--- a/products/catalyst/bootstrap/api/internal/handler/applications_placement_row60_6268_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications_placement_row60_6268_test.go
@@ -1,0 +1,201 @@
+package handler
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	bpv1 "github.com/openova-io/openova/core/controllers/pkg/apis/blueprint/v1alpha1"
+)
+
+// #6268 / UAT row 60 — the Topology tab showed ONE card for an
+// active-hot-standby app whose backing pair was fully healthy.
+//
+// Walked live on hw296 2026-08-14. Everything below the console was correct:
+// primary + standby (not the two-primaries shape of #6200), armed=true, the
+// Continuum CR Healthy and holding the lease, CNPG 3/3, the Application Ready.
+// The tab still drew `Pattern: not reported`, one target card with no Primary,
+// and a DISABLED Switchover control. The endpoint returned a single target
+// carrying an empty `cluster` while its own `regionsObserved` said 2.
+//
+// Cause: derivePlacementTargets keys on the component's OWN pods. For an app
+// whose stateful identity IS its CNPG pair, those pods carry the DATABASE's
+// labels, so occupancy legitimately matched nothing and returned []. The
+// standby augmentation then appended a follower to that empty list — emitting
+// a Standby with no Primary, which renders identically to an honest
+// single-region app. That indistinguishability is the defect, not the missing
+// card: row 60 exists precisely to catch a two-region app collapsing to one.
+
+// pairFixture builds a resolved 2-distinct-region CNPG pair — the state
+// findCNPGPairForApp returns and the only state mergeCNPGPairIntoTargets is
+// ever reached with.
+func pairFixture() *cnpgPairState {
+	return &cnpgPairState{
+		PairName:           "dbapp-pair",
+		Namespace:          "dbapp",
+		PrimaryClusterName: "dbapp-db",
+		ReplicaClusterName: "dbapp-db-replica",
+		PrimaryRegion:      "me-east-215-a",
+		ReplicaRegion:      "me-east-215-b",
+	}
+}
+
+// THE ROW-60 CASE. Occupancy found nothing (the app's pods carry the database
+// identity), so the pair must supply BOTH legs — not just the follower.
+//
+// Falsifiable: on pre-#6268 code this returns 1 target (the Standby alone) and
+// every assertion below fails for the reason row 60 reported.
+func TestRow60_PairWithNoOccupancy_EmitsBothLegs_6268(t *testing.T) {
+	st := pairFixture()
+	got := mergeCNPGPairIntoTargets(nil, st)
+
+	if len(got) != 2 {
+		t.Fatalf("#6268 row 60: got %d target(s) want 2 — a pair with no occupancy must emit BOTH legs, not just the follower (%+v)", len(got), got)
+	}
+	if !hasPrimaryTarget(got) {
+		t.Fatalf("#6268 row 60: no Primary in %+v — this is the half-pair the Topology tab drew as one card with Switchover disabled", got)
+	}
+	if !hasStandbyTarget(got) {
+		t.Fatalf("#6268 row 60: no Standby in %+v", got)
+	}
+
+	var primary, standby *bpv1.PlacementTarget
+	for i := range got {
+		switch got[i].Role {
+		case bpv1.DataRolePrimary:
+			primary = &got[i]
+		case bpv1.DataRoleStandby:
+			standby = &got[i]
+		}
+	}
+	// The Primary must carry the pair's OWN primary half — region AND cluster.
+	// An empty `cluster` was one of the two symptoms reported live.
+	if primary.Region != st.PrimaryRegion {
+		t.Fatalf("#6268: Primary region %q want %q", primary.Region, st.PrimaryRegion)
+	}
+	if primary.Cluster != st.PrimaryClusterName {
+		t.Fatalf("#6268: Primary cluster %q want %q — an empty cluster is the live symptom", primary.Cluster, st.PrimaryClusterName)
+	}
+	if standby.Region != st.ReplicaRegion {
+		t.Fatalf("#6268: Standby region %q want %q", standby.Region, st.ReplicaRegion)
+	}
+	if standby.StandbyType != bpv1.StandbyHot {
+		t.Fatalf("#6268: Standby type %q want Hot", standby.StandbyType)
+	}
+
+	// The assertion row 60 actually makes: the chosen topology is rendered.
+	if p := bpv1.DerivePattern(got, bpv1.CapabilityPrimaryStandby); p != bpv1.PatternActiveHotStandby {
+		t.Fatalf("#6268 row 60: pattern %q want active-hot-standby — the tab showed `Pattern: not reported` (%+v)", p, got)
+	}
+}
+
+// When occupancy DID supply a Primary, the pair must not add a second one —
+// two Primaries is the #6200 shape this app is explicitly not in.
+func TestRow60_PairWithExistingPrimary_DoesNotDuplicate_6268(t *testing.T) {
+	st := pairFixture()
+	occupancy := []bpv1.PlacementTarget{{
+		Region:  st.PrimaryRegion,
+		Cluster: "observed-from-pods",
+		Role:    bpv1.DataRolePrimary,
+	}}
+	got := mergeCNPGPairIntoTargets(occupancy, st)
+
+	if len(got) != 2 {
+		t.Fatalf("#6268: got %d target(s) want 2 (%+v)", len(got), got)
+	}
+	primaries := 0
+	for _, tg := range got {
+		if tg.Role == bpv1.DataRolePrimary {
+			primaries++
+		}
+	}
+	if primaries != 1 {
+		t.Fatalf("#6268: %d Primaries want 1 — the pair must not duplicate a leg occupancy already observed (%+v)", primaries, got)
+	}
+	// The observed leg wins: occupancy read real pods, the pair is the fallback.
+	if got[0].Cluster != "observed-from-pods" {
+		t.Fatalf("#6268: occupancy-derived Primary was overwritten (%+v)", got)
+	}
+}
+
+// The pre-existing guard must survive the change: a Standby already present in
+// the replica region means there is nothing to add, and the list is returned
+// untouched. #6268 must not make this path emit a Primary.
+func TestRow60_ExistingStandbyInReplicaRegion_Unchanged_6268(t *testing.T) {
+	st := pairFixture()
+	occupancy := []bpv1.PlacementTarget{{
+		Region:      st.ReplicaRegion,
+		Cluster:     "observed-replica",
+		Role:        bpv1.DataRoleStandby,
+		StandbyType: bpv1.StandbyHot,
+	}}
+	got := mergeCNPGPairIntoTargets(occupancy, st)
+
+	if len(got) != 1 {
+		t.Fatalf("#6268: got %d target(s) want 1 — an already-represented replica region must short-circuit unchanged (%+v)", len(got), got)
+	}
+}
+
+// CALL SITE, not just the helper. Drives the real HTTP handler with a fixture
+// whose ONLY matching pod is a CNPG replica — occupancy therefore produces a
+// Standby and no Primary, and no dynamic client exists to resolve a pair. The
+// endpoint must refuse to call that a runtime observation.
+//
+// Without this the projection answers one Standby card with
+// `derivedFromRuntime: true`, which the FE trusts over its own spec/status
+// fallback — a two-region app rendered as one region, asserted as observed.
+func TestRow60_StandbyWithoutPrimary_NotDerivedFromRuntime_6268(t *testing.T) {
+	depID := "dep-row60-halfpair"
+	regionA, regionB := "me-east-215-a", "me-east-215-b"
+	h := newPlacementHandler(t, depID, regionA, regionB,
+		[]*unstructured.Unstructured{}, // primary half not visible from this apiserver
+		[]*unstructured.Unstructured{placementFixturePod("dbapp", "dbapp-db-2", "dbapp-db", regionB, "replica")},
+	)
+
+	resp := callPlacement(t, h, depID, "dbapp-db")
+
+	if len(resp.Targets) != 1 || resp.Targets[0].Role != bpv1.DataRoleStandby {
+		t.Fatalf("#6268 fixture did not produce the half-pair it is testing — got %+v; the test would pass on anything", resp.Targets)
+	}
+	if !resp.UnresolvedPrimary {
+		t.Fatalf("#6268: unresolvedPrimary=false for a Standby-with-no-Primary projection (%+v)", resp.Targets)
+	}
+	if resp.DerivedFromRuntime {
+		t.Fatalf("#6268: derivedFromRuntime=true for a half-pair — the FE would draw a false singleton instead of keeping its spec/status fallback (%+v)", resp.Targets)
+	}
+}
+
+// CONTROL — the new flag must not fire on healthy placements, or it would
+// disable `derivedFromRuntime` across the board and silently move every app
+// onto the legacy fallback. An honest single-region app has a Primary and no
+// Standby: not a half-pair, and still a genuine runtime observation.
+func TestRow60_HonestSingleton_StillDerived_Control_6268(t *testing.T) {
+	depID := "dep-row60-control"
+	regionA, regionB := "me-east-215-a", "me-east-215-b"
+	h := newPlacementHandler(t, depID, regionA, regionB,
+		[]*unstructured.Unstructured{placementFixturePod("apps", "solo-xyz", "solo", regionA, "")},
+		[]*unstructured.Unstructured{},
+	)
+
+	resp := callPlacement(t, h, depID, "solo")
+
+	if resp.UnresolvedPrimary {
+		t.Fatalf("#6268 control: unresolvedPrimary fired on an honest singleton (%+v)", resp.Targets)
+	}
+	if !resp.DerivedFromRuntime {
+		t.Fatalf("#6268 control: derivedFromRuntime went false on an honest singleton — the fix would move every app to the legacy fallback (%+v)", resp.Targets)
+	}
+}
+
+// CONTROL — an empty projection is "nothing observed", NOT a half-pair.
+// Collapsing the two would re-introduce the same indistinguishability one
+// level up: `targets: []` is honest and must keep derivedFromRuntime=true
+// (TestPlacementRuntime_Unknown_EmptyTargets asserts that contract).
+func TestRow60_EmptyProjection_IsNotAHalfPair_Control_6268(t *testing.T) {
+	if hasStandbyTarget(nil) {
+		t.Fatal("#6268: an empty list must not report a Standby")
+	}
+	if hasPrimaryTarget(nil) {
+		t.Fatal("#6268: an empty list must not report a Primary")
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/applications_placement_runtime.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications_placement_runtime.go
@@ -97,6 +97,16 @@ type runtimePlacementResponse struct {
 	// UnobservedClusters — this deployment's registered cluster ids whose List
 	// failed (unregistered in the cache, or apiserver unreachable).
 	UnobservedClusters []string `json:"unobservedClusters,omitempty"`
+
+	// UnresolvedPrimary — the projection surfaced a Standby leg but could not
+	// resolve ANY Primary (#6268). That is a half-pair, not a placement: the
+	// standby augmentation asserts a cross-region follower while the thing it
+	// follows is missing from the list. Rendering it as-is puts one card on
+	// the Topology tab, which is indistinguishable from an honest single
+	// region app — the exact collapse row 60 exists to catch. Carried to the
+	// FE alongside `derivedFromRuntime: false` so the tab keeps its
+	// spec/status fallback instead of drawing a false singleton.
+	UnresolvedPrimary bool `json:"unresolvedPrimary,omitempty"`
 }
 
 // HandleApplicationPlacement — GET
@@ -175,7 +185,37 @@ func (h *Handler) HandleApplicationPlacement(w http.ResponseWriter, r *http.Requ
 	// declaredRegions == 0 means we genuinely cannot tell (no record, no
 	// chart-baked env), so (b) is skipped rather than inventing a failure —
 	// the surface-not-gate discipline. It never DOWNGRADES a full observation.
-	derived := len(cov.observed) > 0 && (declaredRegions == 0 || len(cov.observed) >= declaredRegions)
+	// #6268 — a Standby with no Primary is a half-pair, not a placement.
+	//
+	// derivePlacementTargets keys on the component's OWN pods; for an app whose
+	// only stateful identity is its CNPG pair, those pods carry the DATABASE
+	// identity, not the app's, so occupancy legitimately finds nothing. The
+	// standby augmentation below then appends a follower to an empty list, and
+	// the endpoint answers with exactly one Standby target carrying an empty
+	// `cluster`. Walked live on hw296 (row 60): backing state fully correct —
+	// primary + standby, armed=true, Continuum Healthy holding the lease, CNPG
+	// 3/3, Application Ready — while the Topology tab drew `Pattern: not
+	// reported`, one card, and a disabled Switchover control.
+	//
+	// The augmentation now emits the Primary leg from the same resolved pair,
+	// so this state should be unreachable whenever the pair resolves. When it
+	// is still reached, the primary genuinely could not be resolved, and the
+	// honest answer is to say so rather than to ship a one-card projection
+	// that reads identically to a single-region app.
+	unresolvedPrimary := hasStandbyTarget(targets) && !hasPrimaryTarget(targets)
+	if unresolvedPrimary {
+		h.log.Error("placement: surfaced a Standby leg with NO Primary — refusing to assert derivedFromRuntime, a half-pair renders identically to an honest single-region app (#6268)",
+			"id", urlID,
+			"deploymentID", depID,
+			"component", name,
+			"namespace", ns,
+			"targets", len(targets),
+			"regionsDeclared", declaredRegions,
+			"regionsObserved", len(cov.observed),
+		)
+	}
+
+	derived := len(cov.observed) > 0 && (declaredRegions == 0 || len(cov.observed) >= declaredRegions) && !unresolvedPrimary
 	if !derived {
 		h.log.Error("placement: runtime coverage is NARROWER than the deployment declares — refusing to assert derivedFromRuntime, every unobserved region would read as absent and collapse this component to a false singleton (#6015)",
 			"id", urlID,
@@ -194,7 +234,31 @@ func (h *Handler) HandleApplicationPlacement(w http.ResponseWriter, r *http.Requ
 		RegionsDeclared:    declaredRegions,
 		RegionsObserved:    len(cov.observed),
 		UnobservedClusters: cov.unobserved,
+		UnresolvedPrimary:  unresolvedPrimary,
 	})
+}
+
+// hasPrimaryTarget / hasStandbyTarget — role predicates over a target list
+// (#6268). Both roles have to be asked about independently: an EMPTY list has
+// neither, and is an honest "nothing observed", while a list holding only a
+// Standby is a half-pair. Collapsing the two into one "is it paired" helper
+// would make those cases indistinguishable, which is the defect itself.
+func hasPrimaryTarget(targets []bpv1.PlacementTarget) bool {
+	for _, t := range targets {
+		if t.Role == bpv1.DataRolePrimary {
+			return true
+		}
+	}
+	return false
+}
+
+func hasStandbyTarget(targets []bpv1.PlacementTarget) bool {
+	for _, t := range targets {
+		if t.Role == bpv1.DataRoleStandby {
+			return true
+		}
+	}
+	return false
 }
 
 // placementRuntimeCoverage records which of THIS deployment's region clusters
@@ -327,18 +391,7 @@ func (h *Handler) augmentWithCNPGStandby(
 		// as the replica region (defensive — occupancy had no Standby, but
 		// the replica region could coincide with a stateless Primary
 		// occupancy).
-		for _, t := range targets {
-			if t.Role == bpv1.DataRoleStandby && t.Region == st.ReplicaRegion {
-				return targets
-			}
-		}
-		return append(targets, bpv1.PlacementTarget{
-			Region:      st.ReplicaRegion,
-			Cluster:     st.ReplicaClusterName,
-			VCluster:    "",
-			Role:        bpv1.DataRoleStandby,
-			StandbyType: bpv1.StandbyHot,
-		})
+		return mergeCNPGPairIntoTargets(targets, st)
 	}
 
 	// Continuum-CR fallback (the #4551 render-gate fix). The cnpg-pair path
@@ -347,6 +400,57 @@ func (h *Handler) augmentWithCNPGStandby(
 	// Continuum CR, which lives in region-a and carries it in
 	// spec.hotStandbyRegions.
 	return h.augmentWithContinuumStandby(r, client, name, ns, targets)
+}
+
+// mergeCNPGPairIntoTargets folds a fully-resolved CNPG pair into the occupancy
+// derived target list, adding only the legs occupancy did not already supply.
+//
+// Pure by design: the defect this fixes (#6268) lives entirely in which legs
+// get emitted, so keeping the decision free of the dynamic client makes it
+// directly testable rather than only reachable through a live pair lookup.
+//
+// Callers must have already established that `st` holds two DISTINCT non-empty
+// regions — the same invariant deriveLiveContinuumRecord enforces.
+func mergeCNPGPairIntoTargets(targets []bpv1.PlacementTarget, st *cnpgPairState) []bpv1.PlacementTarget {
+	// Already represented as a Standby in the replica region — nothing to add.
+	for _, t := range targets {
+		if t.Role == bpv1.DataRoleStandby && t.Region == st.ReplicaRegion {
+			return targets
+		}
+	}
+
+	// #6268 — emit the PRIMARY leg too when occupancy could not supply one.
+	//
+	// This block already holds a fully resolved pair: findCNPGPairForApp
+	// returned both halves with two distinct non-empty regions. Appending
+	// only the follower was correct while occupancy was assumed to have
+	// produced the Primary — but occupancy keys on the component's own
+	// pods, and for an app whose stateful identity IS its CNPG pair, those
+	// pods carry the database's labels rather than the app's, so occupancy
+	// legitimately yields nothing. The endpoint then answered with one
+	// Standby, no Primary, empty `cluster` (hw296, row 60), which the
+	// Topology tab renders as `Pattern: not reported` with Switchover
+	// disabled.
+	//
+	// st.PrimaryRegion / st.PrimaryClusterName are the same resolved pair
+	// the Standby is being drawn from, so this adds no new source of truth
+	// and cannot fabricate: it is reached only when the pair resolved with
+	// two distinct regions, and only when NO Primary is already present.
+	if !hasPrimaryTarget(targets) {
+		targets = append(targets, bpv1.PlacementTarget{
+			Region:   st.PrimaryRegion,
+			Cluster:  st.PrimaryClusterName,
+			VCluster: "",
+			Role:     bpv1.DataRolePrimary,
+		})
+	}
+	return append(targets, bpv1.PlacementTarget{
+		Region:      st.ReplicaRegion,
+		Cluster:     st.ReplicaClusterName,
+		VCluster:    "",
+		Role:        bpv1.DataRoleStandby,
+		StandbyType: bpv1.StandbyHot,
+	})
 }
 
 // augmentWithContinuumStandby synthesizes a Standby·Hot PlacementTarget from

--- a/scripts/check-sibling-chart-builds.py
+++ b/scripts/check-sibling-chart-builds.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+"""Decide whether the umbrella chart may publish, given its sibling matrix jobs.
+
+Refs #6262.
+
+WHY THIS EXISTS
+───────────────
+`blueprint-release.yaml` builds every changed Blueprint as one `build` matrix
+job with `fail-fast: false`. Matrix jobs are independent by design, and the
+umbrella (`products/catalyst` → `bp-catalyst-platform`) is just another entry
+in that matrix. But the umbrella is not peer to the others: it CARRIES the
+catalog seed, and the seed pins every sub-chart by exact version.
+
+So when a sub-chart build fails, nothing stops the umbrella from publishing a
+seed pin to a tag that was never pushed. That is not hypothetical — it is the
+measured cause of the hw296 cutover dying four times at step 3 of 11:
+
+  1. #6254 merged, moving bp-self-sovereign-cutover to 0.1.183 across the five
+     lockstep sites.
+  2. In run 31734398570, `build (platform/self-sovereign-cutover)` FAILED, so
+     0.1.183 was never pushed — published tags stop at 0.1.182.
+  3. In the SAME run, `build (products/catalyst)` succeeded and published the
+     umbrella carrying the seed pin `bp-self-sovereign-cutover: 0.1.183`.
+  4. hw296's Flux took the new umbrella, repinned the HelmRelease to 0.1.183,
+     and parked on `Ready=False SourceNotReady`:
+       chart pull error: ... 0.1.183: not found
+  5. harbor-prewarm's Phase A0 settled-roll gate then saw its own HelmRelease
+     as mid-roll and fail-closed. Step 3 never started.
+
+The repo already owns a gate for the resulting state —
+`check-catalog-seed-lockstep.sh --check-ghcr` asserts every seed pin resolves
+on ghcr. But it runs in a DIFFERENT workflow, is `continue-on-error` on push
+(it has to be: it races this very workflow), and only fails loud on an hourly
+cron. By the time the cron fires, Sovereigns have already pulled the umbrella.
+
+The fix is to close the race at its source rather than detect it afterwards:
+before the umbrella pushes, wait for its siblings in the SAME run and refuse to
+publish if any of them failed. Then the ghcr existence check is no longer
+racing anything and can be run as a hard gate in the same step.
+
+WHAT THIS SCRIPT DOES
+─────────────────────
+Reads the run's job list (`GET /repos/{repo}/actions/runs/{run_id}/jobs`) and
+returns one of three verdicts about the sibling `build (...)` jobs:
+
+  exit 0  — every sibling completed successfully; publishing is safe.
+  exit 75 — at least one sibling is still queued/in_progress (EX_TEMPFAIL).
+            The caller should sleep and re-ask.
+  exit 1  — at least one sibling failed/was cancelled/timed out. Publishing the
+            umbrella now would ship a pin to a tag that does not exist.
+  exit 2  — input error (see the vacuity guard below).
+
+VACUITY GUARD
+─────────────
+A "no siblings failed" verdict is worthless if the script cannot see the jobs
+at all — a renamed job, a changed matrix key, or a paging bug would all yield
+an empty sibling set and a confident green. Zero siblings is nonetheless
+LEGITIMATE (a push that touches only products/catalyst has none), so emptiness
+alone cannot be the tripwire.
+
+The tripwire is instead: **this script must be able to find its OWN job in the
+list it was handed.** If `--self-name` is absent from the job names, the name
+construction or the API read is broken, and no verdict about siblings is
+trustworthy. That fails as an input error (exit 2), never as a pass.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+# EX_TEMPFAIL — "siblings still running, ask again later". Chosen over a bare
+# non-zero so a caller can never confuse "wait" with "a sibling failed".
+EXIT_OK = 0
+EXIT_FAILED_SIBLING = 1
+EXIT_INPUT_ERROR = 2
+EXIT_WAIT = 75
+
+# Conclusions that mean the sibling did not produce its artifact. `skipped` is
+# NOT here: a skipped job published nothing but was never expected to (e.g. the
+# chart-version-unchanged short-circuit), so it cannot orphan a seed pin.
+BAD_CONCLUSIONS = ("failure", "cancelled", "timed_out", "stale")
+
+
+def classify(jobs, self_name, prefix):
+    """Return (exit_code, lines). Pure — no I/O, so the self-test can drive it."""
+    names = [j.get("name", "") for j in jobs]
+
+    if self_name not in names:
+        return EXIT_INPUT_ERROR, [
+            f"ERROR: could not find this job ({self_name!r}) among the {len(jobs)} "
+            "job(s) returned for this run.",
+            "The job-name construction or the API read is broken, so any verdict "
+            "about sibling jobs would be drawn from a list this script cannot "
+            "actually see. Refusing to report a verdict.",
+            "Jobs seen: " + (", ".join(repr(n) for n in names) or "(none)"),
+        ]
+
+    siblings = [
+        j for j in jobs
+        if j.get("name", "").startswith(prefix) and j.get("name") != self_name
+    ]
+
+    failed = [j for j in siblings if j.get("conclusion") in BAD_CONCLUSIONS]
+    if failed:
+        lines = [
+            f"FAIL: {len(failed)} sibling chart build(s) in this run did not publish:",
+        ]
+        for j in failed:
+            lines.append(f"  {j.get('name')} — conclusion={j.get('conclusion')}")
+        lines += [
+            "",
+            "The umbrella carries the catalog seed, which pins every sub-chart by "
+            "exact version. Publishing it now would ship a pin to a tag that was "
+            "never pushed, and every Sovereign that reconciles the new umbrella "
+            "would park on `chart pull error: ... not found` (#6262).",
+            "Fix the sibling build and re-run; the umbrella will publish then.",
+        ]
+        return EXIT_FAILED_SIBLING, lines
+
+    pending = [j for j in siblings if j.get("status") != "completed"]
+    if pending:
+        lines = [f"WAIT: {len(pending)} sibling chart build(s) still running:"]
+        for j in pending:
+            lines.append(f"  {j.get('name')} — status={j.get('status')}")
+        return EXIT_WAIT, lines
+
+    return EXIT_OK, [
+        f"OK: all {len(siblings)} sibling chart build(s) in this run completed "
+        "successfully; every seed pin they own has been pushed.",
+    ]
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Self-test — proves each verdict is reachable before the gate is trusted.
+# ──────────────────────────────────────────────────────────────────────
+SELF = "build (products/catalyst)"
+PREFIX = "build ("
+
+
+def _job(name, status="completed", conclusion="success"):
+    return {"name": name, "status": status, "conclusion": conclusion}
+
+
+def self_test():
+    cases = [
+        (
+            "all siblings green -> publish",
+            [_job(SELF), _job("build (platform/cilium)"), _job("build (platform/gitea)")],
+            EXIT_OK,
+        ),
+        (
+            "the hw296 shape: one sibling failed -> refuse to publish",
+            [_job(SELF), _job("build (platform/self-sovereign-cutover)", conclusion="failure")],
+            EXIT_FAILED_SIBLING,
+        ),
+        (
+            "sibling cancelled -> refuse (it published nothing either)",
+            [_job(SELF), _job("build (platform/cilium)", conclusion="cancelled")],
+            EXIT_FAILED_SIBLING,
+        ),
+        (
+            "sibling still running -> wait, do not guess",
+            [_job(SELF), _job("build (platform/cilium)", status="in_progress", conclusion=None)],
+            EXIT_WAIT,
+        ),
+        (
+            "sibling queued -> wait",
+            [_job(SELF), _job("build (platform/cilium)", status="queued", conclusion=None)],
+            EXIT_WAIT,
+        ),
+        (
+            "a failed sibling outranks a still-running one",
+            [
+                _job(SELF),
+                _job("build (platform/cilium)", status="in_progress", conclusion=None),
+                _job("build (platform/gitea)", conclusion="failure"),
+            ],
+            EXIT_FAILED_SIBLING,
+        ),
+        (
+            "skipped sibling is not a failure (it was never going to publish)",
+            [_job(SELF), _job("build (platform/cilium)", conclusion="skipped")],
+            EXIT_OK,
+        ),
+        (
+            "umbrella alone in the matrix -> legitimately zero siblings",
+            [_job(SELF)],
+            EXIT_OK,
+        ),
+        (
+            "non-build jobs in the run are not siblings",
+            [_job(SELF), _job("detect"), _job("warmup-bastion-harbor", conclusion="failure")],
+            EXIT_OK,
+        ),
+        # ── VACUITY LEG ──
+        # If the script cannot see its own job, the list it was handed is not
+        # the list it thinks it is. Without this leg, a renamed job or a paging
+        # bug would present as "0 siblings, all green" — a confident pass drawn
+        # from nothing, which is the exact defect class #6262 was filed under.
+        (
+            "VACUITY: own job absent -> input error, never a pass",
+            [_job("build (platform/cilium)"), _job("build (platform/gitea)")],
+            EXIT_INPUT_ERROR,
+        ),
+        (
+            "VACUITY: empty job list -> input error, never a pass",
+            [],
+            EXIT_INPUT_ERROR,
+        ),
+    ]
+
+    failures = 0
+    for label, jobs, want in cases:
+        got, lines = classify(jobs, SELF, PREFIX)
+        ok = got == want
+        print(f"  [{'PASS' if ok else 'FAIL'}] {label} (want {want}, got {got})")
+        if not ok:
+            failures += 1
+            for line in lines:
+                print(f"         {line}")
+
+    if failures:
+        print(f"\nSELF-TEST FAILED: {failures}/{len(cases)} case(s).")
+        return 1
+    print(f"\nSELF-TEST PASSED: {len(cases)}/{len(cases)} cases, all four verdicts reachable.")
+    return 0
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("--jobs-file", help="JSON file: the `jobs` array from the run-jobs API.")
+    ap.add_argument("--self-name", help="Display name of THIS matrix job, e.g. 'build (products/catalyst)'.")
+    ap.add_argument("--prefix", default=PREFIX, help="Job-name prefix identifying sibling chart builds.")
+    ap.add_argument("--self-test", action="store_true", help="Prove every verdict is reachable, then exit.")
+    args = ap.parse_args()
+
+    if args.self_test:
+        return self_test()
+
+    if not args.jobs_file or not args.self_name:
+        print("ERROR: --jobs-file and --self-name are required (or use --self-test).", file=sys.stderr)
+        return EXIT_INPUT_ERROR
+
+    try:
+        with open(args.jobs_file, encoding="utf-8") as fh:
+            payload = json.load(fh)
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"ERROR: could not read {args.jobs_file}: {exc}", file=sys.stderr)
+        return EXIT_INPUT_ERROR
+
+    jobs = payload.get("jobs", payload) if isinstance(payload, dict) else payload
+    if not isinstance(jobs, list):
+        print(f"ERROR: expected a list of jobs in {args.jobs_file}, got {type(jobs).__name__}.", file=sys.stderr)
+        return EXIT_INPUT_ERROR
+
+    code, lines = classify(jobs, args.self_name, args.prefix)
+    for line in lines:
+        print(line)
+    return code
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What row 60 saw

UAT row 60 (#3375) asserts: Catalog → New instance → `active-hot-standby` → Provision → that app's Topology tab shows the chosen topology.

Walked live on hw296 (2026-08-14). **Everything below the console was correct** — primary **+ standby** (not the two-primaries shape of #6200), `armed=true`, the Continuum CR `Healthy` and holding the lease, CNPG 3/3, the Application `Ready`.

The tab rendered:

- `Pattern: not reported`
- **one** target card — no primary, therefore no pair
- **Switchover disabled**

and the endpoint returned a single target with an **empty `cluster`** while its own `regionsObserved` said **2**.

## Cause — both halves in the read path

`derivePlacementTargets` keys on the component's **own** pods. For an app whose stateful identity *is* its CNPG pair, those pods carry the **database's** labels, not the app's — so occupancy legitimately matched nothing and returned `[]`.

`augmentWithCNPGStandby` then appended a follower to that empty list. Its guard asks whether a Standby already covers the replica region; it never asks whether **any Primary exists at all**. Result: one Standby, no Primary, empty `cluster`.

**The deeper defect is not the missing card — it is that the missing card is invisible.** A one-target projection reads identically to an honest single-region app, which is exactly the collapse this row exists to catch, and the same *"a negative result indistinguishable from a positive one"* shape as #5568 and #6015 in this very file.

## The change

**1. Emit the Primary leg.** The pair block is only reached with a fully resolved pair carrying two distinct non-empty regions, and `st.PrimaryRegion` / `st.PrimaryClusterName` are the *same* resolved pair the Standby is already drawn from — no new source of truth, and it cannot fabricate. Extracted as `mergeCNPGPairIntoTargets` so the decision is pure and directly testable rather than only reachable through a live pair lookup.

**2. Make an unresolvable half-pair loud.** When a Standby survives with no Primary, the projection is demonstrably incomplete: `unresolvedPrimary` is reported and `derivedFromRuntime` goes **false**, so the FE keeps its spec/status fallback instead of drawing a false singleton. This reuses the honesty channel #6015 already established, so **no FE change is required**.

## How I know the tests measure the fix

Both halves are mutation-checked, and each mutation kills exactly one test:

| Mutation | Fails | Others |
|---|---|---|
| revert the primary-leg emission (pre-#6268 behaviour) | `PairWithNoOccupancy_EmitsBothLegs` | all pass |
| drop the half-pair term from `derivedFromRuntime` | `StandbyWithoutPrimary_NotDerivedFromRuntime` | all pass |

Two **controls** bound the blast radius, because both changes could easily over-fire:

- an honest **singleton** must still report `derivedFromRuntime: true` — otherwise this fix silently moves *every* app onto the legacy fallback;
- an **empty** projection must not be classified as a half-pair, since `targets: []` is honest and `TestPlacementRuntime_Unknown_EmptyTargets` asserts it stays derived.

The half-pair test also asserts its own fixture actually produced a Standby-with-no-Primary before checking the flag — otherwise it would pass on anything.

Full `internal/handler` suite green (291s).

## Relationship to prior work

#6136 fixed the Topology-tab **Save** (`spec.placement` persists as an object with `targets[]`; verified green this walk as row 16). #6257 fixed `application_controller.go:872` reading `spec.Topology` via `NestedString` against a field the CRD types as an object. Both are write/controller-side and both work. This is the **sovereign-api read projection** — the unfixed third leg.

Refs #6268 #3375 #3986 #6015
