### PR TITLE
fix(cutover): step-06 pivots the org-tenants HelmRepository source on its own branch, and stops grading itself before it writes it (#6293)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -1074,7 +1074,7 @@ spec:
       # chart/tests/ left the package via .helmignore: 757,264 bytes, 72.2%.
       # The rendered manifest is byte-identical modulo comments — no step,
       # value or RBAC change, still 11 steps.
-      version: 0.1.186
+      version: 0.1.187
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1439,7 +1439,19 @@ spec:
       #   refusing to fail open on a roll state it cannot read — stopped the
       #   cutover at the same step it was meant to unblock. Measured on hw296.
       #   Lockstep w/ products/catalyst/chart/Chart.yaml.
-      version: 1.4.1480
+      # 1.4.1481 — #6293: catalog-seed advances bp-self-sovereign-cutover
+      #   0.1.186 -> 0.1.187. Step-06 patched the five per-Org tenant
+      #   HelmRepositories LIVE, then read them back three phases before the
+      #   durable Gitea rewrite that would make the patch stick — and that
+      #   rewrite targeted a `--branch main` clone, while the org-tenants tree
+      #   lives on the dedicated `org-tenants` branch (TBD-C18e). The
+      #   org-tenants Kustomization (1m, prune=true) reverted every patch, and
+      #   hw296's cutover terminal-failed at 6/11 with five STILL-UPSTREAM.
+      #   0.1.187 moves the rewrite onto the org-tenants branch with its own
+      #   staged commit and push, and makes the Phase-3 pre-strip read-back the
+      #   single fail-closed gate (#5436 relocated, not weakened). Lockstep w/
+      #   products/catalyst/chart/Chart.yaml.
+      version: 1.4.1481
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.186
+  version: 0.1.187
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -3793,7 +3793,82 @@ name: bp-self-sovereign-cutover
 # fail-open) cannot pass. Slot-06a pin + blueprint.yaml + catalog-seed
 # spec.version + source.version + the API blueprints.json + the generated UI
 # catalog move to 0.1.185 in lockstep (Inviolable Principle #13).
-version: 0.1.186
+#
+# 0.1.187 (#6293) — STEP-06 PATCHED FIVE OBJECTS IT DOES NOT OWN, THEN GRADED
+# ITSELF ON WHETHER THEY STUCK. hw296's cutover reached 6/11 and terminal-failed
+# there: `live-K8s ok=4 skip=62 fail=0` immediately followed by
+# `FATAL: Phase-1.5 read-back: 5 region-A HelmRepository(ies) are STILL on
+# oci://ghcr.io/openova-io` — bp-agenity / bp-keycloak / bp-openclaw /
+# bp-stalwart-tenant / bp-wordpress-tenant. No retry could converge it; every
+# re-run re-entered the same order.
+#
+# All five are `status.inventory` entries of the `org-tenants` Flux
+# Kustomization: path ./clusters/<fqdn>/org-tenants, interval 1m, prune=true,
+# sourceRef GitRepository/openova-org-tenants, whose spec.ref.branch is
+# `org-tenants`. Their durable source is written by the catalyst-api org-tenant
+# pipeline (organization_gitops.go writeParentTenantsIndex →
+# clusters/<fqdn>/org-tenants/helmrepositories.yaml) and pushed to
+# `HEAD:org-tenants`. So Phase-1's live kubectl patch is reverted on the next
+# reconcile, always. Live proof on hw296: bp-keycloak and bp-newapi at
+# metadata.generation 101, certSecretRef absent on all six, and two of them
+# logged `SKIP (already pivoted)` at scan time yet came back STILL-UPSTREAM at
+# the read-back — reverted between two reads inside one Job.
+#
+# THREE DEFECTS ON ONE PATH, each of which alone was enough:
+#
+#  1. ORDERING. The Phase-1.5 read-back was `|| exit 1` and ran THREE phases
+#     before Phase-2/2b — the durable Gitea rewrite that is the only thing that
+#     can make the pivot stick. Its own comment justified single-shot sampling
+#     with "Phase-1's patches are synchronous API writes, so there is nothing to
+#     converge", which is true of the WRITE and false of a Flux-owned OBJECT.
+#     It is now a DIAGNOSTIC that names its offenders and cites the gate.
+#     #5436 is NOT weakened: the enforcing call is the Phase-3 pre-strip
+#     read-back — bounded budget, reconcile re-pokes, still `|| exit 1`,
+#     deliberately placed to run on EVERY exit path including the
+#     MOTHERSHIP_AUTHS_TO_STRIP-empty early return, and now the only call that
+#     runs after the durable rewrite. step-08's `-A` scan is unchanged.
+#
+#  2. WRONG BRANCH. #4885 added the org-tenants rewrite inside the working tree
+#     of a clone opened `--branch main`. TBD-C18e moved the org-tenants tree to
+#     its own branch precisely so the step-01 mirror's force-push of main could
+#     not clobber per-Org overlays, so main has no clusters/<fqdn>/org-tenants
+#     directory at all — this repo proves it: `find clusters -type d -name
+#     org-tenants` returns nothing. The collector matched zero files and printed
+#     "sed edited 0 org-tenant HelmRepository file(s)" on every Sovereign that
+#     ever ran it. Phase-2b now lives in its own ConfigMap key, clones the
+#     `org-tenants` branch, rewrites, and pushes `HEAD:org-tenants`.
+#
+#  3. UNSTAGED. Even on a match, the commit staged `git add "${target_dir}"` —
+#     clusters/_template/bootstrap-kit only — and pushed `origin main`. A tenant
+#     edit would have been counted into ${edited}, logged as edited, then
+#     dropped onto the "git diff empty after sed" path, which reads as success.
+#     Phase-2b stages the tree it edits and FATALs if the working tree has
+#     changes the index does not.
+#
+# The rewrite emits `oci://registry.<fqdn>/openova-io`, the SAME value shape the
+# catalyst-api generator emits post-cutover (#5527 orgTenantHelmRepositoryURL),
+# so the two writers of that file agree and Flux has nothing to drift-correct.
+# #5527 keys off step-07's env fact and therefore cannot cover step-06's own
+# window; this closes exactly that window.
+#
+# GUARDS. chart/tests/step06-org-tenants-source.sh executes the RENDERED
+# phase2b.sh against REAL local git repositories with a real main and a real
+# org-tenants branch — a stubbed git cannot be on the wrong branch, and the
+# defect IS the branch. Verdicts are read out of the bare origin, never a
+# working tree the script left behind. Five single-behaviour mutants prove each
+# case individually: cloning main (defect 2) leaves all six upstream; a narrowed
+# `git add` (defect 3) empties the index and FATALs; dropping the injector call
+# strips every certSecretRef; widening the collector breaks the scoping control;
+# swallowing the ls-remote verdict turns an unreadable remote into silent
+# success. step06-pivot-readback.sh gains B7/B7b (Phase-1.5 alone exits 0 on the
+# identical offender state B3 uses to prove the gate still fails closed) and
+# asserts both call sites' fail-wiring in both directions. cutover-contract.sh
+# Case 16b's two render-text greps — which stayed green from #4885 to hw296
+# because a render grep cannot see a wrong branch — are replaced with branch and
+# push-target assertions. Slot-06a pin + blueprint.yaml + catalog-seed
+# spec.version + source.version + the API blueprints.json + the generated UI
+# catalog move to 0.1.187 in lockstep (Inviolable Principle #13).
+version: 0.1.187
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/06-helmrepository-patches-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/06-helmrepository-patches-job.yaml
@@ -82,6 +82,139 @@ data:
     {{ . }}
     {{- end }}
   {{- /*
+   #6293 — Phase 2b, the org-tenants DURABLE-SOURCE pivot. Same `.`-source
+   discipline as phase2c.sh (#5593 inline-arg budget), and the same reason to
+   live in its own key: chart/tests/step06-org-tenants-source.sh awk-slices
+   this region out of the RENDERED manifest and runs it against REAL git
+   repositories, so what the test executes is these bytes and not a copy.
+
+   WHAT IT FIXES. The catalyst-api org-tenant pipeline pushes
+   clusters/<fqdn>/org-tenants/helmrepositories.yaml to a DEDICATED
+   `org-tenants` branch; the org-tenants Flux Kustomization reconciles that
+   path every 1m with prune=true. #4885's rewrite ran in the `--branch main`
+   clone, where the tree does not exist, so it matched nothing and the live
+   Phase-1 patch was reverted every reconcile — measured on hw296: bp-keycloak
+   and bp-newapi at metadata.generation 101, all six owned HelmRepositories
+   back on oci://ghcr.io/openova-io with certSecretRef absent.
+
+   It runs AFTER the main-branch push so its own commit cannot be entangled
+   with `git add "${target_dir}"`, which stages the bootstrap-kit directory
+   only — the second half of the same defect.
+  */}}
+  phase2b.sh: |
+    # ---- Phase 2b (#6293): org-tenants durable-source pivot ----
+    if [ "${ORG_TENANTS_PIVOT_ENABLED:-true}" != "true" ]; then
+      echo "[helmrepository-patches] Phase-2b SKIP: helmRepositories.orgTenantsSource.enabled=false"
+    else
+      ot_branch="${ORG_TENANTS_BRANCH:-org-tenants}"
+      {{- /*
+       ls-remote FIRST so an ABSENT branch (a Sovereign that never bootstrapped
+       the per-Org tenants repo — nothing re-applies tenant HelmRepositories
+       there, so there is nothing to make durable) is distinguishable from an
+       AUTH failure. Collapsing those two into one "skip" is how a credential
+       problem would present as a clean no-op, which is the exact shape #4885
+       shipped. Non-zero exit = fail closed.
+      */}}
+      if ! git ls-remote --heads "${push_url}" "${ot_branch}" > /tmp/.ot-heads.txt 2>/tmp/.ot-heads.err; then
+        echo "[helmrepository-patches] FATAL: Phase-2b: git ls-remote ${ot_branch} against ${redacted} failed — an unreadable remote is NOT an absent branch, and guessing leaves every per-Org HelmRepository on ${UPSTREAM_PREFIX} (#6293)" >&2
+        sed -e 's,://[^@]*@,://***@,g' /tmp/.ot-heads.err >&2 || true
+        exit 1
+      fi
+      if ! grep -q "refs/heads/${ot_branch}" /tmp/.ot-heads.txt; then
+        echo "[helmrepository-patches] Phase-2b SKIP: ${redacted} has no ${ot_branch} branch — no per-Org tenants source exists on this Sovereign, so no Kustomization re-applies tenant HelmRepositories from one (Phase-3 read-back remains the gate)"
+      else
+        cd /tmp
+        rm -rf repo-org-tenants
+        if ! git clone --depth 1 --branch "${ot_branch}" "${push_url}" repo-org-tenants >/dev/null 2>/tmp/.ot-clone.err; then
+          echo "[helmrepository-patches] FATAL: Phase-2b: clone of ${redacted} branch ${ot_branch} failed (#6293)" >&2
+          sed -e 's,://[^@]*@,://***@,g' /tmp/.ot-clone.err >&2 || true
+          exit 1
+        fi
+        cd repo-org-tenants
+        {{- /*
+         Scoped to paths containing /org-tenants/. This branch is a branch of
+         the SAME repo, so it also carries clusters/_template/bootstrap-kit —
+         already rewritten on main, and nothing reconciles bootstrap-kit from
+         here. Rewriting it again would be pointless divergence between the two
+         branches.
+        */}}
+        ot_list=/tmp/.ot-targets.txt
+        : > "${ot_list}"
+        grep -rlE "^[[:space:]]*url:[[:space:]]*${UPSTREAM_PREFIX}[[:space:]]*$" clusters 2>/dev/null | grep '/org-tenants/' >> "${ot_list}" || true
+        ot_edited=0
+        for otf in $(awk 'NF' "${ot_list}" | sort -u); do
+          sed -i -E "s,^([[:space:]]*url:[[:space:]]*)${UPSTREAM_PREFIX}([[:space:]]*)$,\1${local_prefix}\2," "${otf}"
+          ot_edited=$((ot_edited+1))
+          echo "[helmrepository-patches] Phase-2b edited ${ot_branch}:${otf}"
+        done
+        {{- /*
+         Same certSecretRef durability the bootstrap-kit files get: without it
+         the pivoted tenant HelmRepositories x509-fail against the in-cluster
+         Harbor the moment the Kustomization re-applies the local url. Calls
+         the shared injector defined in the step args — never a second copy.
+        */}}
+        if [ -n "${trust_secret}" ]; then
+          ot_trust_list=/tmp/.ot-trust-targets.txt
+          : > "${ot_trust_list}"
+          grep -rlE "^[[:space:]]*url:[[:space:]]*${local_prefix}([[:space:]]*|/.*)$" clusters 2>/dev/null | grep '/org-tenants/' >> "${ot_trust_list}" || true
+          ot_trust=0
+          for otf in $(awk 'NF' "${ot_trust_list}" | sort -u); do
+            inject_trust_ref "${otf}"
+            ot_trust=$((ot_trust+1))
+            echo "[helmrepository-patches] Phase-2b trust-injected certSecretRef -> ${ot_branch}:${otf}"
+          done
+          ot_edited=$((ot_edited+ot_trust))
+        fi
+        {{- /*
+         Post-condition on the FILES, before anything is committed: zero
+         org-tenants documents may still declare the upstream prefix. This is
+         the durable-source analogue of #5436's live read-back — it asserts the
+         rewrite's RESULT rather than counting the loop iterations that were
+         supposed to produce it.
+        */}}
+        ot_left=$(grep -rlE "^[[:space:]]*url:[[:space:]]*${UPSTREAM_PREFIX}[[:space:]]*$" clusters 2>/dev/null | grep -c '/org-tenants/' || true)
+        if [ "${ot_left}" -ne 0 ]; then
+          echo "[helmrepository-patches] FATAL: Phase-2b: ${ot_left} org-tenants file(s) still declare ${UPSTREAM_PREFIX} after the rewrite — pushing now would record a durable pivot that does not exist (#6293)" >&2
+          exit 1
+        fi
+        {{- /*
+         Commit on ACTUAL tree state, never on the edit counters: the trust
+         injector is idempotent, so a re-run legitimately reports edits and
+         produces no diff. Gating the commit on ${ot_edited} turned that
+         no-op into a hard failure on every second run.
+        */}}
+        if git diff --quiet; then
+          echo "[helmrepository-patches] Phase-2b: org-tenants source already pivoted (${ot_edited} file-visit(s), no diff) — nothing to push"
+        else
+          {{- /*
+           `git add -A clusters` — NOT `git add <one dir>`. The main-branch
+           commit above stages ${target_dir} alone, which is why a tenant edit
+           there was counted, logged, and then silently dropped onto the
+           "git diff empty after sed" path. Staging the whole tree this leg
+           edits is what makes the commit match the log; the assert below is
+           what makes a future re-narrowing fail loudly instead of silently.
+          */}}
+          git add -A clusters
+          if git diff --staged --quiet; then
+            echo "[helmrepository-patches] FATAL: Phase-2b: the working tree has changes but the index is empty — \`git add\` is mis-scoped and this push would carry none of the rewrite (#6293)" >&2
+            exit 1
+          fi
+          git commit -m "cutover: pivot ${ot_edited} org-tenant HelmRepository URL(s) to local Harbor" >/dev/null
+          if ! ot_push_err=$(git push origin "HEAD:${ot_branch}" 2>&1); then
+            echo "[helmrepository-patches] FATAL: Phase-2b: push to ${ot_branch} failed — the per-Org HelmRepositories keep reverting to ${UPSTREAM_PREFIX} on every reconcile (#6293)" >&2
+            printf '%s\n' "${ot_push_err}" >&2
+            exit 1
+          fi
+          echo "[helmrepository-patches] Phase-2b OK: pushed ${ot_edited} edit(s) to ${redacted} branch ${ot_branch}"
+          kubectl annotate --overwrite gitrepository "${ORG_TENANTS_GITREPO:-openova-org-tenants}" \
+            -n "${ORG_TENANTS_GITREPO_NAMESPACE:-flux-system}" \
+            "reconcile.fluxcd.io/requestedAt=$(date +%s)" >/dev/null 2>&1 || true
+        fi
+        cd /tmp/repo
+      fi
+    fi
+    # ---- end Phase 2b (#6293) ----
+  {{- /*
    #5593 — Phase 2c of the step script, mounted and exec (`.`-sourced) FROM
    FILE. Step-06 renders within a few hundred bytes of the 110000-byte inline
    arg budget, so this block MUST NOT move back into podSpec.args. Its
@@ -639,6 +772,22 @@ data:
           - name: HELMREPO_READBACK_BUDGET_SECONDS
             value: {{ .Values.stepTimeouts.pivotReadbackSeconds | quote }}
           {{- /*
+           #6293 — Phase-2b org-tenants durable-source pivot. The branch MUST
+           track products/catalyst/chart/templates/org-services/
+           org-repo-gitrepository.yaml `ref.branch` (default org-tenants) and
+           the catalyst-api writer's CATALYST_GITOPS_BRANCH; they are the same
+           branch seen from three sides, and a mismatch reverts to the silent
+           no-op this fixes.
+          */}}
+          - name: ORG_TENANTS_PIVOT_ENABLED
+            value: {{ eq (toString .Values.helmRepositories.orgTenantsSource.enabled) "true" | quote }}
+          - name: ORG_TENANTS_BRANCH
+            value: {{ .Values.helmRepositories.orgTenantsSource.branch | quote }}
+          - name: ORG_TENANTS_GITREPO
+            value: {{ .Values.helmRepositories.orgTenantsSource.gitRepositoryName | quote }}
+          - name: ORG_TENANTS_GITREPO_NAMESPACE
+            value: {{ .Values.helmRepositories.orgTenantsSource.gitRepositoryNamespace | quote }}
+          {{- /*
            #5596 — SECONDARY-region DURABLE pivot assert inputs. The #5359
            read-back was single-shot and fired seconds after the patch loop,
            so it measured the PATCH and never the PIVOT: region-B's own
@@ -695,6 +844,10 @@ data:
             readOnly: true
           - name: bootstrap-kit-pins
             mountPath: /pin-extractor
+            readOnly: true
+          {{- /* #6293 — Phase 2b of the step script, `.`-sourced from here. */}}
+          - name: phase2b-script
+            mountPath: /phase2b
             readOnly: true
           {{- /* #5593 — Phase 2c of the step script, `.`-sourced from here. */}}
           - name: phase2c-script
@@ -1189,6 +1342,14 @@ data:
             assert_region_a_pivot() {
               ra_label="$1"
               ra_budget="${2:-0}"
+              {{- /*
+               #6293 — $3 = the word this prints when offenders remain, so the
+               ONE non-gating caller (the Phase-1.5 diagnostic, which runs
+               before Phase-2/2b has written the durable source) cannot print
+               "FATAL" on a condition it does not fail on. Defaults to FATAL:
+               every caller that omits it is a gate, and stays one.
+              */}}
+              ra_severity="${3:-FATAL}"
               ra_deadline=$(( $(date +%s) + ra_budget ))
               ra_left=0
               while : ; do
@@ -1228,7 +1389,7 @@ data:
                 sleep 15
               done
               if [ "${ra_left}" -ne 0 ]; then
-                echo "[helmrepository-patches] FATAL: ${ra_label}: ${ra_left} region-A HelmRepository(ies) are STILL on ${UPSTREAM_PREFIX} after the pivot — the Sovereign would record a SUCCESSFUL cutover step while its charts resolve to the mothership; refusing to succeed (#5436)" >&2
+                echo "[helmrepository-patches] ${ra_severity}: ${ra_label}: ${ra_left} region-A HelmRepository(ies) are STILL on ${UPSTREAM_PREFIX} after the pivot — the Sovereign would record a SUCCESSFUL cutover step while its charts resolve to the mothership; refusing to succeed (#5436)" >&2
                 sed 's/^/  STILL-UPSTREAM /' /tmp/.ra-offenders.txt >&2 || true
                 return 1
               fi
@@ -1331,7 +1492,37 @@ data:
              and now, or one whose patch silently no-op'd, fails HERE
              instead of shipping a green step on a half-pivoted Sovereign.
             */}}
