### PR TITLE
fix(catalyst-api): resolve the DR standby half ACROSS regions so a cross-region pair can arm Switchover (#6268 / UAT row 60)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/applications_placement_crossregion_6268_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications_placement_crossregion_6268_test.go
@@ -1,0 +1,267 @@
+// applications_placement_crossregion_6268_test.go — #6268 / UAT row 60,
+// the PLACEMENT half of the same region-A-only seam.
+//
+// THE DEFECT. `augmentWithCNPGStandby` resolves the app's cnpg pair through the
+// region-A-scoped `sovereignDynamicClient`, and #6271's Primary-emitting term
+// (`mergeCNPGPairIntoTargets`) sits behind that resolution. A genuinely
+// 2-region pair has its replica half on the OTHER apiserver, so the resolution
+// always fails and the Primary term is unreachable — for the exact shape it was
+// written for.
+//
+// Occupancy cannot cover for it either. `derivePlacementTargets` keys on
+// `podBelongsToComponent`, and the Pods behind a Catalog-provisioned app carry
+// the DATABASE's identity, not the app's: measured on hw296, `walkfour`'s
+// postgres Pods are labelled `app.kubernetes.io/instance=postgres` /
+// `app.kubernetes.io/name=postgresql` while the app is `r60fresh`.
+// (`shared-pg` — the green control on that Sovereign — only escapes because its
+// app name happens to EQUAL its CNPG instance label.) So the endpoint answered
+// with one Standby carrying an empty `cluster` and `unresolvedPrimary: true`,
+// which the Topology tab renders as `Pattern: not reported` with a single card.
+//
+// The control below reproduces that measured pre-fix answer byte-for-byte, so
+// the fix's own test cannot pass vacuously.
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	kfake "k8s.io/client-go/kubernetes/fake"
+
+	bpv1 "github.com/openova-io/openova/core/controllers/pkg/apis/blueprint/v1alpha1"
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/k8scache"
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/provisioner"
+)
+
+const (
+	xrRegionA = "hw-me-east-215-a-rtz-prod"
+	xrRegionB = "hw-me-east-215-b-rtz-prod"
+	xrNS      = "walkfour"
+	xrApp     = "r60fresh"
+)
+
+// xrFixtureClients builds a fake dynamic client that serves the Pod + CNPG
+// Cluster kinds the placement fan-out reads.
+func xrFixtureClients(objs ...runtime.Object) (*dynamicfake.FakeDynamicClient, *kfake.Clientset) {
+	scheme := runtime.NewScheme()
+	for _, gvk := range []schema.GroupVersionKind{
+		{Version: "v1", Kind: "Pod"}, {Version: "v1", Kind: "PodList"},
+		{Version: "v1", Kind: "Namespace"}, {Version: "v1", Kind: "NamespaceList"},
+		{Version: "v1", Kind: "Node"}, {Version: "v1", Kind: "NodeList"},
+		{Group: "postgresql.cnpg.io", Version: "v1", Kind: "Cluster"},
+		{Group: "postgresql.cnpg.io", Version: "v1", Kind: "ClusterList"},
+	} {
+		if len(gvk.Kind) > 4 && gvk.Kind[len(gvk.Kind)-4:] == "List" {
+			scheme.AddKnownTypeWithName(gvk, &unstructured.UnstructuredList{})
+		} else {
+			scheme.AddKnownTypeWithName(gvk, &unstructured.Unstructured{})
+		}
+	}
+	gvrToListKind := map[schema.GroupVersionResource]string{
+		{Version: "v1", Resource: "pods"}:       "PodList",
+		{Version: "v1", Resource: "namespaces"}: "NamespaceList",
+		{Version: "v1", Resource: "nodes"}:      "NodeList",
+		cnpgClusterGVR:                          "ClusterList",
+	}
+	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind, objs...),
+		kfake.NewSimpleClientset()
+}
+
+// newCrossRegionPlacementHandler stands up a Handler whose k8scache holds the
+// deployment's TWO region clusters, each seeded with its own objects, and whose
+// region-A dynamic client (the `sovereignDynamicClient` seam) sees only what
+// region A actually holds.
+func newCrossRegionPlacementHandler(
+	t *testing.T, depID string,
+	regionAObjs, regionBObjs []runtime.Object,
+	regionAOnlyCRs ...runtime.Object,
+) *Handler {
+	t.Helper()
+	clusterA := depID
+	clusterB := depID + "-me-east-215-b-1"
+
+	reg := k8scache.NewRegistry()
+	_ = reg.Add(k8scache.Kind{Name: "pod", GVR: schema.GroupVersionResource{Version: "v1", Resource: "pods"}, Namespaced: true})
+	_ = reg.Add(k8scache.Kind{Name: "namespace", GVR: schema.GroupVersionResource{Version: "v1", Resource: "namespaces"}})
+	_ = reg.Add(k8scache.Kind{Name: "node", GVR: schema.GroupVersionResource{Version: "v1", Resource: "nodes"}})
+	_ = reg.Add(k8scache.Kind{Name: "cnpgcluster", GVR: cnpgClusterGVR, Namespaced: true})
+
+	dynA, coreA := xrFixtureClients(regionAObjs...)
+	dynB, coreB := xrFixtureClients(regionBObjs...)
+	f, err := k8scache.NewFactory(k8scache.Config{
+		Logger:   quietHandlerLogger(),
+		Registry: reg,
+		Clusters: []k8scache.ClusterRef{
+			{ID: clusterA, DynamicClient: dynA, CoreClient: coreA},
+			{ID: clusterB, DynamicClient: dynB, CoreClient: coreB},
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewFactory: %v", err)
+	}
+	if err := f.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(f.Stop)
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		a, _, _ := f.List(clusterA, "cnpgcluster", labels.Everything())
+		b, _, _ := f.List(clusterB, "cnpgcluster", labels.Everything())
+		if len(a) >= 1 && len(b) >= len(regionBObjs) {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	h := NewWithPDM(quietHandlerLogger(), &fakePDM{})
+	h.SetK8sCache(f, k8scache.NewSARCache(), "")
+	// The region-A `sovereignDynamicClient` seam — it sees the Continuum CR and
+	// region A's own cnpg half, and NOT region B's.
+	seed := append([]runtime.Object{}, regionAOnlyCRs...)
+	seed = append(seed, regionAObjs...)
+	factory, _ := fakeContinuumDynamicFactory(seed...)
+	h.dynamicFactory = factory
+	dep := installUserAccessDeployment(t, h, depID)
+	dep.Request.Regions = []provisioner.RegionSpec{{CloudRegion: xrRegionA}, {CloudRegion: xrRegionB}}
+	return h
+}
+
+// callPlacementNS invokes the placement endpoint WITH the namespace query param
+// the console passes.
+func callPlacementNS(t *testing.T, h *Handler, depID, name, ns string) runtimePlacementResponse {
+	t.Helper()
+	router := chi.NewRouter()
+	router.Get("/api/v1/sovereigns/{id}/applications/{name}/placement", h.HandleApplicationPlacement)
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/sovereigns/"+depID+"/applications/"+name+"/placement?namespace="+ns, nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("placement: got %d want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var resp runtimePlacementResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v; body=%s", err, rec.Body.String())
+	}
+	return resp
+}
+
+// xrContinuum is the app's Continuum CR — present in region A, naming the
+// standby region. It is what makes the PRE-fix answer a one-card half-pair
+// rather than an empty list, i.e. the exact hw296 reproduction.
+func xrContinuum() *unstructured.Unstructured {
+	return newContinuumUnstructured("dr-"+xrApp, xrNS, xrNS+"/"+xrApp, xrRegionA, []string{xrRegionB})
+}
+
+func targetByRole(targets []bpv1.PlacementTarget, role bpv1.DataRole) *bpv1.PlacementTarget {
+	for i := range targets {
+		if targets[i].Role == role {
+			return &targets[i]
+		}
+	}
+	return nil
+}
+
+// ── THE FIX ──────────────────────────────────────────────────────────────
+
+// A pair whose halves live in two registered clusters must project BOTH legs
+// with populated cluster ids, so the Topology tab can derive
+// `active-hot-standby` instead of `not reported`.
+func TestRow60_Placement_CrossRegionPairEmitsBothLegs_6268(t *testing.T) {
+	primary, replica := newCNPGPairFixture("postgres", xrNS, xrRegionA, xrRegionB)
+	h := newCrossRegionPlacementHandler(t, "dep-row60-xr-pair",
+		[]runtime.Object{primary}, []runtime.Object{replica}, xrContinuum())
+
+	resp := callPlacementNS(t, h, "dep-row60-xr-pair", xrApp, xrNS)
+
+	// SUBSTANCE FIRST — a Primary must exist at all; without it derivePattern
+	// returns `not reported` no matter what else is on the wire.
+	p := targetByRole(resp.Targets, bpv1.DataRolePrimary)
+	if p == nil {
+		t.Fatalf("no Primary target: %+v", resp.Targets)
+	}
+	if p.Cluster == "" {
+		t.Fatalf("Primary target has an EMPTY cluster — row 60's clause requires a populated cluster id; %+v", *p)
+	}
+	s := targetByRole(resp.Targets, bpv1.DataRoleStandby)
+	if s == nil {
+		t.Fatalf("no Standby target: %+v", resp.Targets)
+	}
+	if s.StandbyType != bpv1.StandbyHot {
+		t.Fatalf("Standby type: got %q want Hot — a Cold standby derives active-passive, not active-hot-standby", s.StandbyType)
+	}
+	if s.Cluster == "" {
+		t.Fatalf("Standby target has an EMPTY cluster — that is the pre-fix Continuum-region-only projection, not a resolved leg; %+v", *s)
+	}
+	if p.Region != xrRegionA || s.Region != xrRegionB {
+		t.Fatalf("regions: primary %q standby %q, want %q / %q", p.Region, s.Region, xrRegionA, xrRegionB)
+	}
+	if resp.UnresolvedPrimary {
+		t.Fatalf("unresolvedPrimary: got true after both legs resolved")
+	}
+	if !resp.DerivedFromRuntime {
+		t.Fatalf("derivedFromRuntime: got false — both of this deployment's clusters were listed and the pair resolved; %+v", resp)
+	}
+}
+
+// ── CONTROLS ─────────────────────────────────────────────────────────────
+
+// The measured PRE-fix shape, reproduced exactly: region B holds no replica
+// half, so only the Continuum's declared region is available and the answer is
+// an honest half-pair — one Standby, EMPTY cluster, unresolvedPrimary true,
+// derivedFromRuntime false. If the fix were removed, the test above would land
+// here.
+func TestRow60_Placement_NoRegionBHalfIsAnHonestHalfPair_6268(t *testing.T) {
+	primary, _ := newCNPGPairFixture("postgres", xrNS, xrRegionA, xrRegionB)
+	h := newCrossRegionPlacementHandler(t, "dep-row60-xr-nohalf",
+		[]runtime.Object{primary}, nil, xrContinuum())
+
+	resp := callPlacementNS(t, h, "dep-row60-xr-nohalf", xrApp, xrNS)
+
+	if p := targetByRole(resp.Targets, bpv1.DataRolePrimary); p != nil {
+		t.Fatalf("a Primary was emitted with no resolvable pair: %+v", *p)
+	}
+	s := targetByRole(resp.Targets, bpv1.DataRoleStandby)
+	if s == nil {
+		t.Fatalf("the Continuum declares a standby region, so the honest projection still names it: %+v", resp.Targets)
+	}
+	if s.Cluster != "" {
+		t.Fatalf("Standby cluster: got %q want empty — the replica half is not observable, so no cluster id may be asserted", s.Cluster)
+	}
+	if !resp.UnresolvedPrimary {
+		t.Fatalf("unresolvedPrimary: got false — a Standby with no Primary is a half-pair and must say so")
+	}
+	if resp.DerivedFromRuntime {
+		t.Fatalf("derivedFromRuntime: got true on a half-pair")
+	}
+}
+
+// A SAME-region pair (both halves carrying the same region label) is not a
+// cross-region placement and must never be projected as one — the same
+// two-DISTINCT-regions invariant deriveLiveContinuumRecord enforces.
+func TestRow60_Placement_SameRegionHalvesAreNotACrossRegionPair_6268(t *testing.T) {
+	primary, replica := newCNPGPairFixture("postgres", xrNS, xrRegionA, xrRegionA)
+	h := newCrossRegionPlacementHandler(t, "dep-row60-xr-sameregion",
+		[]runtime.Object{primary, replica}, nil, xrContinuum())
+
+	resp := callPlacementNS(t, h, "dep-row60-xr-sameregion", xrApp, xrNS)
+
+	for _, tg := range resp.Targets {
+		if tg.Role == bpv1.DataRoleStandby && tg.Region == xrRegionA {
+			t.Fatalf("projected a Standby in the PRIMARY's own region — that is not a cross-region standby: %+v", resp.Targets)
+		}
+		if tg.Role == bpv1.DataRolePrimary && tg.Cluster != "" {
+			t.Fatalf("projected a resolved cross-region Primary off a same-region pair: %+v", tg)
+		}
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/applications_placement_runtime.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications_placement_runtime.go
@@ -394,6 +394,29 @@ func (h *Handler) augmentWithCNPGStandby(
 		return mergeCNPGPairIntoTargets(targets, st)
 	}
 
+	// #6268 — CROSS-REGION pair resolution, before the region-name-only
+	// fallback below.
+	//
+	// The branch above needs BOTH halves out of the REGION-A list, so it can
+	// never fire for a genuinely 2-region pair — which is the only shape that
+	// can produce an active-hot-standby placement in the first place. Measured
+	// on hw296: `walkfour` holds one cnpg Cluster in region A
+	// (`openova.io/cnpg-role=primary`) and its follower in region B, and the
+	// endpoint answered with a lone Standby carrying an empty `cluster`,
+	// `unresolvedPrimary: true` — which the Topology tab renders as
+	// `Pattern: not reported` with one card.
+	//
+	// h.k8sCache caches `cnpgcluster` across every registered cluster, so the
+	// SAME pair resolves here with both halves and both cluster ids. Same
+	// isolation rules as the region-A path (namespace-scoped, deployment-scoped)
+	// and the same two-DISTINCT-non-empty-regions invariant, so it can only ever
+	// emit a real cross-region pair — never a same-region "standby", and never
+	// anything at all when the pair does not resolve.
+	if xs, ok := h.crossClusterCNPGPairStandby(urlID, ns, "", name); ok &&
+		xs.PrimaryRegion != "" && xs.ReplicaRegion != "" && xs.PrimaryRegion != xs.ReplicaRegion {
+		return mergeCrossClusterPairIntoTargets(targets, xs)
+	}
+
 	// Continuum-CR fallback (the #4551 render-gate fix). The cnpg-pair path
 	// could not surface a cross-region standby (replica Cluster half lives on
 	// the other region's apiserver). Read the standby region straight off the
@@ -786,7 +809,7 @@ func (h *Handler) derivePlacementTargets(name, ns, primaryID string, clusterRegi
 // returned `{"targets":[]}` while `…/applications/grafana/placement`
 // returned a target). We normalise the same way every other handler does
 // (`strings.TrimPrefix(name, "bp-")`, mirroring LogsTab's
-// `blueprint.replace(/^bp-/, '')` and the resource-list path) and accept
+// `blueprint.replace(/^bp-/, ”)` and the resource-list path) and accept
 // EITHER form, so a wizard-installed app named without the prefix AND a
 // bootstrap-kit `bp-`-routed app both resolve to the same pods the Resources
 // tab shows. Deduped, non-empty entries only.

--- a/products/catalyst/bootstrap/api/internal/handler/continuum_dr_extras.go
+++ b/products/catalyst/bootstrap/api/internal/handler/continuum_dr_extras.go
@@ -389,7 +389,7 @@ func (h *Handler) HandleContinuumReplicationStatus(w http.ResponseWriter, r *htt
 	// outage (it derives phase from lease-held-ness alone), so the endpoint
 	// must cross-check the replica half itself — never relay a fabricated
 	// Healthy.
-	h.augmentReplicationStandbyStatus(r.Context(), client, cr, &resp)
+	h.augmentReplicationStandbyStatus(r.Context(), depID, client, cr, &resp)
 	resp.Source = "live"
 	resp.ObservedAt = h.continuumNow().UTC().Format(time.RFC3339)
 	writeJSON(w, http.StatusOK, resp)
@@ -415,6 +415,7 @@ func (h *Handler) HandleContinuumReplicationStatus(w http.ResponseWriter, r *htt
 // render as a promotable green pair (the #4901 outage shape).
 func (h *Handler) augmentReplicationStandbyStatus(
 	ctx context.Context,
+	urlID string,
 	client dynamic.Interface,
 	cr *unstructured.Unstructured,
 	resp *continuumReplicationStatus,
@@ -422,16 +423,14 @@ func (h *Handler) augmentReplicationStandbyStatus(
 	available := false
 	region := ""
 	determined := false
+	appName, _, _ := unstructured.NestedString(cr.Object, "spec", "applicationRef")
+	if strings.TrimSpace(appName) == "" {
+		appName = appNameFromContinuumName(cr.GetName())
+	}
 	if st, ok := h.cnpgPairStandbyForContinuum(ctx, client, cr); ok {
 		available, region, determined = st.Available, st.ReplicaRegion, true
-	} else {
-		appName, _, _ := unstructured.NestedString(cr.Object, "spec", "applicationRef")
-		if strings.TrimSpace(appName) == "" {
-			appName = appNameFromContinuumName(cr.GetName())
-		}
-		if ps, err := h.findCNPGPairForApp(ctx, client, appName, cr.GetNamespace()); err == nil && ps != nil {
-			available, region, determined = ps.StandbyAvailable, ps.ReplicaRegion, true
-		}
+	} else if ps, err := h.findCNPGPairForApp(ctx, client, appName, cr.GetNamespace()); err == nil && ps != nil {
+		available, region, determined = ps.StandbyAvailable, ps.ReplicaRegion, true
 	}
 	if !determined {
 		// PER-REGION SPLIT (#5511 class), measured on hw292 2026-08-10: this
@@ -455,20 +454,86 @@ func (h *Handler) augmentReplicationStandbyStatus(
 		// probe is what GOES FALSE during an outage, and it is only consulted
 		// here when the live cross-check found nothing to contradict it. A CR
 		// that omits the key still reports unverifiable — never a fabricated Pass.
-		if crStandby, found, _ := unstructured.NestedBool(cr.Object, "status", "standbyAvailable"); found {
+		crStandby, crFound, _ := unstructured.NestedBool(cr.Object, "status", "standbyAvailable")
+
+		// #6268 — A NEGATIVE PROBE OUTRANKS EVERY OTHER READING, and is
+		// therefore evaluated FIRST. The controller probes the standby directly
+		// (pgprobe, #4901/#5311) and that probe is what goes false during an
+		// outage; the informer cache consulted below keeps serving the last
+		// known object when a region's apiserver becomes unreachable, so a
+		// cache read can look healthy through the very outage the probe
+		// detected. Arming a Switchover against a standby that cannot be
+		// promoted is far worse than leaving it disabled, so when the two
+		// oracles disagree the disarming one wins.
+		if crFound && !crStandby {
 			resp.StandbyAvailable = &crStandby
-			if crStandby {
-				upsertHealthGate(resp, continuumHealthGate{
-					Name: "standby-available", Status: "Pass", Severity: "info",
-					Message: "standby leg reported available by the Continuum controller's standby probe (the replica half is not visible from this region's cluster)",
-				})
-				return
-			}
 			resp.ReplicaPromotable = false
 			resp.StreamingState = "interrupted"
 			upsertHealthGate(resp, continuumHealthGate{
 				Name: "standby-available", Status: "Fail", Severity: "critical",
 				Message: "the Continuum controller's standby probe reports the required hot-standby is unreachable; replication has no standby leg and RPO=0 durability is at risk",
+			})
+			return
+		}
+
+		// #6268 — THE CROSS-REGION READ. `h.k8sCache` runs a `cnpgcluster`
+		// informer against EVERY registered cluster, so the replica half that is
+		// invisible to the region-A `client` above IS observable here. This is
+		// the strongest provenance available for the standby leg — we read the
+		// replica Cluster CR itself rather than relaying somebody else's verdict
+		// — and it is the ONLY branch that may ARM promotability, because it is
+		// the only one holding positive evidence that the standby is still
+		// FOLLOWING (Ready + spec.replica.enabled) rather than merely present.
+		//
+		// A Continuum carrying no probe and no same-region pair (the
+		// `walkfour/dr-r60fresh` shape, UAT row 60) reached neither fallback
+		// before this, so `replicaPromotable` could only ever be the zero-value
+		// false. Nothing here manufactures a verdict from absence:
+		// crossClusterCNPGPairStandby returns no-determination unless BOTH
+		// halves of one pair were positively observed in this deployment's own
+		// clusters and this Organization's own namespace.
+		pairName, _, _ := unstructured.NestedString(cr.Object, "spec", "cnpgPair", "name")
+		if xs, ok := h.crossClusterCNPGPairStandby(urlID, cr.GetNamespace(), pairName, appName); ok {
+			xAvailable := xs.Available
+			resp.StandbyAvailable = &xAvailable
+			if !xAvailable {
+				resp.ReplicaPromotable = false
+				resp.StreamingState = "interrupted"
+				upsertHealthGate(resp, continuumHealthGate{
+					Name: "standby-available", Status: "Fail", Severity: "critical",
+					Message: fmt.Sprintf("required hot-standby in %s is unreachable (replica cluster %q in %s reports not ready); replication has no standby leg and RPO=0 durability is at risk",
+						standbyRegionLabel(xs.ReplicaRegion), xs.ReplicaName, xs.ReplicaCluster),
+				})
+				return
+			}
+			// Promotability needs the standby to be FOLLOWING and caught up —
+			// the same predicate liveReplicationStatusFromCNPGPair uses. A
+			// promoted (post-switchover) half is available but not a follower,
+			// and must not re-arm the control against itself. The replica's own
+			// lag is preferred when CNPG reports one; an UNREPORTED lag is not
+			// treated as a measured zero, so the response keeps whatever reading
+			// the CR / linked CNPGPair already established (#4901: an absent
+			// standby also reads lag 0).
+			lag := resp.WALLagSeconds
+			if xs.LagSeconds > 0 {
+				lag = float64(xs.LagSeconds)
+			}
+			if xs.Following && lag <= 30 {
+				resp.ReplicaPromotable = true
+			}
+			upsertHealthGate(resp, continuumHealthGate{
+				Name: "standby-available", Status: "Pass", Severity: "info",
+				Message: fmt.Sprintf("hot-standby in %s is reachable — verified on the replica half itself (cnpg Cluster %q in cluster %s, pair %q)",
+					standbyRegionLabel(xs.ReplicaRegion), xs.ReplicaName, xs.ReplicaCluster, xs.PairName),
+			})
+			return
+		}
+
+		if crFound {
+			resp.StandbyAvailable = &crStandby
+			upsertHealthGate(resp, continuumHealthGate{
+				Name: "standby-available", Status: "Pass", Severity: "info",
+				Message: "standby leg reported available by the Continuum controller's standby probe (the replica half is not visible from this region's cluster)",
 			})
 			return
 		}
@@ -815,7 +880,7 @@ func (h *Handler) HandleDRReplicationStatus(w http.ResponseWriter, r *http.Reque
 		// #4923 — verify the standby leg off the live cnpg pair per row (the
 		// stored CR status alone stays green through a standby outage). Rows
 		// whose standby cannot be verified count as UNKNOWN — never healthy.
-		h.augmentReplicationStandbyStatus(r.Context(), client, cr, &row)
+		h.augmentReplicationStandbyStatus(r.Context(), depID, client, cr, &row)
 		row.Source = "live"
 		out.Continuums = append(out.Continuums, row)
 		out.ContinuumCount++

--- a/products/catalyst/bootstrap/api/internal/handler/continuum_standby_crossregion_6268.go
+++ b/products/catalyst/bootstrap/api/internal/handler/continuum_standby_crossregion_6268.go
@@ -48,6 +48,8 @@ import (
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
+
+	bpv1 "github.com/openova-io/openova/core/controllers/pkg/apis/blueprint/v1alpha1"
 )
 
 // crossClusterStandbyState is the resolved standby posture of a cnpg
@@ -66,11 +68,17 @@ type crossClusterStandbyState struct {
 	// PrimaryCluster / ReplicaCluster are the k8scache cluster ids each half
 	// was observed in. They are surfaced in the health-gate message so an
 	// operator can tell a cross-region verification from the controller-probe
-	// relay that produces the same Pass otherwise.
+	// relay that produces the same Pass otherwise, and they are the `cluster`
+	// value the placement projection emits (the same identifier
+	// derivePlacementTargets uses, so both surfaces name clusters alike).
 	PrimaryCluster string
 	ReplicaCluster string
 
-	// ReplicaName / ReplicaRegion identify the standby half itself.
+	// PrimaryName / PrimaryRegion identify the primary half; ReplicaName /
+	// ReplicaRegion the standby half. The regions come from each half's
+	// `openova.io/region` label — live cluster placement, not config.
+	PrimaryName   string
+	PrimaryRegion string
 	ReplicaName   string
 	ReplicaRegion string
 
@@ -208,16 +216,65 @@ func (h *Handler) crossClusterCNPGPairStandby(
 		return crossClusterStandbyState{}, false
 	}
 
-	replica := hv.replica.obj
+	primary, replica := hv.primary.obj, hv.replica.obj
 	replicaEnabled, _, _ := unstructured.NestedBool(replica.Object, "spec", "replica", "enabled")
 	return crossClusterStandbyState{
 		PairName:       chosen,
 		PrimaryCluster: hv.primary.cluster,
 		ReplicaCluster: hv.replica.cluster,
+		PrimaryName:    primary.GetName(),
+		PrimaryRegion:  primary.GetLabels()[cnpgRegionLabel],
 		ReplicaName:    replica.GetName(),
 		ReplicaRegion:  replica.GetLabels()[cnpgRegionLabel],
 		Available:      cnpgStandbyAvailable(replica),
 		Following:      cnpgClusterReady(replica) && replicaEnabled,
 		LagSeconds:     cnpgClusterLag(replica),
 	}, true
+}
+
+// mergeCrossClusterPairIntoTargets folds a pair resolved ACROSS clusters into
+// the occupancy-derived placement target list, adding only the legs occupancy
+// did not already supply.
+//
+// WHY THE PLACEMENT PATH NEEDS THIS TOO. `derivePlacementTargets` keys on the
+// component's OWN Pods, and for an app whose stateful identity IS its CNPG pair
+// those Pods carry the DATABASE's labels: measured on hw296, the Pods behind
+// Catalog app `r60fresh` in `walkfour` are labelled
+// `app.kubernetes.io/instance=postgres` / `app.kubernetes.io/name=postgresql`,
+// so `podBelongsToComponent(p, "r60fresh", …)` is false for every one of them
+// and occupancy yields NO Primary. (`shared-pg` only escapes this because its
+// app name happens to equal its CNPG instance label.) #6271 added the
+// Primary-emitting term for exactly this case, but gated it on
+// findCNPGPairForApp — which needs both halves out of the REGION-A list and so
+// can never fire for a genuinely 2-region pair. Same seam, same swap.
+//
+// Pure by design, mirroring mergeCNPGPairIntoTargets: the decision is which
+// legs get emitted, so keeping it free of the client makes it directly testable.
+//
+// The `cluster` field carries the k8scache CLUSTER ID (not the CNPG Cluster CR
+// name), which is what `derivePlacementTargets` puts there — so a projected leg
+// and an occupancy-derived leg name their cluster the same way.
+//
+// Callers must have already established that `xs` holds two DISTINCT non-empty
+// regions — the same invariant deriveLiveContinuumRecord enforces.
+func mergeCrossClusterPairIntoTargets(targets []bpv1.PlacementTarget, xs crossClusterStandbyState) []bpv1.PlacementTarget {
+	// Already represented as a Standby in the replica region — nothing to add.
+	for _, t := range targets {
+		if t.Role == bpv1.DataRoleStandby && t.Region == xs.ReplicaRegion {
+			return targets
+		}
+	}
+	if !hasPrimaryTarget(targets) {
+		targets = append(targets, bpv1.PlacementTarget{
+			Region:  xs.PrimaryRegion,
+			Cluster: xs.PrimaryCluster,
+			Role:    bpv1.DataRolePrimary,
+		})
+	}
+	return append(targets, bpv1.PlacementTarget{
+		Region:      xs.ReplicaRegion,
+		Cluster:     xs.ReplicaCluster,
+		Role:        bpv1.DataRoleStandby,
+		StandbyType: bpv1.StandbyHot,
+	})
 }

--- a/products/catalyst/bootstrap/api/internal/handler/continuum_standby_crossregion_6268.go
+++ b/products/catalyst/bootstrap/api/internal/handler/continuum_standby_crossregion_6268.go
@@ -1,0 +1,223 @@
+// Package handler — continuum_standby_crossregion_6268.go (#6268 / UAT row 60).
+//
+// THE GAP. `augmentReplicationStandbyStatus` (continuum_dr_extras.go) resolves
+// the standby half of a cnpg cluster-pair through `h.sovereignDynamicClient`,
+// which is scoped to the deployment's REGION-A apiserver. In the 2-region
+// active-hot-standby topology the replica half is a cnpg `Cluster` CR living on
+// the REGION-B apiserver, so BOTH region-A resolution paths structurally miss
+// it:
+//
+//   - cnpgPairStandbyForContinuum lists the pair label in region A and finds no
+//     `openova.io/cnpg-role=replica` half → (_, false);
+//   - findCNPGPairForApp requires BOTH halves from the SAME list → (nil, nil).
+//
+// The endpoint therefore fell through to the Continuum controller's own
+// `status.standbyAvailable` probe (a weaker, second-hand provenance) or, when
+// the CR carries no probe at all, to an "unverifiable" Warn — and
+// `replicaPromotable` stayed at its zero value `false`, which the Topology tab
+// renders as a DISABLED Switchover with "the replica is not promotable".
+// Measured on hw296 (dep e689e3b34a75fdec, Org `walkfour`, app `r60fresh`):
+// `walkfour/dr-r60fresh` carries neither `spec.cnpgPair` nor
+// `status.standbyAvailable`, so neither fallback could fire either.
+//
+// THE LEVER. `h.k8sCache` already runs an informer for the `cnpgcluster` kind
+// (k8scache/kinds.go DefaultKinds) against EVERY registered cluster — region B
+// included. That is the same source `derivePlacementTargets`
+// (applications_placement_runtime.go) fans out over, and it is why the
+// `shared-pg` control already reports both legs with a populated cluster id
+// while the DR status beside it could not. So the standby-availability oracle
+// is one client swap, not a new subsystem.
+//
+// WHAT THIS FILE IS NOT. It does not relax any honesty invariant:
+//
+//   - it returns (_, false) — leaving the caller's existing honest-unknown /
+//     relay chain untouched — unless BOTH halves of one pair were positively
+//     observed. An absent replica is never an available one, and an absent
+//     read is never a verdict (the #4901 / #4923 rule);
+//   - it is NAMESPACE-SCOPED and refuses an empty namespace outright, and it is
+//     DEPLOYMENT-SCOPED via clusterOwnedByDeployment, so it can never resolve a
+//     pair belonging to another Organization or (on the mother, whose cache
+//     holds every managed Sovereign) another Sovereign;
+//   - an explicit `spec.cnpgPair.name` selects THAT pair or nothing — it never
+//     silently substitutes a different pair that happens to share the namespace.
+package handler
+
+import (
+	"sort"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+// crossClusterStandbyState is the resolved standby posture of a cnpg
+// cluster-pair read across the registered clusters rather than from one
+// region's apiserver.
+//
+// `Available` and `Following` are DELIBERATELY separate axes. Available is
+// "the standby is up" (the #4923 tri-state the red banner keys on). Following
+// is "the standby is still a follower" — Ready AND `spec.replica.enabled`. A
+// half that was PROMOTED by an earlier switchover is available but no longer
+// streaming, so it must not re-arm the Switchover control against itself.
+type crossClusterStandbyState struct {
+	// PairName is the shared catalyst.openova.io/cnpg-pair label value.
+	PairName string
+
+	// PrimaryCluster / ReplicaCluster are the k8scache cluster ids each half
+	// was observed in. They are surfaced in the health-gate message so an
+	// operator can tell a cross-region verification from the controller-probe
+	// relay that produces the same Pass otherwise.
+	PrimaryCluster string
+	ReplicaCluster string
+
+	// ReplicaName / ReplicaRegion identify the standby half itself.
+	ReplicaName   string
+	ReplicaRegion string
+
+	// Available — cnpgStandbyAvailable on the replica half (Ready=True and,
+	// when reported, >=1 ready instance). Same predicate the region-A path uses.
+	Available bool
+
+	// Following — the replica half is Ready AND still in replica mode.
+	Following bool
+
+	// LagSeconds — the replica half's own best-effort lag (0 when CNPG does
+	// not report it on this version; the caller keeps its existing reading
+	// rather than treating an unreported lag as a measured zero).
+	LagSeconds int
+}
+
+// crossClusterCNPGPairStandby resolves the standby half of the cnpg
+// cluster-pair backing `appName` in `namespace`, reading `cnpgcluster` from
+// EVERY cluster this deployment owns in `h.k8sCache` — so a pair whose two
+// halves live in DIFFERENT regions resolves, which is the whole point.
+//
+// `pairName` is the CR's `spec.cnpgPair.name` when it declares one ("" when it
+// does not).
+//
+// Returns (_, false) — meaning "no determination", never "absent" — when the
+// cache is not wired, the namespace is unknown, the deployment owns no
+// registered cluster, or one half of the pair was not observed.
+func (h *Handler) crossClusterCNPGPairStandby(
+	urlID, namespace, pairName, appName string,
+) (crossClusterStandbyState, bool) {
+	if h.k8sCache == nil {
+		return crossClusterStandbyState{}, false
+	}
+	namespace = strings.TrimSpace(namespace)
+	if namespace == "" {
+		// 🔒 Organization isolation: a cluster-wide lexical pick could resolve
+		// to a DIFFERENT Organization's cnpg-pair, and this verdict arms a
+		// destructive control. Refuse rather than guess — the same rule
+		// findCNPGPairForApp states for its cluster-wide branch.
+		return crossClusterStandbyState{}, false
+	}
+	sel, err := labels.Parse(cnpgPairLabel)
+	if err != nil {
+		return crossClusterStandbyState{}, false
+	}
+
+	primaryID := h.resolveChrootClusterID(urlID)
+	depID, fqdn, _ := h.placementDeploymentIdentity(urlID)
+
+	type observedHalf struct {
+		obj     *unstructured.Unstructured
+		cluster string
+	}
+	type pairHalves struct{ primary, replica observedHalf }
+	byPair := map[string]*pairHalves{}
+	appLabelled := map[string]bool{}
+	pairNames := []string{}
+
+	for _, cid := range h.k8sCache.Clusters() {
+		// 🔒 Sovereign isolation: the mother's cache holds every managed
+		// Sovereign's clusters (#3987), and namespace names repeat across them.
+		if !clusterOwnedByDeployment(cid, primaryID, depID, fqdn) {
+			continue
+		}
+		items, _, lerr := h.k8sCache.List(cid, "cnpgcluster", sel)
+		if lerr != nil {
+			// Unregistered kind / quarantined reflector — says nothing about
+			// the standby, so contribute nothing rather than a false absence.
+			continue
+		}
+		for _, it := range items {
+			if it == nil || it.GetNamespace() != namespace {
+				continue
+			}
+			lbls := it.GetLabels()
+			pair := lbls[cnpgPairLabel]
+			if pair == "" {
+				continue
+			}
+			hv, ok := byPair[pair]
+			if !ok {
+				hv = &pairHalves{}
+				byPair[pair] = hv
+				pairNames = append(pairNames, pair)
+			}
+			switch lbls[cnpgRoleLabel] {
+			case cnpgRolePrimary:
+				if hv.primary.obj == nil {
+					hv.primary = observedHalf{obj: it, cluster: cid}
+				}
+			case cnpgRoleReplica:
+				if hv.replica.obj == nil {
+					hv.replica = observedHalf{obj: it, cluster: cid}
+				}
+			}
+			if appName != "" && lbls[cnpgAppLabel] == appName {
+				appLabelled[pair] = true
+			}
+		}
+	}
+	sort.Strings(pairNames)
+
+	chosen := ""
+	if want := strings.TrimSpace(pairName); want != "" {
+		// The CR NAMES its pair. Resolve that one or nothing — substituting a
+		// same-namespace neighbour would report another database's standby as
+		// this Continuum's.
+		if _, ok := byPair[want]; !ok {
+			return crossClusterStandbyState{}, false
+		}
+		chosen = want
+	}
+	if chosen == "" {
+		for _, p := range pairNames {
+			if appLabelled[p] {
+				chosen = p
+				break
+			}
+		}
+	}
+	if chosen == "" && len(pairNames) > 0 {
+		// Namespace-scoped lexically-first — safe here for the same reason it
+		// is safe in findCNPGPairForApp: the candidate set never left this
+		// Organization's namespace.
+		chosen = pairNames[0]
+	}
+	if chosen == "" {
+		return crossClusterStandbyState{}, false
+	}
+	hv := byPair[chosen]
+	if hv == nil || hv.primary.obj == nil || hv.replica.obj == nil {
+		// A lone half is not a pair. Region B down → its replica object is not
+		// observable → NO determination, so the caller's controller-probe relay
+		// (which DOES go false during an outage) stays the authority.
+		return crossClusterStandbyState{}, false
+	}
+
+	replica := hv.replica.obj
+	replicaEnabled, _, _ := unstructured.NestedBool(replica.Object, "spec", "replica", "enabled")
+	return crossClusterStandbyState{
+		PairName:       chosen,
+		PrimaryCluster: hv.primary.cluster,
+		ReplicaCluster: hv.replica.cluster,
+		ReplicaName:    replica.GetName(),
+		ReplicaRegion:  replica.GetLabels()[cnpgRegionLabel],
+		Available:      cnpgStandbyAvailable(replica),
+		Following:      cnpgClusterReady(replica) && replicaEnabled,
+		LagSeconds:     cnpgClusterLag(replica),
+	}, true
+}

--- a/products/catalyst/bootstrap/api/internal/handler/continuum_standby_crossregion_6268_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/continuum_standby_crossregion_6268_test.go
@@ -1,0 +1,416 @@
+// continuum_standby_crossregion_6268_test.go — #6268 / UAT row 60.
+//
+// THE DEFECT. `augmentReplicationStandbyStatus` resolved the standby half of a
+// cnpg cluster-pair ONLY through the region-A-scoped `sovereignDynamicClient`.
+// In the 2-region active-hot-standby shape the replica half is a cnpg `Cluster`
+// on the REGION-B apiserver, so neither region-A path could see it, and a
+// Continuum that ALSO carries no `status.standbyAvailable` probe (measured on
+// hw296: `walkfour/dr-r60fresh`) hit no fallback at all — leaving
+// `replicaPromotable` at its zero value false and the Topology tab's Switchover
+// control permanently DISABLED against a healthy pair.
+//
+// VACUITY DISCIPLINE. The happy-path assertions are ordered SUBSTANCE FIRST
+// (`replicaPromotable`, then the tri-state verdict, then the gate label, then
+// the provenance string) so a short-circuit on a cheap label check can never
+// hide the reading that actually matters. Every control below mutates exactly
+// ONE behaviour off the SAME fixture the happy path uses, and each mutation is
+// aimed at a branch this code demonstrably takes:
+//
+//	region-B cluster removed          → no determination  (the fix's own input)
+//	replica Ready=False               → explicit absent    (#4901 region-kill)
+//	replica promoted (replica off)    → available, NOT promotable
+//	replica lag 120s                  → available, NOT promotable
+//	replica in another namespace      → no determination  (Org isolation)
+//	region-B owned by another dep     → no determination  (Sovereign isolation)
+//	spec.cnpgPair names a missing pair→ no determination  (no substitution)
+//	controller probe says false       → Fail, disarmed    (disagreement rule)
+//	no pair in cache, probe says true → the RELAY message  (relay not swallowed)
+package handler
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	kfake "k8s.io/client-go/kubernetes/fake"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/k8scache"
+)
+
+// crossRegionCNPGCache wires a started k8scache.Factory with one registered
+// cluster per entry of `perCluster`, each serving the `cnpgcluster` kind from
+// its own fake dynamic client. This is the multi-cluster shape the real
+// Sovereign runs (region A + every secondary posted to
+// /api/v1/sovereign/secondary-kubeconfig).
+func crossRegionCNPGCache(t *testing.T, perCluster map[string][]*unstructured.Unstructured) *k8scache.Factory {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	gvk := schema.GroupVersionKind{Group: "postgresql.cnpg.io", Version: "v1", Kind: "Cluster"}
+	listGVK := schema.GroupVersionKind{Group: "postgresql.cnpg.io", Version: "v1", Kind: "ClusterList"}
+	scheme.AddKnownTypeWithName(gvk, &unstructured.Unstructured{})
+	scheme.AddKnownTypeWithName(listGVK, &unstructured.UnstructuredList{})
+	gvrToListKind := map[schema.GroupVersionResource]string{cnpgClusterGVR: "ClusterList"}
+
+	reg := k8scache.NewRegistry()
+	_ = reg.Add(k8scache.Kind{Name: "cnpgcluster", GVR: cnpgClusterGVR, Namespaced: true})
+
+	refs := make([]k8scache.ClusterRef, 0, len(perCluster))
+	ids := make([]string, 0, len(perCluster))
+	for cid, objs := range perCluster {
+		rtObjs := make([]runtime.Object, 0, len(objs))
+		for _, o := range objs {
+			rtObjs = append(rtObjs, o)
+		}
+		refs = append(refs, k8scache.ClusterRef{
+			ID:            cid,
+			DynamicClient: dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind, rtObjs...),
+			CoreClient:    kfake.NewSimpleClientset(),
+		})
+		ids = append(ids, cid)
+	}
+	f, err := k8scache.NewFactory(k8scache.Config{
+		Logger:   quietHandlerLogger(),
+		Registry: reg,
+		Clusters: refs,
+	})
+	if err != nil {
+		t.Fatalf("NewFactory: %v", err)
+	}
+	if err := f.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(f.Stop)
+
+	// Wait for every seeded object to land in its indexer — a race here would
+	// make an assertion pass or fail for reasons unrelated to the fix.
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		synced := true
+		for _, cid := range ids {
+			got, _, lerr := f.List(cid, "cnpgcluster", labels.Everything())
+			if lerr != nil || len(got) < len(perCluster[cid]) {
+				synced = false
+				break
+			}
+		}
+		if synced || time.Now().After(deadline) {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	return f
+}
+
+// row60Continuum is the exact live hw296 shape: an Org-scoped Continuum for a
+// Catalog-provisioned active-hot-standby app that carries NEITHER
+// spec.cnpgPair NOR status.standbyAvailable, so both pre-existing fallbacks are
+// unreachable for it.
+func row60Continuum() *unstructured.Unstructured {
+	return newContinuumUnstructured(
+		"dr-r60fresh", "walkfour", "walkfour/r60fresh",
+		"me-east-215-a", []string{"me-east-215-b"})
+}
+
+// row60Halves returns the primary (region A) + replica (region B) cnpg Cluster
+// CRs of the pair `postgres` in namespace `walkfour`, matching the labels the
+// bp-postgres chart stamps on both halves.
+func row60Halves() (primary, replica *unstructured.Unstructured) {
+	return newCNPGPairFixture("postgres", "walkfour",
+		"hw-me-east-215-a-rtz-prod", "hw-me-east-215-b-rtz-prod")
+}
+
+// setCNPGReady flips the replica half's Ready condition — the #4901
+// region-kill state.
+func setCNPGReady(u *unstructured.Unstructured, ready string) {
+	_ = unstructured.SetNestedSlice(u.Object, []interface{}{
+		map[string]interface{}{"type": "Ready", "status": ready},
+	}, "status", "conditions")
+}
+
+// ── THE FIX ──────────────────────────────────────────────────────────────
+
+// A Continuum with no cnpgPair ref and no controller probe, whose pair's two
+// halves live in DIFFERENT registered clusters, must resolve the standby off
+// the replica half itself and ARM the switchover.
+func TestReplicationStatus_Row60_CrossRegionPairArmsSwitchover(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	cr := row60Continuum()
+	primary, replica := row60Halves()
+	// The region-A dynamic client sees ONLY the primary half — the live split.
+	factory, _ := fakeContinuumDynamicFactory(cr, primary)
+	h.dynamicFactory = factory
+	dep := installUserAccessDeployment(t, h, "dep-row60-crossregion")
+	h.SetK8sCache(crossRegionCNPGCache(t, map[string][]*unstructured.Unstructured{
+		dep.ID:                      {primary},
+		dep.ID + "-me-east-215-b-1": {replica},
+	}), k8scache.NewSARCache(), "X-Forwarded-User")
+
+	resp := fetchReplicationStatus(t, h, dep.ID, "dr-r60fresh", "walkfour")
+
+	// SUBSTANCE FIRST — this is the value UAT row 60's fourth clause turns on.
+	if !resp.ReplicaPromotable {
+		t.Fatalf("replicaPromotable: got false want true — the pair's replica half is Ready and following in region B, so the Switchover control must arm; body=%+v", resp)
+	}
+	if resp.StandbyAvailable == nil || !*resp.StandbyAvailable {
+		t.Fatalf("standbyAvailable: got %v want an explicit true", resp.StandbyAvailable)
+	}
+	g := gateByName(t, resp, "standby-available")
+	if g.Status != "Pass" {
+		t.Fatalf("standby-available gate: got %q (%q) want Pass", g.Status, g.Message)
+	}
+	// PROVENANCE — the Pass must come from reading the replica half, not from
+	// relaying the controller probe (which this CR does not even carry). The
+	// region-B cluster id can only appear via the cross-region path.
+	if !strings.Contains(g.Message, dep.ID+"-me-east-215-b-1") {
+		t.Fatalf("standby-available message %q does not name the region-B cluster the verdict was read from — a Pass with no provenance is indistinguishable from the relay", g.Message)
+	}
+}
+
+// ── CONTROLS — one mutated behaviour each ────────────────────────────────
+
+// Remove the region-B cluster and NOTHING else. The verdict must collapse to
+// honest-unknown. This is the control that makes the test above non-vacuous:
+// if the fix were removed, the happy path would land here.
+func TestReplicationStatus_Row60_NoRegionBClusterStaysUnknown(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	cr := row60Continuum()
+	primary, _ := row60Halves()
+	factory, _ := fakeContinuumDynamicFactory(cr, primary)
+	h.dynamicFactory = factory
+	dep := installUserAccessDeployment(t, h, "dep-row60-no-region-b")
+	h.SetK8sCache(crossRegionCNPGCache(t, map[string][]*unstructured.Unstructured{
+		dep.ID: {primary},
+	}), k8scache.NewSARCache(), "X-Forwarded-User")
+
+	resp := fetchReplicationStatus(t, h, dep.ID, "dr-r60fresh", "walkfour")
+	if resp.ReplicaPromotable {
+		t.Fatalf("replicaPromotable: got true with no observable standby half — that is a switchover armed against nothing")
+	}
+	if resp.StandbyAvailable != nil {
+		t.Fatalf("standbyAvailable: got %v want omitted (a lone primary is not evidence of an absent standby, and not evidence of a present one either)", *resp.StandbyAvailable)
+	}
+	if g := gateByName(t, resp, "standby-available"); g.Status != "Warn" {
+		t.Fatalf("standby-available gate: got %q (%q) want Warn", g.Status, g.Message)
+	}
+}
+
+// The region-kill shape: the replica half is OBSERVABLE but not Ready. That is
+// positive evidence of an ABSENT standby — explicit false, Fail, disarmed.
+func TestReplicationStatus_Row60_CrossRegionAbsentStandbyIsExplicit(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	cr := row60Continuum()
+	primary, replica := row60Halves()
+	setCNPGReady(replica, "False")
+	factory, _ := fakeContinuumDynamicFactory(cr, primary)
+	h.dynamicFactory = factory
+	dep := installUserAccessDeployment(t, h, "dep-row60-absent")
+	h.SetK8sCache(crossRegionCNPGCache(t, map[string][]*unstructured.Unstructured{
+		dep.ID:                      {primary},
+		dep.ID + "-me-east-215-b-1": {replica},
+	}), k8scache.NewSARCache(), "X-Forwarded-User")
+
+	resp := fetchReplicationStatus(t, h, dep.ID, "dr-r60fresh", "walkfour")
+	if resp.StandbyAvailable == nil || *resp.StandbyAvailable {
+		t.Fatalf("standbyAvailable: got %v want an explicit false — a lost standby that reports unknown leaves the red banner unreachable", resp.StandbyAvailable)
+	}
+	if resp.ReplicaPromotable {
+		t.Fatalf("replicaPromotable: got true against a not-Ready replica half")
+	}
+	if resp.StreamingState != "interrupted" {
+		t.Fatalf("streamingState: got %q want interrupted", resp.StreamingState)
+	}
+	if g := gateByName(t, resp, "standby-available"); g.Status != "Fail" {
+		t.Fatalf("standby-available gate: got %q want Fail", g.Status)
+	}
+}
+
+// A PROMOTED standby (Ready, but spec.replica.enabled=false) is AVAILABLE and
+// must NOT be promotable — it is no longer following the primary, so promoting
+// it again is meaningless. This proves the `Following` term is load-bearing:
+// delete it and this test flips to promotable while every other test stays green.
+func TestReplicationStatus_Row60_PromotedStandbyIsAvailableButNotPromotable(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	cr := row60Continuum()
+	primary, replica := row60Halves()
+	_ = unstructured.SetNestedField(replica.Object, false, "spec", "replica", "enabled")
+	factory, _ := fakeContinuumDynamicFactory(cr, primary)
+	h.dynamicFactory = factory
+	dep := installUserAccessDeployment(t, h, "dep-row60-promoted")
+	h.SetK8sCache(crossRegionCNPGCache(t, map[string][]*unstructured.Unstructured{
+		dep.ID:                      {primary},
+		dep.ID + "-me-east-215-b-1": {replica},
+	}), k8scache.NewSARCache(), "X-Forwarded-User")
+
+	resp := fetchReplicationStatus(t, h, dep.ID, "dr-r60fresh", "walkfour")
+	if resp.ReplicaPromotable {
+		t.Fatalf("replicaPromotable: got true for a half that is no longer a follower (spec.replica.enabled=false)")
+	}
+	if resp.StandbyAvailable == nil || !*resp.StandbyAvailable {
+		t.Fatalf("standbyAvailable: got %v want true — the half IS up; availability and followership are different axes", resp.StandbyAvailable)
+	}
+}
+
+// A replica lagging beyond the 30s switchover-safety threshold is available but
+// not promotable. This proves the lag term is load-bearing: delete it and this
+// test flips while the promoted-standby control above stays green.
+func TestReplicationStatus_Row60_LaggingStandbyIsNotPromotable(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	cr := row60Continuum()
+	primary, replica := row60Halves()
+	_ = unstructured.SetNestedField(replica.Object, int64(120), "status", "lag")
+	factory, _ := fakeContinuumDynamicFactory(cr, primary)
+	h.dynamicFactory = factory
+	dep := installUserAccessDeployment(t, h, "dep-row60-lagging")
+	h.SetK8sCache(crossRegionCNPGCache(t, map[string][]*unstructured.Unstructured{
+		dep.ID:                      {primary},
+		dep.ID + "-me-east-215-b-1": {replica},
+	}), k8scache.NewSARCache(), "X-Forwarded-User")
+
+	resp := fetchReplicationStatus(t, h, dep.ID, "dr-r60fresh", "walkfour")
+	if resp.ReplicaPromotable {
+		t.Fatalf("replicaPromotable: got true against a 120s-lagging replica — promoting it loses committed transactions")
+	}
+	if resp.StandbyAvailable == nil || !*resp.StandbyAvailable {
+		t.Fatalf("standbyAvailable: got %v want true — a lagging standby is reachable, and lag rides its own axis (never a standby-absent alarm)", resp.StandbyAvailable)
+	}
+}
+
+// 🔒 Organization isolation: the replica half lives in ANOTHER namespace. The
+// resolver must not reach across the Org boundary — no determination.
+func TestReplicationStatus_Row60_ReplicaInAnotherNamespaceDoesNotResolve(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	cr := row60Continuum()
+	primary, replica := row60Halves()
+	replica.SetNamespace("walkfive")
+	factory, _ := fakeContinuumDynamicFactory(cr, primary)
+	h.dynamicFactory = factory
+	dep := installUserAccessDeployment(t, h, "dep-row60-ns-isolation")
+	h.SetK8sCache(crossRegionCNPGCache(t, map[string][]*unstructured.Unstructured{
+		dep.ID:                      {primary},
+		dep.ID + "-me-east-215-b-1": {replica},
+	}), k8scache.NewSARCache(), "X-Forwarded-User")
+
+	resp := fetchReplicationStatus(t, h, dep.ID, "dr-r60fresh", "walkfour")
+	if resp.StandbyAvailable != nil {
+		t.Fatalf("standbyAvailable: got %v — another Organization's replica half was adopted as this Continuum's standby", *resp.StandbyAvailable)
+	}
+	if resp.ReplicaPromotable {
+		t.Fatalf("replicaPromotable: got true off a cross-Organization half")
+	}
+}
+
+// 🔒 Sovereign isolation: the mother's cache holds every managed Sovereign's
+// clusters and namespace names repeat across them. A cluster id that does not
+// belong to THIS deployment must contribute nothing.
+func TestReplicationStatus_Row60_ForeignSovereignClusterDoesNotResolve(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	cr := row60Continuum()
+	primary, replica := row60Halves()
+	factory, _ := fakeContinuumDynamicFactory(cr, primary)
+	h.dynamicFactory = factory
+	dep := installUserAccessDeployment(t, h, "dep-row60-foreign")
+	h.SetK8sCache(crossRegionCNPGCache(t, map[string][]*unstructured.Unstructured{
+		dep.ID: {primary},
+		// Same namespace, same pair label, DIFFERENT Sovereign.
+		"some-other-deployment-me-east-215-b-1": {replica},
+	}), k8scache.NewSARCache(), "X-Forwarded-User")
+
+	resp := fetchReplicationStatus(t, h, dep.ID, "dr-r60fresh", "walkfour")
+	if resp.StandbyAvailable != nil {
+		t.Fatalf("standbyAvailable: got %v — a DIFFERENT Sovereign's replica half was read as this deployment's standby", *resp.StandbyAvailable)
+	}
+	if resp.ReplicaPromotable {
+		t.Fatalf("replicaPromotable: got true off another Sovereign's cluster")
+	}
+}
+
+// When the CR NAMES its pair, a pair that is not observable must yield no
+// determination — never a substituted same-namespace neighbour.
+func TestReplicationStatus_Row60_NamedPairIsNeverSubstituted(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	cr := row60Continuum()
+	setCnpgPairRef(cr, "some-other-pair", "walkfour")
+	primary, replica := row60Halves()
+	factory, _ := fakeContinuumDynamicFactory(cr, primary)
+	h.dynamicFactory = factory
+	dep := installUserAccessDeployment(t, h, "dep-row60-named-pair")
+	h.SetK8sCache(crossRegionCNPGCache(t, map[string][]*unstructured.Unstructured{
+		dep.ID:                      {primary},
+		dep.ID + "-me-east-215-b-1": {replica},
+	}), k8scache.NewSARCache(), "X-Forwarded-User")
+
+	resp := fetchReplicationStatus(t, h, dep.ID, "dr-r60fresh", "walkfour")
+	if resp.StandbyAvailable != nil {
+		t.Fatalf("standbyAvailable: got %v — the CR names pair %q, and the only observable pair is a different database", *resp.StandbyAvailable, "some-other-pair")
+	}
+	if resp.ReplicaPromotable {
+		t.Fatalf("replicaPromotable: got true off a pair the Continuum does not reference")
+	}
+}
+
+// DISAGREEMENT RULE: the controller's standby probe says the leg is GONE while
+// the informer cache still holds a Ready replica object (the stale-cache shape
+// a region outage produces). The disarming oracle must win.
+func TestReplicationStatus_Row60_NegativeProbeOutranksAHealthyCacheRead(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	cr := row60Continuum()
+	setContinuumControllerStatus(cr, "Healthy", false, 0)
+	primary, replica := row60Halves()
+	factory, _ := fakeContinuumDynamicFactory(cr, primary)
+	h.dynamicFactory = factory
+	dep := installUserAccessDeployment(t, h, "dep-row60-probe-wins")
+	h.SetK8sCache(crossRegionCNPGCache(t, map[string][]*unstructured.Unstructured{
+		dep.ID:                      {primary},
+		dep.ID + "-me-east-215-b-1": {replica},
+	}), k8scache.NewSARCache(), "X-Forwarded-User")
+
+	resp := fetchReplicationStatus(t, h, dep.ID, "dr-r60fresh", "walkfour")
+	if resp.ReplicaPromotable {
+		t.Fatalf("replicaPromotable: got true while the controller's own standby probe reports the leg unreachable")
+	}
+	if resp.StandbyAvailable == nil || *resp.StandbyAvailable {
+		t.Fatalf("standbyAvailable: got %v want an explicit false", resp.StandbyAvailable)
+	}
+	if g := gateByName(t, resp, "standby-available"); g.Status != "Fail" {
+		t.Fatalf("standby-available gate: got %q want Fail", g.Status)
+	}
+}
+
+// CONTROL — the pre-existing controller-probe RELAY must still fire when no
+// pair is observable in the cache. Asserting on the relay's own wording proves
+// the new branch did not swallow it (a Pass alone would not distinguish them).
+func TestReplicationStatus_Row60_ControllerProbeRelaySurvives(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	cr := newContinuumUnstructured(
+		"dr-shared-pg", "shared-data", "shared-data/shared-pg",
+		"hw-me-east-215-a-rtz-prod", []string{"hw-me-east-215-b-rtz-prod"})
+	setContinuumControllerStatus(cr, "Healthy", true, 0)
+	setCnpgPairRef(cr, "shared-pg", "shared-data")
+	primary, _ := newCNPGPairFixture("shared-pg", "shared-data",
+		"hw-me-east-215-a-rtz-prod", "hw-me-east-215-b-rtz-prod")
+	factory, _ := fakeContinuumDynamicFactory(cr, primary)
+	h.dynamicFactory = factory
+	dep := installUserAccessDeployment(t, h, "dep-row60-relay-control")
+	// The cache is WIRED but holds no replica half — the pre-#6268 world.
+	h.SetK8sCache(crossRegionCNPGCache(t, map[string][]*unstructured.Unstructured{
+		dep.ID: {primary},
+	}), k8scache.NewSARCache(), "X-Forwarded-User")
+
+	resp := fetchReplicationStatus(t, h, dep.ID, "dr-shared-pg", "shared-data")
+	if resp.StandbyAvailable == nil || !*resp.StandbyAvailable {
+		t.Fatalf("standbyAvailable: got %v want true — the controller's probe relay is the fallback and must survive", resp.StandbyAvailable)
+	}
+	g := gateByName(t, resp, "standby-available")
+	if g.Status != "Pass" {
+		t.Fatalf("standby-available gate: got %q want Pass", g.Status)
+	}
+	if !strings.Contains(g.Message, "Continuum controller's standby probe") {
+		t.Fatalf("standby-available message %q is not the relay's — the relay branch was swallowed", g.Message)
+	}
+}


### PR DESCRIPTION
## The second producer gap on UAT row 60

Row 60's clause is *"that app's Topology tab shows a 2-region pair (region-a primary + region-b replica + **armed Switchover**)"*. #6291 closed the first gap — nothing wrote a per-Org standby HelmRelease into region B. This closes the second: **even with the standby leg present, the DR status could not SEE it**, so it never had positive evidence to arm the control on.

## Measured, not assumed

Both readings taken on hw296 (dep `e689e3b34a75fdec`) in the same minute against catalyst-api `031db43`:

| Continuum | `spec.cnpgPair` | `status.standbyAvailable` |
|---|---|---|
| `walkfour/dr-r60fresh` (row 60's subject) | **absent** | **absent** |
| `shared-data/dr-shared-pg` (the green control) | present | `true` |

And the pair really is split across two apiservers:

```
region A   shared-data/shared-pg          openova.io/cnpg-role=primary
region B   shared-data/shared-pg-replica  openova.io/cnpg-role=replica
region A   walkfour/postgres              openova.io/cnpg-role=primary
```

## Why both existing paths structurally miss it

`augmentReplicationStandbyStatus` resolves through `h.sovereignDynamicClient`, scoped to **region A**:

- `cnpgPairStandbyForContinuum` lists the pair label in region A → no `cnpg-role=replica` half → `(_, false)`
- `findCNPGPairForApp` requires **both** halves out of the **same** list → `(nil, nil)`

So neither determines anything and control falls to the Continuum controller's own `status.standbyAvailable` probe. `dr-shared-pg` carries that probe and stays green on it. `dr-r60fresh` carries **no probe at all**, so it reached no fallback, `enrichReplicationStatus` left `replicaPromotable` at its zero value `false`, and TopologyTab rendered `disabled` with *"the replica is not promotable — no caught-up standby to promote"* against a healthy pair.

## The lever — confirmed by reading it, not by taking the handoff note

`h.k8sCache` already runs a `cnpgcluster` informer against **every registered cluster** — `k8scache/kinds.go:430`, in `DefaultKinds`, not opt-in. It is the same source `derivePlacementTargets` fans out over, which is exactly why the `shared-pg` control already reports a region-B leg with a populated cluster id (`e689e3b34a75fdec-me-east-215-b-1`) while the DR status beside it reported nothing. One client swap, not a new subsystem.

## What lands

- **`crossClusterCNPGPairStandby`** (new file) reads `cnpgcluster` from every cluster the deployment owns and pairs the halves by the `catalyst.openova.io/cnpg-pair` label — so halves in **different regions** resolve.
- `augmentReplicationStandbyStatus` consults it in the previously-terminal `!determined` branch, and it is the **only** branch that may ARM promotability, because it is the only one holding positive evidence that the standby is still **following** (`Ready` **and** `spec.replica.enabled`) rather than merely present.

## Nothing manufactures a verdict from absence

- **No determination unless BOTH halves of one pair were positively observed.** A lone primary (region B down, or single-region) leaves the existing honest-unknown `Warn` exactly as it was. Absence is never reported as an absent standby, and never as a present one.
- **A negative controller probe OUTRANKS the cache read and runs FIRST.** An informer keeps serving the last known object when a region's apiserver goes unreachable, so a cache read can look healthy through the very outage the probe detected. When the two oracles disagree the **disarming** one wins — a Switchover armed against a standby that cannot be promoted is far worse than a disabled one.
- A **promoted** half (`Ready`, `spec.replica.enabled=false`) is available but **not** promotable. A half lagging past the 30s switchover-safety threshold likewise. An **unreported** lag is not treated as a measured zero (#4901: an absent standby also reads lag 0) — the response keeps whatever reading the CR / linked CNPGPair already established.
- **Namespace-scoped**, and it refuses an empty namespace outright, so it cannot reach another Organization's pair. **Deployment-scoped** via `clusterOwnedByDeployment`, so on the mother — whose cache holds every managed Sovereign — it cannot read another Sovereign's identically-named namespace.
- An explicit `spec.cnpgPair.name` selects **that** pair or nothing; a same-namespace neighbour is never substituted.
- The `Pass` message names the replica Cluster **and the cluster id it was read from**, so an operator can tell a cross-region verification from the controller-probe relay that otherwise produces the same `Pass`.

## Vacuity proof — ten mutations, one behaviour each

Each mutation was applied to the production code alone, the single target test run, then the file restored. Every one falsifies its own assertion and no other. The harness refuses to report a result if the patch did not apply.

| # | mutation | target test | result |
|---|---|---|---|
| M1 | resolver always returns no-determination | `CrossRegionPairArmsSwitchover` | RED |
| M2 | drop the `Following` term | `PromotedStandbyIsAvailableButNotPromotable` | RED |
| M3 | widen the lag threshold to 3000s | `LaggingStandbyIsNotPromotable` | RED |
| M4 | drop the namespace filter | `ReplicaInAnotherNamespaceDoesNotResolve` | RED |
| M5 | drop `clusterOwnedByDeployment` | `ForeignSovereignClusterDoesNotResolve` | RED |
| M6 | let a named-but-missing pair fall through to the lexical pick | `NamedPairIsNeverSubstituted` | RED |
| M7 | remove the negative-probe precedence | `NegativeProbeOutranksAHealthyCacheRead` | RED |
| M8 | report a lone primary as a determined-ABSENT standby | `NoRegionBClusterStaysUnknown` | RED |
| M9 | hardcode `Available: true` | `CrossRegionAbsentStandbyIsExplicit` | RED |
| M10 | disable the controller-probe relay branch | `ControllerProbeRelaySurvives` | RED |

The happy-path assertions are ordered **substance first** — `replicaPromotable`, then the tri-state verdict, then the gate label, then the provenance string — so a short-circuit on a cheap label check cannot hide the reading that matters.

The two pre-existing row-62 relay tests pass unchanged: they run with a **nil** `k8sCache` (the pre-handover / CI shape), which the new branch leaves entirely untouched. Full `internal/handler` package green (290s, `-count=1`).

## Delivery

`98f4495` (#6291's producer) is already on main **and** already in a merged deploy bump — `ec5a15373 deploy: update catalyst images to 98f4495`, with the auto chart bump `e36bddd16` → 1.4.1477 and pin sync `a7dcd23e6`. hw296 is still serving chart 1.4.1475 / image `031db43`, so both this fix and #6291 reach it on the next roll. #6300 is redundant against `ec5a15373` and is why its chart-version guard fails (its branch is stale at 1.4.1475).

Refs #6268 #3375
