### PR TITLE
fix(cutover): grant Phase A0 the namespaces read its #6273 partition depends on

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -1074,7 +1074,7 @@ spec:
       # chart/tests/ left the package via .helmignore: 757,264 bytes, 72.2%.
       # The rendered manifest is byte-identical modulo comments — no step,
       # value or RBAC change, still 11 steps.
-      version: 0.1.185
+      version: 0.1.186
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1431,7 +1431,15 @@ spec:
       #   openova.io/organization namespace label: platform namespaces stay
       #   FATAL, Organization namespaces warn and proceed. Lockstep w/
       #   products/catalyst/chart/Chart.yaml.
-      version: 1.4.1473
+      # 1.4.1474 — #6280: catalog-seed advances bp-self-sovereign-cutover
+      #   0.1.185 -> 0.1.186. 0.1.185 shipped the Phase A0 ownership partition
+      #   above but NOT the RBAC it needs: the runner ServiceAccount has no
+      #   `namespaces` rule, so `kubectl get namespaces -l
+      #   openova.io/organization` was refused and the gate — correctly
+      #   refusing to fail open on a roll state it cannot read — stopped the
+      #   cutover at the same step it was meant to unblock. Measured on hw296.
+      #   Lockstep w/ products/catalyst/chart/Chart.yaml.
+      version: 1.4.1474
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.185
+  version: 0.1.186
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -3705,6 +3705,41 @@ name: bp-self-sovereign-cutover
 # pin + blueprint.yaml + catalog-seed source.version + spec.version + the API
 # blueprints.json + the generated UI catalog move to 0.1.176 in lockstep
 # (Inviolable Principle #13).
+# 0.1.186 (#6280, Refs #6273 #3379) — THE 0.1.185 PARTITION SHIPPED WITHOUT ITS
+# RBAC, SO IT COULD NEVER RUN. 0.1.185 added `kubectl get namespaces -l
+# openova.io/organization` to Phase A0 but no `namespaces` rule to the runner
+# ClusterRole. The API server refused the list; the gate — correctly, by its own
+# #5391 design — refuses to fail open on a roll state it cannot read. Net effect:
+# the release written to stop a customer's failed app from blocking the cutover
+# stopped the cutover itself, at the same step, one phase earlier.
+#
+# Measured on hw296 (dep e689e3b34a75fdec) 2026-08-13T23:57Z, on a genuinely
+# fresh operator-initiated attempt (all 11 step results cleared, new Job
+# cutover-harbor-prewarm-1786665374). Pod ...-qpmtg:
+#   [harbor-prewarm] Phase A0: kubectl get namespaces -l openova.io/organization failed (attempt 1/5); retry in 5s
+#   ... x5 ...
+#   [harbor-prewarm] FATAL: Phase A0 could not list Organization namespaces (-l openova.io/organization) after 5 attempts — the gate cannot partition offenders by ownership it cannot read; refusing to fail open (#6273)
+# Confirmed directly rather than inferred:
+#   $ kubectl auth can-i list namespaces --as=system:serviceaccount:catalyst:bp-self-sovereign-cutover-runner
+#   no
+#
+# WHY THE GUARD MISSED IT. tests/cutover-contract.sh Case 95 executes the
+# rendered gate against a STUBBED kubectl, and the stub answers the namespace
+# listing — so all eight assertion directions passed while the real
+# ServiceAccount was refused. The contract test proves the gate's LOGIC; nothing
+# proved the gate's GRANTS. That gap is now closed by tests/rbac-coverage.sh,
+# which renders the chart, extracts every resource the step scripts actually
+# read, and asserts each one appears in the ClusterRole — with a mutation
+# control that removes the new rule and requires the guard to go red.
+#
+# FIX: one read-only, cluster-scoped rule — namespaces get/list/watch — granted
+# exactly like the blueprints rule beside it. The gate is NOT weakened: no
+# override, no `prewarm.settledRollPreflight.enabled=false`, no change to any
+# classifier or to the platform-FATAL direction. Step count unchanged at 11.
+# Slot-06a pin + blueprint.yaml + catalog-seed source.version + spec.version +
+# the API blueprints.json + the generated UI catalog move to 0.1.186 in
+# lockstep, and the umbrella republishes at 1.4.1474 so the new pin is carried
+# by a published artifact (Inviolable Principle #13).
 # 0.1.185 (#6273, Refs #6262 #6198 #5391) — AN ORGANIZATION'S FAILED APP NO
 # LONGER HOLDS THE SOVEREIGN'S INDEPENDENCE CLOSED. Phase A0 (the settled-roll
 # pre-flight) lists `helmreleases -A` and `deployments,statefulsets -A`, so