-            assert_region_a_pivot "Phase-1.5 read-back" 0 || exit 1
+            {{- /*
+             #6293 — this call is a DIAGNOSTIC, not the gate. It used to be
+             `|| exit 1`, and that is what terminal-failed the hw296 cutover at
+             step 6 with five STILL-UPSTREAM org-tenant HelmRepositories.
+
+             The reason it cannot be the gate is stated, wrongly, in the block
+             comment above assert_region_a_pivot: "the Phase-1.5 call is
+             single-shot: Phase-1's patches are synchronous API writes, so there
+             is nothing to converge." True of the WRITE, false of the OBJECT.
+             Five of these HelmRepositories are owned by the org-tenants
+             Kustomization (1m interval, prune=true), so Flux reverts them
+             asynchronously — and Phase-1 issues up to two kubectl calls per
+             name across ~66 names, which comfortably outruns a 1m reconcile.
+             The durable rewrite that makes the pivot stick is Phase-2/2b,
+             THREE phases further down. Failing closed here asserts an invariant
+             the script has not yet established, and no retry can converge it:
+             every re-run re-enters the same order.
+
+             #5436 is NOT weakened. Its enforcing call is the one at the head of
+             Phase 3 — `assert_region_a_pivot "Phase-3 pre-strip read-back"` with
+             HELMREPO_READBACK_BUDGET_SECONDS and reconcile re-pokes, still
+             `|| exit 1`. That call is deliberately placed so it runs on EVERY
+             exit path including the MOTHERSHIP_AUTHS_TO_STRIP-empty early
+             return, and it runs AFTER the durable Gitea rewrite — the only
+             point in this step where a green result means what it says. An HR
+             the Phase-0.9 enumeration missed, or a patch that silently no-op'd,
+             is still caught there, and again by step-08's wider `-A` scan.
+            */}}
+            if ! assert_region_a_pivot "Phase-1.5 read-back" 0 "DIAGNOSTIC"; then
+              echo "[helmrepository-patches] Phase-1.5: the offenders above are NOT yet a failure — their durable source is rewritten by Phase-2/2b below and asserted, fail-closed, by the Phase-3 pre-strip read-back (#6293 #5436)"
+            fi
 
             {{- /*
              ---- Phase 1.6: parent HelmRelease values override for openova-catalog (TBD-C19) ----
@@ -1543,31 +1734,39 @@ data:
             echo "[helmrepository-patches] sed edited ${edited} bootstrap-kit file(s)"
 
             {{- /*
-             ---- Phase 2b (#4885): pivot the per-Org TENANT shared HelmRepositories ----
+             ---- Phase 2b: MOVED to /phase2b/phase2b.sh (#6293) ----
 
-             The catalyst-api org-tenant pipeline writes the shared bp-* tenant
-             HelmRepositories to clusters/<sov-fqdn>/org-tenants/helmrepositories.yaml
-             (+ per-tenant overlay files under .../org-tenants/<org-id>/), in THIS
-             same openova/openova gitops repo, reconciled by the org-tenants PARENT
-             Flux Kustomization — a DIFFERENT durable source than the bootstrap-kit
-             slots above. So the Phase-1 live patch of these HRs is REVERTED ~1
-             reconcile later unless their Gitea source is rewritten here too (the
-             exact #970/#3526 revert-race, one directory over). Rewrite every
-             org-tenants YAML that still declares the upstream url
-             (bp-agenity / bp-openclaw / bp-stalwart-tenant / bp-wordpress-tenant /
-             bp-keycloak / bp-cnpg / bp-newapi) to the local Harbor prefix so
-             step-08's `-A` offender scan converges durably. Guarded on the tree
-             existing (a Sovereign with no customer Orgs has no org-tenants dir →
-             0 edits, harmless no-op).
+             #4885 put the org-tenants rewrite HERE, inside the working tree of
+             a clone this same block opens with `--branch main`. It could never
+             match a file. The catalyst-api org-tenant pipeline
+             (organization_gitops.go writeParentTenantsIndex) pushes
+             clusters/<fqdn>/org-tenants/helmrepositories.yaml to `HEAD:org-tenants`
+             — a DEDICATED branch (TBD-C18e; products/catalyst/chart/templates/
+             org-services/org-repo-gitrepository.yaml `ref.branch: org-tenants`),
+             precisely so the step-01 mirror's force-push of main cannot clobber
+             per-Org overlays. `main` therefore has no clusters/<fqdn>/org-tenants
+             tree at all, and this repo proves it: `find clusters -type d -name
+             org-tenants` returns nothing.
+
+             So the loop's `grep -rl … | grep '/org-tenants/'` returned empty on
+             every Sovereign that ever ran it, printed "sed edited 0 org-tenant
+             HelmRepository file(s)", and read as a clean no-op. Underneath, the
+             org-tenants Kustomization (1m interval, prune=true, sourceRef
+             openova-org-tenants) kept re-applying the ghcr URLs over Phase-1's
+             live patch — the five offenders #5436's read-back FATALs on
+             (bp-agenity / bp-keycloak / bp-openclaw / bp-stalwart-tenant /
+             bp-wordpress-tenant; bp-newapi is the sixth, tolerated via
+             readbackExcludeNames).
+
+             A second defect sat behind it: even with a match, the commit below
+             stages `git add "${target_dir}"` = clusters/_template/bootstrap-kit
+             ONLY, and pushes `origin main`. Tenant edits would have been counted
+             into ${edited}, logged as edited, then dropped unstaged — the
+             "git diff empty after sed" path, which reads as success.
+
+             The rewrite now runs against its OWN branch in its own clone, with
+             its own add/commit/push, sourced after the main-branch push below.
             */}}
