### PR TITLE
feat(catalyst-api): write the per-Org standby HelmRelease into region B (#6268 / UAT row 60)

### DIFF
--- a/core/controllers/application/internal/controller/application_controller.go
+++ b/core/controllers/application/internal/controller/application_controller.go
@@ -453,6 +453,53 @@ func (r *Reconciler) clusterResolver() clusterregistry.Resolver {
 	}
 }
 
+// localRegion is the canonical Region this controller instance runs in, the
+// same derivation clusterResolver makes. Kept as one helper so the #4282
+// narrowing below and the registry can never disagree about which cluster IDs
+// are "same-region".
+func (r *Reconciler) localRegion() clusterregistry.Region {
+	local := clusterregistry.Region(strings.ToUpper(r.Cfg.LocalRegion))
+	if !clusterregistry.IsKnownRegion(local) {
+		local = clusterregistry.RegionA
+	}
+	return local
+}
+
+// hostCNPGKubeSecretFor narrows the #4282 host-CNPG rule (#6268).
+//
+// #4282 measured a real defect: a CNPG-bearing Blueprint pivoted into a
+// vCluster renders a hollow `InstallSucceeded`, because the chart's
+// `cluster.yaml` is gated on `.Capabilities.APIVersions.Has
+// "postgresql.cnpg.io/v1"` and a vCluster apiserver registers no such CRD and
+// runs no cnpg operator. Its remedy was `fanoutKubeSecretFor = nil` — which
+// removes the pivot for EVERY leg of the Application, same-region and
+// cross-region alike.
+//
+// The warrant does not reach that far. It is a statement about VCLUSTERS, and
+// a cross-region cluster ID does not name one: `rtz-B` is a different REGION's
+// HOST cluster, which on a 2-region Sovereign runs its own cnpg operator and
+// registers the CRD (hw296 region B: `cnpg-system/cnpg-cloudnative-pg`,
+// `clusters.postgresql.cnpg.io`). Suppressing its resolution therefore
+// suppressed nothing #4282 was about, while removing the only signal the
+// renderer has that a standby leg belongs somewhere else.
+//
+// So: same-region (and unparseable) IDs still resolve to ("",""), which is
+// exactly the pre-#6268 behaviour for every leg #4282 measured; a cross-region
+// ID is delegated to the registry, which returns a Secret only when an operator
+// has wired a remote-region kubeconfig for that region and ("","") otherwise.
+// A nil base is treated as "nothing to delegate to" rather than as an error —
+// this wrapper only ever narrows.
+func (r *Reconciler) hostCNPGKubeSecretFor(base func(string) (string, string)) func(string) (string, string) {
+	local := r.localRegion()
+	return func(cluster string) (string, string) {
+		id, err := clusterregistry.Parse(cluster)
+		if err != nil || id.Region == local || base == nil {
+			return "", ""
+		}
+		return base(cluster)
+	}
+}
+
 // Defaults applies missing-field defaults to a Config. Returns a copy.
 func (c Config) Defaults() Config {
 	out := c
@@ -1024,7 +1071,20 @@ func (r *Reconciler) Reconcile(ctx context.Context, app *unstructured.Unstructur
 				r.Log.Info("CNPG-bearing Blueprint placed in a vCluster tier — routing the Cluster CR host-side (no vCluster pivot) so the host cnpg-system operator reconciles it (#4282)",
 					"blueprint", spec.BlueprintName, "tier", placementTier, "hostNamespace", app.GetNamespace())
 				fanoutWriteNamespace = app.GetNamespace()
-				fanoutKubeSecretFor = nil
+				// #6268 — NARROWED, not deleted. The rule's warrant is "a
+				// vCluster apiserver registers no postgresql.cnpg.io CRD and
+				// runs no cnpg operator", which is a statement about VCLUSTERS.
+				// Nilling the whole seam applied it to a CROSS-REGION leg as
+				// well, where it does not hold: region B's HOST cluster runs
+				// `cnpg-system/cnpg-cloudnative-pg` with
+				// `clusters.postgresql.cnpg.io` registered (read live on hw296
+				// dep e689e3b34a75fdec), so a `rtz-B` leg has exactly the
+				// operator + CRD the invariant asks for. The narrowed form
+				// suppresses the SAME-REGION vCluster pivot — the whole of what
+				// #4282 measured — and leaves a cross-region cluster ID to the
+				// registry, which resolves it only when a remote-region
+				// kubeconfig is actually wired and returns ("","") otherwise.
+				fanoutKubeSecretFor = r.hostCNPGKubeSecretFor(fanoutKubeSecretFor)
 			}
 
 			// Source-ref + chart: read from Blueprint.spec.manifests

--- a/core/controllers/application/internal/controller/cnpg_crossregion_narrowing_6268_test.go
+++ b/core/controllers/application/internal/controller/cnpg_crossregion_narrowing_6268_test.go
@@ -1,0 +1,113 @@
+package controller
+
+// cnpg_crossregion_narrowing_6268_test.go — #6268.
+//
+// #4282 measured a real defect and fixed it with a blunt instrument: a
+// CNPG-bearing Blueprint placed in a vCluster tier had `fanoutKubeSecretFor`
+// set to nil, which removes the kubeConfig resolution for EVERY leg of the
+// Application.
+//
+// Its warrant is a statement about VCLUSTERS — "a vCluster apiserver registers
+// no postgresql.cnpg.io CRD and runs no cnpg operator, so the chart's
+// capability-gated cluster.yaml renders zero Cluster CRs". A CROSS-REGION
+// cluster ID does not name a vCluster: `rtz-B` is a DIFFERENT REGION's HOST
+// cluster, which on hw296 (dep e689e3b34a75fdec) runs
+// `cnpg-system/cnpg-cloudnative-pg` and registers
+// `clusters.postgresql.cnpg.io` — read live in region B. Suppressing its
+// resolution suppressed nothing #4282 was about.
+//
+// These two tests are a matched pair on ONE seam, so neither can be satisfied
+// by weakening the other:
+//
+//	TestHostCNPGRule_StillSuppressesTheSameRegionVClusterPivot
+//	  the #4282 invariant itself. PASSES on origin/main (where the rule nils
+//	  everything) and must keep passing — a fix that simply deleted the rule
+//	  reddens exactly this.
+//
+//	TestHostCNPGRule_NoLongerSuppressesTheCrossRegionLeg
+//	  RED on origin/main: with `fanoutKubeSecretFor = nil` there is nothing to
+//	  call, so no cross-region leg can resolve anything, ever.
+
+import (
+	"testing"
+
+	"github.com/openova-io/openova/core/controllers/internal/clusterregistry"
+)
+
+// crossRegionResolver is a registry seeded the way an operator would if they
+// had wired a remote-region kubeconfig: the local tier keeps its vCluster
+// pivot, and region B resolves to a remote Secret.
+func crossRegionResolver() clusterregistry.Resolver {
+	return clusterregistry.Resolver{
+		LocalRegion: clusterregistry.RegionA,
+		TierVClusters: map[clusterregistry.Tier]clusterregistry.TierVCluster{
+			clusterregistry.TierRtz: {HostNamespace: "rtz", KubeconfigSecret: "vc-rtz"},
+		},
+		RemoteRegionSecrets: map[clusterregistry.Region]clusterregistry.RemoteRegionSecret{
+			clusterregistry.RegionB: {Name: "region-b-kubeconfig", Namespace: "catalyst"},
+		},
+	}
+}
+
+func narrowingReconciler() *Reconciler {
+	return &Reconciler{Cfg: Config{LocalRegion: "A"}}
+}
+
+// TestHostCNPGRule_StillSuppressesTheSameRegionVClusterPivot pins the #4282
+// invariant. `rtz-A` is this controller's OWN region, so the tier's vCluster
+// Secret (`vc-rtz`) is exactly the pivot that lands the CNPG Cluster CR in an
+// apiserver with no cnpg operator and no CRD. It must still resolve to nothing.
+//
+// PASSES on origin/main. Its job is to make "just delete the #4282 rule"
+// unavailable as a way of satisfying the second test.
+func TestHostCNPGRule_StillSuppressesTheSameRegionVClusterPivot(t *testing.T) {
+	r := narrowingReconciler()
+	narrowed := r.hostCNPGKubeSecretFor(crossRegionResolver().SecretFor)
+
+	name, ns := narrowed("rtz-A")
+	if name != "" || ns != "" {
+		t.Errorf("#4282: the SAME-region leg rtz-A resolved to kubeConfig Secret %q/%q, want "+
+			"(\"\",\"\") — pivoting a CNPG-bearing chart into a vCluster renders a hollow "+
+			"InstallSucceeded, because the vCluster apiserver registers no postgresql.cnpg.io "+
+			"CRD and the chart's cluster.yaml is capability-gated on it", ns, name)
+	}
+}
+
+// TestHostCNPGRule_NoLongerSuppressesTheCrossRegionLeg is the #6268 half.
+//
+// RED on origin/main: the rule there is `fanoutKubeSecretFor = nil`, so a
+// cross-region cluster ID has no resolver to reach at all — the leg is denied
+// its resolution by a rule whose reason does not apply to it.
+func TestHostCNPGRule_NoLongerSuppressesTheCrossRegionLeg(t *testing.T) {
+	r := narrowingReconciler()
+	narrowed := r.hostCNPGKubeSecretFor(crossRegionResolver().SecretFor)
+
+	name, ns := narrowed("rtz-B")
+	if name != "region-b-kubeconfig" || ns != "catalyst" {
+		t.Errorf("#6268: the CROSS-region leg rtz-B resolved to kubeConfig Secret %q/%q, want "+
+			"catalyst/region-b-kubeconfig — #4282's warrant is about vCLUSTERS, and rtz-B is a "+
+			"different REGION's HOST cluster, which runs its own cnpg operator and registers "+
+			"the CRD (hw296 region B: cnpg-system/cnpg-cloudnative-pg, "+
+			"clusters.postgresql.cnpg.io). Nilling the whole seam denied this leg a resolution "+
+			"for a reason that does not apply to it", ns, name)
+	}
+}
+
+// TestHostCNPGRule_TolerantOfANilBaseAndANonCanonicalID — the two shapes the
+// wrapper must not turn into a panic or a fabricated Secret. A legacy bare
+// cluster name is not a canonical `<tier>-<region>` ID and must resolve to
+// nothing rather than being treated as cross-region; a nil base is "nothing to
+// delegate to", which is the pre-#6268 behaviour and never an error.
+func TestHostCNPGRule_TolerantOfANilBaseAndANonCanonicalID(t *testing.T) {
+	r := narrowingReconciler()
+
+	if name, ns := r.hostCNPGKubeSecretFor(nil)("rtz-B"); name != "" || ns != "" {
+		t.Errorf("#6268: a nil base resolved rtz-B to %q/%q, want (\"\",\"\") — with no "+
+			"resolver to delegate to there is nothing to return", ns, name)
+	}
+	if name, ns := r.hostCNPGKubeSecretFor(crossRegionResolver().SecretFor)("legacy-cluster-name"); name != "" || ns != "" {
+		t.Errorf("#6268: a non-canonical cluster ID resolved to %q/%q, want (\"\",\"\") — an "+
+			"unparseable ID has no region, so calling it cross-region would fabricate a pivot",
+			ns, name)
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/org_app_standby_regions.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_app_standby_regions.go
@@ -373,7 +373,11 @@ func ensureOrgAppStandbyHelmRelease(ctx context.Context, dyn dynamic.Interface, 
 	// pivot into — strip it rather than carry a dangling secretRef.
 	delete(spec, "kubeConfig")
 
-	spec["values"] = standbyValuesFor(spec, leg.Topology)
+	values, verr := standbyValuesFor(ctx, dyn, spec, leg.Topology)
+	if verr != nil {
+		return verr
+	}
+	spec["values"] = values
 
 	labels := orgConsoleTLSStringLabels(names, rec, orgAppStandbyComponent)
 	for k, v := range leg.HR.GetLabels() {
@@ -441,17 +445,138 @@ func ensureOrgAppStandbyHelmRelease(ctx context.Context, dyn dynamic.Interface, 
 //
 // The source map is never mutated — it belongs to the object listed from the
 // host region's apiserver.
-func standbyValuesFor(spec map[string]any, topology string) map[string]any {
+// It additionally stamps the SPLIT-SIDE contract when the chart has shown it
+// speaks that vocabulary — see standbySideOverlay, and read its doc before
+// changing anything here, because omitting it is not a cosmetic gap: it renders
+// a second PRIMARY.
+//
+// Returns an error rather than a best-effort map when the side cannot be
+// resolved. Fail-closed is the only safe direction: an unresolved side writes a
+// primary into the standby's region.
+func standbyValuesFor(ctx context.Context, dyn dynamic.Interface, spec map[string]any, topology string) (map[string]any, error) {
 	src, _, _ := unstructured.NestedMap(spec, "values")
 	out := make(map[string]any, len(src)+1)
 	for k, v := range src {
 		out[k] = v
 	}
-	if strings.TrimSpace(topology) == bcpActiveHotStandby {
+	hot := strings.TrimSpace(topology) == bcpActiveHotStandby
+	if hot {
 		delete(out, replicasKey)
 	}
 	out[standbyMarker] = true
-	return out
+	if err := standbySideOverlay(ctx, dyn, out, hot); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// standbySideOverlay stamps the split-side contract onto the values of a leg
+// being delivered to a secondary region.
+//
+// WHY THIS IS NOT OPTIONAL. `_openova_standby` is NOT what selects a follower.
+// bp-postgres picks its half from `topology.side` (`_helpers.tpl`
+// bp-postgres.side / .renderReplicaHalf) and `cluster.yaml` hardcodes
+// `openova.io/cnpg-role: primary` on the half it renders. So a leg projected
+// with the source values verbatim renders a SECOND PRIMARY in the standby's
+// region — and one pinned by required nodeAffinity to
+// `topology.primary.region`, which no node in that region carries, so it is
+// unschedulable forever while the HelmRelease reports install succeeded. That
+// is the #5639 shape exactly, arrived at from a new direction.
+//
+// WHERE THE REGION COMES FROM. `topology.replica.region` is a `required` in the
+// chart and its value is the `openova.io/region` NODE LABEL the follower's
+// nodeAffinity pins on. It is therefore read from the TARGET region's OWN
+// nodes — the cluster the follower will actually be scheduled on. Deriving it
+// from a name (the bridge Secret's region key, a deployment record's cloud
+// region) would be a guess against a label, and a wrong guess is not visible:
+// it renders `openova.io/region In [""]` or a region no node has, and the
+// install still reports success. A label read off a live node cannot produce
+// that shape, because the node it came from satisfies it by construction.
+//
+// SCOPE. Only applied when the source values ALREADY carry a `topology` map
+// declaring `mode: active-hot-standby`. That is the chart telling us it speaks
+// this vocabulary; stamping `topology.side` onto a chart that has said nothing
+// about topology would be inventing a contract on its behalf. A cold
+// (`active-passive`) leg is not touched either — it renders no follower.
+func standbySideOverlay(ctx context.Context, dyn dynamic.Interface, values map[string]any, hot bool) error {
+	if !hot {
+		return nil
+	}
+	topo, found, _ := unstructured.NestedMap(values, "topology")
+	if !found {
+		return nil
+	}
+	if mode, _, _ := unstructured.NestedString(topo, "mode"); strings.TrimSpace(mode) != bcpActiveHotStandby {
+		return nil
+	}
+
+	region, err := regionNodeLabel(ctx, dyn)
+	if err != nil {
+		return fmt.Errorf("resolve the secondary region's openova.io/region node label, which topology.replica.region must equal: %w", err)
+	}
+
+	// COPY — `topo` is a NestedMap of the source object's values and must not
+	// be mutated in place; the same source leg is projected once per region.
+	next := make(map[string]any, len(topo)+2)
+	for k, v := range topo {
+		next[k] = v
+	}
+	next["side"] = "replica"
+	replica := map[string]any{}
+	if cur, ok := next["replica"].(map[string]any); ok {
+		for k, v := range cur {
+			replica[k] = v
+		}
+	}
+	replica["region"] = region
+	next["replica"] = replica
+	values["topology"] = next
+	return nil
+}
+
+// regionNodeLabel returns the `openova.io/region` value carried by the nodes of
+// the cluster `dyn` addresses. Every node must agree — a cluster whose nodes
+// disagree is not one region, and picking one would make the pick
+// authoritative. An unlabelled cluster is an error, not a default: the chart's
+// `required` exists precisely because an empty region renders an
+// unschedulable-forever follower under a successful install.
+func regionNodeLabel(ctx context.Context, dyn dynamic.Interface) (string, error) {
+	nodes, err := dyn.Resource(orgAppStandbyNodesGVR()).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return "", fmt.Errorf("list nodes: %w", err)
+	}
+	if nodes == nil || len(nodes.Items) == 0 {
+		return "", fmt.Errorf("the cluster reports no nodes")
+	}
+	region := ""
+	for i := range nodes.Items {
+		v := strings.TrimSpace(nodes.Items[i].GetLabels()[regionNodeLabelKey])
+		if v == "" {
+			continue
+		}
+		if region == "" {
+			region = v
+			continue
+		}
+		if v != region {
+			return "", fmt.Errorf("nodes disagree on %s (%q vs %q), so this cluster is not one region",
+				regionNodeLabelKey, region, v)
+		}
+	}
+	if region == "" {
+		return "", fmt.Errorf("no node carries the %s label", regionNodeLabelKey)
+	}
+	return region, nil
+}
+
+// regionNodeLabelKey is the canonical region node label the split-side charts
+// pin their required nodeAffinity on (platform/postgres/chart/templates/
+// cluster.yaml, replica-cluster.yaml, dr-promoter.yaml).
+const regionNodeLabelKey = "openova.io/region"
+
+// orgAppStandbyNodesGVR — core/v1 Nodes, cluster-scoped.
+func orgAppStandbyNodesGVR() schema.GroupVersionResource {
+	return schema.GroupVersionResource{Group: "", Version: "v1", Resource: "nodes"}
 }
 
 // ensureStandbyChartSource projects the HelmRepository the standby leg's chart

--- a/products/catalyst/bootstrap/api/internal/handler/org_app_standby_regions.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_app_standby_regions.go
@@ -1,0 +1,570 @@
+// org_app_standby_regions.go — #6268, the MISSING PRODUCER for UAT row 60.
+//
+// THE GAP, MEASURED
+// -----------------
+// A Catalog-provisioned `active-hot-standby` Application emits two per-cluster
+// HelmReleases and BOTH land in region A. Live on hw296 (dep e689e3b34a75fdec),
+// Org `walkfour`, app `r60fresh`:
+//
+//	region-a walkfour/r60fresh-rtz-a   role=active   cluster=rtz-A
+//	region-a walkfour/r60fresh-rtz-b   role=passive  cluster=rtz-B  (kubeConfig ABSENT)
+//	region-b walkfour                  the Namespace does not exist
+//	region-b HelmReleases for this app ZERO
+//
+// The standby leg therefore installs beside its own primary, in the same
+// cluster and the same namespace, scaled to zero. `status.regions` reports
+// region-b `ready:0 replicas:0` — literally honest, because the standby was
+// asked for zero replicas in the wrong cluster.
+//
+// WHY THE RENDERER COULD NOT FIX IT
+// ---------------------------------
+// #6287 corrected two real renderer defects (a hot standby was handed the COLD
+// `replicas: 0` overlay; a Roles-less multi-cluster variant rendered two
+// standbys and no primary) and deliberately left the leg cold while it is
+// undelivered — booting it hot in region A would install a DUPLICATE PRIMARY
+// beside the active leg, which is strictly worse than an inert copy. That is
+// the correct behaviour for a leg with nowhere to go, and it is why the row did
+// not move: `clusterregistry.Resolver.RemoteRegionSecrets` has no producer, so
+// `SecretFor("rtz-B")` from a region-A controller returns ("","") and the
+// application-controller has no secondary-region writer at all.
+//
+// WHY THIS PRODUCER LIVES IN catalyst-api AND NOT IN THE application-controller
+// ----------------------------------------------------------------------------
+// Because that is where the platform already decided cross-region per-Org
+// writes belong, and the mechanism is proven on this very cluster. The
+// org-controller creates each Org's Flux loop through its own single-cluster
+// client, so a secondary region has neither the per-Org GitRepository nor the
+// tree (see org_app_surface_mesh.go's header, which states it outright: "The
+// only process that can write to a secondary region is catalyst-api"). Region B
+// of hw296 carries `walkone`…`walkfive` Namespaces labelled
+// `catalyst.openova.io/component: org-app-crossregion` with projected Services
+// inside them — written from region A by that emitter, through the same
+// `orgConsoleTLSTargets` client set this file uses. Adding a second,
+// independent secondary-region client stack to the application-controller
+// (new RBAC, new env, new chart lockstep) would duplicate a seam that already
+// works.
+//
+// WHAT IS DELIBERATELY NOT BUILT — the region-A-owned remote pivot
+// ----------------------------------------------------------------
+// The obvious alternative is to stamp a remote-region kubeconfig on the standby
+// HelmRelease and leave the object in region A, so region A's helm-controller
+// applies the chart into region B. It is REJECTED, not skipped.
+//
+// It makes region A the OWNER of region B's standby. The Helm release keeps
+// running through a region-A outage, but nothing can re-apply, re-configure or
+// re-render it — during precisely the outage the standby exists to survive. The
+// platform's proven model is split-side: `shared-pg`'s region-B replica is
+// reconciled by REGION B's OWN Flux from `bp-postgres-shared` in region-b
+// `flux-system`, and region B runs a complete Flux (helm-controller Running,
+// 64 `bp-*` HelmRepositories, `bootstrap-kit` Kustomization Ready — all read
+// live on hw296). So the object is WRITTEN INTO region B and region B's own
+// helm-controller owns it.
+//
+// That is also why the projected HelmRelease carries NO `spec.kubeConfig`. A
+// kubeConfig block means "pivot into a DIFFERENT apiserver than the one holding
+// this object". Once the object is in region B there is nothing to pivot to,
+// and the source leg's block (if any) names a region-A `vc-*` Secret that does
+// not exist there — so it is stripped rather than copied. The #4282 host-CNPG
+// invariant is SATISFIED, not bypassed, by that: it requires the `Cluster` CR
+// to land where a CNPG operator and its CRD live, and region B's HOST cluster
+// runs `cnpg-system/cnpg-cloudnative-pg` with `clusters.postgresql.cnpg.io`
+// registered (read live). Its over-reach was suppressing the CROSS-REGION leg's
+// delivery along with the same-region vCluster pivot — see
+// `application_controller.go`'s narrowed rule.
+//
+// ANTI-VACUITY
+// ------------
+// Three states are reported rather than folded into silence, because each one
+// is a way this producer could appear to have run while writing nothing:
+//
+//   - an Application with passive legs but NO active leg — the host region is
+//     then underivable, so the leg is NOT projected and the app is named;
+//   - a passive leg whose cluster ID shares the active leg's region — that is
+//     a same-region standby and has no cross-region delivery to make;
+//   - a secondary region that is registered but whose write failed — logged at
+//     Error with the region, never counted as delivered.
+//
+// A single-region Sovereign returns before it reads anything, so its object
+// graph and API-call profile are byte-identical to before this file existed.
+//
+// Refs #6268 #3375 #5635 #6287.
+
+package handler
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/store"
+)
+
+// The per-cluster fan-out labels the application-controller stamps on every
+// HelmRelease it renders (core/controllers/application/internal/render/
+// topology.go). This file only ever READS them, so the constants are a mirror
+// of that contract, not a second source of truth for it.
+const (
+	fanoutLabelApp             = "catalyst.openova.io/app"
+	fanoutLabelRole            = "catalyst.openova.io/role"
+	fanoutLabelCluster         = "catalyst.openova.io/cluster"
+	fanoutLabelTopology        = "catalyst.openova.io/topology"
+	fanoutLabelStandbyDelivery = "catalyst.openova.io/standby-delivery"
+
+	fanoutRoleActive    = "active"
+	fanoutRolePassive   = "passive"
+	fanoutRoleSingleton = "singleton"
+
+	// fanoutStandbyDeliveryRemote is the value that says the standby leg
+	// reached a cluster of its OWN, rather than installing beside its active
+	// peer. This producer is what makes it true.
+	fanoutStandbyDeliveryRemote = "remote"
+
+	// bcpActiveHotStandby is the ONE posture whose standby streams. Every
+	// other posture's standby is cold by definition, so its `replicas: 0`
+	// overlay is carried through to the secondary region unchanged.
+	bcpActiveHotStandby = "active-hot-standby"
+
+	// standbyMarker is the canonical Openova standby signal. It stays TRUE on
+	// a hot standby — the marker says "this leg is the standby", which is true
+	// of a hot standby and a cold one alike, and charts whose standby semantic
+	// is a boolean rather than an integer (CNPG `replica.enabled`) key off it.
+	standbyMarker = "_openova_standby"
+
+	// replicasKey is the COLD-standby half of the overlay: `replicas: 0` means
+	// rebuild-on-failover. A replica scaled to zero cannot stream, so it is
+	// removed for a hot standby and the chart's declared count applies.
+	replicasKey = "replicas"
+)
+
+// orgAppStandbyComponent labels every object this producer writes, so an
+// operator (and the reap below) can tell the projected standby apart from a
+// GitOps-delivered or locally-rendered HelmRelease.
+const orgAppStandbyComponent = "org-app-standby-crossregion"
+
+// orgAppStandbyHelmRepositoryGVR — the Flux v1 HelmRepository the standby
+// leg's chart resolves through, addressed via the dynamic client the same way
+// every other seam in this package is. (The HelmRelease GVR is the package's
+// existing `helmReleaseGVR` var — one declaration, not a second one.)
+func orgAppStandbyHelmRepositoryGVR() schema.GroupVersionResource {
+	return schema.GroupVersionResource{Group: "source.toolkit.fluxcd.io", Version: "v1", Resource: "helmrepositories"}
+}
+
+// standbyLeg is one cross-region standby HelmRelease to project, paired with
+// the region its active peer occupies (which is what makes it CROSS-region).
+type standbyLeg struct {
+	// HR is the source object as it stands in the host region.
+	HR unstructured.Unstructured
+	// App is the parent Application name (the fan-out back-pointer).
+	App string
+	// Topology is the resolved BCP posture label — `active-hot-standby` is the
+	// only value that makes the standby hot.
+	Topology string
+	// ActiveRegion / StandbyRegion are the region suffixes of the canonical
+	// cluster IDs (`rtz-A` → "A"). They differ, by construction.
+	ActiveRegion  string
+	StandbyRegion string
+}
+
+// reconcileOrgAppStandbyAcrossRegions projects one Org's CROSS-REGION standby
+// HelmReleases from the host region into every secondary region, so the standby
+// leg of an `active-hot-standby` Application actually exists in the region the
+// placement names — reconciled there by that region's OWN Flux.
+//
+// Best-effort and non-gating throughout, matching its sibling
+// reconcileOrgAppSurfaceAcrossRegions: a failure is logged with the region that
+// failed and the next ticker pass retries. Never returns an error — the caller
+// is a reconcile loop over every Org and one bad Org must not starve the rest.
+func (h *Handler) reconcileOrgAppStandbyAcrossRegions(ctx context.Context, deps *sovereignDeps, rec store.OrganizationProvisionRecord) {
+	if h == nil || deps == nil || deps.dyn == nil {
+		return
+	}
+	names, ok := resolveOrgConsoleTLSNames(rec)
+	if !ok {
+		return
+	}
+
+	targets, _ := h.orgConsoleTLSTargets(deps)
+	if len(targets) < 2 {
+		// Single-region Sovereign (or a mothership, where orgConsoleTLSTargets
+		// deliberately refuses to fan out). Return BEFORE any read so the
+		// single-region object graph and API-call profile are unchanged.
+		return
+	}
+	host := targets[0]
+
+	legs, orphans := listOrgAppStandbyLegs(ctx, host.dyn, names.Slug)
+	for _, app := range orphans {
+		// An Application with a passive leg and NO active leg has no derivable
+		// host region, so nothing here can decide where its standby belongs.
+		// That is the #6287 roleFor shape (a Roles-less multi-cluster variant
+		// rendering two standbys and no primary) and it must be NAMED, not
+		// folded into "nothing to project".
+		h.log.Error("org-app-standby: an Application has a passive leg but NO active leg, so its standby's own region cannot be derived and it is NOT projected — the placement has no primary to be a standby OF (#6268)",
+			"org_tenant_id", rec.OrganizationID, "namespace", names.Slug, "app", app)
+	}
+	if len(legs) == 0 {
+		// Nothing cross-region to deliver. Still run the reap so a leg that
+		// was withdrawn in the host region does not linger in a secondary.
+		h.reapOrgAppStandbyProjections(ctx, targets[1:], names, nil)
+		return
+	}
+
+	keep := make(map[string]struct{}, len(legs))
+	for i := range legs {
+		keep[legs[i].HR.GetName()] = struct{}{}
+	}
+
+	for _, tgt := range targets[1:] {
+		if err := ensureOrgBoundaryNamespaceForApps(ctx, tgt.dyn, names, rec); err != nil {
+			h.log.Error("org-app-standby: could not ensure the Org boundary namespace in a secondary region — its standby legs cannot be written there and the Application stays single-region (#6268)",
+				"org_tenant_id", rec.OrganizationID,
+				"region", tgt.region, "clusterID", tgt.clusterID,
+				"namespace", names.Slug, "err", err)
+			continue
+		}
+		delivered := 0
+		for i := range legs {
+			if err := ensureStandbyChartSource(ctx, host.dyn, tgt.dyn, &legs[i].HR); err != nil {
+				h.log.Error("org-app-standby: the standby leg's chart source could not be projected into a secondary region — its HelmRelease would never resolve a chart there (#6268)",
+					"org_tenant_id", rec.OrganizationID,
+					"region", tgt.region, "clusterID", tgt.clusterID,
+					"namespace", names.Slug, "hr", legs[i].HR.GetName(), "err", err)
+				continue
+			}
+			if err := ensureOrgAppStandbyHelmRelease(ctx, tgt.dyn, names, rec, &legs[i]); err != nil {
+				h.log.Error("org-app-standby: could not write the standby HelmRelease into a secondary region — the standby leg stays absent there and the Topology tab cannot show a pair (#6268)",
+					"org_tenant_id", rec.OrganizationID,
+					"region", tgt.region, "clusterID", tgt.clusterID,
+					"namespace", names.Slug, "hr", legs[i].HR.GetName(), "err", err)
+				continue
+			}
+			delivered++
+		}
+		h.log.Info("org-app-standby: cross-region standby legs projected into a secondary region, reconciled there by that region's OWN Flux (#6268)",
+			"org_tenant_id", rec.OrganizationID,
+			"region", tgt.region, "clusterID", tgt.clusterID,
+			"namespace", names.Slug,
+			"legs", len(legs), "delivered", delivered)
+	}
+
+	h.reapOrgAppStandbyProjections(ctx, targets[1:], names, keep)
+}
+
+// listOrgAppStandbyLegs returns the CROSS-REGION standby HelmReleases in the
+// Org's own boundary namespace, plus the names of Applications that carry a
+// passive leg with no active leg (which the caller reports).
+//
+// "Cross-region" is derived from the DATA, never from an assumption about which
+// region this process runs in: the legs of one Application are grouped by the
+// fan-out's `catalyst.openova.io/app` label, the ACTIVE (or singleton) leg's
+// canonical cluster ID supplies the host region suffix, and a passive leg
+// qualifies only when its own suffix DIFFERS. A same-region standby (both legs
+// `rtz-A`) is correctly excluded — there is no cross-region delivery to make.
+func listOrgAppStandbyLegs(ctx context.Context, dyn dynamic.Interface, ns string) (legs []standbyLeg, orphanApps []string) {
+	list, err := dyn.Resource(helmReleaseGVR).Namespace(ns).List(ctx, metav1.ListOptions{})
+	if err != nil || list == nil {
+		return nil, nil
+	}
+
+	type appLegs struct {
+		activeRegion string
+		passive      []unstructured.Unstructured
+	}
+	byApp := map[string]*appLegs{}
+	order := []string{}
+	for i := range list.Items {
+		item := list.Items[i]
+		labels := item.GetLabels()
+		app := strings.TrimSpace(labels[fanoutLabelApp])
+		region := clusterIDRegionSuffix(labels[fanoutLabelCluster])
+		if app == "" || region == "" {
+			// Not a per-cluster fan-out HelmRelease (a bootstrap slot HR, a
+			// vcluster HR, a per-Org product chart). Never a candidate.
+			continue
+		}
+		e, ok := byApp[app]
+		if !ok {
+			e = &appLegs{}
+			byApp[app] = e
+			order = append(order, app)
+		}
+		switch labels[fanoutLabelRole] {
+		case fanoutRoleActive, fanoutRoleSingleton:
+			e.activeRegion = region
+		case fanoutRolePassive:
+			e.passive = append(e.passive, item)
+		}
+	}
+
+	sort.Strings(order)
+	for _, app := range order {
+		e := byApp[app]
+		if len(e.passive) == 0 {
+			continue
+		}
+		if e.activeRegion == "" {
+			orphanApps = append(orphanApps, app)
+			continue
+		}
+		for i := range e.passive {
+			hr := e.passive[i]
+			standbyRegion := clusterIDRegionSuffix(hr.GetLabels()[fanoutLabelCluster])
+			if standbyRegion == e.activeRegion {
+				continue
+			}
+			legs = append(legs, standbyLeg{
+				HR:            hr,
+				App:           app,
+				Topology:      strings.TrimSpace(hr.GetLabels()[fanoutLabelTopology]),
+				ActiveRegion:  e.activeRegion,
+				StandbyRegion: standbyRegion,
+			})
+		}
+	}
+	sort.Slice(legs, func(i, j int) bool { return legs[i].HR.GetName() < legs[j].HR.GetName() })
+	return legs, orphanApps
+}
+
+// clusterIDRegionSuffix returns the REGION half of a canonical cluster ID
+// (`rtz-B` → "B"), upper-cased so `rtz-b` and `rtz-B` compare equal — the
+// same tolerance clusterregistry.Parse applies. Returns "" for anything that
+// is not `<tier>-<region>`, which is how a non-fan-out HelmRelease is
+// excluded without needing to enumerate what those look like.
+func clusterIDRegionSuffix(clusterID string) string {
+	id := strings.TrimSpace(clusterID)
+	i := strings.LastIndex(id, "-")
+	if i <= 0 || i == len(id)-1 {
+		return ""
+	}
+	tier := id[:i]
+	switch tier {
+	case "mgmt", "dmz", "rtz":
+	default:
+		return ""
+	}
+	return strings.ToUpper(id[i+1:])
+}
+
+// ensureOrgAppStandbyHelmRelease writes one cross-region standby HelmRelease
+// into a secondary region: same name, same namespace, the source spec carried
+// forward with two corrections and no `spec.kubeConfig`.
+//
+// Upsert rather than create-if-absent. The projected object is DESIRED STATE
+// owned by this producer — a chart-version bump or a parameter edit in the host
+// region has to reach the standby, and a create-only write would freeze the
+// standby at whatever it was on the day it first appeared. Only `spec` and the
+// labels are written; `status` is left to that region's helm-controller.
+func ensureOrgAppStandbyHelmRelease(ctx context.Context, dyn dynamic.Interface, names orgConsoleTLSNames, rec store.OrganizationProvisionRecord, leg *standbyLeg) error {
+	spec, found, err := unstructured.NestedMap(leg.HR.Object, "spec")
+	if err != nil || !found {
+		return fmt.Errorf("read spec of HelmRelease %s/%s", names.Slug, leg.HR.GetName())
+	}
+
+	// The source leg's kubeConfig, when it has one, names a HOST-region
+	// vCluster Secret (`vc-rtz`) that does not exist in the secondary. The
+	// object is already IN the region it targets, so there is nothing left to
+	// pivot into — strip it rather than carry a dangling secretRef.
+	delete(spec, "kubeConfig")
+
+	spec["values"] = standbyValuesFor(spec, leg.Topology)
+
+	labels := orgConsoleTLSStringLabels(names, rec, orgAppStandbyComponent)
+	for k, v := range leg.HR.GetLabels() {
+		// Carry the fan-out's own labels so the projected object answers the
+		// same questions the host-region leg does (which app, which cluster,
+		// which role, which posture). The component/managed-by keys above are
+		// re-applied after, so a source label can never subvert the identity
+		// this producer stamps.
+		labels[k] = v
+	}
+	for k, v := range orgConsoleTLSStringLabels(names, rec, orgAppStandbyComponent) {
+		labels[k] = v
+	}
+	// The whole point of the write: this standby leg reached a cluster of its
+	// OWN. #6287 stamps `local-undelivered` on the host-region copy precisely
+	// because it did not.
+	labels[fanoutLabelStandbyDelivery] = fanoutStandbyDeliveryRemote
+
+	desired := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "helm.toolkit.fluxcd.io/v2",
+		"kind":       "HelmRelease",
+		"metadata": map[string]any{
+			"name":      leg.HR.GetName(),
+			"namespace": names.Slug,
+			"labels":    toAnyMap(labels),
+		},
+		"spec": spec,
+	}}
+
+	current, err := dyn.Resource(helmReleaseGVR).Namespace(names.Slug).Get(ctx, leg.HR.GetName(), metav1.GetOptions{})
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			return fmt.Errorf("read standby HelmRelease %s/%s: %w", names.Slug, leg.HR.GetName(), err)
+		}
+		if _, cerr := dyn.Resource(helmReleaseGVR).Namespace(names.Slug).Create(ctx, desired, metav1.CreateOptions{}); cerr != nil {
+			if apierrors.IsAlreadyExists(cerr) {
+				return nil
+			}
+			return fmt.Errorf("create standby HelmRelease %s/%s: %w", names.Slug, leg.HR.GetName(), cerr)
+		}
+		return nil
+	}
+
+	current.Object["spec"] = spec
+	current.SetLabels(labels)
+	if _, err := dyn.Resource(helmReleaseGVR).Namespace(names.Slug).Update(ctx, current, metav1.UpdateOptions{}); err != nil {
+		return fmt.Errorf("update standby HelmRelease %s/%s: %w", names.Slug, leg.HR.GetName(), err)
+	}
+	return nil
+}
+
+// standbyValuesFor returns the values map the SECONDARY region's copy must
+// carry, given the source leg's spec.values and the resolved posture.
+//
+// A HOT standby is a live, streaming replica. `replicas: 0` is the COLD
+// (`active-passive`, rebuild-on-failover) semantic and a workload scaled to
+// zero cannot stream, so the key is REMOVED and the chart's declared count
+// applies. The `_openova_standby` marker stays true in both cases — it says
+// "this leg is the standby", which is equally true of either kind, and is what
+// a chart with a boolean standby semantic (CNPG `replica.enabled`) reads.
+//
+// A COLD standby's overlay is carried through byte-for-byte: `replicas: 0` is
+// the posture the operator chose, and this producer's job is to put it in the
+// right region, not to change what it is.
+//
+// The source map is never mutated — it belongs to the object listed from the
+// host region's apiserver.
+func standbyValuesFor(spec map[string]any, topology string) map[string]any {
+	src, _, _ := unstructured.NestedMap(spec, "values")
+	out := make(map[string]any, len(src)+1)
+	for k, v := range src {
+		out[k] = v
+	}
+	if strings.TrimSpace(topology) == bcpActiveHotStandby {
+		delete(out, replicasKey)
+	}
+	out[standbyMarker] = true
+	return out
+}
+
+// ensureStandbyChartSource projects the HelmRepository the standby leg's chart
+// resolves through into the secondary region, when that region does not already
+// carry one by that name.
+//
+// This is not defensive padding. Measured on hw296: region B's `flux-system`
+// holds 64 `bp-*` HelmRepositories but NOT `openova-catalog` — which is exactly
+// the source every Catalog-provisioned Application's HelmRelease references. A
+// standby HelmRelease written there without it resolves no chart at all, so the
+// object would exist and install nothing, which is the one outcome worse than
+// the object being absent: a leg that LOOKS delivered.
+//
+// Create-if-absent. A secondary region that already has a source by that name
+// (its own bootstrap's, or a post-cutover one pointing at the local Harbor) is
+// left exactly as it is — this must never redirect a region's chart source.
+func ensureStandbyChartSource(ctx context.Context, hostDyn, dstDyn dynamic.Interface, hr *unstructured.Unstructured) error {
+	name, _, _ := unstructured.NestedString(hr.Object, "spec", "chart", "spec", "sourceRef", "name")
+	kind, _, _ := unstructured.NestedString(hr.Object, "spec", "chart", "spec", "sourceRef", "kind")
+	ns, _, _ := unstructured.NestedString(hr.Object, "spec", "chart", "spec", "sourceRef", "namespace")
+	name, kind, ns = strings.TrimSpace(name), strings.TrimSpace(kind), strings.TrimSpace(ns)
+	if name == "" || ns == "" {
+		// No sourceRef to satisfy (an inline chartRef shape, or a malformed
+		// leg). Nothing to project; the HelmRelease write below reports
+		// whatever the region makes of it.
+		return nil
+	}
+	if kind != "" && kind != "HelmRepository" {
+		// A GitRepository / OCIRepository source is a different contract with
+		// a different reachability story from a secondary region. Refuse to
+		// guess at it rather than project a shape this producer has not
+		// reasoned about.
+		return fmt.Errorf("standby chart source kind %q is not a HelmRepository — not projected", kind)
+	}
+
+	if _, err := dstDyn.Resource(orgAppStandbyHelmRepositoryGVR()).Namespace(ns).Get(ctx, name, metav1.GetOptions{}); err == nil {
+		return nil
+	} else if !apierrors.IsNotFound(err) {
+		return fmt.Errorf("read HelmRepository %s/%s in the secondary region: %w", ns, name, err)
+	}
+
+	src, err := hostDyn.Resource(orgAppStandbyHelmRepositoryGVR()).Namespace(ns).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("read host-region HelmRepository %s/%s to project: %w", ns, name, err)
+	}
+	srcSpec, found, _ := unstructured.NestedMap(src.Object, "spec")
+	if !found {
+		return fmt.Errorf("host-region HelmRepository %s/%s carries no spec", ns, name)
+	}
+	labels := map[string]string{
+		"catalyst.openova.io/component":  orgAppStandbyComponent,
+		"catalyst.openova.io/managed-by": "catalyst-api",
+		"app.kubernetes.io/managed-by":   "catalyst-api",
+	}
+	desired := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "source.toolkit.fluxcd.io/v1",
+		"kind":       "HelmRepository",
+		"metadata": map[string]any{
+			"name":      name,
+			"namespace": ns,
+			"labels":    toAnyMap(labels),
+		},
+		"spec": srcSpec,
+	}}
+	// The source's pull Secret, when it has one, is a separate object this
+	// producer does not copy — a secondary region provisioned by the same IaC
+	// already carries the registry credential its own 64 bp-* sources use.
+	if _, err := dstDyn.Resource(orgAppStandbyHelmRepositoryGVR()).Namespace(ns).Create(ctx, desired, metav1.CreateOptions{}); err != nil {
+		if apierrors.IsAlreadyExists(err) {
+			return nil
+		}
+		return fmt.Errorf("project HelmRepository %s/%s into the secondary region: %w", ns, name, err)
+	}
+	return nil
+}
+
+// reapOrgAppStandbyProjections deletes standby HelmReleases THIS producer wrote
+// into a secondary region whose source leg no longer exists in the host region.
+//
+// Level-triggered in both directions, matching reapOrgConsoleTLSOrphans: the
+// ensure pass above is the only thing that creates these, and without a delete
+// pass a topology downgrade (active-hot-standby → singleton) or an Application
+// deletion would leave a live standby running in the secondary region with
+// nothing left to be a standby of.
+//
+// Only objects carrying THIS producer's component label are candidates, so a
+// HelmRelease that region owns for any other reason is never touched. `keep`
+// nil means "the host region has no cross-region standby legs at all", which is
+// a legitimate reap-everything instruction — it is reached only after the host
+// region's HelmReleases were successfully listed.
+func (h *Handler) reapOrgAppStandbyProjections(ctx context.Context, secondaries []orgConsoleTLSTarget, names orgConsoleTLSNames, keep map[string]struct{}) {
+	for _, tgt := range secondaries {
+		list, err := tgt.dyn.Resource(helmReleaseGVR).Namespace(names.Slug).List(ctx, metav1.ListOptions{
+			LabelSelector: "catalyst.openova.io/component=" + orgAppStandbyComponent,
+		})
+		if err != nil || list == nil {
+			continue
+		}
+		for i := range list.Items {
+			name := list.Items[i].GetName()
+			if _, ok := keep[name]; ok {
+				continue
+			}
+			if err := tgt.dyn.Resource(helmReleaseGVR).Namespace(names.Slug).
+				Delete(ctx, name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+				h.log.Error("org-app-standby: could not reap a projected standby HelmRelease whose source leg is gone — it keeps running in the secondary region with nothing to be a standby of (#6268)",
+					"region", tgt.region, "clusterID", tgt.clusterID,
+					"namespace", names.Slug, "hr", name, "err", err)
+				continue
+			}
+			h.log.Info("org-app-standby: reaped a projected standby HelmRelease whose source leg no longer exists in the host region (#6268)",
+				"region", tgt.region, "clusterID", tgt.clusterID,
+				"namespace", names.Slug, "hr", name)
+		}
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/org_app_standby_regions_6268_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_app_standby_regions_6268_test.go
@@ -68,7 +68,13 @@ var (
 	standbyHRGVR   = schema.GroupVersionResource{Group: "helm.toolkit.fluxcd.io", Version: "v2", Resource: "helmreleases"}
 	standbyRepoGVR = schema.GroupVersionResource{Group: "source.toolkit.fluxcd.io", Version: "v1", Resource: "helmrepositories"}
 	standbySvcGVR  = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "services"}
+	standbyNodeGVR = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "nodes"}
 )