@@ -3758,7 +3793,7 @@ name: bp-self-sovereign-cutover
 # fail-open) cannot pass. Slot-06a pin + blueprint.yaml + catalog-seed
 # spec.version + source.version + the API blueprints.json + the generated UI
 # catalog move to 0.1.185 in lockstep (Inviolable Principle #13).
-version: 0.1.185
+version: 0.1.186
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/rbac.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/rbac.yaml
@@ -133,6 +133,9 @@ rules:
   - apiGroups: ["catalyst.openova.io"]
     resources: ["blueprints"]   # step 03 (#5443) Phase A2-catalog enumerates the LIVE Blueprint CRs — what the marketplace OFFERS — so harbor-prewarm mirrors the catalog's chart set, not only the charts something already installed. Cluster-scoped CRD; read-only.
     verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["namespaces"]   # step 03 (#6280) Phase A0 partitions settled-roll offenders by OWNERSHIP: Organization namespaces are read by the openova.io/organization label the org-controller stamps, so a customer's failed Application warns instead of fail-closing the cutover (#6273). Cluster-scoped; read-only. WITHOUT this grant the partition cannot list and the gate — correctly refusing to fail open — stops the cutover at the same step it was meant to unblock.
+    verbs: ["get", "list", "watch"]
   - apiGroups: ["cilium.io"]
     resources: ["ciliumnetworkpolicies"]
     verbs: ["get", "list", "watch"]