-            tenant_edited=0
-            for f in $(grep -rlE "^[[:space:]]*url:[[:space:]]*${UPSTREAM_PREFIX}[[:space:]]*$" clusters 2>/dev/null | grep '/org-tenants/' || true); do
-              sed -i -E "s,^([[:space:]]*url:[[:space:]]*)${UPSTREAM_PREFIX}([[:space:]]*)$,\1${local_prefix}\2," "${f}"
-              tenant_edited=$((tenant_edited+1))
-              edited=$((edited+1))
-              echo "[helmrepository-patches] edited tenant-HR ${f}"
-            done
-            echo "[helmrepository-patches] sed edited ${tenant_edited} org-tenant HelmRepository file(s)"
 
             {{- /*
              Phase-2 trust durability (Refs #3379): inject `certSecretRef:`
@@ -1581,22 +1780,19 @@ data:
              pivoted url line has no matching certSecretRef immediately after.
              Only runs when a trust secret was actually built (Phase-0.5).
             */}}
-            if [ -n "${trust_secret}" ]; then
-              trust_edited=0
-              {{- /*
-               #4885: union the bootstrap-kit slot files with the org-tenants HR
-               files (Phase-2b) so the pivoted TENANT HelmRepositories carry the
-               source-controller trust ref too — else they x509-fail pulling the
-               LE-staging in-cluster Harbor once the org-tenants Kustomization
-               reconciles the durable local url. Collect both into a temp file
-               (avoids an unindented continuation line inside this YAML block scalar).
-              */}}
-              trust_list=/tmp/cutover-trust-targets.txt
-              : > "${trust_list}"
-              grep -lE "^[[:space:]]*url:[[:space:]]*${local_prefix}([[:space:]]*|/.*)$" "${target_dir}"/*.yaml 2>/dev/null >> "${trust_list}" || true
-              grep -rlE "^[[:space:]]*url:[[:space:]]*${local_prefix}([[:space:]]*|/.*)$" clusters 2>/dev/null | grep '/org-tenants/' >> "${trust_list}" || true
-              for f in $(awk 'NF' "${trust_list}" | sort -u); do
-                awk -v ref="${trust_secret}" -v lp="${local_prefix}" '
+            {{- /*
+             #6293 — the injector is a FUNCTION defined UNCONDITIONALLY, not an
+             inline awk inside the trust_secret branch, because phase2b.sh needs
+             the identical transform on the org-tenants branch. A pasted second
+             copy is the #5646 shape: the two drift and only one gets fixed.
+             `.`-sourced phase2b.sh runs in THIS shell, so it just calls this.
+             The two markers are `#` comments on purpose — chart/tests/
+             step06-org-tenants-source.sh awk-slices this region out of the
+             RENDERED manifest so it exercises these bytes, not a copy.
+            */}}
+            # ---- inject_trust_ref (#3379 #6293) ----
+            inject_trust_ref() {
+              awk -v ref="${trust_secret}" -v lp="${local_prefix}" '
                   {{- /*
                    Match a pivoted `url:` line (local Harbor prefix). Capture
                    its leading whitespace so the injected block aligns with the
@@ -1637,7 +1833,29 @@ data:
                     injected_here=0
                     print line
                   }
-                ' "${f}" > "${f}.trust" && mv "${f}.trust" "${f}"
+                ' "$1" > "$1.trust" && mv "$1.trust" "$1"
+            }
+            # ---- end inject_trust_ref ----
+
+            if [ -n "${trust_secret}" ]; then
+              trust_edited=0
+              {{- /*
+               Collected into a temp file (avoids an unindented continuation
+               line inside this YAML block scalar).
+
+               #6293: the second collector line — a `grep -rl … clusters | grep
+               '/org-tenants/'` added by #4885 — is REMOVED, not relocated by
+               accident. This clone is `--branch main`; the org-tenants tree
+               lives on the `org-tenants` branch, so it matched nothing here.
+               The tenant HelmRepositories get their certSecretRef from this
+               same injector, called inside phase2b.sh in a clone that actually
+               holds them.
+              */}}
+              trust_list=/tmp/cutover-trust-targets.txt
+              : > "${trust_list}"
+              grep -lE "^[[:space:]]*url:[[:space:]]*${local_prefix}([[:space:]]*|/.*)$" "${target_dir}"/*.yaml 2>/dev/null >> "${trust_list}" || true
+              for f in $(awk 'NF' "${trust_list}" | sort -u); do
+                inject_trust_ref "${f}"
                 trust_edited=$((trust_edited+1))
                 echo "[helmrepository-patches] trust-injected certSecretRef -> ${f}"
               done
@@ -1789,6 +2007,18 @@ data:
                   "reconcile.fluxcd.io/requestedAt=$(date +%s)" >/dev/null || true
               fi
             fi
+
+            {{- /*
+             Phase 2b (#6293) — the org-tenants branch pivot, `.`-sourced from
+             file for the same #5593 budget reason as Phase-2c. It runs HERE,
+             after the main-branch commit/push, on purpose: it operates on a
+             different branch in its own clone, so entangling it with the
+             ${target_dir}-scoped `git add` above is what produced the original
+             silent drop. Sourced (not `sh`) so ${push_url}, ${local_prefix},
+             ${trust_secret}, ${redacted} and inject_trust_ref() are in scope
+             and its `exit 1` FATALs the whole step.
+            */}}
+            . /phase2b/phase2b.sh
 
             {{- /*
              ====================================================================
@@ -2756,6 +2986,13 @@ data:
           items:
             - key: extract-pins.sh
               path: extract-pins.sh
+      {{- /* #6293 — the same step-06 ConfigMap, exposing ONLY the phase2b.sh key. */}}
+      - name: phase2b-script
+        configMap:
+          name: cutover-step-06-helmrepository-patches
+          items:
+            - key: phase2b.sh
+              path: phase2b.sh
       {{- /* #5593 — the same step-06 ConfigMap, exposing ONLY the phase2c.sh key. */}}
       - name: phase2c-script
         configMap:

--- a/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
+++ b/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
@@ -701,11 +701,28 @@ if ! grep -q "grep '/org-tenants/'" "$TMP/render.yaml"; then
   echo "FAIL: Step-06 Phase-2b does not rewrite the clusters/<fqdn>/org-tenants HelmRepository files — the tenant-HR pivot is non-durable and reverts (#4885)" >&2
   exit 1
 fi
-if ! grep -q 'org-tenant HelmRepository file(s)' "$TMP/render.yaml"; then
-  echo "FAIL: Step-06 Phase-2b org-tenant durable-edit log line missing (#4885)" >&2
+# #6293 — the two checks that used to sit here were the defect's own camouflage.
+# They grepped the render for the collector expression and for a log line, and
+# BOTH were present in a code path that ran inside a `git clone --branch main`
+# working tree. The org-tenants tree lives on the dedicated `org-tenants`
+# branch, so the collector matched nothing, the log line printed "0 file(s)",
+# and this case stayed green from #4885 until hw296 terminal-failed step 6 with
+# five reverted HelmRepositories. A render-text assertion cannot see a wrong
+# branch; what follows asserts the branch, and chart/tests/
+# step06-org-tenants-source.sh asserts the BEHAVIOUR against real git repos.
+if ! grep -q -- '--branch "${ot_branch}"' "$TMP/render.yaml"; then
+  echo "FAIL: Step-06 Phase-2b does not clone the org-tenants BRANCH — the rewrite runs in a tree that cannot contain clusters/<fqdn>/org-tenants (#6293)" >&2
   exit 1
 fi
-echo "  PASS (Step-06 pivots tenant HelmRepositories live + durably)"
+if ! grep -q 'git push origin "HEAD:${ot_branch}"' "$TMP/render.yaml"; then
+  echo "FAIL: Step-06 Phase-2b does not push to the org-tenants branch — the per-Org HelmRepositories keep reverting on every 1m reconcile (#6293)" >&2
+  exit 1
+fi
+if ! grep -q 'Phase-2b OK: pushed' "$TMP/render.yaml"; then
+  echo "FAIL: Step-06 Phase-2b durable-push log line missing (#6293)" >&2
+  exit 1
+fi
+echo "  PASS (Step-06 pivots tenant HelmRepositories live + durably, on their own branch)"
 
 echo "[cutover-contract] Case 18: Step-06 Phase-0 probe is escape-free + has wait-loop (Fix #77, Gap A)"
 # 0.1.24 used kubectl jsonpath `{.data['.dockerconfigjson']}` which

