### PR TITLE
fix(cutover): an Organization's failed app no longer fail-closes the sovereignty cutover

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -1074,7 +1074,7 @@ spec:
       # chart/tests/ left the package via .helmignore: 757,264 bytes, 72.2%.
       # The rendered manifest is byte-identical modulo comments — no step,
       # value or RBAC change, still 11 steps.
-      version: 0.1.184
+      version: 0.1.185
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1424,7 +1424,14 @@ spec:
       #   hardcoded 30s and returns `{Enabled:false}, nil` on expiry, so the
       #   operator stays alive and healthy with the controller permanently
       #   off). Lockstep w/ products/catalyst/chart/Chart.yaml.
-      version: 1.4.1470
+      # 1.4.1471 — #6273: catalog-seed advances bp-self-sovereign-cutover
+      #   0.1.184 -> 0.1.185, the release that stops an Organization's failed
+      #   application install from fail-closing the sovereignty cutover.
+      #   harbor-prewarm's Phase A0 now partitions offenders by the
+      #   openova.io/organization namespace label: platform namespaces stay
+      #   FATAL, Organization namespaces warn and proceed. Lockstep w/
+      #   products/catalyst/chart/Chart.yaml.
+      version: 1.4.1471
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.184
+  version: 0.1.185
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -3705,7 +3705,60 @@ name: bp-self-sovereign-cutover
 # pin + blueprint.yaml + catalog-seed source.version + spec.version + the API
 # blueprints.json + the generated UI catalog move to 0.1.176 in lockstep
 # (Inviolable Principle #13).