--- a/platform/self-sovereign-cutover/chart/tests/rbac-coverage.sh
+++ b/platform/self-sovereign-cutover/chart/tests/rbac-coverage.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+# #6280 — every resource the cutover step scripts READ must be GRANTED.
+#
+# WHY THIS EXISTS. 0.1.185 (#6273) added `kubectl get namespaces -l
+# openova.io/organization` to harbor-prewarm's Phase A0 and did not add a
+# `namespaces` rule to the runner ClusterRole. The API server refused the list,
+# and the gate — correctly refusing to fail open on a roll state it cannot read
+# — stopped the cutover at the very step the release was written to unblock.
+#
+# WHY THE EXISTING GUARD DID NOT CATCH IT. tests/cutover-contract.sh Case 95
+# executes the rendered Phase A0 block against a STUBBED kubectl. The stub
+# answers every call, including the namespace listing, so all eight assertion
+# directions went green while the real ServiceAccount was being refused. That
+# suite proves the gate's LOGIC. Nothing proved the gate's GRANTS. A stub can
+# never be refused by RBAC, so this class of defect is structurally invisible to
+# it — which is exactly the "guard tested a surface that cannot fail" shape.
+#
+# WHAT THIS ASSERTS. Render the chart, extract every resource the embedded step
+# scripts actually pass to `kubectl get` (and to the srp_kubectl_json wrapper),
+# and require each one to appear in the ClusterRole's resource lists. Both
+# inputs come from the RENDER, never from a copy kept in this file — #5646
+# showed a suite validating a hand-kept copy that had silently drifted from the
+# shipped source and went on passing after the real thing changed.
+#
+# PROVEN ABLE TO FAIL. The last case deletes the `namespaces` rule from the
+# rendered ClusterRole and requires this guard to go RED. A coverage check that
+# has only ever been observed passing is not yet known to be a check.
+set -uo pipefail
+
+CHART_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+FQDN="hw296.omani.works"
+TMP="$(mktemp -d)"
+trap 'rm -rf "${TMP}"' EXIT
+FAILURES=0
+
+fail() { echo "  FAIL — $*"; FAILURES=$((FAILURES + 1)); }
+pass() { echo "  ok   — $*"; }
+
+echo "== #6280 RBAC coverage — every resource read must be granted =="
+
+helm template ssc "${CHART_DIR}" --set sovereign.fqdn="${FQDN}" >"${TMP}/render.yaml" 2>"${TMP}/render.err" || {
+  echo "helm template failed:"; cat "${TMP}/render.err"; exit 1
+}
+
+# ── The extractor, shared by the live run and the mutation control ───────────
+cat >"${TMP}/extract.py" <<'PYEOF'
+import re, sys, yaml
+
+render_path, role_path = sys.argv[1], sys.argv[2]
+render = open(render_path, encoding="utf-8", errors="replace").read()
+
+# Tokens that follow `get`/the wrapper but are not resources. Each is listed
+# with its reason; the list is deliberately tiny and must stay that way — a
+# growing ignore list is how a coverage guard quietly stops covering.
+IGNORE = {
+    "-o", "-n", "-A", "-l", "--raw", "--all-namespaces",   # flags
+    "po", "no",                                            # short aliases; long form is asserted
+}
+
+def resources_from(text):
+    found = set()
+    # `kubectl [flags] get <resource[,resource...]>` and the Phase A0 wrapper
+    # `srp_kubectl_json <resource>`.
+    pats = [
+        r"kubectl\s+(?:-[^\s]+\s+|--[^\s]+\s+|[a-z-]+=[^\s]+\s+)*get\s+([A-Za-z][A-Za-z0-9.,-]*)",
+        r"srp_kubectl_json\s+([A-Za-z][A-Za-z0-9.,-]*)",
+    ]
+    for p in pats:
+        for m in re.finditer(p, text):
+            for tok in m.group(1).split(","):
+                tok = tok.strip()
+                if not tok or tok in IGNORE or "$" in tok or "{" in tok:
+                    continue
+                # providers.pkg.crossplane.io -> providers
+                found.add(tok.split(".")[0].lower())
+    return found
+
+read = resources_from(render)
+
+granted = set()
+for doc in yaml.safe_load_all(open(role_path, encoding="utf-8", errors="replace")):
+    if not doc or doc.get("kind") not in ("ClusterRole", "Role"):
+        continue
+    for rule in doc.get("rules") or []:
+        for r in rule.get("resources") or []:
+            granted.add(r.split("/")[0].lower())
+
+# kubectl accepts singular and short forms; RBAC only ever names the plural.
+# Normalising here is what keeps the guard honest in BOTH directions: without
+# it every `kubectl get pod` reads as a missing grant (noise that would get the
+# guard muted), and with a blanket ignore list instead, a genuinely missing
+# grant would be muted too.
+ALIAS = {
+    "po": "pods", "no": "nodes", "cm": "configmaps", "svc": "services",
+    "deploy": "deployments", "ds": "daemonsets", "sts": "statefulsets",
+    "rs": "replicasets", "pvc": "persistentvolumeclaims",
+    "pv": "persistentvolumes", "ns": "namespaces", "sa": "serviceaccounts",
+    "hr": "helmreleases", "crd": "customresourcedefinitions",
+    "ep": "endpoints", "netpol": "networkpolicies", "cnp": "ciliumnetworkpolicies",
+}
+
+def is_granted(tok):
+    for cand in (tok, ALIAS.get(tok), tok + "s", tok + "es",
+                 (tok[:-1] + "ies") if tok.endswith("y") else None):
+        if cand and cand in granted:
+            return True
+    return False
+
+missing = sorted(r for r in read if not is_granted(r))
+print("READ=%d GRANTED=%d MISSING=%d" % (len(read), len(granted), len(missing)))
+for r in missing:
+    print("MISSING %s" % r)
+PYEOF
+
+# Isolate the ClusterRole/Role documents from the render.
+python3 - "${TMP}/render.yaml" "${TMP}/role.yaml" <<'PYEOF'
+import sys, yaml
+src, dst = sys.argv[1], sys.argv[2]
+out = [d for d in yaml.safe_load_all(open(src, encoding="utf-8", errors="replace"))
+       if d and d.get("kind") in ("ClusterRole", "Role")]
+yaml.safe_dump_all(out, open(dst, "w", encoding="utf-8"))
+print("extracted %d Role/ClusterRole document(s)" % len(out))
+PYEOF
+
+# ── Case 1 — the render must carry a ClusterRole at all (vacuity control) ────
+if [ -s "${TMP}/role.yaml" ]; then
+  pass "render carries at least one Role/ClusterRole document"
+else
+  fail "render carries NO Role/ClusterRole — the guard would pass on nothing"
+  echo "RESULT: FAIL (${FAILURES})"; exit 1
+fi
+
+# ── Case 2 — the extractor must actually find reads (vacuity control) ────────
+OUT="$(python3 "${TMP}/extract.py" "${TMP}/render.yaml" "${TMP}/role.yaml")"
+READ_N="$(printf '%s\n' "${OUT}" | sed -n 's/^READ=\([0-9]*\).*/\1/p')"
+if [ "${READ_N:-0}" -ge 10 ]; then
+  pass "extractor found ${READ_N} distinct resources read by the step scripts"
+else
+  fail "extractor found only ${READ_N:-0} resources — it is not reading the scripts, so a pass would be meaningless"
+fi
+
+# ── Case 3 — `namespaces` specifically must be both read and granted (#6280) ─
+if grep -q 'srp_kubectl_json namespaces -l' "${TMP}/render.yaml"; then
+  pass "Phase A0 does list Organization namespaces (srp_kubectl_json namespaces -l ...)"
+else
+  fail "Phase A0 no longer lists Organization namespaces — #6273 partition is gone"
+fi
+if grep -q '"namespaces"' "${TMP}/role.yaml" || grep -q '^\s*- namespaces$' "${TMP}/role.yaml"; then
+  pass "ClusterRole grants: namespaces"
+else
+  fail "ClusterRole does NOT grant namespaces — this is the #6280 defect"
+fi
+
+# ── Case 4 — no resource read anywhere may be ungranted ─────────────────────
+MISSING="$(printf '%s\n' "${OUT}" | grep '^MISSING ' | sed 's/^MISSING //' || true)"
+if [ -z "${MISSING}" ]; then
+  pass "every resource the step scripts read is granted by the ClusterRole"
+else
+  fail "resources read but NOT granted:"
+  printf '%s\n' "${MISSING}" | sed 's/^/         - /'
+fi
+
+# ── Case 5 — MUTATION CONTROL: strip the namespaces rule, demand RED ────────
+python3 - "${TMP}/role.yaml" "${TMP}/role-mutated.yaml" <<'PYEOF'
+import sys, yaml
+src, dst = sys.argv[1], sys.argv[2]
+docs = list(yaml.safe_load_all(open(src, encoding="utf-8", errors="replace")))
+for d in docs:
+    if not d:
+        continue
+    for rule in d.get("rules") or []:
+        rule["resources"] = [r for r in (rule.get("resources") or []) if r != "namespaces"]
+    d["rules"] = [r for r in (d.get("rules") or []) if r.get("resources")]
+yaml.safe_dump_all([d for d in docs if d], open(dst, "w", encoding="utf-8"))
+PYEOF
+
+MUT="$(python3 "${TMP}/extract.py" "${TMP}/render.yaml" "${TMP}/role-mutated.yaml")"
+if printf '%s\n' "${MUT}" | grep -q '^MISSING namespaces$'; then
+  pass "mutation control: removing the namespaces rule makes this guard report it missing"
+else
+  fail "mutation control did NOT go red — this guard cannot detect the very defect it exists for"
+  printf '%s\n' "${MUT}" | sed 's/^/         /'
+fi
+
+echo
+if [ "${FAILURES}" -eq 0 ]; then
+  echo "RESULT: PASS"
+else
+  echo "RESULT: FAIL (${FAILURES})"
+fi
+exit $(( FAILURES > 0 ? 1 : 0 ))

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -4640,7 +4640,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "0.1.185",
+      "version": "0.1.186",
       "section": "pts-2-3-per-sovereign-supporting-services",
       "depends": [
         "bp-gitea",

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -4775,7 +4775,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "0.1.185",
+    "version": "0.1.186",
     "section": "pts-2-3-per-sovereign-supporting-services",
     "depends": [
       "bp-gitea",

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3968,7 +3968,7 @@ name: bp-catalyst-platform
 #   file's 1.4.1325 entry records as permanently burned. The republish
 #   therefore lands on 1.4.1468 — ahead of main's 1.4.1467, absent from GHCR,
 #   and claimed by no open PR.)
-version: 1.4.1473
+version: 1.4.1474
 # 1.4.1229 — #5389: catalog-seed bp-newapi declares its `ui` endpoint
 #   (newapi.<fqdn>, ssoEnabled, launchDefault, ssoInitPath "/") instead of
 #   `endpoints: []`. The empty list made userUIGatePasses fail closed, which

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5115,7 +5115,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.1.185"
+  version: "0.1.186"
   visibility: unlisted
   card:
     title: "Self-Sovereignty Cutover"
@@ -5132,7 +5132,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-self-sovereign-cutover
-    version: "0.1.185"
+    version: "0.1.186"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
fix(cutover): grant Phase A0 the namespaces read its #6273 partition depends on

0.1.185 added `kubectl get namespaces -l openova.io/organization` to
harbor-prewarm's Phase A0 and did not add a `namespaces` rule to the runner
ClusterRole. The API server refused the list, and the gate — correctly, by its
own #5391 design — refuses to fail open on a roll state it cannot read. The
release written to stop a customer's failed Application from fail-closing the
sovereignty cutover therefore stopped the cutover itself, at the same step, one
phase earlier.

Measured on hw296 (dep e689e3b34a75fdec) at 2026-08-13T23:57Z, on a genuinely
fresh operator-initiated attempt rather than a carried-over report — the status
ConfigMap cleared all 11 step results, cutoverLastAttemptStartedAt advanced to
23:56:14Z, and a NEW Job cutover-harbor-prewarm-1786665374 was created (the
prior 1786655169 having failed BackoffLimitExceeded, which jobFailedTransiently
does not match, so no controller auto-retry would ever have re-run it). Pod
cutover-harbor-prewarm-1786665374-qpmtg:

    [harbor-prewarm] Phase A0: settled-roll pre-flight — no HelmRelease/workload may be mid-roll before the mirror is built
    [harbor-prewarm] Phase A0: kubectl get namespaces -l openova.io/organization failed (attempt 1/5); retry in 5s
    ... attempts 2..5 ...
    [harbor-prewarm] FATAL: Phase A0 could not list Organization namespaces (-l openova.io/organization) after 5 attempts — the gate cannot partition offenders by ownership it cannot read; refusing to fail open (#6273)

Confirmed directly rather than inferred from the log:

    $ kubectl auth can-i list namespaces --as=system:serviceaccount:catalyst:bp-self-sovereign-cutover-runner
    no

The partition itself is correct and is doing its job. Replicating Phase A0's
own two predicates against live hw296 — the HelmRelease pass and the workload
pass, both partitioned by the gate's own namespace selector — yields 8 offenders
and every one of them is ORG (walkfour/bp-stalwart-tenant plus walkthree's
bp-agenity, bp-newapi, bp-wordpress-tenant and their four workloads), against
ZERO platform offenders. The four flux-system HelmReleases without a Ready
condition are all suspend=true and are excluded by the gate's own
`select((.spec.suspend // false) | not)`. So on this Sovereign 0.1.186 is the
only thing standing between a healthy env and a cutover attempt.

WHY THE GUARD DID NOT CATCH IT. cutover-contract.sh Case 95 executes the
rendered Phase A0 block against a STUBBED kubectl, and the stub answers the
namespace listing — so all eight assertion directions went green while the real
ServiceAccount was being refused. That suite proves the gate's LOGIC; nothing
proved the gate's GRANTS, and a stub can never be refused by RBAC, so this
defect class was structurally invisible to it.

GUARD. New tests/rbac-coverage.sh renders the chart, extracts every resource the
embedded step scripts actually pass to `kubectl get` and to the srp_kubectl_json
wrapper (31 distinct resources today), normalises kubectl's singular and short
forms onto the plural RBAC names, and requires each one to appear in the
ClusterRole. Both inputs come from the RENDER, never a copy kept in the test
(#5646). It carries two vacuity controls — the render must contain a ClusterRole
at all, and the extractor must find a non-trivial number of reads, so it cannot
pass on nothing — and a mutation control that strips the namespaces rule and
requires the guard to report it missing. Proven able to fail end-to-end as well:
with the rule removed from rbac.yaml the suite goes RED on both Case 3 and Case
4 and exits non-zero. Normalisation is deliberate rather than an ignore list —
without it every `kubectl get pod` reads as a missing grant, and the noise is
how a coverage guard gets muted; with a blanket ignore list a genuinely missing
grant would be muted too. CI needs no workflow change: chart-tests-pr.yaml
already runs every chart/tests/*.sh.

The gate is NOT weakened. One read-only, cluster-scoped rule, granted exactly
like the blueprints rule beside it. No override, no
prewarm.settledRollPreflight.enabled=false, no change to any classifier and no
change to the platform-FATAL direction. Step count unchanged at 11. The full
cutover-contract suite stays green, Case 95 included.

Slot-06a pin + blueprint.yaml + catalog-seed spec.version + source.version + the
API blueprints.json + the generated UI catalog move to 0.1.186 in lockstep, and
the umbrella republishes at 1.4.1474 so the new pin is carried by a published
artifact (Inviolable Principle #13). check-cutover-version-floor.py reports all
7 pins across the 5 lockstep sites at 0.1.186; check-bootstrap-kit-pin-sync.sh
reports chart=pin for both bp-self-sovereign-cutover and bp-catalyst-platform.

Refs #6280 #6273 #6262 #3379