--- a/platform/self-sovereign-cutover/chart/tests/step06-org-tenants-source.sh
+++ b/platform/self-sovereign-cutover/chart/tests/step06-org-tenants-source.sh
@@ -1,0 +1,426 @@
+#!/usr/bin/env bash
+# #6293 — step-06 Phase-2b: the per-Org tenant HelmRepository DURABLE-SOURCE pivot.
+#
+# THE DEFECT THIS LOCKS OUT
+# ─────────────────────────
+# The six shared bp-* HelmRepositories the per-Org overlays sourceRef are owned
+# by the `org-tenants` Flux Kustomization: path ./clusters/<fqdn>/org-tenants,
+# interval 1m, prune=true, sourceRef GitRepository/openova-org-tenants whose
+# spec.ref.branch is `org-tenants`. Step-06 Phase-1 patches those objects LIVE,
+# and Flux reverts every patch on its next reconcile.
+#
+# #4885 knew that and added a Gitea rewrite for them — inside the working tree
+# of a clone opened `--branch main`. The org-tenants tree does not exist on
+# main (TBD-C18e split it onto its own branch precisely so the step-01 mirror's
+# force-push of main could not clobber per-Org overlays), so the rewrite matched
+# nothing, printed "sed edited 0 org-tenant HelmRepository file(s)", and read as
+# a clean no-op for every Sovereign that ever ran it. Behind it sat a second
+# defect: the commit stages `git add "${target_dir}"` — clusters/_template/
+# bootstrap-kit only — and pushes `origin main`, so a matched tenant edit would
+# have been counted into ${edited}, logged as edited, then dropped unstaged onto
+# the "git diff empty after sed" path, which also reads as success.
+#
+# Measured on hw296 (dep 2026-08-14, cutover terminal-failed at step 6):
+# bp-keycloak and bp-newapi at metadata.generation 101, all six HelmRepositories
+# back on oci://ghcr.io/openova-io with certSecretRef absent, and the Job log
+# containing no `org-tenant`, no `tenant-HR`, no `sed edited`, no commit/push
+# line at all.
+#
+# WHY THIS TEST USES REAL GIT AND NOT A STUB
+# ──────────────────────────────────────────
+# A stubbed `git` cannot be on the wrong branch — the defect IS the branch. So
+# every case below runs the REAL rendered phase2b.sh bytes against REAL local
+# git repositories with a real `main` and a real `org-tenants` branch, and reads
+# its verdict out of the bare origin (`git show org-tenants:<path>`), never out
+# of a working tree the script itself left behind. The only stub is `kubectl`,
+# used solely by the trailing `annotate … || true` reconcile poke, which no
+# assertion depends on.
+#
+# EVERY ASSERTION IS VACUITY-PROVED INDIVIDUALLY. Section M re-runs the suite
+# against single-behaviour mutants of the real script — one mutation each — and
+# requires the matching case to go RED. A case with no mutant partner is a
+# CONTROL, and Section M includes mutants that turn the controls red too, so the
+# suite cannot be satisfied by deleting, disabling or blanket-widening Phase-2b.
+#
+# Usage: bash tests/step06-org-tenants-source.sh [CHART_DIR]
+set -uo pipefail
+
+CHART_DIR="${1:-$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/.." && pwd)}"
+CHART_DIR="$(cd "${CHART_DIR}" && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "${TMP}"' EXIT
+
+FQDN="hw296.omani.works"
+UPSTREAM="oci://ghcr.io/openova-io"
+LOCAL="oci://registry.${FQDN}/openova-io"
+TRUST="cutover-harbor-ca"
+OT_PATH="clusters/${FQDN}/org-tenants/helmrepositories.yaml"
+BK_PATH="clusters/_template/bootstrap-kit/19-harbor.yaml"
+
+pass=0; fail=0
+ok()  { echo "  ok   — $1"; pass=$((pass+1)); }
+bad() { echo "  FAIL — $1"; fail=$((fail+1)); }
+
+mkdir -p "${TMP}/bin"
+
+# ── Render ─────────────────────────────────────────────────────────────────
+helm template ssc "${CHART_DIR}" --set sovereign.fqdn="${FQDN}" \
+  >"${TMP}/render.yaml" 2>"${TMP}/render.err" || {
+  echo "FAIL — helm template failed:"; cat "${TMP}/render.err"; exit 1
+}
+
+# ── Extract the bytes under test straight from the render ──────────────────
+# Plain awk over the render text, deliberately NO PyYAML: the same dependency
+# surface as the Job (sh + awk + git), so this suite cannot skip itself on a
+# runner missing a python module.
+awk '/# ---- Phase 2b \(#6293\)/,/# ---- end Phase 2b \(#6293\) ----/' "${TMP}/render.yaml" \
+  | sed 's/^    //' >"${TMP}/phase2b.orig.sh"
+awk '/# ---- inject_trust_ref \(#3379 #6293\) ----/,/# ---- end inject_trust_ref ----/' "${TMP}/render.yaml" \
+  | sed 's/^            //' >"${TMP}/injector.sh"
+
+if grep -q 'ORG_TENANTS_BRANCH' "${TMP}/phase2b.orig.sh"; then
+  ok "extracted phase2b.sh from the render"
+else
+  echo "FAIL — phase2b.sh did not extract (marker comments changed?)"; exit 1
+fi
+# Truncation guard: a short extraction would still `sh` cleanly and exit 0 —
+# the fail-open shape this suite exists to eliminate.
+if ! tail -3 "${TMP}/phase2b.orig.sh" | grep -q 'end Phase 2b'; then
+  echo "FAIL — phase2b.sh extraction was truncated"; exit 1
+fi
+if grep -q 'inject_trust_ref()' "${TMP}/injector.sh"; then
+  ok "extracted the shared inject_trust_ref function from the render"
+else
+  echo "FAIL — inject_trust_ref did not extract"; exit 1
+fi
+sh -n "${TMP}/phase2b.orig.sh" || { echo "FAIL — phase2b.sh is not valid POSIX sh"; exit 1; }
+
+# Relocate the container's literal /tmp paths into the test tmpdir. Assert the
+# substitution actually applied, so a path rename in the template cannot
+# silently turn every case below into a no-op.
+tmp_hits=$(grep -c '/tmp' "${TMP}/phase2b.orig.sh" || true)
+if [ "${tmp_hits}" -lt 3 ]; then
+  echo "FAIL — phase2b.sh no longer uses /tmp paths; harness relocation is stale"; exit 1
+fi
+relocate() { sed "s,/tmp,${TMP}/t,g" "$1" >"$2"; }
+relocate "${TMP}/phase2b.orig.sh" "${TMP}/phase2b.sh"
+
+# ── Stub kubectl (reconcile poke only; no assertion depends on it) ─────────
+cat >"${TMP}/bin/kubectl" <<'FAKE'
+#!/usr/bin/env sh
+echo "kubectl $*" >>"${FAKE_KUBECTL_LOG}"
+exit 0
+FAKE
+chmod +x "${TMP}/bin/kubectl"
+
+# ── Fixtures: a real bare origin with a real main and a real org-tenants ───
+hr_doc() {
+  # $1 = name, $2 = url
+  printf -- '---\napiVersion: source.toolkit.fluxcd.io/v1beta2\nkind: HelmRepository\nmetadata:\n  name: %s\n  namespace: flux-system\nspec:\n  type: oci\n  interval: 15m\n  url: %s\n  secretRef:\n    name: ghcr-pull\n' "$1" "$2"
+}
+
+build_origin() {
+  # $1 = "with-branch" | "no-branch"
+  rm -rf "${TMP}/origin.git" "${TMP}/seed"
+  git init --bare -q "${TMP}/origin.git"
+  git init -q -b main "${TMP}/seed"
+  (
+    cd "${TMP}/seed"
+    git config user.name t; git config user.email t@example.invalid
+    mkdir -p "$(dirname "${BK_PATH}")"
+    hr_doc bp-harbor "${UPSTREAM}" >"${BK_PATH}"
+    git add -A; git commit -qm seed
+    git remote add origin "${TMP}/origin.git"
+    git push -q origin main
+    if [ "$1" = "with-branch" ]; then
+      git checkout -q -b org-tenants
+      mkdir -p "$(dirname "${OT_PATH}")" "clusters/${FQDN}/org-tenants/org-abc"
+      {
+        # Multi-document, exactly the shape organization_gitops.go emits.
+        hr_doc bp-keycloak         "${UPSTREAM}"
+        hr_doc bp-newapi           "${UPSTREAM}"
+        hr_doc bp-wordpress-tenant "${UPSTREAM}"
+        hr_doc bp-openclaw         "${UPSTREAM}"
+        hr_doc bp-stalwart-tenant  "${UPSTREAM}"
+        hr_doc bp-agenity          "${UPSTREAM}"
+      } >"${OT_PATH}"
+      printf 'resources:\n  - org-abc\n' >"clusters/${FQDN}/org-tenants/kustomization.yaml"
+      # A per-Org overlay HelmRelease: carries a sourceRef but NO url. Nothing
+      # here may be rewritten; it is why the collector greps `url:` lines.
+      printf 'apiVersion: helm.toolkit.fluxcd.io/v2\nkind: HelmRelease\nmetadata:\n  name: bp-keycloak\nspec:\n  chart:\n    spec:\n      sourceRef:\n        kind: HelmRepository\n        name: bp-keycloak\n' \
+        >"clusters/${FQDN}/org-tenants/org-abc/bp-keycloak.yaml"
+      git add -A; git commit -qm tenants
+      git push -q origin org-tenants
+    fi
+  ) >/dev/null 2>&1
+}
+
+# Read a path out of the BARE origin — never out of a working tree the script
+# left behind. Pushed-or-it-did-not-happen.
+origin_show() { git --git-dir="${TMP}/origin.git" show "$1:$2" 2>/dev/null; }
+origin_has_branch() { git --git-dir="${TMP}/origin.git" rev-parse --verify -q "$1" >/dev/null 2>&1; }
+
+# ── Runner: execute the real phase2b.sh with the parent-shell contract ────
+# push_url / redacted / UPSTREAM_PREFIX / local_prefix / trust_secret and
+# inject_trust_ref() are supplied by the step args in production; here they are
+# supplied identically, with the injector sourced from the render.
+run_phase2b() {
+  # $1 = script path   $2 = push_url   $3 = ORG_TENANTS_PIVOT_ENABLED
+  : >"${TMP}/kubectl.log"
+  mkdir -p "${TMP}/t/repo"
+  cat >"${TMP}/driver.sh" <<DRIVER
+push_url='$2'
+redacted='gitea.example.invalid/openova/openova.git'
+UPSTREAM_PREFIX='${UPSTREAM}'
+local_prefix='${LOCAL}'
+trust_secret='${TRUST}'
+. '${TMP}/injector.sh'
+. '$1'
+DRIVER
+  env -i \
+    PATH="${TMP}/bin:${PATH}" \
+    HOME="${TMP}" \
+    FAKE_KUBECTL_LOG="${TMP}/kubectl.log" \
+    GIT_AUTHOR_NAME=cutover GIT_AUTHOR_EMAIL=cutover@example.invalid \
+    GIT_COMMITTER_NAME=cutover GIT_COMMITTER_EMAIL=cutover@example.invalid \
+    GIT_TERMINAL_PROMPT=0 \
+    ORG_TENANTS_PIVOT_ENABLED="$3" \
+    ORG_TENANTS_BRANCH=org-tenants \
+    ORG_TENANTS_GITREPO=openova-org-tenants \
+    ORG_TENANTS_GITREPO_NAMESPACE=flux-system \
+    sh "${TMP}/driver.sh" >"${TMP}/out.log" 2>&1
+  echo $?
+}
+
+count_upstream() { origin_show "$1" "$2" | grep -c "url: ${UPSTREAM}$" || true; }
+count_local()    { origin_show "$1" "$2" | grep -c "url: ${LOCAL}$" || true; }
+count_trust()    { origin_show "$1" "$2" | grep -c "name: ${TRUST}$" || true; }
+
+# ═══════════════════════════════════════════════════════════════════════════
+echo "== C. behaviour against real git repositories =="
+
+# ── C1/C2/C3/C7: the happy path, read back out of the bare origin ─────────
+build_origin with-branch
+rc=$(run_phase2b "${TMP}/phase2b.sh" "${TMP}/origin.git" true)
+
+if [ "${rc}" -eq 0 ]; then ok "C0 happy path exits 0"
+else bad "C0 happy path exit ${rc}"; sed 's/^/      /' "${TMP}/out.log" | tail -20; fi
+
+c1_up=$(count_upstream org-tenants "${OT_PATH}")
+c1_lo=$(count_local org-tenants "${OT_PATH}")
+if [ "${c1_up}" -eq 0 ] && [ "${c1_lo}" -eq 6 ]; then
+  ok "C1 all 6 org-tenant HelmRepositories pivoted to local Harbor ON THE org-tenants BRANCH"
+else
+  bad "C1 org-tenants branch has ${c1_up} still on ${UPSTREAM} and ${c1_lo} on local (want 0 / 6) — the per-Org durable source was not rewritten (#6293)"
+fi
+
+if [ "$(count_trust org-tenants "${OT_PATH}")" -eq 6 ]; then
+  ok "C2 certSecretRef=${TRUST} injected beside every pivoted url"
+else
+  bad "C2 certSecretRef present on $(count_trust org-tenants "${OT_PATH}") of 6 — pivoted tenant HRs would x509-fail the in-cluster Harbor"
+fi
+
+if [ "$(count_upstream org-tenants "${BK_PATH}")" -eq 1 ]; then
+  ok "C3 CONTROL: the bootstrap-kit file on this branch is untouched (scoping holds)"
+else
+  bad "C3 Phase-2b rewrote a non-org-tenants file — the /org-tenants/ scope was widened"
+fi
+
+# The overlay legitimately contains the string `kind: HelmRepository` inside its
+# sourceRef, so this compares the pushed bytes to the seeded bytes rather than
+# grepping for a token that is expected to be present.
+if origin_show org-tenants "clusters/${FQDN}/org-tenants/org-abc/bp-keycloak.yaml" \
+   | cmp -s - "${TMP}/seed/clusters/${FQDN}/org-tenants/org-abc/bp-keycloak.yaml"; then
+  ok "C4 CONTROL: the per-Org HelmRelease overlay (sourceRef, no url) is byte-identical"
+else
+  bad "C4 CONTROL: the per-Org HelmRelease overlay was modified — Phase-2b touched a file with no url: line"
+fi
+
+if [ "$(count_upstream main "${BK_PATH}")" -eq 1 ]; then
+  ok "C5 CONTROL: Phase-2b did not push anything to main"
+else
+  bad "C5 Phase-2b modified main — it must only ever write the org-tenants branch"
+fi
+
+if grep -q "gitrepository openova-org-tenants" "${TMP}/kubectl.log"; then
+  ok "C6 the openova-org-tenants GitRepository is re-poked after the push"
+else
+  bad "C6 no reconcile poke of openova-org-tenants — the pivot waits out the polling interval"
+fi
+
+# ── C8: idempotent re-run ─────────────────────────────────────────────────
+rc=$(run_phase2b "${TMP}/phase2b.sh" "${TMP}/origin.git" true)
+if [ "${rc}" -eq 0 ] && [ "$(count_trust org-tenants "${OT_PATH}")" -eq 6 ] \
+   && [ "$(count_local org-tenants "${OT_PATH}")" -eq 6 ]; then
+  ok "C8 re-run is idempotent (exit 0, still 6 local urls, still 6 certSecretRefs — no duplicates)"
+else
+  bad "C8 re-run was not idempotent: exit ${rc}, $(count_local org-tenants "${OT_PATH}") local urls, $(count_trust org-tenants "${OT_PATH}") certSecretRefs"
+fi
+
+# ── C9: absent branch is a SKIP, not a failure ────────────────────────────
+build_origin no-branch
+rc=$(run_phase2b "${TMP}/phase2b.sh" "${TMP}/origin.git" true)
+if [ "${rc}" -eq 0 ] && grep -q 'Phase-2b SKIP' "${TMP}/out.log" && ! origin_has_branch org-tenants; then
+  ok "C9 CONTROL: a Sovereign with no org-tenants branch skips cleanly (exit 0, nothing created)"
+else
+  bad "C9 absent-branch handling wrong: exit ${rc}"; sed 's/^/      /' "${TMP}/out.log" | tail -10
+fi
+
+# ── C10: an UNREADABLE remote must FAIL, never present as the same SKIP ───
+build_origin with-branch
+rc=$(run_phase2b "${TMP}/phase2b.sh" "${TMP}/origin.git/does-not-exist" true)
+if [ "${rc}" -ne 0 ] && grep -q 'FATAL' "${TMP}/out.log"; then
+  ok "C10 an unreadable remote FATALs (an auth failure can never masquerade as an absent branch)"
+else
+  bad "C10 unreadable remote exited ${rc} without FATAL — a verdict from absent evidence"
+fi
+
+# ── C11: the disable switch ───────────────────────────────────────────────
+build_origin with-branch
+rc=$(run_phase2b "${TMP}/phase2b.sh" "${TMP}/origin.git" false)
+if [ "${rc}" -eq 0 ] && [ "$(count_upstream org-tenants "${OT_PATH}")" -eq 6 ]; then
+  ok "C11 CONTROL: enabled=false is a genuine no-op"
+else
+  bad "C11 enabled=false did not no-op: exit ${rc}, $(count_upstream org-tenants "${OT_PATH}") still upstream"
+fi
+
+# ═══════════════════════════════════════════════════════════════════════════
+# M. VACUITY PROOFS — one mutated behaviour each; the named case must go RED.
+# ═══════════════════════════════════════════════════════════════════════════
+echo "== M. vacuity proofs (single-behaviour mutants must break the named case) =="
+
+mutant() {
+  # $1 = label   $2 = sed expression applied to the ORIGINAL extracted script
+  sed "$2" "${TMP}/phase2b.orig.sh" >"${TMP}/mut.orig.sh"
+  if cmp -s "${TMP}/mut.orig.sh" "${TMP}/phase2b.orig.sh"; then
+    bad "M:$1 mutation matched nothing — the vacuity proof itself is vacuous"
+    return 1
+  fi
+  relocate "${TMP}/mut.orig.sh" "${TMP}/mut.sh"
+  return 0
+}
+
+# M1 — the shipped defect: clone main instead of the org-tenants branch.
+if mutant "wrong-branch" 's,--branch "\${ot_branch}",--branch main,'; then
+  build_origin with-branch
+  run_phase2b "${TMP}/mut.sh" "${TMP}/origin.git" true >/dev/null
+  if [ "$(count_upstream org-tenants "${OT_PATH}")" -eq 6 ]; then
+    ok "M1 cloning main instead of org-tenants leaves all 6 upstream → C1 goes RED (this is the shipped defect)"
+  else
+    bad "M1 C1 still passed with the branch mutated to main — C1 is vacuous"
+  fi
+fi
+
+# M2 — drop the trust injection.
+if mutant "no-trust" 's,^\( *\)inject_trust_ref "\${otf}",\1:,'; then
+  build_origin with-branch
+  run_phase2b "${TMP}/mut.sh" "${TMP}/origin.git" true >/dev/null
+  if [ "$(count_trust org-tenants "${OT_PATH}")" -eq 0 ]; then
+    ok "M2 removing the injector call drops every certSecretRef → C2 goes RED"
+  else
+    bad "M2 C2 still passed without the injector call — C2 is vacuous"
+  fi
+fi
+
+# M3 — widen the collector past /org-tenants/ (breaks the C3 control).
+if mutant "wide-scope" "s,| grep '/org-tenants/' >> \"\${ot_list}\",>> \"\${ot_list}\","; then
+  build_origin with-branch
+  run_phase2b "${TMP}/mut.sh" "${TMP}/origin.git" true >/dev/null
+  if [ "$(count_upstream org-tenants "${BK_PATH}")" -eq 0 ]; then
+    ok "M3 widening the collector rewrites the bootstrap-kit file → C3 goes RED"
+  else
+    bad "M3 C3 still passed with the scope widened — C3 is vacuous"
+  fi
+fi
+
+# M4 — the second shipped defect: stage only the bootstrap-kit directory.
+if mutant "narrow-add" 's,git add -A clusters$,git add -A clusters/_template,'; then
+  build_origin with-branch
+  rc=$(run_phase2b "${TMP}/mut.sh" "${TMP}/origin.git" true)
+  if [ "${rc}" -ne 0 ] && [ "$(count_upstream org-tenants "${OT_PATH}")" -eq 6 ]; then
+    ok "M4 staging only bootstrap-kit leaves the index empty → the FATAL fires and C1 goes RED"
+  else
+    bad "M4 a narrowed \`git add\` exited ${rc} and still pivoted — the empty-index guard is vacuous"
+  fi
+fi
+
+# M5 — swallow the ls-remote verdict (breaks the C10 discrimination).
+if mutant "swallow-lsremote" '/ls-remote .* against .* failed/,+2 s,^\( *\)exit 1,\1:,'; then
+  build_origin with-branch
+  rc=$(run_phase2b "${TMP}/mut.sh" "${TMP}/origin.git/does-not-exist" true)
+  if [ "${rc}" -eq 0 ]; then
+    ok "M5 swallowing the ls-remote verdict turns an unreadable remote into a silent success → C10 goes RED"
+  else
+    bad "M5 C10 still passed with the ls-remote guard swallowed — C10 is vacuous"
+  fi
+fi
+
+# ═══════════════════════════════════════════════════════════════════════════
+echo "== R. render wiring =="
+
+# The step args, as the container receives them.
+python3 - "${TMP}/render.yaml" "${TMP}/args.sh" <<'PY'
+import sys, yaml
+for d in yaml.safe_load_all(open(sys.argv[1])):
+    if not d or d.get("kind") != "ConfigMap":
+        continue
+    if d["metadata"]["name"] != "cutover-step-06-helmrepository-patches":
+        continue
+    spec = yaml.safe_load(d["data"]["podSpec"])
+    c = [x for x in spec["containers"] if x["name"] == "helmrepository-patches"][0]
+    open(sys.argv[2], "w").write(c["args"][0])
+    sys.exit(0)
+sys.exit("step-06 ConfigMap not found")
+PY
+
+# R1 — Phase-2b must run AFTER the main-branch push, so its commit can never be
+# entangled with the ${target_dir}-scoped `git add` (the M4 shape).
+push_ln=$(awk 'index($0,"git push origin main"){print NR; exit}' "${TMP}/args.sh")
+p2b_ln=$(awk 'index($0,". /phase2b/phase2b.sh"){print NR; exit}' "${TMP}/args.sh")
+if [ -n "${push_ln}" ] && [ -n "${p2b_ln}" ] && [ "${p2b_ln}" -gt "${push_ln}" ]; then
+  ok "R1 phase2b.sh is sourced (line ${p2b_ln}) AFTER the main-branch push (line ${push_ln})"
+else
+  bad "R1 phase2b source at ${p2b_ln:-<none>} does not follow the main push at ${push_ln:-<none>}"
+fi
+
+# R2 — the ConfigMap key, the volume and the mount all have to exist together.
+r2=0
+grep -q '^  phase2b.sh: |' "${TMP}/render.yaml" || r2=1
+grep -q 'mountPath: /phase2b' "${TMP}/render.yaml" || r2=1
+grep -q 'key: phase2b.sh' "${TMP}/render.yaml" || r2=1
+if [ "${r2}" -eq 0 ]; then
+  ok "R2 phase2b.sh key + /phase2b mount + volume item are all wired"
+else
+  bad "R2 phase2b.sh is not fully wired — the source would fail at runtime"
+fi
+
+# R3 — #5436 is NOT weakened. Phase-1.5 is a diagnostic; the Phase-3 pre-strip
+# call is still the fail-closed gate. Both directions asserted: a future edit
+# that deletes the gate, or restores the premature one, fails here.
+if grep -q 'assert_region_a_pivot "Phase-1.5 read-back" 0 "DIAGNOSTIC"' "${TMP}/args.sh"; then
+  ok "R3a Phase-1.5 read-back is a DIAGNOSTIC (it runs before Phase-2/2b writes the durable source)"
+else
+  bad "R3a Phase-1.5 read-back is not the diagnostic form — a premature gate no retry can converge (#6293)"
+fi
+if grep -qE 'assert_region_a_pivot "Phase-1.5 read-back"[^|]*\|\|[[:space:]]*exit 1' "${TMP}/args.sh"; then
+  bad "R3b Phase-1.5 still fails closed — this is the hw296 terminal failure"
+else
+  ok "R3b Phase-1.5 does not fail closed"
+fi
+if grep -qE 'assert_region_a_pivot "Phase-3 pre-strip read-back"[^|]*\|\|[[:space:]]*exit 1' "${TMP}/args.sh"; then
+  ok "R3c the Phase-3 pre-strip read-back IS still fail-closed (#5436 intact)"
+else
+  bad "R3c the Phase-3 pre-strip gate lost its \`|| exit 1\` — #5436 would be weakened, not relocated"
+fi
+
+# R4 — phase2b must CALL the shared injector, never carry a second copy of it.
+if grep -q 'inject_trust_ref' "${TMP}/phase2b.orig.sh" \
+   && ! grep -q 'awk -v ref=' "${TMP}/phase2b.orig.sh"; then
+  ok "R4 phase2b calls the shared injector instead of duplicating the awk (#5646)"
+else
+  bad "R4 phase2b carries its own copy of the trust injector — the two will drift"
+fi
+
+echo
+echo "RESULT: ${pass} passed, ${fail} failed"
+[ "${fail}" -eq 0 ]