-version: 0.1.184
+# 0.1.185 (#6273, Refs #6262 #6198 #5391) — AN ORGANIZATION'S FAILED APP NO
+# LONGER HOLDS THE SOVEREIGN'S INDEPENDENCE CLOSED. Phase A0 (the settled-roll
+# pre-flight) lists `helmreleases -A` and `deployments,statefulsets -A`, so
+# every Organization namespace has always been in scope and a customer's failed
+# install was a hard stop on Pillar 5. Measured twice, independently: hw290
+# ("7 offenders, ALL per-Org customer apps") and hw296 on 2026-08-13, where the
+# walk's Organization `walkthree` carried HelmRelease/{bp-agenity,bp-newapi,
+# bp-wordpress-tenant} Stalled=True/RetriesExceeded — TERMINAL by this gate's
+# own classifier — plus four Deployments/StatefulSets at 0/1, against ZERO
+# platform offenders and all 68 flux-system HelmReleases Ready=True. A fully
+# healthy Sovereign could not become independent because a customer app failed
+# to install.
+#
+# Phase A0 now partitions offenders by OWNERSHIP. Platform namespaces are
+# UNCHANGED — still FATAL, still named, still classified. An offender in an
+# Organization namespace is a loud, fully-enumerated WARNING and the cutover
+# proceeds. #6198 already carved out the cutover's own workloads for
+# circularity and #6262 its own HelmRelease; this is the same shape one scope
+# wider, argued on the stronger ground: a sovereign-admin cannot be required to
+# repair an Organization's Application to earn sovereignty.
+#
+# The predicate is DERIVED, not invented — no new namespace list enters the
+# chart. `openova.io/organization=<slug>` is stamped on every Organization's
+# host namespace by core/controllers/organization/internal/gitops/manifests.go,
+# pinned as an invariant by that package's org_namespace_invariant_4292_test.go,
+# and already read through this exact selector by
+# core/services/provisioning/handlers/kubeconfig_reconciler.go. Being POSITIVE,
+# it is fail-closed by construction: a namespace WITHOUT the label is platform.
+#
+# BOTH passes carry it. Applying it to the HelmRelease pass alone would have
+# fixed nothing — the #5391 named override is HelmRelease-only, so four of the
+# seven hw296 offenders had no escape but the whole-gate kill switch. The
+# #5391 override VALIDATION also stops judging Organization releases, or a stale
+# annotation would fail the gate closed the moment the customer's app recovered.
+#
+# THE COST IS PRINTED, not hidden: mirroring is unchanged (still best-effort
+# over every running tag, Organization namespaces included), so a genuinely
+# mid-roll app can be mirrored at a tag the post-cutover roll moves away from
+# and may need a re-install. The Sovereign is unaffected.
+#
+# GUARDS. cutover-contract.sh Case 95 EXECUTES the rendered gate in eight
+# directions over the live hw296 fixtures — the HelmRelease pass and the
+# override-free workload pass each warn-and-proceed with every offender named
+# and its TERMINAL tag intact; platform offenders stay fatal and are counted
+# alone in the headline; leak controls (identical workloads in `harbor`,
+# unlabelled namespaces, a stale override on a platform release) all stay red;
+# and a VACUITY CONTROL flips the one discriminating input to prove the
+# platform-FATAL direction can go the other way. The Case 77/90 kubectl stubs
+# REFUSE a namespace listing that omits the label selector, so a gate that
+# listed namespaces unfiltered (every namespace an Organization, total
+# fail-open) cannot pass. Slot-06a pin + blueprint.yaml + catalog-seed
+# spec.version + source.version + the API blueprints.json + the generated UI
+# catalog move to 0.1.185 in lockstep (Inviolable Principle #13).
+version: 0.1.185
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml
@@ -169,6 +169,32 @@ data:
     # ── settled-roll-preflight BEGIN (Case 77 extraction anchor — tests/cutover-contract.sh executes this block verbatim with a stubbed kubectl) ──
     SETTLED_ROLL_OVERRIDE_ANNOTATION="catalyst.openova.io/cutover-settled-roll-override"
     {{- /*
+     #6273 — the OWNERSHIP partition. An Organization's application release
+     must not fail-close the Sovereign's cutover; a PLATFORM namespace
+     offender still does, unchanged.
+
+     This label is a FIXED contract with the org-controller, exactly like
+     the override annotation key above. `openova.io/organization=<slug>` is
+     stamped on the host Namespace of EVERY Organization at EVERY tier by
+     core/controllers/organization/internal/gitops/manifests.go
+     (namespaceTemplate), it is pinned as an invariant by that package's
+     org_namespace_invariant_4292_test.go ("EVERY Organization, at EVERY
+     tier, owns EXACTLY ONE host namespace, named after its slug and
+     carrying openova.io/organization=<slug>"), and production already
+     reads the estate through this exact selector —
+     core/services/provisioning/handlers/kubeconfig_reconciler.go lists
+     `/api/v1/namespaces?labelSelector=openova.io/organization`.
+
+     So the predicate is DERIVED, not invented: no new namespace list is
+     introduced here, and there is nothing to keep in sync. It is also
+     POSITIVE and therefore fail-closed by construction — a namespace
+     WITHOUT the label is platform and stays FATAL. Measured on live hw296
+     (dep e689e3b34a75fdec, 2026-08-13): 55 namespaces, exactly 4 carry the
+     label (hw296-omani-works, walkone, walktwo, walkthree), and every one
+     of the 7 current Phase A0 offenders sits in `walkthree`.
+    */}}
+    ORG_NAMESPACE_LABEL="openova.io/organization"
+    {{- /*
      #6253 (Refs #5391 #5392 #3379) — the TERMINAL classifier, defined ONCE
      and consumed by BOTH the override-validation and the offender-tagging
      below. It used to be re-hand-rolled at each call site as the bare
@@ -284,6 +310,29 @@ data:
       def _is_own_release($own):
         ((.spec.chart.spec.chart // "") == $own) or ((.metadata.name // "") == $own);
     '
+    {{- /*
+     #6273 — defined ONCE and consumed by ALL THREE jq sites (the override
+     validation, the HelmRelease offender pass, and the workload
+     `wl_pending` pass). Re-hand-rolling `index` at each site is how the
+     two terminal classifiers drifted apart before #6253; and a partition
+     applied to only one of the two passes fixes nothing, because the
+     #5391 override annotation is HelmRelease-only — a workload offender's
+     ONLY escape today is the whole-gate kill switch.
+    */}}
+    SRP_ORG_NS_JQ='
+      def _in_org_ns($orgns):
+        {{- /*
+         Bind the namespace FIRST — the SAME trap `_source_absent` above
+         carries a warning for. `$orgns | index($x)` re-binds `.` to the
+         array, so an inline `.metadata.namespace` inside the index
+         argument is evaluated against the ARRAY and dies with "Cannot
+         index array with string metadata". Caught by executing the
+         extracted gate against the live hw296 fixtures before this
+         shipped, exactly as Case 77 direction 1 caught it for #6253.
+        */}}
+        (.metadata.namespace // "") as $ns
+        | (($orgns | index($ns)) != null);
+    '
     srp_kubectl_json() {
       {{- /*
        kubectl get "$@" -o json with a bounded retry; JSON on stdout,
@@ -340,6 +389,24 @@ data:
         return 1
       fi
       {{- /*
+       #6273 — read the Organization-namespace set from the LABEL, not from
+       a list this chart carries. Fail-closed on an unreadable answer for
+       the same reason as the two reads above: without it every namespace
+       would classify as platform, which is the STRICTER verdict, but the
+       gate would then be certifying an ownership split it could not see.
+       An EMPTY answer is a legitimate reading (a Sovereign with no
+       Organizations yet) and is NOT a failure — kubectl still returns a
+       well-formed `{"items":[]}`.
+      */}}
+      if ! _srp_ns_json=$(srp_kubectl_json namespaces -l "${ORG_NAMESPACE_LABEL}"); then
+        echo "[harbor-prewarm] FATAL: Phase A0 could not list Organization namespaces (-l ${ORG_NAMESPACE_LABEL}) after 5 attempts — the gate cannot partition offenders by ownership it cannot read; refusing to fail open (#6273)"
+        return 1
+      fi
+      org_ns=$(printf '%s' "${_srp_ns_json}" | jq -c '[.items[].metadata.name]') || {
+        echo "[harbor-prewarm] FATAL: Phase A0 Organization-namespace jq failed — refusing to fail open (#6273)"
+        return 1
+      }
+      {{- /*
        #5391 override validation FIRST, before ANY exclusion — the gate
        fail-closes on a malformed or over-broad override rather than
        honoring it. A SUSPENDED HR is outside the gate's domain entirely
@@ -347,11 +414,17 @@ data:
        this chart's OWN release — judging an override on a release the gate
        does not gate would reject it as "names a HEALTHY HelmRelease" and
        fail the whole gate closed on an annotation that was never needed.
+       #6273: an Organization-namespace release is now in that same
+       position. Its offenders only WARN, so an override there is never
+       needed — but a sovereign-admin who annotated one under the old
+       fail-closed contract would otherwise have that stale annotation
+       FATAL the whole cutover the moment the customer's app recovered.
       */}}
-      or_bad=$(printf '%s' "${_srp_hr_json}" | jq -r --arg okey "${SETTLED_ROLL_OVERRIDE_ANNOTATION}" --arg own {{ .Chart.Name | quote }} "${SRP_TERMINAL_JQ}"'
+      or_bad=$(printf '%s' "${_srp_hr_json}" | jq -r --arg okey "${SETTLED_ROLL_OVERRIDE_ANNOTATION}" --arg own {{ .Chart.Name | quote }} --argjson orgns "${org_ns}" "${SRP_TERMINAL_JQ}${SRP_ORG_NS_JQ}"'
         .items[]
         | select((.spec.suspend // false) | not)
         | select(_is_own_release($own) | not)
+        | select(_in_org_ns($orgns) | not)
         | select((.metadata.annotations // {}) | has($okey))
         | ((.metadata.annotations[$okey] // "") | gsub("^\\s+|\\s+$"; "")) as $reason
         | ((((.status.conditions // []) | map(select(.type=="Ready")) | (.[0].status // "Unknown")) == "True")
@@ -414,7 +487,14 @@ data:
        operator to a command that cannot work; name the real one instead
        (publish the pinned version, or re-pin to a published one).
       */}}
-      hr_pending=$(printf '%s' "${_srp_hr_json}" | jq -r --arg okey "${SETTLED_ROLL_OVERRIDE_ANNOTATION}" --arg own {{ .Chart.Name | quote }} "${SRP_TERMINAL_JQ}"'
+      {{- /*
+       #6273 — ONE enumeration, tagged by ownership, split in shell. The
+       row TEXT after the tag is byte-identical in both directions, so an
+       Organization offender is reported with exactly the evidence the
+       FATAL path prints (including the #6253 TERMINAL classification) and
+       the two can never drift into two different formatters.
+      */}}
+      hr_all=$(printf '%s' "${_srp_hr_json}" | jq -r --arg okey "${SETTLED_ROLL_OVERRIDE_ANNOTATION}" --arg own {{ .Chart.Name | quote }} --argjson orgns "${org_ns}" "${SRP_TERMINAL_JQ}${SRP_ORG_NS_JQ}"'
         .items[]
         | select((.spec.suspend // false) | not)
         | select(_is_own_release($own) | not)
@@ -426,7 +506,8 @@ data:
         | _stalled as $stalled
         | _source_absent as $source_absent
         | (((.status.conditions // []) | map(select(.type=="Ready")) | (.[0].message // "")) | split("\n")[0]) as $why
-        | "HelmRelease/\(.metadata.namespace)/\(.metadata.name)"
+        | (if _in_org_ns($orgns) then "ORG " else "PLT " end)
+          + "HelmRelease/\(.metadata.namespace)/\(.metadata.name)"
           + (if $stalled then "  [TERMINAL: Flux stalled — it has STOPPED retrying and will never clear itself]"
              elif $source_absent then "  [TERMINAL: the pinned chart version does not exist in the registry — retrying cannot create it]"
              else "" end)
@@ -434,6 +515,8 @@ data:
         echo "[harbor-prewarm] FATAL: Phase A0 HelmRelease-offender jq failed — refusing to fail open (#5391)"
         return 1
       }
+      hr_pending=$(printf '%s\n' "${hr_all}" | grep '^PLT ' | sed 's/^PLT //' || true)
+      hr_org=$(printf '%s\n' "${hr_all}" | grep '^ORG ' | sed 's/^ORG //' || true)
       {{- /*
        #6262 — the own-release exclusion must not be SILENT. Skipping the
        gate is the right call (the deadlock above), but an unsettled own
@@ -494,7 +577,14 @@ data:
        (`prewarm.settledRollPreflight.enabled=false`), which stays available
        and stays a last resort.
       */}}
-      wl_pending=$(printf '%s' "${_srp_wl_json}" | jq -r --arg own {{ .Chart.Name | quote }} '
+      {{- /*
+       #6273 — the workload pass carries the SAME ownership tag. This half
+       is the one that actually mattered on hw296: four of the seven
+       offenders were Deployments/StatefulSets in `walkthree`, and the
+       #5391 named override is HelmRelease-only, so nothing short of the
+       whole-gate kill switch could clear them.
+      */}}
+      wl_all=$(printf '%s' "${_srp_wl_json}" | jq -r --arg own {{ .Chart.Name | quote }} --argjson orgns "${org_ns}" "${SRP_ORG_NS_JQ}"'
         .items[]
         | select((.spec.replicas // 1) > 0)
         | select(((.metadata.labels // {})["app.kubernetes.io/name"] // "") != $own)
@@ -503,10 +593,44 @@ data:
             or ((.status.updatedReplicas // 0) < (.spec.replicas // 1))
             or ((.status.readyReplicas // 0) < (.spec.replicas // 1))
           )
-        | "\(.kind // "Workload")/\(.metadata.namespace)/\(.metadata.name)"') || {
+        | (if _in_org_ns($orgns) then "ORG " else "PLT " end)
+          + "\(.kind // "Workload")/\(.metadata.namespace)/\(.metadata.name)"') || {
         echo "[harbor-prewarm] FATAL: Phase A0 workload-offender jq failed — refusing to fail open (#5391)"
         return 1
       }
+      wl_pending=$(printf '%s\n' "${wl_all}" | grep '^PLT ' | sed 's/^PLT //' || true)
+      wl_org=$(printf '%s\n' "${wl_all}" | grep '^ORG ' | sed 's/^ORG //' || true)
+      {{- /*
+       #6273 — the WARNING, printed BEFORE the platform verdict so it is
+       visible on a passing run AND on a failing one. It is deliberately
+       loud and fully enumerated: this is the one place a narrowing of a
+       fail-closed gate could become silent, and a silent narrowing is
+       indistinguishable from the gate not working.
+
+       The argument is OWNERSHIP, which is stronger ground than the #6198
+       circularity carve-out one scope down. A sovereign-admin cannot be
+       required to repair an Organization's application in order to earn
+       the Sovereign's independence: the app belongs to the Organization
+       that installed it, and on hw296 a fully healthy Sovereign (all 68
+       flux-system HelmReleases Ready=True, zero platform offenders) was
+       held out of Pillar 5 by three customer releases in `walkthree`
+       whose install had failed. hw290 was the same shape a month earlier
+       ("7 offenders, ALL per-Org customer apps", recorded below).
+
+       The cost is REAL and is stated in the output rather than buried
+       here: mirroring is unchanged (still best-effort over every running
+       tag, Organization namespaces included), so a genuinely MID-ROLL app
+       can still be mirrored at a tag the post-cutover roll moves away
+       from. That app can then fail to pull and need a re-install. What
+       changes is only whether that possibility fail-closes the Sovereign.
+      */}}
+      org_unsettled=$(printf '%s\n%s\n' "${hr_org}" "${wl_org}" | grep -c . || true)
+      if [ "${org_unsettled}" -gt 0 ]; then
+        echo "[harbor-prewarm] WARNING: Phase A0 found ${org_unsettled} unsettled release(s)/workload(s) in Organization namespaces. The cutover PROCEEDS anyway (#6273) — an Organization's application belongs to the Organization that installed it, and a sovereign-admin must not have to repair a customer's app to gain the Sovereign's independence. Platform namespaces are UNCHANGED: any offender there is still FATAL below."
+        printf '%s\n%s\n' "${hr_org}" "${wl_org}" | grep . | sed 's/^/  not gated (Organization namespace): /'
+        echo "[harbor-prewarm] WHAT THIS COSTS, stated plainly: if one of the above is GENUINELY MID-ROLL rather than terminally stuck, harbor-prewarm mirrors the tag it is running NOW and the post-cutover roll may move it to a desired tag that was never mirrored — that Application can then fail to pull its image after the cutover and may need a re-install. The Sovereign itself is unaffected; every platform workload is still gated."
+        echo "[harbor-prewarm] Organization namespaces are read from the live cluster by the ${ORG_NAMESPACE_LABEL} label the org-controller stamps on every Organization namespace — a namespace WITHOUT that label is treated as platform and stays FATAL."
+      fi
       unsettled=$(printf '%s\n%s\n' "${hr_pending}" "${wl_pending}" | grep -c . || true)
       if [ "${unsettled}" -gt 0 ]; then
         terminal=$(printf '%s\n' "${hr_pending}" | grep -c 'TERMINAL:' || true)
@@ -517,7 +641,7 @@ data:
         */}}
         terminal_hollow=$(printf '%s\n' "${hr_pending}" | grep -c 'does not exist in the registry' || true)
         terminal_stalled=$((terminal - terminal_hollow))
-        echo "[harbor-prewarm] FATAL: env NOT settled — ${unsettled} release(s)/workload(s) are mid-roll; harbor-prewarm would mirror running tags the cutover then rolls away from (running != desired):"
+        echo "[harbor-prewarm] FATAL: env NOT settled — ${unsettled} PLATFORM-namespace release(s)/workload(s) are mid-roll; harbor-prewarm would mirror running tags the cutover then rolls away from (running != desired):"
         printf '%s\n%s\n' "${hr_pending}" "${wl_pending}" | grep . | sed 's/^/  mid-roll: /'
         if [ "${terminal}" -gt 0 ]; then
           {{- /* #5391 — do NOT tell the operator to wait when waiting cannot work. */}}
@@ -561,7 +685,7 @@ data:
         printf '%s\n' "${or_used}" | sed 's/^/  override: /'
         echo "[harbor-prewarm] override record written to ConfigMap ${STATUS_CONFIGMAP_NAMESPACE}/${STATUS_CONFIGMAP_NAME} key settledRollOverrides (surfaced on GET /sovereign/cutover/status)"
       else
-        echo "[harbor-prewarm] Phase A0: env settled — no HelmRelease/Deployment/StatefulSet mid-roll; building the mirror from running == desired tags"
+        echo "[harbor-prewarm] Phase A0: env settled — no PLATFORM-namespace HelmRelease/Deployment/StatefulSet mid-roll; building the mirror from running == desired tags"
       fi
       return 0
     }

--- a/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
+++ b/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
@@ -4479,6 +4479,19 @@ cat > "$TMP/c77/bin/kubectl" <<'C77STUB'
 #!/bin/sh
 # Case 77 stub kubectl — dispatches on argv; fixtures + patch log via env.
 case "$*" in
+  # #6273 ownership read. The stub REFUSES a namespace listing that does not
+  # carry the label selector: if the gate ever listed namespaces unfiltered,
+  # every namespace would classify as an Organization namespace and the whole
+  # gate would fail OPEN — a leak no output assertion below would notice.
+  # C77_NS_FIXTURE unset => no Organization namespaces, so every pre-#6273
+  # direction in this case keeps its exact fail-closed semantics (the
+  # delta-corp / flux-system fixtures classify as platform).
+  *"get namespaces"*)
+      case "$*" in
+        *"-l openova.io/organization"*) ;;
+        *) echo "c77-stub-kubectl: namespace listing without the openova.io/organization selector: $*" >&2; exit 9 ;;
+      esac
+      if [ -n "${C77_NS_FIXTURE:-}" ]; then cat "${C77_NS_FIXTURE}"; else printf '{"items":[]}'; fi ;;
   *"get helmreleases"*) cat "${C77_HR_FIXTURE:?}" ;;
   *"get deployments,statefulsets"*) printf '{"items":[]}' ;;
   *"patch configmap"*) printf '%s\n' "$*" >> "${C77_PATCH_LOG:?}"; exit "${C77_PATCH_RC:-0}" ;;
@@ -4869,6 +4882,13 @@ printf '{"items":[]}' > "$TMP/c90/empty-hr.json"
 cat > "$TMP/c90/bin/kubectl" <<'C90STUB'
 #!/bin/sh
 case "$*" in
+  # See the Case 77 stub for why the selector is REQUIRED here (#6273).
+  *"get namespaces"*)
+      case "$*" in
+        *"-l openova.io/organization"*) ;;
+        *) echo "c90-stub-kubectl: namespace listing without the openova.io/organization selector: $*" >&2; exit 9 ;;
+      esac
+      if [ -n "${C77_NS_FIXTURE:-}" ]; then cat "${C77_NS_FIXTURE}"; else printf '{"items":[]}'; fi ;;
   *"get helmreleases"*) cat "${C77_HR_FIXTURE:?}" ;;
   *"get deployments,statefulsets"*) cat "${C90_WL_FIXTURE:?}" ;;
   *"patch configmap"*) printf '%s\n' "$*" >> "${C77_PATCH_LOG:?}"; exit "${C77_PATCH_RC:-0}" ;;
@@ -5071,5 +5091,229 @@ if [ "$c93_steps" = "$c93_typo" ]; then
   exit 1
 fi
 echo "  PASS (#6235: $c93_count step slugs seeded, exactly matching the step ConfigMaps; totalSteps=$c93_total; CONTROL proves a one-character slug drift is rejected)"
+
+echo "[cutover-contract] Case 95: Step-03 Phase A0 partitions offenders by OWNERSHIP — an Organization-namespace offender WARNS and the cutover proceeds, a platform-namespace offender is still FATAL (#6273) — EXECUTED, both passes, with controls"
+# WHY. Phase A0's premise is "running != desired", and it lists `helmreleases -A`
+# plus `deployments,statefulsets -A` — so a customer's failed app install lands
+# in the same fail-closed bucket as a broken platform component and holds the
+# Sovereign's independence closed. Measured twice, independently:
+#   hw290 — "7 offenders, ALL per-Org customer apps" (the template records it).
+#   hw296, 2026-08-13 — the walk created Organization namespace `walkthree`;
+#     HelmRelease/walkthree/{bp-agenity,bp-newapi,bp-wordpress-tenant} all
+#     Ready=False Stalled=True RetriesExceeded (TERMINAL by this gate's own
+#     classifier — Flux has permanently stopped retrying), plus
+#     Deployment/walkthree/{bp-newapi,bp-wordpress-tenant} and
+#     StatefulSet/walkthree/{bp-agenity,bp-stalwart-tenant} at 0/1. ZERO
+#     platform offenders: all 68 flux-system HelmReleases Ready=True.
+# A fully healthy Sovereign could not become independent because a customer app
+# failed to install. #6198 already carved out the cutover's OWN workloads for
+# circularity; this is the same shape one scope wider, argued on OWNERSHIP —
+# the sovereign-admin cannot be required to repair an Organization's Application to
+# earn sovereignty.
+#
+# BOTH passes must carry the partition or it fixes nothing: the #5391 named
+# override is HelmRelease-ONLY (`wl_pending` has no override check at all), so
+# four of those seven hw296 offenders had no escape except the whole-gate kill
+# switch. Directions (1) and (2) below exercise the HR pass and the workload
+# pass SEPARATELY, each with its own leak control.
+#
+# No yq here: this case executes the RENDERED gate against kubectl JSON
+# fixtures consumed by jq, so the v4.44.3 multi-document `//` trap (#6262)
+# has no surface in it.
+mkdir -p "$TMP/c95"
+c95_run() {
+  # $1 = HR fixture; $2 = workload fixture; $3 = namespaces fixture.
+  # Reuses the Case 77 extracted gate + the Case 90 stub (which reads BOTH
+  # object fixtures), so what runs here is what production runs.
+  : > "$TMP/c77/patch.log"
+  C77_HR_FIXTURE="$1" C90_WL_FIXTURE="$2" C77_NS_FIXTURE="$3" \
+  C77_PATCH_LOG="$TMP/c77/patch.log" C77_PATCH_RC=0 \
+  PATH="$TMP/c90/bin:$PATH" \
+  STATUS_CONFIGMAP_NAME=self-sovereign-cutover-status \
+  STATUS_CONFIGMAP_NAMESPACE=cutover-test \
+  SETTLED_ROLL_PREFLIGHT=true \
+  sh "$TMP/c77/gate.sh" > "$TMP/c95/out.txt" 2>&1
+}
+# The ownership label is a FIXED contract with the org-controller
+# (core/controllers/organization/internal/gitops/manifests.go stamps
+# openova.io/organization=<slug> on every Organization namespace; pinned by
+# org_namespace_invariant_4292_test.go). Assert the literal, exactly as this
+# file already does for the #5391 override annotation key.
+if ! grep -q 'ORG_NAMESPACE_LABEL="openova.io/organization"' "$TMP/c77/gate.sh"; then
+  echo "FAIL: the Organization-namespace label drifted from the org-controller's contract openova.io/organization — the partition would classify every customer namespace as platform (#6273)" >&2
+  exit 1
+fi
+# Fixtures: the live hw296 label-selected namespace list, and the live offenders.
+cat > "$TMP/c95/ns-org.json" <<'C95NS'
+{"items":[
+{"metadata":{"name":"hw296-omani-works","labels":{"openova.io/organization":"hw296-omani-works","openova.io/tier":"org"}}},
+{"metadata":{"name":"walkone","labels":{"openova.io/organization":"walkone","openova.io/tier":"org"}}},
+{"metadata":{"name":"walktwo","labels":{"openova.io/organization":"walktwo","openova.io/tier":"org"}}},
+{"metadata":{"name":"walkthree","labels":{"openova.io/organization":"walkthree","openova.io/tier":"org"}}}
+]}
+C95NS
+printf '{"items":[]}' > "$TMP/c95/ns-none.json"
+printf '{"items":[]}' > "$TMP/c95/empty.json"
+cat > "$TMP/c95/hr-org.json" <<'C95HR'
+{"items":[
+{"metadata":{"name":"bp-agenity","namespace":"walkthree","generation":1},"spec":{"chart":{"spec":{"chart":"bp-agenity"}}},"status":{"observedGeneration":1,"conditions":[{"type":"Ready","status":"False","reason":"InstallFailed","message":"Helm install failed for release walkthree/bp-agenity: timed out waiting for the condition"},{"type":"Stalled","status":"True","reason":"RetriesExceeded","message":"Failed to install after 1 attempt(s)"}]}},
+{"metadata":{"name":"bp-newapi","namespace":"walkthree","generation":1},"spec":{"chart":{"spec":{"chart":"bp-newapi"}}},"status":{"observedGeneration":1,"conditions":[{"type":"Ready","status":"False","reason":"InstallFailed","message":"Helm install failed for release walkthree/bp-newapi: timed out waiting for the condition"},{"type":"Stalled","status":"True","reason":"RetriesExceeded","message":"Failed to install after 1 attempt(s)"}]}},
+{"metadata":{"name":"bp-wordpress-tenant","namespace":"walkthree","generation":1},"spec":{"chart":{"spec":{"chart":"bp-wordpress-tenant"}}},"status":{"observedGeneration":1,"conditions":[{"type":"Ready","status":"False","reason":"InstallFailed","message":"Helm install failed for release walkthree/bp-wordpress-tenant: timed out waiting for the condition"},{"type":"Stalled","status":"True","reason":"RetriesExceeded","message":"Failed to install after 1 attempt(s)"}]}}
+]}
+C95HR
+cat > "$TMP/c95/wl-org.json" <<'C95WL'
+{"items":[
+{"kind":"Deployment","metadata":{"name":"bp-newapi","namespace":"walkthree","generation":1},"spec":{"replicas":1},"status":{"observedGeneration":1,"updatedReplicas":1,"readyReplicas":0}},
+{"kind":"Deployment","metadata":{"name":"bp-wordpress-tenant","namespace":"walkthree","generation":1},"spec":{"replicas":1},"status":{"observedGeneration":1,"updatedReplicas":1,"readyReplicas":0}},
+{"kind":"StatefulSet","metadata":{"name":"bp-agenity","namespace":"walkthree","generation":1},"spec":{"replicas":1},"status":{"observedGeneration":1,"updatedReplicas":1,"readyReplicas":0}},
+{"kind":"StatefulSet","metadata":{"name":"bp-stalwart-tenant","namespace":"walkthree","generation":1},"spec":{"replicas":1},"status":{"observedGeneration":1,"updatedReplicas":1,"readyReplicas":0}}
+]}
+C95WL
+# Workload CONTROL — byte-identical shapes moved into a PLATFORM namespace.
+jq '[.items[] | .metadata.namespace = "harbor"] as $i | {items: $i}' \
+  "$TMP/c95/wl-org.json" > "$TMP/c95/wl-plt.json"
+# Platform HelmRelease offender: the live hw296 hollow pin, in flux-system.
+cat > "$TMP/c95/hr-plt.json" <<'C95P'
+{"items":[{"metadata":{"name":"bp-guacamole","namespace":"flux-system","generation":3},"spec":{"chart":{"spec":{"chart":"bp-guacamole","version":"0.2.40"}}},"status":{"observedGeneration":2,"conditions":[{"type":"Ready","status":"False","reason":"SourceNotReady","message":"HelmChart 'flux-system/flux-system-bp-guacamole' is not ready: chart pull error: failed to download chart for remote reference: failed to get 'oci://ghcr.io/openova-io/bp-guacamole:0.2.40': ghcr.io/openova-io/bp-guacamole:0.2.40: not found"}]}}]}
+C95P
+# VACUITY CONTROL fixture for the platform-FATAL direction: the SAME offender,
+# with the ONE discriminating input flipped — flux-system listed as an
+# Organization namespace. Synthetic (the org-controller never labels
+# flux-system), and that is the point: it isolates the predicate.
+jq '.items += [{"metadata":{"name":"flux-system","labels":{"openova.io/organization":"flux-system"}}}]' \
+  "$TMP/c95/ns-org.json" > "$TMP/c95/ns-plus-fluxsystem.json"
+# Stale-override fixtures: a HEALTHY release still carrying a #5391 annotation.
+cat > "$TMP/c95/hr-org-healthy-annotated.json" <<'C95OA'
+{"items":[{"metadata":{"name":"bp-agenity","namespace":"walkthree","generation":2,"annotations":{"catalyst.openova.io/cutover-settled-roll-override":"was stalled during the 2026-08-13 walk"}},"spec":{"chart":{"spec":{"chart":"bp-agenity"}}},"status":{"observedGeneration":2,"conditions":[{"type":"Ready","status":"True","reason":"ReconciliationSucceeded","message":"Release reconciliation succeeded"}]}}]}
+C95OA
+jq '.items[0].metadata.namespace = "flux-system"' \
+  "$TMP/c95/hr-org-healthy-annotated.json" > "$TMP/c95/hr-plt-healthy-annotated.json"
+
+# (1) HELMRELEASE PASS — the three live walkthree releases WARN and the gate
+#     proceeds, naming every one with the same evidence the FATAL path prints.
+if ! c95_run "$TMP/c95/hr-org.json" "$TMP/c95/empty.json" "$TMP/c95/ns-org.json"; then
+  echo "FAIL: the gate REFUSED a Sovereign whose only unsettled HelmReleases are customer apps in an Organization namespace — a failed customer install still fail-closes Pillar 5 (#6273)" >&2
+  sed -n '1,25p' "$TMP/c95/out.txt" >&2
+  exit 1
+fi
+for _r in bp-agenity bp-newapi bp-wordpress-tenant; do
+  if ! grep -q "not gated (Organization namespace): HelmRelease/walkthree/${_r}" "$TMP/c95/out.txt"; then
+    echo "FAIL: the gate skipped Organization-namespace release ${_r} WITHOUT naming it — a silent narrowing of a fail-closed gate is indistinguishable from the gate not working (#6273)" >&2
+    cat "$TMP/c95/out.txt" >&2
+    exit 1
+  fi
+done
+if ! grep -q 'not gated (Organization namespace): HelmRelease/walkthree/bp-agenity  \[TERMINAL' "$TMP/c95/out.txt"; then
+  echo "FAIL: the warning rows dropped the #6253 TERMINAL classification — the skipped releases must be reported with exactly the evidence the FATAL path formats (#6273)" >&2
+  exit 1
+fi
+if ! grep -q 'may need a re-install' "$TMP/c95/out.txt"; then
+  echo "FAIL: the warning never states what the skip COSTS (a genuinely mid-roll app may be mirrored at a tag the post-cutover roll moves away from, and then fail to pull) — hiding the cost makes this a silent narrowing (#6273)" >&2
+  exit 1
+fi
+if grep -q 'env NOT settled' "$TMP/c95/out.txt"; then
+  echo "FAIL: the gate warned about the Organization offenders AND still declared the env not settled (#6273)" >&2
+  exit 1
+fi
+# (2) WORKLOAD PASS — the half with no override seam at all. Same verdict.
+if ! c95_run "$TMP/c95/empty.json" "$TMP/c95/wl-org.json" "$TMP/c95/ns-org.json"; then
+  echo "FAIL: the gate REFUSED a Sovereign whose only unsettled workloads are customer apps in an Organization namespace — wl_pending has NO override check, so this shape's only escape was the whole-gate kill switch (#6273)" >&2
+  sed -n '1,25p' "$TMP/c95/out.txt" >&2
+  exit 1
+fi
+for _w in "Deployment/walkthree/bp-newapi" "Deployment/walkthree/bp-wordpress-tenant" "StatefulSet/walkthree/bp-agenity" "StatefulSet/walkthree/bp-stalwart-tenant"; do
+  if ! grep -q "not gated (Organization namespace): ${_w}" "$TMP/c95/out.txt"; then
+    echo "FAIL: Organization-namespace workload ${_w} was skipped without being named (#6273)" >&2
+    cat "$TMP/c95/out.txt" >&2
+    exit 1
+  fi
+done
+# (3) CONTROL for (2) — the same four workloads in a PLATFORM namespace must
+#     still be FATAL and named. Without this the workload partition could match
+#     everything and every assertion above would still pass.
+if c95_run "$TMP/c95/empty.json" "$TMP/c95/wl-plt.json" "$TMP/c95/ns-org.json"; then
+  echo "FAIL: CONTROL — byte-identical unsettled workloads in the PLATFORM namespace harbor were NOT caught; the #6273 workload partition leaked and the settled-roll gate is fail-open" >&2
+  cat "$TMP/c95/out.txt" >&2
+  exit 1
+fi
+if ! grep -q 'mid-roll: Deployment/harbor/bp-newapi' "$TMP/c95/out.txt"; then
+  echo "FAIL: CONTROL — the platform-namespace workload was refused but never NAMED (#6273)" >&2
+  exit 1
+fi
+# (4) PLATFORM HELMRELEASE OFFENDER — still FATAL, still named, still carrying
+#     the #6253 hollow-pin remedy, with Organizations present on the cluster.
+if c95_run "$TMP/c95/hr-plt.json" "$TMP/c95/empty.json" "$TMP/c95/ns-org.json"; then
+  echo "FAIL: a PLATFORM-namespace HelmRelease offender (flux-system/bp-guacamole) passed the gate — #6273 must not weaken the platform half in any way" >&2
+  cat "$TMP/c95/out.txt" >&2
+  exit 1
+fi
+if ! grep -q 'mid-roll: HelmRelease/flux-system/bp-guacamole' "$TMP/c95/out.txt"; then
+  echo "FAIL: the platform offender was refused but never NAMED (#6273)" >&2
+  exit 1
+fi
+if ! grep -q 'does not exist in the registry' "$TMP/c95/out.txt"; then
+  echo "FAIL: the platform offender lost its #6253 hollow-pin classification under the #6273 partition" >&2
+  exit 1
+fi
+if grep -q 'not gated (Organization namespace)' "$TMP/c95/out.txt"; then
+  echo "FAIL: a flux-system release was reported as an Organization-namespace skip — the partition is matching namespaces it must not (#6273)" >&2
+  exit 1
+fi
+# (5) VACUITY CONTROL for (4) — the platform-FATAL direction must be ABLE to go
+#     the other way. Same offender, same fixtures, ONE input flipped:
+#     flux-system now appears in the label-selected namespace list. If this run
+#     also FATALs, direction (4) proves nothing about the predicate (it would be
+#     passing because everything fails, not because ownership decided).
+if ! c95_run "$TMP/c95/hr-plt.json" "$TMP/c95/empty.json" "$TMP/c95/ns-plus-fluxsystem.json"; then
+  echo "FAIL: VACUITY CONTROL — flipping the ONLY discriminating input (flux-system present in the org-labelled namespace list) did NOT flip the verdict, so direction (4)'s FATAL is not evidence that the ownership predicate decides anything (#6273)" >&2
+  cat "$TMP/c95/out.txt" >&2
+  exit 1
+fi
+if ! grep -q 'not gated (Organization namespace): HelmRelease/flux-system/bp-guacamole' "$TMP/c95/out.txt"; then
+  echo "FAIL: VACUITY CONTROL — the run passed but the release was never reported as a skip; the pass came from somewhere other than the partition (#6273)" >&2
+  exit 1
+fi
+# (6) MIXED — a platform offender alongside Organization offenders: FATAL on the
+#     platform one ONLY, the Organization rows still named, and the count in the
+#     FATAL headline must exclude them (a count that included them would send the
+#     operator hunting for offenders the gate is not blocking on).
+if c95_run "$TMP/c95/hr-plt.json" "$TMP/c95/wl-org.json" "$TMP/c95/ns-org.json"; then
+  echo "FAIL: a platform offender was swallowed by the Organization warning path (#6273)" >&2
+  exit 1
+fi
+if ! grep -q 'FATAL: env NOT settled — 1 PLATFORM-namespace' "$TMP/c95/out.txt"; then
+  echo "FAIL: the FATAL headline count includes Organization-namespace offenders the gate is NOT blocking on (#6273)" >&2
+  grep 'env NOT settled' "$TMP/c95/out.txt" >&2
+  exit 1
+fi
+if ! grep -q 'not gated (Organization namespace): StatefulSet/walkthree/bp-agenity' "$TMP/c95/out.txt"; then
+  echo "FAIL: on a FAILING run the Organization skips are not reported — the operator sees only half the picture (#6273)" >&2
+  exit 1
+fi
+# (7) FAIL-CLOSED DEFAULT — the very same customer offenders on a Sovereign with
+#     NO org-labelled namespaces stay FATAL. An unlabelled namespace is platform;
+#     the partition can never widen by accident.
+if c95_run "$TMP/c95/hr-org.json" "$TMP/c95/wl-org.json" "$TMP/c95/ns-none.json"; then
+  echo "FAIL: offenders in namespaces carrying NO openova.io/organization label passed the gate — the partition is not label-driven and defaults open (#6273)" >&2
+  cat "$TMP/c95/out.txt" >&2
+  exit 1
+fi
+# (8) A STALE #5391 OVERRIDE on a now-HEALTHY Organization release must not
+#     fail the gate closed. Organization releases are not gated, so an override
+#     there is never needed — but the fail-closed validator would reject it as
+#     "names a HEALTHY HelmRelease" and take the whole cutover down with it, the
+#     exact dead end #6262 removed for this chart's own release.
+if ! c95_run "$TMP/c95/hr-org-healthy-annotated.json" "$TMP/c95/empty.json" "$TMP/c95/ns-org.json"; then
+  echo "FAIL: a stale override annotation on a HEALTHY Organization-namespace release fail-closed the whole gate (#6273)" >&2
+  cat "$TMP/c95/out.txt" >&2
+  exit 1
+fi
+# CONTROL — the SAME stale annotation on a PLATFORM release is still rejected.
+if c95_run "$TMP/c95/hr-plt-healthy-annotated.json" "$TMP/c95/empty.json" "$TMP/c95/ns-org.json"; then
+  echo "FAIL: CONTROL — a stale override on a HEALTHY flux-system release was honored; #6273 weakened the #5391 fail-closed override validation" >&2
+  exit 1
+fi
+grep -q 'names a HEALTHY HelmRelease' "$TMP/c95/out.txt" || { echo "FAIL: CONTROL — the platform stale-override rejection lost its class name (#5391/#6273)" >&2; exit 1; }
+echo "  PASS (#6273: BOTH Phase A0 passes partition by ownership — the HelmRelease pass and the override-free wl_pending pass each WARN-and-proceed on Organization namespaces with every offender named, its TERMINAL tag intact and the re-install cost stated; platform offenders stay FATAL, named and classified, are counted alone in the headline, and the VACUITY CONTROL proves that FATAL flips to a warning when the one discriminating input flips; leak controls: identical workloads in harbor still fatal, unlabelled namespaces still fatal, stale override on a platform release still rejected)"
 
 echo "[cutover-contract] All gates green."

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-13T19:30:36.588Z",
+  "generatedAt": "2026-08-13T22:59:24.881Z",
   "blueprints": [
     {
       "id": "bp-agenity",
@@ -4640,7 +4640,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "0.1.184",
+      "version": "0.1.185",
       "section": "pts-2-3-per-sovereign-supporting-services",
       "depends": [
         "bp-gitea",

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -4775,7 +4775,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "0.1.184",
+    "version": "0.1.185",
     "section": "pts-2-3-per-sovereign-supporting-services",
     "depends": [
       "bp-gitea",

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3968,7 +3968,7 @@ name: bp-catalyst-platform
 #   file's 1.4.1325 entry records as permanently burned. The republish
 #   therefore lands on 1.4.1468 — ahead of main's 1.4.1467, absent from GHCR,
 #   and claimed by no open PR.)
-version: 1.4.1470
+version: 1.4.1471
 # 1.4.1229 — #5389: catalog-seed bp-newapi declares its `ui` endpoint
 #   (newapi.<fqdn>, ssoEnabled, launchDefault, ssoInitPath "/") instead of
 #   `endpoints: []`. The empty list made userUIGatePasses fail closed, which
@@ -4123,7 +4123,7 @@ version: 1.4.1470
 # scripts/check-chart-version-forward.sh (#5743) fails unless the two match —
 # main was carrying a pre-existing 1.4.1330/1.4.1329 split, so this bump heals
 # it in the same commit, exactly as the documented self-heal contract does.
-appVersion: 1.4.1470
+appVersion: 1.4.1471
 # 1.4.239 — Wave 3 / Issue #2140 (2026-05-23): Huawei provider
 # implementation lands behind the Wave 2 CloudProvider interface.
 # Adds the OpenTofu module at infra/providers/huawei/ (VPC + Subnet +

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5115,7 +5115,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.1.184"
+  version: "0.1.185"
   visibility: unlisted
   card:
     title: "Self-Sovereignty Cutover"
@@ -5132,7 +5132,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-self-sovereign-cutover
-    version: "0.1.184"
+    version: "0.1.185"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
## What this changes

`harbor-prewarm`'s **Phase A0 settled-roll pre-flight** now partitions offenders by **ownership**:

| namespace class | before | after |
|---|---|---|
| platform (`flux-system`, `harbor`, `kube-system`, `catalyst`, … — anything unlabelled) | FATAL | **FATAL, unchanged** — still named, still TERMINAL-classified, still counted, still offered the #5391 override |
| Organization (`openova.io/organization=<slug>`) | FATAL | **loud, fully enumerated WARNING; the cutover proceeds** |

## Why

Phase A0 enumerates `helmreleases -A` and `deployments,statefulsets -A`, so Organization namespaces have always been in scope: a customer's failed application install was a hard stop on Pillar 5. Measured twice, independently:

- **hw290** — the template's own comment records *"7 offenders, ALL per-Org customer apps"*.
- **hw296, 2026-08-13** (dep `e689e3b34a75fdec`), read live and read-only during this work — Organization namespace `walkthree` carried `HelmRelease/{bp-agenity,bp-newapi,bp-wordpress-tenant}` all `Ready=False Stalled=True RetriesExceeded` (**TERMINAL by this gate's own classifier** — Flux has permanently stopped retrying), plus `Deployment/{bp-newapi,bp-wordpress-tenant}` and `StatefulSet/{bp-agenity,bp-stalwart-tenant}` at `0/1`. **Zero platform offenders**; all 68 `flux-system` HelmReleases `Ready=True`.

A fully healthy Sovereign could not become independent because a customer app failed to install. #6198 already carved out the cutover's own workloads and #6262 its own HelmRelease, both on circularity grounds; this is the same shape one scope wider, argued on the stronger ground: **a sovereign-admin cannot be required to repair an Organization's Application to earn sovereignty.**

## The namespace predicate is derived, not invented

`openova.io/organization=<slug>` is:

- stamped on every Organization's host namespace by `core/controllers/organization/internal/gitops/manifests.go` (`namespaceTemplate`),
- pinned as an invariant by that package's `org_namespace_invariant_4292_test.go` — *"EVERY Organization, at EVERY tier, owns EXACTLY ONE host namespace, named after its slug and carrying `openova.io/organization=<slug>`"*,
- already the production selector in `core/services/provisioning/handlers/kubeconfig_reconciler.go` (`/api/v1/namespaces?labelSelector=openova.io/organization`).

No new namespace list enters the chart, so there is nothing to keep in sync. Being a **positive** label test it is **fail-closed by construction** — a namespace *without* the label is platform. Verified live on hw296: 55 namespaces, exactly 4 labelled (`hw296-omani-works`, `walkone`, `walktwo`, `walkthree`), and every current Phase A0 offender sits in `walkthree`.

## Both passes, or it fixes nothing

The #5391 named override is **HelmRelease-only** — `wl_pending` has no override check at all — so four of the seven hw296 offenders had no escape but the whole-gate kill switch `prewarm.settledRollPreflight.enabled=false`. The partition is applied to:

1. the HelmRelease offender pass (`hr_all` → `hr_pending` / `hr_org`),
2. the workload pass (`wl_all` → `wl_pending` / `wl_org`),
3. the #5391 override **validation** (`or_bad`), which stops judging Organization releases — a stale annotation would otherwise fail the gate closed the moment the customer's app recovered, the exact dead end #6262 removed for this chart's own release.

One `_in_org_ns` definition is shared by all three sites (`SRP_ORG_NS_JQ`), for the same reason #6253 collapsed the two hand-rolled terminal classifiers into one.

## The cost is printed, not hidden

Mirroring is unchanged — still best-effort over every running tag, Organization namespaces included. The warning states plainly that a genuinely mid-roll app may be mirrored at a tag the post-cutover roll moves away from, so that Application can fail to pull after cutover and may need a re-install; the Sovereign is unaffected. Rendered output on the live hw296 shape:

```
[harbor-prewarm] WARNING: Phase A0 found 4 unsettled release(s)/workload(s) in Organization namespaces. The cutover PROCEEDS anyway (#6273) — ...
  not gated (Organization namespace): HelmRelease/walkthree/bp-agenity  [TERMINAL: Flux stalled — it has STOPPED retrying and will never clear itself]  (Helm install failed ...)
  not gated (Organization namespace): StatefulSet/walkthree/bp-agenity
[harbor-prewarm] WHAT THIS COSTS, stated plainly: ... that Application can then fail to pull its image after the cutover and may need a re-install. ...
[harbor-prewarm] Organization namespaces are read from the live cluster by the openova.io/organization label ... a namespace WITHOUT that label is treated as platform and stays FATAL.
```

## Guards

`chart/tests/cutover-contract.sh` **Case 95** EXECUTES the rendered gate (extracted between the settled-roll anchors, driven by a stubbed kubectl) in eight directions over the live hw296 fixtures:

1. HelmRelease pass — the three `walkthree` releases WARN, all named, TERMINAL tags intact, cost line present, no `env NOT settled`.
2. Workload pass — the four `walkthree` workloads WARN, all named. This is the half with no override seam.
3. **CONTROL** — the identical four workloads in `harbor` are still FATAL and named (the workload partition does not leak).
4. Platform HelmRelease offender still FATAL, named, and still carrying the #6253 hollow-pin remedy.
5. **VACUITY CONTROL** — the same offender with the one discriminating input flipped (`flux-system` present in the label-selected list) passes and warns, so direction 4's FATAL is evidence about the predicate rather than about everything failing.
6. Mixed — FATAL on the platform offender only; the headline count excludes the Organization rows; those rows are still reported on a failing run.
7. Fail-closed default — the same customer offenders with no org-labelled namespaces stay FATAL.
8. A stale #5391 override on a now-healthy Organization release no longer fail-closes the gate; **CONTROL** — the same annotation on a healthy platform release is still rejected.

Plus: the annotation-style literal assertion on `ORG_NAMESPACE_LABEL`, and the Case 77/90 kubectl stubs now **refuse** a namespace listing that omits the label selector — a gate that listed namespaces unfiltered (every namespace an Organization, total fail-open) cannot pass.

**Proven able to fail, by mutation** (not by inspection):

- partition forced `false` (pre-fix behaviour) → Case 95 direction 1 goes RED: *"the gate REFUSED a Sovereign whose only unsettled HelmReleases are customer apps in an Organization namespace"*.
- partition forced `true` → the suite goes RED at Case 77 (`gate PASSED on a Stalled HR with no override`), and running direction 4's exact scenario against that mutant returns `rc=0` on `HelmRelease/flux-system/bp-guacamole` — precisely what Case 95 direction 4 asserts must not happen.

The first probe run also caught a real defect before it shipped: `$orgns | index(.metadata.namespace)` re-binds `.` to the array (`Cannot index array with string "metadata"`) — the same trap `_source_absent` carries a warning for. The namespace is now bound first.

## Verification run locally

- `cutover-contract.sh` — **all gates green**, 87 PASS lines including the new Case 95 (and Cases 77/90/94, which now traverse the new namespace read).
- all 15 sibling `chart/tests/*.sh` — rc=0.
- `check-catalog-seed-lockstep.sh`, `check-bootstrap-kit-pin-sync.sh`, `check-no-banned-words.sh`, `check-no-conflict-markers.sh` — PASS.
- `check-umbrella-republish-gate.py --ref HEAD` — PASS (160 pins across 80 Blueprints, umbrella at 1.4.1471).
- `check-helm-release-payload-size.py` — 74.78% of the 1 MiB ceiling, 159 579 bytes under budget (all new prose is `{{/* */}}`, stripped at render).

## Lockstep

`bp-self-sovereign-cutover` 0.1.184 → **0.1.185** across all five sites in this commit — `chart/Chart.yaml`, `blueprint.yaml`, catalog-seed `spec.version` + `source.version`, the generated `blueprints.json` + `catalog.generated.ts` (regenerated with `build-catalog.mjs`), and slot `06a` — plus the umbrella republish at **1.4.1471** with its kit slot-13 pin, so the new pin is carried by a published artifact (Inviolable Principle #13).

Cluster access during this work was strictly read-only (`kubectl get` only); the cutover was not fired.

Refs #6273 #6262 #6198 #5391

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HvMZTDx7W6EPZMmjyXmYh1
