### PR TITLE
deploy: bump catalyst-api image to 98f4495 (delivers the region-B standby producer, #6268)

### DIFF
--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -554,7 +554,13 @@ images:
     # new chart emits only the new name, so handoverSigner never
     # initialises and /api/v1/auth/pin/issue returns 503 "handover
     # signer unavailable". ff778a36 reads both names with fallback.
-    tag: "031db43"
+    # 2026-08-14 (#6268): bumped 031db43 -> 98f4495 to DELIVER the region-B
+    # per-Org standby producer (PR #6291). Until this pin moves, UAT row 60
+    # cannot be walked against the fix: the running image is 031db43 and
+    # `git merge-base --is-ancestor 98f44954b 031db43` is FALSE. catalystUi is
+    # deliberately NOT bumped with it — the UI carries no part of this change,
+    # and moving a pin whose component did not change is an unverified rollout.
+    tag: "98f4495"
   catalystUi:
     tag: "031db43"
   # 2026-08-11 (#5451): marketplaceApi / console / admin were ALL frozen at


### PR DESCRIPTION
Delivers the region-B per-Org standby producer (PR #6291, merged as `98f44954b`) to every Sovereign.

The deploy-bot bumped the **application-controller** for this merge (`82c1d2119`) but not catalyst-api — and the producer lives in **catalyst-api**. Without this pin the fix is merged and undeployed.

## Verified before bumping, not assumed

- `ghcr.io/openova-io/openova/catalyst-api:98f4495` is **published** (listed in the package versions API).
- `git merge-base --is-ancestor 98f44954b origin/main` → **rc=0**.

## Why this is what row 60 is waiting on

The image running on hw296 is `031db43`, and

    git merge-base --is-ancestor 98f44954b 031db43   →  FALSE

so the row cannot be walked against the fix until this rolls. Once it does, the ancestry check flips and the re-walk is meaningful.

## `catalystUi` deliberately not moved

The UI carries no part of this change. Bumping a pin whose component did not change rolls an unverified image for no reason, so it stays at `031db43`. Same single-file, single-line shape as the bot's own deploy commits.

Refs #6268 #3375