--- a/platform/self-sovereign-cutover/chart/tests/step06-org-tenants-source.sh
+++ b/platform/self-sovereign-cutover/chart/tests/step06-org-tenants-source.sh
@@ -169,6 +169,10 @@ run_phase2b() {
   : >"${TMP}/kubectl.log"
   mkdir -p "${TMP}/t/repo"
   cat >"${TMP}/driver.sh" <<DRIVER
+# The step container runs the whole script under \`set -eu\` (line 1 of the
+# rendered args). Sourcing phase2b.sh without it would let an unset variable or
+# an unguarded non-zero command pass here and kill the step in production.
+set -eu
 push_url='$2'
 redacted='gitea.example.invalid/openova/openova.git'
 UPSTREAM_PREFIX='${UPSTREAM}'

--- a/platform/self-sovereign-cutover/chart/tests/step06-pivot-readback.sh
+++ b/platform/self-sovereign-cutover/chart/tests/step06-pivot-readback.sh
@@ -100,11 +100,30 @@ else
   ok "no assert_region_a_pivot call site swallows its verdict"
 fi
 
-callsites=$(grep -cE '^[[:space:]]*assert_region_a_pivot "' "${TMP}/step06.sh" || true)
+# Counts BOTH invocation shapes: the bare `assert_region_a_pivot "…"` gate and
+# the `if ! assert_region_a_pivot "…"` diagnostic (#6293). Anchoring on
+# start-of-line matched only the first and under-counted the diagnostic form to
+# zero — a guard that silently stops seeing what it is counting.
+callsites=$(grep -cE 'assert_region_a_pivot "' "${TMP}/step06.sh" || true)
 if [ "${callsites}" -ge 2 ]; then
-  ok "read-back is called at ${callsites} sites (post-Phase-1 + pre-strip)"
+  ok "read-back is called at ${callsites} sites (post-Phase-1 diagnostic + pre-strip gate)"
 else
-  bad "read-back called at ${callsites} site(s); expected >= 2 (post-Phase-1 fail-fast + pre-strip gate)"
+  bad "read-back called at ${callsites} site(s); expected >= 2 (post-Phase-1 diagnostic + pre-strip gate)"
+fi
+
+# #6293 — and exactly ONE of them may be the fail-closed gate, at Phase 3. If a
+# future edit restores `|| exit 1` on the Phase-1.5 call, the cutover
+# terminal-fails again on offenders whose durable source Phase-2/2b has not yet
+# rewritten; if the Phase-3 call loses it, #5436 is gone entirely.
+if grep -qE 'assert_region_a_pivot "Phase-1.5 read-back"[^|]*\|\|[[:space:]]*exit 1' "${TMP}/step06.sh"; then
+  bad "the Phase-1.5 read-back fails closed — it runs BEFORE Phase-2/2b writes the durable source (the hw296 wedge, #6293)"
+else
+  ok "the Phase-1.5 read-back is a diagnostic, not a gate"
+fi
+if grep -qE 'assert_region_a_pivot "Phase-3 pre-strip read-back"[^|]*\|\|[[:space:]]*exit 1' "${TMP}/step06.sh"; then
+  ok "the Phase-3 pre-strip read-back is still the fail-closed gate (#5436 intact)"
+else
+  bad "the Phase-3 pre-strip read-back lost its \`|| exit 1\` — #5436 would be weakened, not relocated"
 fi
 
 # The pre-strip call MUST precede the executable mothership-auth strip, or
@@ -122,13 +141,34 @@ fi
 # ── B. execution harness ──────────────────────────────────────────────────
 echo "== B. exit-code assertions against a fake kubectl =="
 
-# Truncate the real script immediately after the Phase-1.5 read-back call.
+# Truncate the real script at the END of the Phase-1.5 read-back block — the
+# closing `fi` of the diagnostic, not the call line, or the `if` is left
+# unterminated and every case below exits 2 on a SYNTAX ERROR while still
+# looking like the expected non-zero verdict (#6293 caught exactly that).
 cut_ln=$(awk 'index($0,"assert_region_a_pivot \"Phase-1.5"){print NR; exit}' "${TMP}/step06.sh")
 if [ -z "${cut_ln}" ]; then
   bad "no Phase-1.5 read-back call to truncate at — cannot run the exit-code cases"
   echo; echo "RESULT: ${pass} passed, ${fail} failed"; [ "${fail}" -eq 0 ]; exit
 fi
-head -n "${cut_ln}" "${TMP}/step06.sh" > "${TMP}/step06.phase15.sh"
+end_ln=$(awk -v s="${cut_ln}" 'NR>=s && /^[[:space:]]*fi[[:space:]]*$/{print NR; exit}' "${TMP}/step06.sh")
+[ -n "${end_ln}" ] || end_ln="${cut_ln}"
+head -n "${end_ln}" "${TMP}/step06.sh" > "${TMP}/step06.diag.sh"
+if bash -n "${TMP}/step06.diag.sh" 2>/dev/null; then
+  ok "the truncated Phase-1.5 slice is syntactically complete"
+else
+  bad "the truncated Phase-1.5 slice does not parse — every exit-code case below would report a syntax error as a verdict"
+fi
+
+# #6293 — Phase-1.5 is a DIAGNOSTIC: it runs BEFORE Phase-2/2b writes the
+# durable Gitea source, so offenders owned by the org-tenants Kustomization are
+# expected there and no retry can converge them. The fail-closed gate is the
+# Phase-3 pre-strip call, which runs after the durable rewrite. The cases below
+# drive THAT call — appended verbatim, with a 0s budget so the suite does not
+# sit out HELMREPO_READBACK_BUDGET_SECONDS. Section A independently asserts the
+# real call site still carries `|| exit 1`.
+cp "${TMP}/step06.diag.sh" "${TMP}/step06.phase15.sh"
+printf '\nassert_region_a_pivot "Phase-3 pre-strip read-back" 0 || exit 1\n' \
+  >> "${TMP}/step06.phase15.sh"
 
 # Relocate the container mount path (the harness is not a container). Assert
 # the substitution actually applied so a template rename cannot silently turn
@@ -138,6 +178,7 @@ if [ "${work_hits}" -lt 1 ]; then
   bad "step-06 no longer reads /work/helmrepository-names.txt — harness mount relocation is stale"
 fi
 sed -i "s,/work/helmrepository-names.txt,${TMP}/work/helmrepository-names.txt,g" "${TMP}/step06.phase15.sh"
+sed -i "s,/work/helmrepository-names.txt,${TMP}/work/helmrepository-names.txt,g" "${TMP}/step06.diag.sh"
 
 # ── fake kubectl ──
 # Models the LIVE shape: `kubectl patch helmrepository` returns 0 and the
@@ -253,7 +294,7 @@ run_case() {
     FAKE_PATCH_ERRORS="${FAKE_PATCH_ERRORS:-}" \
     FAKE_LATE_ARRIVAL="${late}" \
     HARBOR_USERNAME=admin HARBOR_PASSWORD=notasecret \
-    bash -c "set -a; . '${TMP}/step06.env'; set +a; bash '${TMP}/step06.phase15.sh'" \
+    bash -c "set -a; . '${TMP}/step06.env'; set +a; bash '${RUN_SCRIPT:-${TMP}/step06.phase15.sh}'" \
     > "${TMP}/out.log" 2>&1
   rc=$?
   set -e
@@ -314,6 +355,32 @@ FAKE_PATCH_ERRORS="bp-keycloak" run_case "B6 kubectl patch returns non-zero" \
   "bp-cilium=${UP}
 bp-keycloak=${UP}" \
   "" 1
+
+# B7 (#6293) — the SAME offender state as B3, run against the Phase-1.5 slice
+#      ALONE (no appended gate). It must exit 0: at that point in the step the
+#      durable Gitea rewrite has not happened yet, so failing closed there
+#      terminal-fails a cutover no retry can converge — the hw296 wedge. B3
+#      above proves the gate still fails closed on this identical state, so
+#      B3+B7 together pin "diagnostic here, gate there" in both directions.
+RUN_SCRIPT="${TMP}/step06.diag.sh" run_case "B7 Phase-1.5 alone does not fail closed on org-tenants offenders" \
+  "bp-cilium=${UP}
+bp-agenity=${UP}
+bp-keycloak=${UP}
+bp-openclaw=${UP}
+bp-stalwart-tenant=${UP}
+bp-wordpress-tenant=${UP}" \
+  "bp-agenity bp-keycloak bp-openclaw bp-stalwart-tenant bp-wordpress-tenant" 0
+
+# B7b — and it must not be SILENT. A diagnostic that prints nothing is worse
+#       than the gate it replaced.
+if grep -q 'STILL-UPSTREAM bp-agenity' "${TMP}/out.log" \
+   && grep -q 'DIAGNOSTIC' "${TMP}/out.log" \
+   && grep -q 'Phase-3 pre-strip read-back' "${TMP}/out.log"; then
+  ok "B7b the Phase-1.5 diagnostic names its offenders and points at the gate that will judge them"
+else
+  bad "B7b the Phase-1.5 diagnostic is silent or unattributed — offenders must be named and the real gate cited"
+  sed 's/^/      /' "${TMP}/out.log" | tail -10
+fi
 
 # ── C. sibling step-11: same class, same wiring requirement ───────────────
 echo "== C. step-11 crossplane-provider-pivot patch verdicts are wired (#5436) =="

--- a/platform/self-sovereign-cutover/chart/values.yaml
+++ b/platform/self-sovereign-cutover/chart/values.yaml
@@ -1087,6 +1087,34 @@ helmRepositories:
     - "bootstrap-kit"
     - "org-tenants"
 
+  # ── #6293: per-Org tenant HelmRepository DURABLE-SOURCE pivot (Phase-2b) ──
+  #
+  # The six shared bp-* HelmRepositories the per-Org overlays sourceRef
+  # (bp-keycloak / bp-newapi / bp-wordpress-tenant / bp-openclaw /
+  # bp-stalwart-tenant / bp-agenity) are NOT owned by bootstrap-kit. The
+  # catalyst-api org-tenant pipeline writes them to
+  # clusters/<fqdn>/org-tenants/helmrepositories.yaml on a DEDICATED branch
+  # and the org-tenants Kustomization re-applies that file every 1m with
+  # prune=true. A live `kubectl patch` of an object under that Kustomization
+  # is reverted before it can matter — hw296 measured bp-keycloak at
+  # metadata.generation 101 while step-06 logged `live-K8s ok=4 fail=0`.
+  #
+  # `branch` MUST equal the branch three other places already agree on:
+  #   - products/catalyst/chart/templates/org-services/
+  #     org-repo-gitrepository.yaml  → spec.ref.branch
+  #   - the same chart's gitea-org-repo-bootstrap-job.yaml → the branch it
+  #     creates
+  #   - catalyst-api's CATALYST_GITOPS_BRANCH → where the writer pushes
+  # Override all four together or not at all.
+  orgTenantsSource:
+    enabled: true
+    branch: "org-tenants"
+    # Flux GitRepository poked after the push so the pivot lands on the next
+    # reconcile instead of the polling interval. A name that does not exist is
+    # a harmless no-op (the annotate is `|| true`).
+    gitRepositoryName: "openova-org-tenants"
+    gitRepositoryNamespace: "flux-system"
+
   # ── #5650: vcluster loft chart-source pivot (step-06 Phase-2c) ──────────
   #
   # The ONE Flux source the URL-pivot above cannot reach. The

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -4640,7 +4640,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "0.1.186",
+      "version": "0.1.187",
       "section": "pts-2-3-per-sovereign-supporting-services",
       "depends": [
         "bp-gitea",

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -4775,7 +4775,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "0.1.186",
+    "version": "0.1.187",
     "section": "pts-2-3-per-sovereign-supporting-services",
     "depends": [
       "bp-gitea",

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3968,7 +3968,24 @@ name: bp-catalyst-platform
 #   file's 1.4.1325 entry records as permanently burned. The republish
 #   therefore lands on 1.4.1468 — ahead of main's 1.4.1467, absent from GHCR,
 #   and claimed by no open PR.)
-version: 1.4.1480
+version: 1.4.1481
+# 1.4.1481 — #6293: catalog-seed advances bp-self-sovereign-cutover
+#   0.1.186 -> 0.1.187, the release that stops step-06 from patching five
+#   HelmRepositories it does not own and then grading itself on whether they
+#   stuck. bp-agenity / bp-keycloak / bp-openclaw / bp-stalwart-tenant /
+#   bp-wordpress-tenant belong to the `org-tenants` Kustomization (1m,
+#   prune=true) whose source is the `org-tenants` BRANCH; step-06's durable
+#   rewrite for them ran in a `--branch main` clone where that tree does not
+#   exist, and the read-back that judged the result ran three phases before the
+#   rewrite. hw296 terminal-failed at 6/11 on exactly this. The seed pin is the
+#   delivery half — without this republish a pinned Sovereign resolves 0.1.186
+#   and repeats the wedge. This chart's own templates are unchanged apart from
+#   the seed entry. Lockstep w/ clusters/_template/bootstrap-kit/
+#   13-bp-catalyst-platform.yaml.
+#   (Rebase note: authored as 1.4.1480; main's deploy-bot published 1.4.1480
+#   while this branch's checks ran, so landing it would have moved `version:`
+#   BACKWARD — the shape the 1.4.1325 entry above records as permanently
+#   burned. Re-taken at 1.4.1481.)
 # 1.4.1478 — #3988 (UAT row 222): republish so the bp-alloy 1.0.3 catalog-seed
 #   pin is actually carried by a published OCI artifact. On a pre-cutover
 #   Sovereign the catalog Gitea Orgs are empty, so every catalog GetVersion

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5115,7 +5115,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.1.186"
+  version: "0.1.187"
   visibility: unlisted
   card:
     title: "Self-Sovereignty Cutover"
@@ -5132,7 +5132,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-self-sovereign-cutover
-    version: "0.1.186"
+    version: "0.1.187"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
## What happened

hw296's cutover reached 6/11 and terminal-failed at step 6:

```
[helmrepository-patches] live-K8s ok=4 skip=62 fail=0
[helmrepository-patches] FATAL: Phase-1.5 read-back: 5 region-A HelmRepository(ies) are STILL on
oci://ghcr.io/openova-io after the pivot — the Sovereign would record a SUCCESSFUL cutover step
while its charts resolve to the mothership; refusing to succeed (#5436)
  STILL-UPSTREAM bp-agenity / bp-keycloak / bp-openclaw / bp-stalwart-tenant / bp-wordpress-tenant
```

No retry could converge it: every re-run re-entered the same order.

## The named writer, and confirmation of the ownership diagnosis

The `./clusters/<fqdn>/org-tenants` tree is written by **`products/catalyst/bootstrap/api/internal/handler/organization_gitops.go`** — `writeParentTenantsIndex`, emitting `helmrepositories.yaml` from the `orgTenantSharedHelmRepositories` const and pushing to `HEAD:${cfg.Branch}`, where the branch is `CATALYST_GITOPS_BRANCH`, default **`org-tenants`**. It is generated by a controller, not committed to this repo.

The ownership diagnosis is **confirmed**, and read-only live state on hw296 pins every element of it:

| Fact | Evidence |
|---|---|
| Kustomization `org-tenants` owns the five | `spec.path ./clusters/hw296.omani.works/org-tenants`, `interval 1m`, `prune true`, `sourceRef GitRepository/openova-org-tenants`; `status.inventory` lists all six bp-* HelmRepositories |
| Its source is a **different branch** | `GitRepository/openova-org-tenants` → `spec.ref.branch: org-tenants`, and `spec.ignore` allowlists `!/clusters/hw296.omani.works` |
| The revert is real, not theoretical | `bp-keycloak` and `bp-newapi` at `metadata.generation` **101**; `certSecretRef` absent on all six |
| It reverts *inside one Job* | `bp-keycloak` and `bp-newapi` logged `SKIP (already pivoted)` at scan time and came back `STILL-UPSTREAM` at the read-back |
| Why 5 and not 6 | `bp-newapi` is in `helmRepositories.readbackExcludeNames`; the offender set is exactly `orgTenantSharedHelmRepositories` minus that one |
| The 62 skips are unrelated | every other flux-system HelmRepository is already on `oci://registry.hw296.omani.works/openova-io`, `OWNER: bootstrap-kit` |
| Region B is not affected | no `org-tenants` Kustomization there; 0 HelmRepositories on ghcr |

## Correction to the framing

The brief's framing — "the pivot has to happen where the desired state lives" — is right, and **a seam for it already existed**: `#4885` added a Phase-2b rewrite of `clusters/**/org-tenants/**` inside step-06's Gitea leg, and `#5527` already makes catalyst-api's own generator emit `oci://registry.<fqdn>/openova-io` post-cutover so the two writers of that file agree. Nothing had to be invented. What was wrong was that the existing seam **could not execute**, in three independent ways:

1. **Ordering.** `assert_region_a_pivot "Phase-1.5 read-back" 0 || exit 1` runs at line 1334; Phase-2/2b — the durable rewrite that is the only thing that can make the pivot stick — runs at line 1631. The guard fired three phases before the code that satisfies it. Its own comment justifies single-shot sampling with *"Phase-1's patches are synchronous API writes, so there is nothing to converge"* — true of the **write**, false of a Flux-owned **object**. The hw296 log ends at that FATAL: there is no `org-tenant`, no `tenant-HR`, no `sed edited`, no commit/push line anywhere in it. **Phase-2b never ran at all.**

2. **Wrong branch.** Phase-2b's collector ran inside a `git clone --depth 1 --branch main` working tree. TBD-C18e moved the org-tenants tree onto its own branch precisely so the step-01 mirror's force-push of `main` could not clobber per-Org overlays — so `main` has no `clusters/<fqdn>/org-tenants` directory at all. This repo proves it: `find clusters -type d -name org-tenants` returns nothing. The collector matched zero files and printed `sed edited 0 org-tenant HelmRepository file(s)` on every Sovereign that ever ran it.

3. **Unstaged.** Even on a match, the commit stages `git add "${target_dir}"` — `clusters/_template/bootstrap-kit` only — and pushes `origin main`. A tenant edit would have been counted into `${edited}`, logged as edited, then dropped onto the `git diff empty after sed` path, which reads as success. Defect 2 masked defect 3; fixing either alone would have left the other.

## The design decision I had to make, and why

**Phase-1.5 stops being a gate. The Phase-3 pre-strip read-back becomes the single fail-closed gate.**

The alternative was to move the Phase-1.5 call after Phase-2/2b. I rejected it: Phase-3's call already exists, already has a convergence budget, already re-pokes the `openova` GitRepository *and* the `org-tenants` Kustomization each cycle, and is deliberately positioned at the head of Phase 3 so it runs on **every** exit path including the `MOTHERSHIP_AUTHS_TO_STRIP`-empty early return. Adding a second post-Phase-2 gate would duplicate it.

**#5436 is relocated, not weakened.** The class it exists for — an HR the Phase-0.9 enumeration never saw, or a patch that silently no-op'd — is still caught, fail-closed, at Phase 3, and again by step-08's wider `-A` scan. Phase-1.5 still names its offenders; it now says which gate will judge them. Both directions are asserted in tests, so restoring `|| exit 1` on Phase-1.5 **or** dropping it from Phase-3 fails CI.

I did **not** suspend the `org-tenants` Kustomization. Suspending it would make the cutover's own failure modes worse (a cutover that then fails leaves per-Org GitOps suspended with no resumer), and it is unnecessary once the source agrees with the objects.

**Residual, stated rather than hidden:** between step-06 and step-07 the catalyst-api generator still emits ghcr, because `#5527` keys off step-07's env fact. An Org signup landing in that window would regenerate the file upstream. Step-07 closes it durably and the window is minutes; widening `#5527`'s trigger is separate work and touches a file another lane owns.

## The fix

`platform/self-sovereign-cutover/chart` → **0.1.187**; Phase-2b moves into its own ConfigMap key (`.`-sourced, same `#5593` inline-arg discipline as Phase-2c — the step renders at 53 KB of args and 75.9% of the Helm release-Secret ceiling). It `ls-remote`s first so an **absent branch** (skip) can never be confused with an **auth failure** (fatal), clones `org-tenants`, rewrites, calls the now-shared `inject_trust_ref`, asserts on the resulting files that zero org-tenants documents still declare the upstream prefix, commits the tree it edited, FATALs if the working tree has changes the index does not, pushes `HEAD:org-tenants`, and re-pokes `openova-org-tenants`. The trust injector became a function rather than a second pasted `awk` (#5646).

## Tests, with per-assertion vacuity proofs

`chart/tests/step06-org-tenants-source.sh` (new, 24 assertions) executes the **rendered** `phase2b.sh` against **real local git repositories** with a real `main` and a real `org-tenants` branch. This is deliberate: `cutover-contract.sh` stubs `kubectl`, and a stubbed `git` cannot be on the wrong branch — the defect *is* the branch. Verdicts are read out of the bare origin (`git show org-tenants:<path>`), never a working tree the script left behind. Fixtures are multi-document, matching what `organization_gitops.go` emits.

Five mutants, one behaviour each, each proving a specific case is not vacuous:

| Mutant | Case it must break | Result |
|---|---|---|
| `--branch "${ot_branch}"` → `--branch main` (**defect 2 verbatim**) | C1 pivot lands on the branch | all six left upstream ✅ RED |
| `git add -A clusters` → `git add -A clusters/_template` (**defect 3 verbatim**) | C1 via the empty-index FATAL | exit 1, nothing pivoted ✅ RED |
| drop the `inject_trust_ref` call | C2 certSecretRef | 0 of 6 injected ✅ RED |
| drop `| grep '/org-tenants/'` | C3 scoping **control** | bootstrap-kit rewritten ✅ RED |
| swallow the `ls-remote` verdict | C10 unreadable-remote discrimination | silent exit 0 ✅ RED |

Controls green on both trees: the per-Org HelmRelease overlay stays byte-identical, `main` is never written, an absent branch skips cleanly, `enabled=false` no-ops. The mutation harness itself fails if a `sed` expression matches nothing, so a vacuous vacuity proof is caught.

`step06-pivot-readback.sh` gains **B7/B7b**: the Phase-1.5 slice alone must exit 0 on the *identical* offender state **B3** uses to prove the gate still fails closed — the two together pin "diagnostic here, gate there" in both directions. Writing it surfaced a real defect in the existing harness: truncating at the call line now left an unterminated `if`, and the resulting **syntax error** (exit 2) was being read as the expected non-zero verdict — B1–B4 "passed" for the wrong reason. It now truncates at the closing `fi` and asserts the slice parses.

`cutover-contract.sh` Case 16b's two render-text greps are replaced. They asserted the collector expression and a log line were *present in the render* — both were, inside a code path that could never match a file. **A render grep cannot see a wrong branch**, which is why this case stayed green from #4885 all the way to hw296. It now asserts the clone branch and the push target.

All 18 cutover chart suites pass; `check-cutover-version-floor.py` confirms all 7 pins across the 5 lockstep sites at 0.1.187.

## Operational notes for whoever fires the next run

- **hw296 is terminal-failed and must be operator-fired.** `cutover.go:1948` misses both retry arms for a `BackoffLimitExceeded` Job, so an auto-retry re-reports the old failure without creating a new Job (#6288 family).
- **This carries a chart bump**, so `ResumeInterruptedCutover` restarts from step 1 and can delete the completed prewarm — budget ~50 minutes. hw296 currently has steps 1–5 `success` and `progressPercent: 45`.
- `docs/ledger/UAT.md`'s H1 still reports `cutoverComplete=false, progressPercent=0, all 44 per-step keys empty`; live is `progressPercent: 45`, `failedStep: helmrepository-patches`.
- **G11 stays ❌.** This is merged-but-unproven until a cutover completes; that is the honest state.

Refs #6293 #3379 #5436

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HvMZTDx7W6EPZMmjyXmYh1
