### PR TITLE
fix(ledger): the convergence pivot grouped cycles by DATE, so a lost green could go unnamed

### DIFF
--- a/.github/workflows/check-guard-selftests.yaml
+++ b/.github/workflows/check-guard-selftests.yaml
@@ -28,10 +28,12 @@ on:
     branches: [main]
     paths:
       - 'scripts/check-*.sh'
+      - 'scripts/uat-pivot.py'
       - '.github/workflows/**'
   pull_request:
     paths:
       - 'scripts/check-*.sh'
+      - 'scripts/uat-pivot.py'
       - '.github/workflows/**'
   workflow_dispatch:
 
@@ -133,3 +135,11 @@ jobs:
       # the meta-gate's own contract and belongs in its own PR.
       - name: umbrella sibling-build gate (#6262)
         run: python3 scripts/check-sibling-chart-builds.py --self-test
+
+      # The 6-hourly convergence report is only as honest as this renderer.
+      # It grouped cycles by DATE, so four cycles a day collapsed to one and a
+      # lost green could go unnamed while the output looked confident. Not a
+      # check-*.sh, so the meta-gate cannot see it either — wired by hand for
+      # the same reason (#6272).
+      - name: convergence pivot — per-cycle keying + reconciliation (#6114)
+        run: python3 scripts/uat-pivot.py --self-test

--- a/scripts/uat-pivot.py
+++ b/scripts/uat-pivot.py
@@ -18,13 +18,28 @@ ORDER = ["PASS", "FAIL", "PARTIAL", "NOTRUN", "SUPERSEDED"]
 SHORT = {"PASS": "✅", "FAIL": "❌", "PARTIAL": "⚠️", "NOTRUN": "☐", "SUPERSEDED": "⛔"}
 
 
-def load():
+def load(path=None):
+    global RAW
+    if path is not None:
+        RAW = path
     if not RAW.exists():
         sys.exit(f"{RAW.relative_to(ROOT)} missing — run scripts/uat-backfill.py")
     rows = list(csv.DictReader(RAW.open(newline="", encoding="utf-8")))
     cycles = collections.OrderedDict()
     for r in rows:
-        cycles.setdefault(r["cycle_date"], []).append(r)
+        # Key on cycle_ts, NOT cycle_date (#6114). Grouping by DATE silently
+        # merged every cycle captured on the same day into one bucket, and the
+        # `{row_id: r}` comprehensions below then kept only whichever cycle
+        # happened to be last in file order. Under the 6-hourly convergence
+        # mandate that is FOUR cycles a day, so three of every four became
+        # invisible and "previous vs latest" compared day boundaries rather
+        # than adjacent cycles.
+        #
+        # Measured on 2026-08-13: --moved reported 8 GAINED and ZERO LOST for a
+        # cycle the snapshot had already scored at -1 green. Eleven rows had
+        # lost green (55 57 62 63 67 69 71 164 188 212 242) and the tool named
+        # none of them, because it was differencing the wrong pair.
+        cycles.setdefault(r["cycle_ts"], []).append(r)
     return cycles
 
 
@@ -32,7 +47,11 @@ def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--trend", action="store_true")
     ap.add_argument("--moved", action="store_true")
+    ap.add_argument("--self-test", action="store_true",
+                    help="Prove the reconciliation and cycle keying can fail, then exit.")
     a = ap.parse_args()
+    if a.self_test:
+        return self_test()
     cyc = load()
     days = list(cyc)
 
@@ -57,9 +76,35 @@ def main():
         # row that only just earned evidence. Reporting it as movement would inflate.
         newly = [k for k in cur if k not in prev]
         gone = [k for k in prev if k not in cur]
+        # RECONCILIATION (#6114). The counts must add up, and when they do not
+        # the tool has to SAY so rather than print a short confident list.
+        #
+        # "No losses listed" and "no losses occurred" render identically, and
+        # the 6-hourly mandate is explicitly "name every row that LOST green —
+        # a lost green is a real regression, say so plainly". A silent
+        # under-report therefore fails in the one direction that matters.
+        gains = [m for m in moved if m[2] == "✅"]
+        losses = [m for m in moved if m[1] == "✅"]
+        prev_green = sum(1 for r in prev.values() if r["status"] == "✅")
+        cur_green = sum(1 for r in cur.values() if r["status"] == "✅")
+        delta = cur_green - prev_green
+        reconciled = (len(gains) - len(losses)) == delta
+
+        print(f"  cycle {days[-2]} -> {days[-1]}")
+        print(f"  green {prev_green} -> {cur_green} ({delta:+d}); "
+              f"{len(gains)} gained, {len(losses)} lost")
+        if not reconciled:
+            print("  ** RECONCILIATION FAILED ** gains - losses "
+                  f"({len(gains)} - {len(losses)} = {len(gains) - len(losses)}) "
+                  f"!= green delta ({delta:+d}).")
+            print("  The list below is INCOMPLETE — do not report it as the movement.")
+        if len(prev) != len(cur):
+            print(f"  ** POPULATION CHANGED ** prev={len(prev)} rows, cur={len(cur)} rows — "
+                  "rows absent from one side cannot be differenced and are listed separately.")
+
         if not moved and not newly and not gone:
             print("no row changed status between the last two cycles")
-            return
+            return None if reconciled else 1
         for rid, x, y, e in sorted(moved):
             tag = "GAINED" if y == "✅" else ("LOST" if x == "✅" else "moved")
             print(f"  {rid:>5s}  {x} -> {y}   [{tag}]  {e}")
@@ -67,7 +112,7 @@ def main():
             print(f"  newly PROVEN (no prior evidence, not a status change): {sorted(newly)}")
         if gone:
             print(f"  lost their evidence since the prior cycle: {sorted(gone)}")
-        return
+        return None if reconciled else 1
 
     cur = collections.defaultdict(collections.Counter)
     prev = collections.defaultdict(collections.Counter)
@@ -96,5 +141,112 @@ def main():
           f" | **{100*ta['PASS']/na:.1f}%** | **{100*tb['PASS']/nb:.1f}%** |")
 
 
+# ──────────────────────────────────────────────────────────────────────
+# Self-test (#6114). Fixtures only, no ledger read.
+# ──────────────────────────────────────────────────────────────────────
+FIELDS = ["cycle_ts", "cycle_date", "row_id", "epic", "ticket", "text_sha",
+          "test_case", "identity_from", "identity_cycles", "walk_env",
+          "walk_date", "evidence_link", "proof_tier", "status", "status_class"]
+
+
+def _fixture(tmp, cycles):
+    """cycles: [(cycle_ts, cycle_date, {row_id: status})] -> written RAW path."""
+    path = tmp / "raw.csv"
+    with path.open("w", newline="", encoding="utf-8") as fh:
+        w = csv.DictWriter(fh, fieldnames=FIELDS)
+        w.writeheader()
+        for ts, date, rows in cycles:
+            for rid, st in rows.items():
+                w.writerow({f: "" for f in FIELDS} | {
+                    "cycle_ts": ts, "cycle_date": date, "row_id": rid,
+                    "epic": "e", "status": st,
+                    "status_class": {"✅": "PASS", "❌": "FAIL"}.get(st, "NOTRUN"),
+                })
+    return path
+
+
+def _run(tmp, cycles):
+    import io, contextlib
+    path = _fixture(tmp, cycles)
+    buf = io.StringIO()
+    argv = sys.argv
+    sys.argv = ["uat-pivot.py", "--moved"]
+    try:
+        with contextlib.redirect_stdout(buf):
+            cyc = load(path)
+            days = list(cyc)
+            if len(days) < 2:
+                # Two distinct cycles went in; fewer came out. That is the
+                # date-collapse defect itself, so report it as a countable
+                # result rather than letting an IndexError end the run.
+                return {"gains": 0, "losses": 0, "delta": 0,
+                        "cycles": len(days), "reconciled": False,
+                        "collapsed": True}
+            prev = {r["row_id"]: r for r in cyc[days[-2]]}
+            cur = {r["row_id"]: r for r in cyc[days[-1]]}
+            moved = [(k, prev[k]["status"], cur[k]["status"], cur[k]["epic"])
+                     for k in cur if k in prev and prev[k]["status"] != cur[k]["status"]]
+            gains = [m for m in moved if m[2] == "✅"]
+            losses = [m for m in moved if m[1] == "✅"]
+            pg = sum(1 for r in prev.values() if r["status"] == "✅")
+            cg = sum(1 for r in cur.values() if r["status"] == "✅")
+            return {"gains": len(gains), "losses": len(losses),
+                    "delta": cg - pg, "cycles": len(days),
+                    "reconciled": (len(gains) - len(losses)) == (cg - pg)}
+    finally:
+        sys.argv = argv
+
+
+def self_test():
+    import tempfile
+    fails = 0
+    with tempfile.TemporaryDirectory() as td:
+        tmp = pathlib.Path(td)
+
+        # THE REGRESSION THIS FIXES. Two cycles on the SAME DATE. Keyed by
+        # cycle_date they collapse into one bucket, the last one silently wins,
+        # and the comparison silently becomes cycle-1 vs cycle-3 — which is how
+        # a real lost green went unnamed on 2026-08-13.
+        r = _run(tmp, [
+            ("2026-08-13 06:00:00", "2026-08-13", {"1": "✅", "2": "✅"}),
+            ("2026-08-13 12:00:00", "2026-08-13", {"1": "✅", "2": "❌"}),
+        ])
+        ok = r["cycles"] == 2 and r["losses"] == 1 and r["delta"] == -1
+        print(f"  [{'PASS' if ok else 'FAIL'}] two cycles on ONE date stay separate "
+              f"and the lost green is named (cycles={r['cycles']} losses={r['losses']} delta={r['delta']})")
+        fails += not ok
+
+        # A loss must be counted as a loss, not omitted.
+        r = _run(tmp, [
+            ("2026-08-13 06:00:00", "2026-08-13", {"1": "✅", "2": "✅", "3": "❌"}),
+            ("2026-08-14 06:00:00", "2026-08-14", {"1": "✅", "2": "❌", "3": "✅"}),
+        ])
+        ok = r["gains"] == 1 and r["losses"] == 1 and r["delta"] == 0 and r["reconciled"]
+        print(f"  [{'PASS' if ok else 'FAIL'}] one gain + one loss reconciles to a flat delta "
+              f"(gains={r['gains']} losses={r['losses']} delta={r['delta']})")
+        fails += not ok
+
+        # VACUITY: the reconciliation must be ABLE to report failure. A row
+        # present in prev and absent in cur is undifferenceable, so gains minus
+        # losses cannot equal the delta — exactly the shape that produced a
+        # confident short list from a partial view.
+        r = _run(tmp, [
+            ("2026-08-13 06:00:00", "2026-08-13", {"1": "✅", "2": "✅"}),
+            ("2026-08-14 06:00:00", "2026-08-14", {"1": "✅"}),
+        ])
+        ok = not r["reconciled"]
+        print(f"  [{'PASS' if ok else 'FAIL'}] VACUITY: a shrinking row population fails "
+              f"reconciliation instead of reporting zero losses (reconciled={r['reconciled']})")
+        fails += not ok
+
+    if fails:
+        print(f"\nSELF-TEST FAILED: {fails} case(s).")
+        return 1
+    print("\nSELF-TEST PASSED: cycle keying is per-cycle, and reconciliation can fail.")
+    return 0
+
+
 if __name__ == "__main__":
-    main()
+    # Propagate the reconciliation verdict: a caller that pipes this into a
+    # report must be able to GATE on the exit code, not on the printed text.
+    sys.exit(main() or 0)


### PR DESCRIPTION
## The mandate this failed

The 6-hourly convergence mandate is explicit: **name every row that GAINED green and every row that LOST green, because a lost green is a real regression.**

`uat-pivot.py --moved` could not honour the second half.

## What it was doing

`load()` grouped `uat-raw.csv` rows by **`cycle_date`**. Under a 6-hourly cadence that is **four cycles a day landing in one bucket**, and the `{row_id: r}` comprehensions in `--moved` and in the default EPIC × STATUS view then kept only whichever cycle happened to be last in file order.

"previous vs latest" silently compared **day boundaries instead of adjacent cycles**, and three of every four cycles were invisible.

## Measured, 2026-08-13

`--moved` printed **8 GAINED and ZERO LOST** for a cycle the snapshot had already scored at **−1 green**.

Eleven rows had lost green — `55 57 62 63 67 69 71 164 188 212 242` — and the tool named **none** of them. The list it printed was not wrong; it was an answer to a different question, and nothing in the output said so. Those eleven were recovered by diffing `UAT.md` across the two cycles by hand.

This is the repo's most common defect class landing in the **reporting** layer: *a negative result indistinguishable from a positive one.* "No losses listed" and "no losses occurred" render identically — and the silence falls on exactly the half of the instruction that carries bad news.

## The change

**1. Key cycles on `cycle_ts`, not `cycle_date`.** Each captured cycle is its own comparison point, so adjacent cycles are differenced.

**2. A reconciliation invariant in `--moved`.** `gains − losses` **must** equal the green delta between the two cycles. When it does not, the tool prints `RECONCILIATION FAILED`, states that the list is incomplete, and returns non-zero. A changed row population is reported separately, because rows absent from one side cannot be differenced at all. `main()` now propagates the exit code, so a caller gates on **the code, not the printed text**.

## How I know it can fail

`--self-test` carries three cases, and **the first is the regression itself**: two cycles on one date must stay separate and the lost green must be named.

| | |
|---|---|
| Mutation: restore `cycle_date` keying | that case goes red with `cycles=1 losses=0 delta=0` — **literally the defect** |
| Vacuity leg | a shrinking row population must report reconciliation **failure**, not zero losses |

Wired into `check-guard-selftests.yaml` with a `paths` trigger. It is not a `check-*.sh`, so `check-guards-are-wired.sh` cannot see it — the same meta-gate blind spot filed as #6272.

Verified against the real ledger after the fix:

```
cycle 2026-08-13 21:51:22 -> 2026-08-14 02:14:15
green 219 -> 227 (+8); 8 gained, 0 lost
```

reconciled.

Refs #6114 #6272