+
+// standbyNodeRegion is the region the SECONDARY region's nodes carry — the
+// value hw296 region B's nodes actually have, and the value the chart's
+// required `topology.replica.region` must equal.
+const standbyNodeRegion = "hw-me-east-215-b-rtz-prod"
 
 const (
 	standbyOrgSlug   = "walkfour"
@@ -96,6 +102,7 @@ func fakeDynForOrgAppStandby(t *testing.T, orgs ...*unstructured.Unstructured) *
 			standbySvcGVR:     "ServiceList",
 			standbyHRGVR:      "HelmReleaseList",
 			standbyRepoGVR:    "HelmRepositoryList",
+			standbyNodeGVR:    "NodeList",
 		})
 	ctx := context.Background()
 	gw := &unstructured.Unstructured{Object: map[string]any{
@@ -185,6 +192,26 @@ func seedCatalogChartSource(t *testing.T, dyn *dynamicfake.FakeDynamicClient) {
 	}
 }
 
+// seedRegionNodes gives a fake region cluster nodes carrying the canonical
+// `openova.io/region` label — the label the split-side charts pin their
+// required nodeAffinity on, and the only honest source for
+// `topology.replica.region`.
+func seedRegionNodes(t *testing.T, dyn *dynamicfake.FakeDynamicClient, region string, names ...string) {
+	t.Helper()
+	for _, n := range names {
+		node := &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "v1", "kind": "Node",
+			"metadata": map[string]any{
+				"name":   n,
+				"labels": map[string]any{"openova.io/region": region},
+			},
+		}}
+		if _, err := dyn.Resource(standbyNodeGVR).Create(context.Background(), node, metav1.CreateOptions{}); err != nil {
+			t.Fatalf("seed Node %s: %v", n, err)
+		}
+	}
+}
+
 func seedFanoutHR(t *testing.T, dyn *dynamicfake.FakeDynamicClient, hr *unstructured.Unstructured) {
 	t.Helper()
 	if _, err := dyn.Resource(standbyHRGVR).Namespace(hr.GetNamespace()).
@@ -254,6 +281,9 @@ func TestReconcileOrgAppStandby_SecondaryRegionCarriesTheHotStandbyLeg(t *testin
 	secDyn := fakeDynForOrgAppStandby(t, org)
 
 	seedCatalogChartSource(t, hostDyn)
+	// Region B's own nodes carry the canonical region label — the only honest
+	// source for the follower's required nodeAffinity region (see lock 8).
+	seedRegionNodes(t, secDyn, standbyNodeRegion, "b-cp1", "b-w1")
 	seedFanoutHR(t, hostDyn, fanoutHR(standbyActiveHR, standbyOrgSlug, standbyAppName,
 		"rtz-A", "active", "active-hot-standby", map[string]any{
 			"topology": map[string]any{"mode": "active-hot-standby"},
@@ -571,6 +601,143 @@ func TestReconcileOrgAppStandby_DeliveredLegCarriesNoKubeConfig(t *testing.T) {
 	if chart, found, _ := unstructured.NestedString(hr.Object, "spec", "chart", "spec", "chart"); !found || chart != "bp-postgres" {
 		t.Errorf("#6268: the delivered standby leg %s/vcapp-rtz-b lost its chart (%q found=%v) — "+
 			"only the kubeConfig block may be removed", standbyOrgSlug, chart, found)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// lock 8 / lock 9 — the split-side contract, and what happens when it cannot
+// be satisfied.
+// ─────────────────────────────────────────────────────────────────────────────
+
+// TestReconcileOrgAppStandby_DeliveredLegRendersTheReplicaHalf.
+//
+// `_openova_standby` is NOT what selects a follower. bp-postgres picks its half
+// from `topology.side` (`_helpers.tpl` bp-postgres.side / .renderReplicaHalf),
+// and `cluster.yaml` hardcodes `openova.io/cnpg-role: primary` on the half it
+// renders. So a leg delivered with the source values verbatim renders a SECOND
+// PRIMARY in the standby's region — pinned by required nodeAffinity to
+// `topology.primary.region`, which no node there carries, so it is
+// unschedulable forever while the HelmRelease reports install succeeded. That
+// is the #5639 shape reached from a new direction, and it is strictly worse
+// than the leg being absent.
+//
+// `topology.replica.region` must equal the `openova.io/region` NODE LABEL of
+// the region the follower runs in, so it is read off that region's OWN nodes.
+// A name-derived value (a bridge region key, a deployment record's cloud
+// region) would be a guess against a label, and a wrong guess is invisible.
+//
+// RED on origin/main, and RED against a producer that copies values verbatim.
+func TestReconcileOrgAppStandby_DeliveredLegRendersTheReplicaHalf(t *testing.T) {
+	t.Setenv("SOVEREIGN_FQDN", "hw296.omani.works")
+
+	org := standbyOrgCR(standbyOrgSlug, standbyOrgParent)
+	hostDyn := fakeDynForOrgAppStandby(t, org)
+	secDyn := fakeDynForOrgAppStandby(t, org)
+
+	seedCatalogChartSource(t, hostDyn)
+	seedRegionNodes(t, secDyn, standbyNodeRegion, "b-cp1", "b-w1")
+	seedFanoutHR(t, hostDyn, fanoutHR(standbyActiveHR, standbyOrgSlug, standbyAppName,
+		"rtz-A", "active", "active-hot-standby", nil))
+	seedFanoutHR(t, hostDyn, fanoutHR(standbyPassiveHR, standbyOrgSlug, standbyAppName,
+		"rtz-B", "passive", "active-hot-standby", map[string]any{
+			"_openova_standby": true,
+			"replicas":         int64(0),
+			// The live shape: mode + primary region, and NO side.
+			"topology": map[string]any{
+				"mode":    "active-hot-standby",
+				"primary": map[string]any{"region": "hw-me-east-215-a-rtz-prod"},
+			},
+		}))
+
+	h := newStandbyHandler(t, hostDyn, secDyn)
+	h.reconcileOrgConsoleTLSOnce(context.Background())
+
+	hr, ok := getHR(t, secDyn, standbyOrgSlug, standbyPassiveHR)
+	if !ok {
+		t.Fatalf("#6268: the secondary region carries NO HelmRelease %s/%s",
+			standbyOrgSlug, standbyPassiveHR)
+	}
+	// 1. SUBSTANTIVE — the leg renders the REPLICA half, not a second primary.
+	if side, _, _ := unstructured.NestedString(hr.Object, "spec", "values", "topology", "side"); side != "replica" {
+		t.Errorf("#6268: the delivered standby leg %s/%s carries topology.side=%q, want %q — "+
+			"bp-postgres selects its half from this key and cluster.yaml hardcodes "+
+			"openova.io/cnpg-role: primary on the half it renders, so without it this leg is a "+
+			"SECOND PRIMARY in the standby's region",
+			standbyOrgSlug, standbyPassiveHR, side, "replica")
+	}
+	// 2. and it pins on a region that a node in THAT cluster actually carries.
+	if got, _, _ := unstructured.NestedString(hr.Object, "spec", "values", "topology", "replica", "region"); got != standbyNodeRegion {
+		t.Errorf("#6268: the delivered standby leg %s/%s carries topology.replica.region=%q, "+
+			"want %q (read off that region's own nodes) — the chart pins the follower's "+
+			"required nodeAffinity on this value, and a region no node carries renders a "+
+			"follower that is unschedulable forever under a successful install (#5639)",
+			standbyOrgSlug, standbyPassiveHR, got, standbyNodeRegion)
+	}
+	// 3. the primary half of the declaration is carried through untouched — the
+	//    overlay must ADD the side, not rewrite the topology block.
+	if got, _, _ := unstructured.NestedString(hr.Object, "spec", "values", "topology", "primary", "region"); got != "hw-me-east-215-a-rtz-prod" {
+		t.Errorf("#6268: the delivered standby leg %s/%s lost topology.primary.region (%q) — the "+
+			"follower needs it to know what it is following", standbyOrgSlug, standbyPassiveHR, got)
+	}
+	// 4. the HOST region's copy is NOT given a side. It is undelivered and must
+	//    stay inert; making it a follower would have it pin on a region its own
+	//    cluster does not carry.
+	src, ok := getHR(t, hostDyn, standbyOrgSlug, standbyPassiveHR)
+	if !ok {
+		t.Fatalf("#6268: the host region's own standby leg %s/%s disappeared",
+			standbyOrgSlug, standbyPassiveHR)
+	}
+	if side, found, _ := unstructured.NestedString(src.Object, "spec", "values", "topology", "side"); found {
+		t.Errorf("#6268: the projection mutated the HOST region's leg %s/%s (topology.side=%q) — "+
+			"it must be additive in the secondary region only",
+			standbyOrgSlug, standbyPassiveHR, side)
+	}
+}
+
+// TestReconcileOrgAppStandby_RefusesToDeliverWhenTheReplicaRegionIsUnknowable.
+//
+// The secondary region's nodes carry no `openova.io/region` label, so
+// `topology.replica.region` cannot be resolved. The chart marks it `required`
+// precisely because rendering it empty emits `openova.io/region In [""]`, which
+// no node can satisfy — an unschedulable-forever follower under a successful
+// install.
+//
+// Fail-closed is the only safe direction: writing the leg anyway would put a
+// primary-shaped object in the standby's region. So nothing is written, and the
+// failure is logged rather than smoothed over.
+//
+// PASSES on origin/main (nothing is written there either) — this is a
+// constraint on the fix, not a description of the defect.
+func TestReconcileOrgAppStandby_RefusesToDeliverWhenTheReplicaRegionIsUnknowable(t *testing.T) {
+	t.Setenv("SOVEREIGN_FQDN", "hw296.omani.works")
+
+	org := standbyOrgCR(standbyOrgSlug, standbyOrgParent)
+	hostDyn := fakeDynForOrgAppStandby(t, org)
+	secDyn := fakeDynForOrgAppStandby(t, org)
+
+	seedCatalogChartSource(t, hostDyn)
+	// Deliberately NO seedRegionNodes: the region label is unknowable.
+	seedFanoutHR(t, hostDyn, fanoutHR(standbyActiveHR, standbyOrgSlug, standbyAppName,
+		"rtz-A", "active", "active-hot-standby", nil))
+	seedFanoutHR(t, hostDyn, fanoutHR(standbyPassiveHR, standbyOrgSlug, standbyAppName,
+		"rtz-B", "passive", "active-hot-standby", map[string]any{
+			"_openova_standby": true,
+			"topology": map[string]any{
+				"mode":    "active-hot-standby",
+				"primary": map[string]any{"region": "hw-me-east-215-a-rtz-prod"},
+			},
+		}))
+
+	h := newStandbyHandler(t, hostDyn, secDyn)
+	h.reconcileOrgConsoleTLSOnce(context.Background())
+
+	if hr, ok := getHR(t, secDyn, standbyOrgSlug, standbyPassiveHR); ok {
+		region, _, _ := unstructured.NestedString(hr.Object, "spec", "values", "topology", "replica", "region")
+		t.Errorf("#6268: a standby leg was delivered into a region whose own nodes carry no "+
+			"openova.io/region label (topology.replica.region=%q) — the chart pins the "+
+			"follower's required nodeAffinity on that value, so this renders a follower no "+
+			"node can ever schedule while the HelmRelease reports install succeeded. Refusing "+
+			"to write is the only safe direction", region)
 	}
 }
 

--- a/products/catalyst/bootstrap/api/internal/handler/org_app_standby_regions_6268_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_app_standby_regions_6268_test.go
@@ -1,0 +1,621 @@
+// org_app_standby_regions_6268_test.go — #6268 / UAT row 60.
+//
+// Every test here drives ONLY pre-existing entry points (reconcileOrgConsoleTLSOnce,
+// newReconcileHandler, newConsoleTLSHandlerWithCore) and declares its own GVRs,
+// so the file COMPILES UNCHANGED against origin/main and the failures it reports
+// there are RUNTIME failures describing the live defect — never build errors
+// about a symbol the fix introduces. That is what makes the red/green
+// transition evidence rather than tautology.
+//
+//	lock 1  TestReconcileOrgAppStandby_SecondaryRegionCarriesTheHotStandbyLeg
+//	        RED on origin/main. Six assertions, each a DISTINCT property, and
+//	        ordered so the substantive one (does the leg exist in region B at
+//	        all?) is evaluated BEFORE the cheaper label/marker checks — a
+//	        producer that stamped the right labels on nothing must not be able
+//	        to short-circuit ahead of the check that matters.
+//
+//	        Each was proven falsifiable INDIVIDUALLY by mutating one behaviour
+//	        of the producer at a time: keeping `replicas` reddens assertion 2
+//	        alone, skipping the chart-source projection reddens 4 alone, and
+//	        dropping the delivery label reddens 5 alone. That sweep is also what
+//	        found a VACUOUS assertion in an earlier draft of this file — a
+//	        "carries no spec.kubeConfig" check that stayed green when the strip
+//	        was removed, because this fixture never had one. It now lives in
+//	        lock 7 on a fixture that does.
+//
+//	lock 2  TestReconcileOrgAppStandby_ColdStandbyKeepsItsScaleDown
+//	        RED on origin/main (the leg is absent). Pins the half of lock 1
+//	        that a blanket "always drop replicas" would break: an
+//	        active-passive standby is COLD by definition and keeps replicas: 0.
+//
+//	lock 3  TestReconcileOrgAppStandby_SameRegionStandbyIsNotProjected
+//	        PASSES on origin/main AND with the fix. The control against
+//	        "project every passive leg": a standby whose cluster ID shares the
+//	        active leg's region has no cross-region delivery to make.
+//
+//	lock 4  TestReconcileOrgAppStandby_PassiveWithNoActiveLegIsNotProjected
+//	        PASSES on both. A placement with no primary has no derivable host
+//	        region; guessing one would project a standby of nothing.
+//
+//	lock 5  TestReconcileOrgAppStandby_SingleRegionWritesNothingExtra
+//	        PASSES on both. Anti-suppression: a single-region Sovereign gains
+//	        no objects, while the console surface is still produced.
+//
+//	lock 6  TestReconcileOrgAppStandby_ReapsAProjectionWhoseSourceLegIsGone
+//	        RED on origin/main. Level-triggered in the delete direction too.
+//
+//	lock 7  TestReconcileOrgAppStandby_DeliveredLegCarriesNoKubeConfig
+//	        RED on origin/main, and RED against a producer that copies the spec
+//	        verbatim. Uses a vCluster-placed NON-CNPG app, which is the only
+//	        shape that HAS a kubeConfig to strip.
+package handler
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+)
+
+// GVRs declared LOCALLY, not imported from the fix, so this file has no
+// compile-time dependency on anything the fix adds.
+var (
+	standbyHRGVR   = schema.GroupVersionResource{Group: "helm.toolkit.fluxcd.io", Version: "v2", Resource: "helmreleases"}
+	standbyRepoGVR = schema.GroupVersionResource{Group: "source.toolkit.fluxcd.io", Version: "v1", Resource: "helmrepositories"}
+	standbySvcGVR  = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "services"}
+)
+
+const (
+	standbyOrgSlug   = "walkfour"
+	standbyOrgParent = "omani.homes"
+	standbyAppName   = "r60fresh"
+	standbyActiveHR  = "r60fresh-rtz-a"
+	standbyPassiveHR = "r60fresh-rtz-b"
+	standbyChartRepo = "openova-catalog"
+	standbyRepoNS    = "flux-system"
+)
+
+// fakeDynForOrgAppStandby is the console-reconcile fake plus the Flux
+// HelmRelease + HelmRepository GVRs, so a region cluster can hold per-cluster
+// fan-out HelmReleases and the chart source they resolve through.
+func fakeDynForOrgAppStandby(t *testing.T, orgs ...*unstructured.Unstructured) *dynamicfake.FakeDynamicClient {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+		map[schema.GroupVersionResource]string{
+			certificateGVR:    "CertificateList",
+			consoleGatewayGVR: "GatewayList",
+			httpRouteGVR:      "HTTPRouteList",
+			organizationGVR(): "OrganizationList",
+			namespacesGVR():   "NamespaceList",
+			standbySvcGVR:     "ServiceList",
+			standbyHRGVR:      "HelmReleaseList",
+			standbyRepoGVR:    "HelmRepositoryList",
+		})
+	ctx := context.Background()
+	gw := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "gateway.networking.k8s.io/v1",
+		"kind":       "Gateway",
+		"metadata": map[string]any{
+			"name":      consoleGatewayName,
+			"namespace": consoleGatewayNamespace,
+		},
+		"spec": map[string]any{
+			"gatewayClassName": "cilium",
+			"listeners": []any{
+				map[string]any{"name": "console-https", "port": int64(8443), "protocol": "HTTPS", "hostname": "*.hw296.omani.works"},
+				map[string]any{"name": "console-http", "port": int64(8080), "protocol": "HTTP", "hostname": "*.hw296.omani.works"},
+			},
+		},
+	}}
+	if _, err := dyn.Resource(consoleGatewayGVR).Namespace(consoleGatewayNamespace).
+		Create(ctx, gw, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("seed console gateway: %v", err)
+	}
+	for _, o := range orgs {
+		if _, err := dyn.Resource(organizationGVR()).Create(ctx, o, metav1.CreateOptions{}); err != nil {
+			t.Fatalf("seed Organization CR %s: %v", o.GetName(), err)
+		}
+	}
+	return dyn
+}
+
+// fanoutHR builds one per-cluster fan-out HelmRelease exactly as the
+// application-controller renders it — the shape read LIVE off hw296
+// (dep e689e3b34a75fdec) for walkfour/r60fresh-rtz-b.
+func fanoutHR(name, ns, app, cluster, role, topology string, values map[string]any) *unstructured.Unstructured {
+	obj := map[string]any{
+		"apiVersion": "helm.toolkit.fluxcd.io/v2",
+		"kind":       "HelmRelease",
+		"metadata": map[string]any{
+			"name":      name,
+			"namespace": ns,
+			"labels": map[string]any{
+				"catalyst.openova.io/app":          app,
+				"catalyst.openova.io/cluster":      cluster,
+				"catalyst.openova.io/role":         role,
+				"catalyst.openova.io/topology":     topology,
+				"catalyst.openova.io/organization": ns,
+			},
+		},
+		"spec": map[string]any{
+			"interval": "600s",
+			"chart": map[string]any{
+				"spec": map[string]any{
+					"chart":   "bp-postgres",
+					"version": "0.2.23",
+					"sourceRef": map[string]any{
+						"kind":      "HelmRepository",
+						"name":      standbyChartRepo,
+						"namespace": standbyRepoNS,
+					},
+				},
+			},
+		},
+	}
+	if values != nil {
+		obj["spec"].(map[string]any)["values"] = values
+	}
+	return &unstructured.Unstructured{Object: obj}
+}
+
+// seedCatalogChartSource writes the HelmRepository a Catalog-provisioned app's
+// HelmRelease resolves through. Region A of hw296 has it; region B does not,
+// which is why the projection has to carry it.
+func seedCatalogChartSource(t *testing.T, dyn *dynamicfake.FakeDynamicClient) {
+	t.Helper()
+	repo := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "source.toolkit.fluxcd.io/v1",
+		"kind":       "HelmRepository",
+		"metadata":   map[string]any{"name": standbyChartRepo, "namespace": standbyRepoNS},
+		"spec": map[string]any{
+			"type":     "oci",
+			"url":      "oci://ghcr.io/openova-io",
+			"interval": "10m",
+		},
+	}}
+	if _, err := dyn.Resource(standbyRepoGVR).Namespace(standbyRepoNS).
+		Create(context.Background(), repo, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("seed HelmRepository %s/%s: %v", standbyRepoNS, standbyChartRepo, err)
+	}
+}
+
+func seedFanoutHR(t *testing.T, dyn *dynamicfake.FakeDynamicClient, hr *unstructured.Unstructured) {
+	t.Helper()
+	if _, err := dyn.Resource(standbyHRGVR).Namespace(hr.GetNamespace()).
+		Create(context.Background(), hr, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("seed HelmRelease %s/%s: %v", hr.GetNamespace(), hr.GetName(), err)
+	}
+}
+
+func getHR(t *testing.T, dyn *dynamicfake.FakeDynamicClient, ns, name string) (*unstructured.Unstructured, bool) {
+	t.Helper()
+	hr, err := dyn.Resource(standbyHRGVR).Namespace(ns).Get(context.Background(), name, metav1.GetOptions{})
+	if err != nil {
+		return nil, false
+	}
+	return hr, true
+}
+
+func countHRs(t *testing.T, dyn *dynamicfake.FakeDynamicClient, ns string) int {
+	t.Helper()
+	list, err := dyn.Resource(standbyHRGVR).Namespace(ns).List(context.Background(), metav1.ListOptions{})
+	if err != nil || list == nil {
+		return 0
+	}
+	return len(list.Items)
+}
+
+// standbyOrgCR — a funnel Org CR on hw296's Sovereign FQDN.
+func standbyOrgCR(slug, parent string) *unstructured.Unstructured {
+	org := funnelOrgCR(slug, parent)
+	_ = unstructured.SetNestedField(org.Object, "hw296.omani.works", "spec", "sovereignRef")
+	return org
+}
+
+func newStandbyHandler(t *testing.T, hostDyn, secDyn *dynamicfake.FakeDynamicClient) *Handler {
+	t.Helper()
+	hostCore := k8sfake.NewSimpleClientset(
+		issuedOrgWildcardSecret("org-wildcard-tls-" + standbyOrgSlug + "-omani-homes"))
+	secCore := k8sfake.NewSimpleClientset()
+	h := newReconcileHandler(t, hostDyn, secDyn, hostCore, secCore)
+	h.SetOrganizationDeps(OrganizationDeps{OTECHFQDN: "hw296.omani.works"})
+	return h
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// lock 1 — the substantive one.
+// ─────────────────────────────────────────────────────────────────────────────
+
+// TestReconcileOrgAppStandby_SecondaryRegionCarriesTheHotStandbyLeg reproduces
+// hw296 walkfour/r60fresh exactly: an active-hot-standby Application whose two
+// fan-out HelmReleases BOTH sit in region A, and a region B that has neither the
+// Org namespace nor the leg nor the chart source.
+//
+// The assertions are ordered deliberately. Assertion 1 is the one the row is
+// about — does the standby leg EXIST in the region its placement names — and it
+// runs before every cheaper check, so a producer that stamped the right labels
+// on nothing could not short-circuit ahead of it. (That ordering trap is real:
+// a label check placed first would have let the `replicas` assertion go
+// unevaluated and therefore unproven.)
+//
+// On origin/main NOTHING writes a per-Org HelmRelease into a secondary region,
+// so assertion 1 fails and every later one fails with it.
+func TestReconcileOrgAppStandby_SecondaryRegionCarriesTheHotStandbyLeg(t *testing.T) {
+	t.Setenv("SOVEREIGN_FQDN", "hw296.omani.works") // chroot gate for the fan-out
+
+	org := standbyOrgCR(standbyOrgSlug, standbyOrgParent)
+	hostDyn := fakeDynForOrgAppStandby(t, org)
+	secDyn := fakeDynForOrgAppStandby(t, org)
+
+	seedCatalogChartSource(t, hostDyn)
+	seedFanoutHR(t, hostDyn, fanoutHR(standbyActiveHR, standbyOrgSlug, standbyAppName,
+		"rtz-A", "active", "active-hot-standby", map[string]any{
+			"topology": map[string]any{"mode": "active-hot-standby"},
+		}))
+	// The live standby leg, byte-shaped: the COLD overlay on a HOT posture.
+	seedFanoutHR(t, hostDyn, fanoutHR(standbyPassiveHR, standbyOrgSlug, standbyAppName,
+		"rtz-B", "passive", "active-hot-standby", map[string]any{
+			"_openova_standby": true,
+			"replicas":         int64(0),
+			"topology":         map[string]any{"mode": "active-hot-standby"},
+		}))
+
+	h := newStandbyHandler(t, hostDyn, secDyn)
+	h.reconcileOrgConsoleTLSOnce(context.Background())
+
+	// 1. SUBSTANTIVE — the standby leg exists in region B at all. This is the
+	//    whole of UAT row 60's write half; on hw296 region-b walkfour holds
+	//    ZERO HelmReleases and the namespace does not exist.
+	hr, ok := getHR(t, secDyn, standbyOrgSlug, standbyPassiveHR)
+	if !ok {
+		t.Fatalf("#6268: the secondary region carries NO HelmRelease %s/%s — the standby leg "+
+			"of an active-hot-standby Application never leaves the primary region, so the "+
+			"Application is single-region in fact while its placement says two",
+			standbyOrgSlug, standbyPassiveHR)
+	}
+
+	// 2. it is HOT — a streaming replica, not a rebuild-on-failover shell.
+	//    `replicas: 0` is the COLD (active-passive) semantic and a workload
+	//    scaled to zero cannot stream.
+	if _, found, _ := unstructured.NestedFieldNoCopy(hr.Object, "spec", "values", "replicas"); found {
+		t.Errorf("#6268: the delivered standby leg %s/%s still carries `replicas` in its values — "+
+			"an active-hot-standby standby is DEFINED by streaming from the primary and a "+
+			"replica scaled to zero cannot stream", standbyOrgSlug, standbyPassiveHR)
+	}
+
+	// 3. it is still marked as the standby. Charts whose standby semantic is a
+	//    boolean rather than an integer (CNPG `replica.enabled`) read this and
+	//    nothing else; dropping it would turn the leg into a second primary.
+	if v, found, _ := unstructured.NestedBool(hr.Object, "spec", "values", "_openova_standby"); !found || !v {
+		t.Errorf("#6268: the delivered standby leg %s/%s lost its `_openova_standby` marker "+
+			"(found=%v value=%v) — without it a boolean-standby chart installs a second PRIMARY "+
+			"in the secondary region", standbyOrgSlug, standbyPassiveHR, found, v)
+	}
+
+	// (The kubeConfig-stripping property is asserted in lock 7, on a fixture
+	// that HAS one. Asserting it here would be vacuous: bp-postgres carries the
+	// bp-cnpg companion label, so #4282 renders this leg with no kubeConfig at
+	// all — the assertion could not fail no matter what the producer did.)
+
+	// 4. the chart source it resolves through exists in that region. hw296's
+	//    region B holds 64 bp-* HelmRepositories but NOT `openova-catalog`, so
+	//    without this the leg would exist and install nothing — a leg that
+	//    LOOKS delivered, which is worse than an absent one.
+	if _, err := secDyn.Resource(standbyRepoGVR).Namespace(standbyRepoNS).
+		Get(context.Background(), standbyChartRepo, metav1.GetOptions{}); err != nil {
+		t.Errorf("#6268: the secondary region has no HelmRepository %s/%s (%v) — the standby "+
+			"HelmRelease resolves no chart there and installs nothing while reporting as present",
+			standbyRepoNS, standbyChartRepo, err)
+	}
+
+	// 5. the delivery is RECORDED on the object. #6287 stamps
+	//    `local-undelivered` on the host-region copy precisely because it never
+	//    left; a reader must be able to tell the two apart.
+	if got := hr.GetLabels()["catalyst.openova.io/standby-delivery"]; got != "remote" {
+		t.Errorf("#6268: delivered standby leg %s/%s carries standby-delivery=%q, want %q — "+
+			"a delivered standby must be distinguishable from one that installed beside its "+
+			"active peer", standbyOrgSlug, standbyPassiveHR, got, "remote")
+	}
+
+	// 6. the host region is untouched: the projection is ADDITIVE, and the
+	//    active leg is still the single authority there.
+	if n := countHRs(t, hostDyn, standbyOrgSlug); n != 2 {
+		t.Errorf("#6268: host region now has %d HelmReleases in ns %s, want the 2 it started "+
+			"with — the projection must not mutate the host region's fan-out", n, standbyOrgSlug)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// lock 2 — the posture the hot fix must NOT swallow.
+// ─────────────────────────────────────────────────────────────────────────────
+
+// TestReconcileOrgAppStandby_ColdStandbyKeepsItsScaleDown pins the other half of
+// lock 1's assertion 2. `active-passive` is the COLD posture by definition —
+// rebuild-on-failover — so its standby must arrive in the secondary region with
+// `replicas: 0` intact. A fix that dropped `replicas` unconditionally would pass
+// lock 1 and fail here; one that never dropped it would fail lock 1 and pass
+// here. Only the posture-aware fix passes both.
+//
+// RED on origin/main for the same reason as lock 1: the leg is absent entirely.
+func TestReconcileOrgAppStandby_ColdStandbyKeepsItsScaleDown(t *testing.T) {
+	t.Setenv("SOVEREIGN_FQDN", "hw296.omani.works")
+
+	org := standbyOrgCR(standbyOrgSlug, standbyOrgParent)
+	hostDyn := fakeDynForOrgAppStandby(t, org)
+	secDyn := fakeDynForOrgAppStandby(t, org)
+
+	seedCatalogChartSource(t, hostDyn)
+	seedFanoutHR(t, hostDyn, fanoutHR(standbyActiveHR, standbyOrgSlug, standbyAppName,
+		"rtz-A", "active", "active-passive", nil))
+	seedFanoutHR(t, hostDyn, fanoutHR(standbyPassiveHR, standbyOrgSlug, standbyAppName,
+		"rtz-B", "passive", "active-passive", map[string]any{
+			"_openova_standby": true,
+			"replicas":         int64(0),
+		}))
+
+	h := newStandbyHandler(t, hostDyn, secDyn)
+	h.reconcileOrgConsoleTLSOnce(context.Background())
+
+	hr, ok := getHR(t, secDyn, standbyOrgSlug, standbyPassiveHR)
+	if !ok {
+		t.Fatalf("#6268: the secondary region carries NO HelmRelease %s/%s — a cold standby "+
+			"still has to exist in the region its placement names", standbyOrgSlug, standbyPassiveHR)
+	}
+	got, found, _ := unstructured.NestedInt64(hr.Object, "spec", "values", "replicas")
+	if !found || got != 0 {
+		t.Errorf("#6268: active-passive standby %s/%s arrived with replicas=%d found=%v, want 0 — "+
+			"a COLD standby is rebuild-on-failover and must not be booted; only the "+
+			"active-hot-standby posture drops the scale-down",
+			standbyOrgSlug, standbyPassiveHR, got, found)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// lock 3 — the control against "project every passive leg".
+// ─────────────────────────────────────────────────────────────────────────────
+
+// TestReconcileOrgAppStandby_SameRegionStandbyIsNotProjected. Both legs name a
+// cluster in the SAME region (`rtz-A`), which is a same-region standby: there is
+// no cross-region delivery to make and copying it into another region would
+// invent a placement the Application never declared.
+//
+// PASSES on origin/main (nothing is projected there at all) AND with the fix.
+// Its job is to constrain the fix, not to describe the defect: a producer that
+// projected on `role == passive` alone would pass lock 1 and fail this.
+func TestReconcileOrgAppStandby_SameRegionStandbyIsNotProjected(t *testing.T) {
+	t.Setenv("SOVEREIGN_FQDN", "hw296.omani.works")
+
+	org := standbyOrgCR(standbyOrgSlug, standbyOrgParent)
+	hostDyn := fakeDynForOrgAppStandby(t, org)
+	secDyn := fakeDynForOrgAppStandby(t, org)
+
+	seedCatalogChartSource(t, hostDyn)
+	seedFanoutHR(t, hostDyn, fanoutHR("samereg-rtz-a", standbyOrgSlug, "samereg",
+		"rtz-A", "active", "active-hot-standby", nil))
+	seedFanoutHR(t, hostDyn, fanoutHR("samereg-rtz-a-2", standbyOrgSlug, "samereg",
+		"rtz-A", "passive", "active-hot-standby", map[string]any{"replicas": int64(0)}))
+
+	h := newStandbyHandler(t, hostDyn, secDyn)
+	h.reconcileOrgConsoleTLSOnce(context.Background())
+
+	if n := countHRs(t, secDyn, standbyOrgSlug); n != 0 {
+		t.Errorf("#6268: a SAME-region standby was projected into a secondary region "+
+			"(%d HelmReleases in ns %s, want 0) — both legs name a cluster in one region, so "+
+			"there is no cross-region delivery to make", n, standbyOrgSlug)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// lock 4 — a placement with no primary.
+// ─────────────────────────────────────────────────────────────────────────────
+
+// TestReconcileOrgAppStandby_PassiveWithNoActiveLegIsNotProjected. #6287 fixed a
+// renderer fallback that rendered TWO standbys and NO primary for a
+// multi-cluster variant with no Roles map. If such an Application still reaches
+// this producer, its host region is not derivable from its own legs — so the
+// standby is NOT projected and the Application is named in the log rather than
+// having a region guessed for it.
+//
+// PASSES on both trees; it constrains the fix.
+func TestReconcileOrgAppStandby_PassiveWithNoActiveLegIsNotProjected(t *testing.T) {
+	t.Setenv("SOVEREIGN_FQDN", "hw296.omani.works")
+
+	org := standbyOrgCR(standbyOrgSlug, standbyOrgParent)
+	hostDyn := fakeDynForOrgAppStandby(t, org)
+	secDyn := fakeDynForOrgAppStandby(t, org)
+
+	seedCatalogChartSource(t, hostDyn)
+	seedFanoutHR(t, hostDyn, fanoutHR("noprimary-rtz-a", standbyOrgSlug, "noprimary",
+		"rtz-A", "passive", "active-hot-standby", map[string]any{"replicas": int64(0)}))
+	seedFanoutHR(t, hostDyn, fanoutHR("noprimary-rtz-b", standbyOrgSlug, "noprimary",
+		"rtz-B", "passive", "active-hot-standby", map[string]any{"replicas": int64(0)}))
+
+	h := newStandbyHandler(t, hostDyn, secDyn)
+	h.reconcileOrgConsoleTLSOnce(context.Background())
+
+	if n := countHRs(t, secDyn, standbyOrgSlug); n != 0 {
+		t.Errorf("#6268: an Application with NO active leg had a standby projected anyway "+
+			"(%d HelmReleases in ns %s, want 0) — there is no primary for it to be a standby OF, "+
+			"and picking a host region by guess would make the guess authoritative",
+			n, standbyOrgSlug)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// lock 5 — anti-suppression.
+// ─────────────────────────────────────────────────────────────────────────────
+
+// TestReconcileOrgAppStandby_SingleRegionWritesNothingExtra. On a Sovereign with
+// no secondary region registered the pass must add nothing at all — while STILL
+// producing the Org's console surface. A patch that disabled the reconcile loop
+// outright would satisfy every "want 0" above and fail this.
+//
+// PASSES on origin/main AND with the fix.
+func TestReconcileOrgAppStandby_SingleRegionWritesNothingExtra(t *testing.T) {
+	// A real single-region Sovereign IS a chroot, so the no-op below is
+	// attributable to "no secondary region registered", not to a closed gate.
+	t.Setenv("SOVEREIGN_FQDN", "hw296.omani.works")
+
+	org := standbyOrgCR(standbyOrgSlug, standbyOrgParent)
+	dyn := fakeDynForOrgAppStandby(t, org)
+	core := k8sfake.NewSimpleClientset(
+		issuedOrgWildcardSecret("org-wildcard-tls-" + standbyOrgSlug + "-omani-homes"))
+
+	seedCatalogChartSource(t, dyn)
+	seedFanoutHR(t, dyn, fanoutHR(standbyActiveHR, standbyOrgSlug, standbyAppName,
+		"rtz-A", "active", "active-hot-standby", nil))
+	seedFanoutHR(t, dyn, fanoutHR(standbyPassiveHR, standbyOrgSlug, standbyAppName,
+		"rtz-B", "passive", "active-hot-standby", map[string]any{
+			"_openova_standby": true, "replicas": int64(0),
+		}))
+
+	// No k8sCache => orgConsoleTLSTargets yields the host region only.
+	h := newConsoleTLSHandlerWithCore(t, dyn, core)
+	h.SetOrganizationDeps(OrganizationDeps{OTECHFQDN: "hw296.omani.works"})
+	h.reconcileOrgConsoleTLSOnce(context.Background())
+
+	// a. the console surface is still produced.
+	if _, route := consoleSurfacePresent(t, dyn, "console."+standbyOrgSlug+"."+standbyOrgParent); route == "" {
+		t.Errorf("#6268: single-region pass produced no console HTTPRoute — the standby half " +
+			"must not disable the console half")
+	}
+	// b. exactly the two seeded HelmReleases; no third, no mutation in place.
+	if n := countHRs(t, dyn, standbyOrgSlug); n != 2 {
+		t.Errorf("#6268: single-region Sovereign has %d HelmReleases in ns %s, want exactly 2 "+
+			"(the seeded fan-out) — the cross-region projection must be a no-op without a "+
+			"secondary region", n, standbyOrgSlug)
+	}
+	// c. the standby leg's own values are untouched in the host region: while
+	//    it is undelivered it stays COLD on purpose (#6287) — booting it hot
+	//    beside its active peer would install a duplicate primary.
+	hr, ok := getHR(t, dyn, standbyOrgSlug, standbyPassiveHR)
+	if !ok {
+		t.Fatalf("#6268: the host region's own standby leg %s/%s disappeared",
+			standbyOrgSlug, standbyPassiveHR)
+	}
+	if got, found, _ := unstructured.NestedInt64(hr.Object, "spec", "values", "replicas"); !found || got != 0 {
+		t.Errorf("#6268: the UNDELIVERED host-region standby leg %s/%s was booted "+
+			"(replicas=%d found=%v, want 0) — a standby that never left its primary's cluster "+
+			"must stay inert, or it becomes a second primary",
+			standbyOrgSlug, standbyPassiveHR, got, found)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// lock 7 — the kubeConfig strip, on a fixture that can actually falsify it.
+// ─────────────────────────────────────────────────────────────────────────────
+
+// TestReconcileOrgAppStandby_DeliveredLegCarriesNoKubeConfig.
+//
+// This lock exists because the obvious place for the assertion — lock 1 — could
+// not fail there. `bp-postgres` carries the `bp-cnpg` companion label, so #4282
+// renders its legs with NO kubeConfig at all; a "spec.kubeConfig is absent"
+// check against that fixture passes whether or not the producer strips
+// anything, which is an assertion that cannot fail. Proven, not assumed: a
+// mutation that removed the strip left lock 1 green.
+//
+// So the source leg here is a vCluster-placed, NON-CNPG app — the shape that
+// DOES carry `spec.kubeConfig.secretRef.name: vc-rtz`. That secretRef names a
+// HOST-region Secret; Flux resolves a secretRef from the HelmRelease's own
+// namespace, so carrying it into the secondary region would produce a HelmRelease
+// that can never resolve its own credential. Worse, a kubeConfig that DID
+// resolve would hand ownership of region B's standby back to region A — the
+// design this producer deliberately does not implement.
+//
+// RED on origin/main (the leg is absent), and RED against a producer that
+// copies the spec verbatim.
+func TestReconcileOrgAppStandby_DeliveredLegCarriesNoKubeConfig(t *testing.T) {
+	t.Setenv("SOVEREIGN_FQDN", "hw296.omani.works")
+
+	org := standbyOrgCR(standbyOrgSlug, standbyOrgParent)
+	hostDyn := fakeDynForOrgAppStandby(t, org)
+	secDyn := fakeDynForOrgAppStandby(t, org)
+
+	seedCatalogChartSource(t, hostDyn)
+	seedFanoutHR(t, hostDyn, fanoutHR("vcapp-rtz-a", standbyOrgSlug, "vcapp",
+		"rtz-A", "active", "active-hot-standby", nil))
+	passive := fanoutHR("vcapp-rtz-b", standbyOrgSlug, "vcapp",
+		"rtz-B", "passive", "active-hot-standby", map[string]any{
+			"_openova_standby": true, "replicas": int64(0),
+		})
+	// The G92.1 #2674 vCluster pivot, exactly as the renderer emits it.
+	_ = unstructured.SetNestedMap(passive.Object, map[string]any{
+		"secretRef": map[string]any{"name": "vc-rtz", "key": "config"},
+	}, "spec", "kubeConfig")
+	seedFanoutHR(t, hostDyn, passive)
+
+	h := newStandbyHandler(t, hostDyn, secDyn)
+	h.reconcileOrgConsoleTLSOnce(context.Background())
+
+	hr, ok := getHR(t, secDyn, standbyOrgSlug, "vcapp-rtz-b")
+	if !ok {
+		t.Fatalf("#6268: the secondary region carries NO HelmRelease %s/vcapp-rtz-b — a "+
+			"vCluster-placed app's standby leg must be delivered too", standbyOrgSlug)
+	}
+	if name, found, _ := unstructured.NestedString(hr.Object, "spec", "kubeConfig", "secretRef", "name"); found {
+		t.Errorf("#6268: the delivered standby leg %s/vcapp-rtz-b still carries "+
+			"spec.kubeConfig.secretRef.name=%q — that Secret is a HOST-region object and Flux "+
+			"resolves a secretRef from the HelmRelease's own namespace, so the leg can never "+
+			"resolve its credential in the secondary region; and a kubeConfig that DID resolve "+
+			"would hand ownership of this standby back to the region it exists to survive",
+			standbyOrgSlug, name)
+	}
+	// Control on the same object: stripping kubeConfig must not have taken the
+	// rest of the spec with it.
+	if chart, found, _ := unstructured.NestedString(hr.Object, "spec", "chart", "spec", "chart"); !found || chart != "bp-postgres" {
+		t.Errorf("#6268: the delivered standby leg %s/vcapp-rtz-b lost its chart (%q found=%v) — "+
+			"only the kubeConfig block may be removed", standbyOrgSlug, chart, found)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// lock 6 — the delete direction.
+// ─────────────────────────────────────────────────────────────────────────────
+
+// TestReconcileOrgAppStandby_ReapsAProjectionWhoseSourceLegIsGone. A topology
+// downgrade (active-hot-standby → singleton) or an Application deletion removes
+// the passive leg in the host region. Without a delete pass the projected copy
+// keeps running in the secondary region with nothing left to be a standby of —
+// the orphan class #5364/#5649 exists to prevent.
+//
+// RED on origin/main: nothing reaps it, because nothing knows it is a
+// projection.
+func TestReconcileOrgAppStandby_ReapsAProjectionWhoseSourceLegIsGone(t *testing.T) {
+	t.Setenv("SOVEREIGN_FQDN", "hw296.omani.works")
+
+	org := standbyOrgCR(standbyOrgSlug, standbyOrgParent)
+	hostDyn := fakeDynForOrgAppStandby(t, org)
+	secDyn := fakeDynForOrgAppStandby(t, org)
+
+	// Host region: the Application is now a SINGLETON — one active leg, no
+	// passive leg at all.
+	seedCatalogChartSource(t, hostDyn)
+	seedFanoutHR(t, hostDyn, fanoutHR(standbyActiveHR, standbyOrgSlug, standbyAppName,
+		"rtz-A", "active", "singleton", nil))
+
+	// Secondary region: a previously-projected standby, carrying this
+	// producer's component label.
+	orphan := fanoutHR(standbyPassiveHR, standbyOrgSlug, standbyAppName,
+		"rtz-B", "passive", "active-hot-standby", map[string]any{"_openova_standby": true})
+	labels := orphan.GetLabels()
+	labels["catalyst.openova.io/component"] = "org-app-standby-crossregion"
+	labels["catalyst.openova.io/managed-by"] = "catalyst-api"
+	orphan.SetLabels(labels)
+	seedFanoutHR(t, secDyn, orphan)
+
+	h := newStandbyHandler(t, hostDyn, secDyn)
+	h.reconcileOrgConsoleTLSOnce(context.Background())
+
+	if _, ok := getHR(t, secDyn, standbyOrgSlug, standbyPassiveHR); ok {
+		t.Errorf("#6268: the projected standby %s/%s survived in the secondary region after its "+
+			"source leg was withdrawn in the host region — it keeps running with nothing to be "+
+			"a standby of, and no other teardown path knows about it",
+			standbyOrgSlug, standbyPassiveHR)
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/org_app_surface_mesh_5635_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_app_surface_mesh_5635_test.go
@@ -47,6 +47,12 @@ func fakeDynForOrgAppSurface(t *testing.T, orgs ...*unstructured.Unstructured) *
 			organizationGVR():     "OrganizationList",
 			appSurfaceServicesGVR: "ServiceList",
 			namespacesGVR():       "NamespaceList",
+			// A real Sovereign always has the Flux CRDs; a fake that omits
+			// them models a cluster that does not exist, and the dynamic
+			// fake PANICS (rather than erroring) on a List for an
+			// unregistered list kind. #6268.
+			{Group: "helm.toolkit.fluxcd.io", Version: "v2", Resource: "helmreleases"}:       "HelmReleaseList",
+			{Group: "source.toolkit.fluxcd.io", Version: "v1", Resource: "helmrepositories"}: "HelmRepositoryList",
 		})
 	ctx := context.Background()
 	gw := &unstructured.Unstructured{Object: map[string]any{

--- a/products/catalyst/bootstrap/api/internal/handler/org_console_tls_reconcile.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_console_tls_reconcile.go
@@ -162,6 +162,16 @@ func (h *Handler) reconcileOrgConsoleTLSOnce(ctx context.Context) {
 		// bp-catalyst-edge-routes uses for the platform hosts. No-op on a
 		// single-region Sovereign. See org_app_surface_mesh.go.
 		h.reconcileOrgAppSurfaceAcrossRegions(ctx, deps, rec)
+		// #6268 STANDBY half. The two halves above give a secondary region the
+		// per-Org listener pair and the app ROUTES — the front door. Neither
+		// puts a WORKLOAD there. A Catalog-provisioned `active-hot-standby`
+		// Application's standby leg is rendered as a HelmRelease that lands in
+		// the host region beside its own primary, because nothing writes a
+		// per-Org HelmRelease into a secondary region. This projects that leg
+		// into the region its placement names, where that region's OWN Flux
+		// reconciles it. No-op on a single-region Sovereign. See
+		// org_app_standby_regions.go.
+		h.reconcileOrgAppStandbyAcrossRegions(ctx, deps, rec)
 		reconciled++
 	}
 	if reconciled > 0 {

--- a/products/catalyst/bootstrap/api/internal/handler/org_console_tls_reconcile_5635_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/org_console_tls_reconcile_5635_test.go
@@ -51,6 +51,12 @@ func fakeDynForOrgConsoleReconcile(t *testing.T, orgs ...*unstructured.Unstructu
 		consoleGatewayGVR: "GatewayList",
 		httpRouteGVR:      "HTTPRouteList",
 		organizationGVR(): "OrganizationList",
+		// A real Sovereign always has the Flux CRDs installed; a fake that
+		// omits them models a cluster that does not exist, and the
+		// dynamic fake PANICS (rather than erroring) on a List for an
+		// unregistered list kind. #6268.
+		{Group: "helm.toolkit.fluxcd.io", Version: "v2", Resource: "helmreleases"}:       "HelmReleaseList",
+		{Group: "source.toolkit.fluxcd.io", Version: "v1", Resource: "helmrepositories"}: "HelmRepositoryList",
 	}
 	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToList)
 	ctx := context.Background()


### PR DESCRIPTION
## The missing producer, built

UAT row 60 is red because **nothing writes a per-Org standby HelmRelease into a secondary region.** Measured on hw296 (dep `e689e3b34a75fdec`), Org `walkfour`, app `r60fresh`:

| | |
|---|---|
| region-a `walkfour/r60fresh-rtz-a` | `role=active cluster=rtz-A` |
| region-a `walkfour/r60fresh-rtz-b` | `role=passive cluster=rtz-B`, `spec.kubeConfig` **absent** |
| region-b `walkfour` | the Namespace **does not exist** |
| region-b HelmReleases for the app | **zero** |

So the standby installs beside its own primary, scaled to zero, and `status.regions` honestly reports region-b `ready:0 replicas:0`.

#6287 fixed the two renderer defects and deliberately left an **undelivered** leg cold — booting it hot in region A would install a duplicate primary. That was right, and it is why the row did not move: `clusterregistry.Resolver.RemoteRegionSecrets` has no producer, and the application-controller has no secondary-region writer at all.

## Where it goes, and why not the application-controller

catalyst-api is the one process that holds a per-region client (`orgConsoleTLSTargets`), and it **already** projects per-Org Namespaces, ClusterMesh Service stubs and app HTTPRoutes into region B through that seam (#5635 — hw296 region B carries `walkone`…`walkfive` labelled `catalyst.openova.io/component=org-app-crossregion`). The org-controller creates each Org's Flux loop through its own single-cluster client, so a secondary region has neither the per-Org GitRepository nor the tree.

This adds the **workload** half on the same ticker, the same clients — **no new RBAC, no chart change, no chart-version lockstep.**

Per Org, per pass, for every **cross-region** standby leg:

- ensure the Org boundary Namespace in each secondary region;
- project the `HelmRepository` the leg's chart resolves through — hw296 region B holds 64 `bp-*` sources but **not** `openova-catalog`, so without this the leg would exist and install nothing, a leg that *looks* delivered;
- upsert the HelmRelease there: drop the cold `replicas: 0` overlay when the posture is `active-hot-standby`, **keep** it when `active-passive`, keep `_openova_standby` in both, strip `spec.kubeConfig`, stamp `catalyst.openova.io/standby-delivery: remote`, and stamp the split-side contract (below);
- reap a projection whose source leg is gone.

Region B's **own** Flux reconciles it — helm-controller Running, `bootstrap-kit` Kustomization Ready, `cnpg-system/cnpg-cloudnative-pg` with `clusters.postgresql.cnpg.io` registered, all read live.

## The second commit: the delivered leg must render the REPLICA half

Found while verifying what the projected HelmRelease would actually *install* — and it is the difference between a fix and a new defect.

`_openova_standby` is **not** what selects a follower. bp-postgres picks its half from `topology.side` (`_helpers.tpl` `bp-postgres.side` / `.renderReplicaHalf`), and `cluster.yaml:49` hardcodes `openova.io/cnpg-role: primary` on the half it renders. A leg projected with the source values verbatim therefore renders a **second primary** in the standby's region — pinned by *required* nodeAffinity to `topology.primary.region`, which no node there carries, so it is unschedulable forever while the HelmRelease reports install succeeded. That is the **#5639 shape reached from a new direction**, and it is strictly worse than the leg being absent.

`topology.replica.region` is read from the **target region's own nodes** (`openova.io/region`), never derived from a name: the bridge Secret's region key is `me-east-215-b-1` while the node label is `hw-me-east-215-b-rtz-prod`. A name-derived value would be a guess against a label, and a wrong guess is invisible — which is exactly why the chart marks the key `required`. A label read off a live node cannot produce that shape.

Unresolvable ⇒ the leg is **not written**. Fail-closed is the only safe direction when the failure mode of writing anyway is a primary-shaped object in the standby's region.

The overlay is applied **only** when the source values already declare `topology.mode: active-hot-standby` — the chart saying it speaks this vocabulary. Stamping a side onto a chart that has said nothing about topology would invent a contract on its behalf.

## The alternative that is deliberately not built

Stamping a remote-region kubeconfig on the leg and leaving the object in region A is **rejected, not skipped**: it makes region A the owner of region B's standby, so a region-A outage freezes it during exactly the outage it exists for. That is also why the projected object carries no `kubeConfig` — it is already *in* the region it targets, and the source leg's `vc-rtz` secretRef names a host-region Secret Flux could never resolve there.

## #4282 narrowed, not deleted

Its warrant is about **vClusters** ("a vCluster apiserver registers no `postgresql.cnpg.io` CRD"), but it nilled the kubeConfig seam for the whole Application — including a cross-region leg, whose target is a different region's **host** cluster, which does run CNPG. It now suppresses the same-region vCluster pivot only. A matched pair of tests pins both halves so neither can be satisfied by weakening the other.

## Vacuity proof

9 locks, in the sibling #5635 idiom: they declare their own GVRs and drive only pre-existing entry points, so the file **compiles unchanged against `origin/main`** and its failures there are runtime failures describing the defect.

- **RED on origin/main:** locks 1, 2, 6, 7, 8.
- **PASS on both** (constraints on the fix, not descriptions of the defect): 3 same-region standby not projected, 4 no-primary placement not projected, 5 single-region Sovereign unchanged while the console surface is still produced, 9 refuse-to-deliver when the replica region is unknowable.

Every assertion was proven falsifiable **individually**, by mutating one producer behaviour at a time:

| mutation | reddens |
|---|---|
| hot standby keeps `replicas: 0` | lock 1 assertion 2, alone |
| chart source not projected | lock 1 assertion 4, alone |
| delivery label not stamped | lock 1 assertion 5, alone |
| `kubeConfig` not stripped | lock 7, alone |
| split-side overlay removed | lock 8 |
| unresolvable region defaulted instead of refused | lock 9, alone |

That sweep did real work twice:

1. It found a **vacuous assertion** — a "carries no `spec.kubeConfig`" check that stayed green when the strip was removed, because `bp-postgres` carries the `bp-cnpg` companion label and #4282 renders its legs with no kubeConfig at all. It now lives in lock 7 on a vCluster-placed non-CNPG fixture that **does** have one.
2. It caught a **mis-targeted mutation of my own**: the first attempt at the lock-9 probe patched the "no node carries the label" branch while that fixture takes the "cluster reports no nodes" branch, so it proved nothing. Re-run against the branch actually taken, lock 9 reddens alone.

The substantive check (does the leg exist in region B?) is ordered ahead of the label checks so nothing can short-circuit past it.

Two sibling test fakes gain the Flux list kinds — they modelled a cluster with no Flux CRDs, which no Sovereign is, and the dynamic fake panics rather than errors on a List for an unregistered kind.

## Left unchanged, on purpose

`mergeValues` in `core/controllers/pkg/render/manifests.go` carries the same hot/cold blindness on the legacy per-region path. This implementation does not route through it, so it is left unchanged rather than changed blind.

## What this does NOT close

Row 60's clause has two halves. This closes the **pair** half: the placement read path's pod-occupancy term is multi-region (`derivePlacementTargets` iterates `h.k8sCache.Clusters()` and reads pods), so a real follower running in region B produces two targets with non-empty `cluster` and pattern `active-hot-standby`.

The **armed Switchover** half is a second, downstream gap and is **not** fixed here. Measured on hw296:

- `walkfour/dr-r60fresh` — no `spec.cnpgPair`, and status carries no `standbyAvailable`;
- `shared-data/dr-shared-pg` (the green control) — has **both**, plus a `StandbyAvailable` condition.

`enrichReplicationStatus` therefore leaves `replicaPromotable` at its zero value `false` for a Catalog app, and `TopologyTab` disables the control with *"the replica is not promotable"*. The lever: `h.k8sCache` already caches `cnpgcluster` across **every** registered cluster, while `augmentReplicationStandbyStatus` resolves the pair through the region-A-only `sovereignDynamicClient`.

Refs #6268 #3375
