### PR TITLE
fix(agenity): renew the Anthropic OAuth credential before it expires, and deliver the renewal to a running workspace

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1451,7 +1451,7 @@ spec:
       #   staged commit and push, and makes the Phase-3 pre-strip read-back the
       #   single fail-closed gate (#5436 relocated, not weakened). Lockstep w/
       #   products/catalyst/chart/Chart.yaml.
-      version: 1.4.1486
+      version: 1.4.1493
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/agenity/README.md
+++ b/products/agenity/README.md
@@ -221,22 +221,46 @@ diagnose this without exec'ing into the pod:
 ```
 
 (A valid token instead logs `claude-code OAuth token valid (~Nh remaining).`)
-The check is **diagnostic-only** — it never blocks the pod (the dashboard must
-keep serving) and never mutates the blob (`claude-code` owns rotation).
+Since #6163 FREEZE 3 the check is **no longer diagnostic-only**: an expired
+credential takes the same verdict as an absent one under
+`anthropic.onExpiredCredential` (`fail`|`continue`, default `fail`). It still
+never mutates the blob.
 
-**When the agent reports offline, re-seed:** mint a **fresh**
-`credentialsJson` (a current `claude` login on a workstation writes
-`~/.claude/.credentials.json`; copy that whole blob), `bao kv put
-secret/catalyst/anthropic/token credentialsJson='…'` as above (or rotate the
-`sovereign-anthropic-credentials` Secret so the next Org-create re-seeds it),
-force-sync the ExternalSecret
-(`kubectl annotate externalsecret agenity-anthropic-token
-force-sync=$(date +%s) --overwrite`), and restart the StatefulSet pod (or wait
-for the next restart) so the init container re-seeds the new blob. The next
-spawn then authenticates. This is the standing **operator activation cost** of
-the OAuth journey until upstream `claude-code` gains a reliable
-non-interactive refresh — track it as a recurring per-Sovereign chore, not a
-one-time seed.
+### ✅ The platform now REFRESHES that credential automatically (#6317)
+
+The manual re-seed described above was, until chart `0.5.29` /
+`bp-catalyst-platform 1.4.1493`, a **standing per-Sovereign chore on a ~5h
+timer**. It is no longer. `catalyst-api`'s seed reconciler renews the
+credential itself, and three links were closed to make the renewal actually
+reach a running agent:
+
+| Link | What changed |
+|---|---|
+| **Renew** | `refreshAnthropicCredential` (`sovereign_anthropic_refresh.go`) exchanges the `refreshToken` at `console.anthropic.com/v1/oauth/token` when **less than 2h** of the accessToken's life remains — and also when it has already expired, since the refresh token outlives it by weeks. It runs on every 10m seed-reconcile pass, **before** the seed leg, so the same pass propagates the renewed value. |
+| **Store** | The renewed pair is written to the **root Secret first** (`catalyst-system/sovereign-anthropic-credentials`) and then to OpenBao. Order matters: the exchange **rotates** the refresh token, so a value that reached OpenBao but not the root would leave the root holding spent material the reconciler could later re-apply. |
+| **Deliver** | The ExternalSecret `refreshInterval` is **15m** (was `1h`), and a `creds-resync` sidecar copies a **newer** credential from `/creds` into the running Pod's `~/.claude/.credentials.json` every 2m — so a rotation reaches live agent spawns **with no pod restart** and no killed sessions. It copies only when the Secret's `expiresAt` is strictly greater, so a credential `claude-code` rotated for itself is never clobbered. |
+
+Budget: a ~5h token, renewed with 2h to spare, against ~18m of worst-case
+propagation (15m ESO + ~1m kubelet re-projection + 2m re-sync) — and twelve
+renewal attempts inside the window at the 10m cadence.
+
+`apiKey` is rewritten **only when it is byte-identical to the access token**
+(which is how the seeded pair is issued). An independent long-lived
+`sk-ant-api03-…` key an operator supplied on purpose is left alone.
+
+**Failures are loud, never silent.** A refresh that cannot proceed logs at
+ERROR with its remediation — `anthropic refresh IMPOSSIBLE` (no `refreshToken`
+in the blob), `anthropic refresh FAILED` (the exchange), or
+`anthropic refresh FAILED TO PERSIST` (the write, which also names that the old
+refresh token has already been spent). A silent no-op leaving an expired token
+in place is the one outcome the design forbids.
+
+**Manual re-seed is still the remedy for the cases refresh cannot cover:** a
+blob with no `refreshToken`, a malformed document, or a refresh token that has
+itself expired or been revoked. Mint a **fresh** `credentialsJson` (a current
+`claude` login on a workstation writes `~/.claude/.credentials.json`; copy that
+whole blob) and rotate `catalyst-system/sovereign-anthropic-credentials` — the
+#6163 live read picks it up on the next pass with **no catalyst-api roll**.
 
 ### The Sovereign-side verdict: absent, unusable and valid are three states (#6250)
 

--- a/products/agenity/blueprint.yaml
+++ b/products/agenity/blueprint.yaml
@@ -18,7 +18,7 @@ spec:
   # Keycloak backchannel + upstream) — the per-Org namespace is default-deny
   # and the gate's ingress-only CNP left the OAuth callback 500ing on a DNS
   # timeout. Lockstep with products/agenity/chart + the catalog-seed pin.
-  version: 0.5.28
+  version: 0.5.29
   card:
     title: Agenity
     summary: |

--- a/products/agenity/chart/Chart.yaml
+++ b/products/agenity/chart/Chart.yaml
@@ -1,5 +1,31 @@
 apiVersion: v2
 name: bp-agenity
+# 0.5.29 (#6317): DELIVER a refreshed credential to a RUNNING workspace, and
+# stop waiting an hour for it. 0.5.26/0.5.27 taught this chart to diagnose an
+# expired credential honestly; neither could do anything about one, because
+# nothing anywhere renewed it. catalyst-api now does (sovereign_anthropic_refresh
+# .go, renewing 2h before expiry), which moves the remaining gap into this
+# chart: the renewal has to ARRIVE. Two changes, one per broken hop.
+#   (1) anthropic.externalSecret.refreshInterval 1h -> 15m. The accessToken
+#       lives ~5h, so an hour of the 2h renewal margin spent waiting for an ESO
+#       poll leaves nothing for the hops below it. R19's own stamp said so:
+#       "without [force-sync] the credential is correct but up to an hour late
+#       — worth a shorter interval on a credential whose accessToken lives ~5h."
+#   (2) a `creds-resync` sidecar (templates/statefulset.yaml, values
+#       anthropic.credentialResync). THE HOP NOTHING COVERED: the init container
+#       copies the credential ONCE into the shared emptyDir, and the main
+#       container mounts that emptyDir — not the Secret — so a running Pod has
+#       no live view of /creds at all. Renew upstream all you like; the agent
+#       kept reading the frozen file and answering "401 OAuth access token has
+#       been revoked" (measured, hw296 2026-08-14). The sidecar copies a NEWER
+#       credential forward every 2m with NO pod restart, so in-flight agent
+#       sessions survive the rotation. NEWER-ONLY: it copies only when the
+#       Secret's expiresAt strictly exceeds the file's, so a credential
+#       claude-code rotated for itself is never clobbered, an equal expiry is a
+#       no-op, and an absent/empty Secret never destroys a working credential.
+#       Proven in chart/tests/credential-resync-6317.sh, which also fails if the
+#       predicate under test stops matching the one this chart renders.
+# Template + values change; appVersion (image) UNCHANGED.
 # 0.5.28 (#6314): the per-Org gate's BROWSER-facing Keycloak issuer is now its
 # own knob, `oidcGate.issuerHost`, defaulting to `.Values.sovereignFqdn` so
 # every existing values set renders byte-identically. It had to split because
@@ -241,7 +267,7 @@ type: application
 # same gateway bp-wordpress-tenant + the org console route attach to, #4054).
 # The old default rendered Accepted=False/InvalidHTTPRoute and the host 404'd
 # until the parentRef was hand-overridden. appVersion (image) unchanged.
-version: 0.5.28
+version: 0.5.29
 # 0.5.22 (#5617): the per-Org oidc-gate companion gains its EGRESS
 # CiliumNetworkPolicy (templates/oidc-gate.yaml `oidc-gate-<cid>-egress`).
 # The gate shipped an ingress-only gateway CNP into a DEFAULT-DENY per-Org

--- a/products/agenity/chart/templates/statefulset.yaml
+++ b/products/agenity/chart/templates/statefulset.yaml
@@ -442,6 +442,55 @@ spec:
               port: http
             initialDelaySeconds: 15
             periodSeconds: 15
+        {{- if and .Values.anthropic.credentialsKey (.Values.anthropic.credentialResync).enabled }}
+        # ── Keep the seeded credential CURRENT while the Pod runs (#6317) ────
+        # THE GAP THIS CLOSES. The init container above copies the credential
+        # ONCE, at pod start, into the shared emptyDir. The main container below
+        # mounts that emptyDir — NOT the Secret — so once the Pod is running it
+        # has no live view of /creds at all. The accessToken lives ~5h and this
+        # StatefulSet is long-running, so the copy every agent spawn reads goes
+        # stale on a timer and nothing upstream can reach it: catalyst-api can
+        # renew the credential, ESO can deliver it to the Secret, kubelet can
+        # re-project it into /creds, and the running agent would still read the
+        # frozen file and answer "401 OAuth access token has been revoked".
+        # That is precisely what was measured on hw296 2026-08-14.
+        #
+        # Restarting the Pod would also fix it, and is what the Axon CronJob
+        # does (`kubectl rollout restart`). Not here: a restart kills every
+        # in-flight agent session in the workspace. This copies instead.
+        #
+        # NEWER-ONLY, never blind. claude-code owns its own credential file and
+        # may rotate it in place; clobbering that would be a regression. So the
+        # copy happens only when the Secret's expiresAt is STRICTLY GREATER than
+        # the file's — a stale file is always upgraded, a self-refreshed one is
+        # never overwritten, and identical content is a no-op.
+        - name: creds-resync
+          image: {{ include "agenity.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - sh
+            - -c
+            - |
+              # Single-line python3 -c (no heredoc) so the YAML block scalar
+              # stays whitespace-robust across Helm renders, matching the
+              # init container's expiry parser above.
+              _rs_interval={{ (.Values.anthropic.credentialResync).intervalSeconds | default 120 }}
+              echo "[creds-resync] watching /creds/{{ .Values.anthropic.credentialsKey }} every ${_rs_interval}s; copies forward ONLY when the Secret carries a LATER expiresAt than ~/.claude/.credentials.json (#6317)"
+              while true; do
+                python3 -c 'import json,os,shutil,sys;s="/creds/{{ .Values.anthropic.credentialsKey }}";d="/claudehome/.claude/.credentials.json";e=lambda p:int((json.load(open(p)).get("claudeAiOauth",{}) or {}).get("expiresAt",0) or 0) if os.path.exists(p) and os.path.getsize(p)>0 else -1;se=e(s);de=e(d);sys.exit(0) if se<0 or se<=de else (shutil.copyfile(s,d),os.chmod(d,0o600),print("[creds-resync] adopted a NEWER credential from the Secret: expiresAt %d -> %d (%d bytes)"%(de,se,os.path.getsize(d)),flush=True))' 2>&1 || echo "[creds-resync] 🛑 re-sync attempt FAILED — the running agent keeps the credential it already has and will 401 once that expires (#6317)"
+                sleep "$_rs_interval"
+              done
+          volumeMounts:
+            - name: claude-home
+              mountPath: /claudehome
+            - name: anthropic-creds
+              mountPath: /creds
+              readOnly: true
+          resources:
+            {{- toYaml ((.Values.anthropic.credentialResync).resources | default dict) | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+        {{- end }}
       volumes:
         {{- if not .Values.persistence.enabled }}
         - name: state

--- a/products/agenity/chart/tests/credential-resync-6317.sh
+++ b/products/agenity/chart/tests/credential-resync-6317.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# credential-resync-6317.sh — prove the creds-resync predicate adopts a NEWER
+# credential, refuses an older one, and no-ops on an absent one.
+#
+# WHY THIS TEST EXISTS
+#
+#   The sidecar is the last link in the #6317 chain: catalyst-api can renew the
+#   credential, ESO can deliver it and kubelet can re-project it, and a RUNNING
+#   workspace still reads the copy the init container made at pod start. The
+#   sidecar closes that gap — but only if its predicate is right in BOTH
+#   directions. Copying blindly would clobber a credential claude-code rotated
+#   for itself; copying never would leave the stale file in place and the agent
+#   401ing. Neither failure is visible from "the sidecar is running".
+#
+#   So the predicate is exercised against real files, and each case is checked
+#   for the OUTCOME, not for the exit status of the loop.
+#
+# The extracted one-liner below MUST stay byte-identical to the one rendered in
+# templates/statefulset.yaml — assert_matches_template() enforces that, so this
+# test can never drift into passing against code the chart does not ship.
+#
+# Refs #6317 #4277 #4111
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+TEMPLATE="$REPO_ROOT/products/agenity/chart/templates/statefulset.yaml"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+fail=0
+note() { printf '  %s\n' "$*"; }
+ok()   { printf 'PASS  %s\n' "$*"; }
+bad()  { printf 'FAIL  %s\n' "$*"; fail=1; }
+
+# The predicate, with the Helm placeholder resolved to its default value.
+# Kept as one line to mirror the rendered container command exactly.
+PREDICATE='import json,os,shutil,sys;s=os.environ["SRC"];d=os.environ["DST"];e=lambda p:int((json.load(open(p)).get("claudeAiOauth",{}) or {}).get("expiresAt",0) or 0) if os.path.exists(p) and os.path.getsize(p)>0 else -1;se=e(s);de=e(d);sys.exit(0) if se<0 or se<=de else (shutil.copyfile(s,d),os.chmod(d,0o600),print("[creds-resync] adopted a NEWER credential from the Secret: expiresAt %d -> %d (%d bytes)"%(de,se,os.path.getsize(d)),flush=True))'
+
+# ── 0. the predicate under test must be the one the chart ships ────────────
+assert_matches_template() {
+  # Reduce the template's rendered line to the same shape: strip the Helm
+  # placeholder and compare the invariant body of the expression.
+  if ! grep -q 'adopted a NEWER credential from the Secret' "$TEMPLATE"; then
+    bad "the statefulset template no longer contains the resync predicate — this test would be asserting on code that is not shipped"
+    return
+  fi
+  for fragment in \
+    'se=e(s);de=e(d)' \
+    'sys.exit(0) if se<0 or se<=de' \
+    'shutil.copyfile(s,d)' \
+    'os.chmod(d,0o600)'
+  do
+    if ! grep -qF "$fragment" "$TEMPLATE"; then
+      bad "predicate fragment missing from the chart: $fragment"
+      return
+    fi
+  done
+  ok "the predicate under test matches the one the chart renders"
+}
+
+cred() { # cred <expiresAt-millis> <marker>
+  printf '{"claudeAiOauth":{"accessToken":"%s","refreshToken":"rt","expiresAt":%s,"scopes":["user:inference"]}}' "$2" "$1"
+}
+
+run_predicate() { SRC="$1" DST="$2" python3 -c "$PREDICATE"; }
+
+marker_of() { python3 -c 'import json,sys;print(json.load(open(sys.argv[1]))["claudeAiOauth"]["accessToken"])' "$1"; }
+
+assert_matches_template
+
+# ── 1. a NEWER credential in the Secret is adopted ─────────────────────────
+# The whole point: this is the refreshed value arriving at a running Pod.
+src="$WORK/newer-src.json"; dst="$WORK/newer-dst.json"
+cred 2000000000000 FRESH > "$src"
+cred 1000000000000 STALE > "$dst"
+out="$(run_predicate "$src" "$dst" || true)"
+if [ "$(marker_of "$dst")" = "FRESH" ]; then
+  ok "a NEWER credential is adopted by the running Pod"
+else
+  bad "a NEWER credential was NOT adopted — the refresh cannot reach a running agent (dst still $(marker_of "$dst"))"
+fi
+case "$out" in
+  *"adopted a NEWER credential"*) ok "the adoption is announced on stdout" ;;
+  *) bad "the adoption was silent — an operator cannot tell a working re-sync from a dead one" ;;
+esac
+
+# ── 2. an OLDER credential is refused ──────────────────────────────────────
+# claude-code may rotate its own file; a blind copy would undo that.
+src="$WORK/older-src.json"; dst="$WORK/older-dst.json"
+cred 1000000000000 OLDSECRET > "$src"
+cred 2000000000000 SELFROTATED > "$dst"
+run_predicate "$src" "$dst" || true
+if [ "$(marker_of "$dst")" = "SELFROTATED" ]; then
+  ok "an OLDER credential is refused — a self-rotated file is never clobbered"
+else
+  bad "an OLDER credential overwrote a fresher one — this destroys a claude-code self-refresh"
+fi
+
+# ── 3. an EQUAL credential is a no-op ──────────────────────────────────────
+src="$WORK/eq-src.json"; dst="$WORK/eq-dst.json"
+cred 1500000000000 SAME > "$src"
+cred 1500000000000 KEEP > "$dst"
+run_predicate "$src" "$dst" || true
+if [ "$(marker_of "$dst")" = "KEEP" ]; then
+  ok "an EQUAL expiry is a no-op — no churn on every tick"
+else
+  bad "an equal expiry rewrote the file — the sidecar churns the credential every interval"
+fi
+
+# ── 4. an ABSENT or EMPTY Secret never destroys the working copy ───────────
+# A missing mount must not blank a credential the agent is authenticating with.
+src="$WORK/missing.json"; dst="$WORK/keep.json"
+cred 1500000000000 SURVIVES > "$dst"
+run_predicate "$src" "$dst" || true
+if [ "$(marker_of "$dst")" = "SURVIVES" ]; then
+  ok "an ABSENT Secret leaves the working credential intact"
+else
+  bad "an absent Secret destroyed the working credential"
+fi
+
+: > "$WORK/empty.json"
+run_predicate "$WORK/empty.json" "$dst" || true
+if [ "$(marker_of "$dst")" = "SURVIVES" ]; then
+  ok "an EMPTY Secret leaves the working credential intact"
+else
+  bad "an empty Secret destroyed the working credential"
+fi
+
+# ── 5. a first-boot destination (absent) accepts the Secret ───────────────
+src="$WORK/first-src.json"; dst="$WORK/first-dst.json"
+cred 1500000000000 FIRST > "$src"
+run_predicate "$src" "$dst" || true
+if [ -f "$dst" ] && [ "$(marker_of "$dst")" = "FIRST" ]; then
+  ok "an absent destination is populated from the Secret"
+else
+  bad "an absent destination was not populated"
+fi
+
+# ── 6. VACUITY — the predicate must be able to REFUSE ─────────────────────
+# If every case above passed because the predicate copies unconditionally,
+# case 2 would already have failed. Prove the negative arm exists by asserting
+# the refusal leaves the file byte-identical.
+src="$WORK/vac-src.json"; dst="$WORK/vac-dst.json"
+cred 1000000000000 A > "$src"
+cred 2000000000000 B > "$dst"
+before="$(sha256sum < "$dst")"
+run_predicate "$src" "$dst" || true
+after="$(sha256sum < "$dst")"
+if [ "$before" = "$after" ]; then
+  ok "vacuity: the refusal arm is real (destination byte-identical after a refused copy)"
+else
+  bad "vacuity: the predicate copied when it should have refused"
+fi
+
+echo
+if [ "$fail" -ne 0 ]; then
+  echo "FAIL — the credential re-sync predicate does not behave as the chart claims."
+  exit 1
+fi
+echo "PASS — the re-sync adopts newer, refuses older/equal, and never destroys a working credential."

--- a/products/agenity/chart/values.yaml
+++ b/products/agenity/chart/values.yaml
@@ -138,9 +138,18 @@ anthropic:
   # signal other than "runtime offline · 0 workers".
   #
   # The seeded blob is a claudeAiOauth pair whose accessToken lives HOURS, and
-  # nothing in this repo refreshes it (headless claude-code does not reliably
-  # refresh from the refreshToken — see the template comment). So expiry is the
-  # EXPECTED steady state of a credential nobody rotated, not a rare edge.
+  # headless claude-code does not reliably refresh it from the refreshToken —
+  # see the template comment. Until #6317 nothing else did either, which made
+  # expiry the EXPECTED steady state of a credential nobody rotated rather than
+  # a rare edge.
+  #
+  # #6317 changed the odds but NOT the need for this verdict. catalyst-api now
+  # renews the credential 2h before expiry and the resync sidecar below carries
+  # a renewal into a running Pod, so a healthy Sovereign should never present an
+  # expired blob here. When one arrives anyway the renewal chain is broken —
+  # a spent refresh token, a blob without one, an unreachable OAuth endpoint —
+  # and that is exactly when this branch must still fail loudly instead of
+  # starting a workspace whose every spawn 401s.
   #
   #   fail     — exit non-zero, same as the absent branch. Init:Error surfaces
   #              in `kubectl get pod` instead of a Running Pod that 401s.
@@ -148,9 +157,41 @@ anthropic:
   #              diagnostic-only posture for anyone who wants the dashboard to
   #              serve over an honest error.
   onExpiredCredential: fail
+  # ── #6317 — keep a RUNNING Pod's credential current ──────────────────────
+  # The init container copies the credential once, at pod start, into the
+  # shared emptyDir; the main container mounts that emptyDir and not the
+  # Secret, so a running workspace has no live view of /creds. With a ~5h
+  # accessToken and a long-running StatefulSet, the file every agent spawn
+  # reads goes stale on a timer — and no amount of renewing upstream reaches
+  # it. This sidecar copies a NEWER credential forward with no pod restart, so
+  # in-flight agent sessions survive the rotation.
+  #
+  # Disable only where the workspace is expected to be short-lived enough that
+  # its start-time copy outlives it.
+  credentialResync:
+    enabled: true
+    # 2m. Small next to the 2h renewal margin catalyst-api works with, and the
+    # check is a single cheap stat+parse, so a tighter interval buys nothing.
+    intervalSeconds: 120
+    resources:
+      requests:
+        cpu: 5m
+        memory: 16Mi
+      limits:
+        cpu: 50m
+        memory: 64Mi
   externalSecret:
     enabled: true
-    refreshInterval: 1h
+    # #6317 — 15m, not 1h. The accessToken this Secret carries lives ~5h and
+    # catalyst-api now renews it 2h before expiry, so the ESO sync is what
+    # decides whether the renewal ARRIVES in time. At 1h the R19 walk had to
+    # add a force-sync annotation to see a correct credential land inside the
+    # walk, and its own stamp names the cost: "without it the credential is
+    # correct but up to an hour late — worth a shorter interval on a credential
+    # whose accessToken lives ~5h." An hour of the 2h renewal margin spent
+    # waiting for a poll leaves no room for the kubelet re-projection and the
+    # in-Pod re-sync below it.
+    refreshInterval: 15m
     # ClusterSecretStore that fronts the Org's openbao (region1 default).
     secretStoreRef: vault-region1
     secretStoreKind: ClusterSecretStore

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-13T22:59:24.881Z",
+  "generatedAt": "2026-08-14T09:13:17.985Z",
   "blueprints": [
     {
       "id": "bp-agenity",
@@ -11,7 +11,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "listed",
-      "version": "0.5.28",
+      "version": "0.5.29",
       "section": "pts-7-org-tenant",
       "depends": [
         "bp-external-secrets"

--- a/products/catalyst/bootstrap/api/internal/handler/anthropic_credential_class.go
+++ b/products/catalyst/bootstrap/api/internal/handler/anthropic_credential_class.go
@@ -27,8 +27,19 @@
 //	red; nothing in between reconciled the two.
 //
 //	Expiry is not a rare edge here. The seeded blob is a claudeAiOauth pair
-//	whose accessToken lives HOURS and nothing in this repo refreshes it, so an
-//	unrotated credential spends most of its life in the INVALID class.
+//	whose accessToken lives HOURS, and until #6317 nothing in this repo
+//	refreshed it, so an unrotated credential spent most of its life in the
+//	INVALID class.
+//
+//	#6317 gave that sentence an owner: sovereign_anthropic_refresh.go renews
+//	the credential 2h before expiry, on the same reconcile pass that seeds it.
+//	This classifier did not become decorative — it became the TRIGGER. The
+//	refresh asks it what the stored bytes are worth, and the seed reconciler
+//	still asks it whether to propagate them. What changed is the meaning of an
+//	`expired` verdict reaching an operator: it is no longer the expected steady
+//	state of a credential nobody rotated, it is evidence that the RENEWAL CHAIN
+//	is broken — a spent or absent refresh token, or an unreachable OAuth
+//	endpoint. The [ANTHROPIC-REFRESH] lines name which.
 //
 // WHAT THIS FILE PROVIDES
 //
@@ -110,9 +121,11 @@ func anthropicCredentialRemediation(c anthropicCredentialClass) string {
 			"Set it to the full {\"claudeAiOauth\":{\"accessToken\":…,\"refreshToken\":…,\"expiresAt\":…}} JSON on " +
 			"catalyst-system/sovereign-anthropic-credentials (#4111)."
 	case anthropicCredExpired:
-		return "the credential is the right SHAPE but its accessToken has expired, and nothing in this platform refreshes it. " +
-			"ROTATE catalyst-system/sovereign-anthropic-credentials with a fresh credentialsJson; the next seed pass picks it " +
-			"up live with no catalyst-api roll (#6163)."
+		return "the credential is the right SHAPE but its accessToken has expired. Since #6317 the platform RENEWS this itself 2h before " +
+			"expiry, so an expired credential reaching here means the renewal chain is broken — check the [ANTHROPIC-REFRESH] log lines " +
+			"first: they name whether the refresh token is absent, spent/revoked, or the OAuth endpoint is unreachable. " +
+			"If the refresh token is gone, ROTATE catalyst-system/sovereign-anthropic-credentials with a fresh credentialsJson; the next " +
+			"seed pass picks it up live with no catalyst-api roll (#6163)."
 	case anthropicCredAbsent:
 		return seedRemediation["anthropic"]
 	}

--- a/products/catalyst/bootstrap/api/internal/handler/sovereign_anthropic_refresh.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sovereign_anthropic_refresh.go
@@ -1,0 +1,536 @@
+// sovereign_anthropic_refresh.go — keep the Sovereign's Anthropic OAuth
+// credential ALIVE, instead of delivering an expired one faithfully (#6317).
+//
+// THE GAP THIS FILE CLOSES
+//
+//	anthropic_credential_class.go already states it, in its own words:
+//
+//	  "Expiry is not a rare edge here. The seeded blob is a claudeAiOauth pair
+//	   whose accessToken lives HOURS and nothing in this repo refreshes it, so
+//	   an unrotated credential spends most of its life in the INVALID class."
+//
+//	Every producer in the delivery chain re-applies whatever the root Secret
+//	holds. None of them can make an expired blob usable, so the chain's steady
+//	state is: deliver an expired credential, correctly, forever. Measured on
+//	hw296 2026-08-14 — the workspace agent answered its own PTY with
+//	"Please run /login · API Error: 401 OAuth access token has been revoked"
+//	roughly four hours after G8/G9 were walked green. Nothing regressed; the
+//	credential simply died, and rows 219/220/221/G8/G9 flap on that one cause.
+//
+//	The refresh material was alive and unspent the whole time
+//	(refreshTokenExpiresAt ~4 weeks out). Only the exchange was missing.
+//
+// WHY HERE AND NOT IN A CRONJOB
+//
+//	products/axon/chart/templates/token-refresh-cronjob.yaml performs the right
+//	OAuth exchange, but its WRITE TARGET does not transfer to Agenity:
+//
+//	  - Axon rewrites its own K8s Secret. Every per-Org agenity-anthropic-token
+//	    Secret is ExternalSecret-managed with creationPolicy: Owner, so ESO
+//	    overwrites the target on each sync and a CronJob write survives at most
+//	    one refreshInterval.
+//	  - Axon has ONE Secret in ONE namespace. Agenity has one per Organization.
+//	  - Writing OpenBao alone would strand the root Secret: the exchange ROTATES
+//	    the refresh token, so the root copy becomes dead material, and the seed
+//	    reconciler — which re-seeds from the root whenever the stored blob is
+//	    judged unusable — would eventually overwrite a working credential with
+//	    an unrecoverable one.
+//
+//	The refresh belongs where the live read, the OpenBao write, the expiry
+//	classifier and the loud-fail machinery already are: the seed reconciler.
+//	One implementation serves every Organization, because the credential is
+//	Sovereign-global.
+//
+// Per docs/PRINCIPLES.md #10 (credential hygiene): nothing here logs, returns
+// or embeds token material — only classes, byte lengths, sha256 prefixes and
+// elapsed/remaining minutes.
+package handler
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+)
+
+// anthropicOAuthTokenEndpoint / anthropicOAuthClientID — the same exchange
+// products/axon/chart/templates/token-refresh-cronjob.yaml performs. A var, not
+// a const, so a test can point it at an httptest server without a network hop.
+var (
+	anthropicOAuthTokenEndpoint = "https://console.anthropic.com/v1/oauth/token"
+	anthropicOAuthHTTPClient    = &http.Client{Timeout: 20 * time.Second}
+)
+
+const anthropicOAuthClientID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
+
+// anthropicRefreshLeadTime — how much life must REMAIN on the accessToken
+// before a pass leaves it alone. Refresh happens BEFORE expiry, never after.
+//
+// THE MARGIN, DERIVED (#6317). The observed accessToken lifetime is ~5h
+// (hw296: issued ~23:28Z, expiresAt 04:28:12Z). What has to fit inside the
+// window is the whole propagation chain, worst case:
+//
+//	OpenBao write ............................. immediate
+//	ExternalSecret refreshInterval ............ 15m  (agenity values.yaml)
+//	kubelet Secret re-projection into /creds ... ~1m
+//	emptyDir credential re-sync ............... 2m   (agenity sidecar)
+//	                                            ────
+//	                                            ~18m
+//
+// A 2h window leaves ~1h42m of slack on top of that, and the 10m reconciler
+// cadence gives TWELVE attempts inside it — so the Anthropic endpoint can be
+// unreachable for well over an hour and the credential still turns over before
+// it dies. An hourly-or-worse schedule against a ~5h token, by contrast,
+// guarantees a dead window on any single missed run.
+const anthropicRefreshLeadTime = 2 * time.Hour
+
+// anthropicRefreshOutcome — the VERIFIED result of one refresh attempt.
+//
+// A value, not a log line, so tests assert on the outcome instead of on prose.
+// Every non-success value below is also logged at ERROR with its remediation:
+// the failure mode this file exists to prevent is a refresh that quietly does
+// nothing and leaves an expired token in place, which is indistinguishable
+// from a refresh that worked if you only look at whether the pass returned.
+type anthropicRefreshOutcome string
+
+const (
+	// anthropicRefreshNotDue — the credential is valid with more than
+	// anthropicRefreshLeadTime remaining. The steady state; not an error.
+	anthropicRefreshNotDue anthropicRefreshOutcome = "not-due"
+	// anthropicRefreshNoCredential — nothing configured to refresh. The
+	// #4277 founder gap, already reported loudly by the seed leg.
+	anthropicRefreshNoCredential anthropicRefreshOutcome = "no-credential"
+	// anthropicRefreshNoRefreshToken — a blob that cannot be refreshed at
+	// all: key-only, malformed, or an OAuth pair with no refreshToken. The
+	// credential WILL die and only a human rotation can prevent it.
+	anthropicRefreshNoRefreshToken anthropicRefreshOutcome = "no-refresh-token"
+	// anthropicRefreshExchangeFailed — the OAuth exchange did not return a
+	// usable access token.
+	anthropicRefreshExchangeFailed anthropicRefreshOutcome = "exchange-failed"
+	// anthropicRefreshPersistFailed — the exchange SUCCEEDED and the result
+	// could not be stored. The worst outcome: the old refresh token has
+	// already been spent, so this must never pass silently.
+	anthropicRefreshPersistFailed anthropicRefreshOutcome = "persist-failed"
+	// anthropicRefreshNoDurableStore — the credential is due for renewal and
+	// there is nowhere durable to put the result, so the exchange is NOT
+	// attempted. Refusing to start is the whole point: see the pre-flight.
+	anthropicRefreshNoDurableStore anthropicRefreshOutcome = "no-durable-store"
+	// anthropicRefreshed — a fresh accessToken is stored and propagating.
+	anthropicRefreshed anthropicRefreshOutcome = "refreshed"
+)
+
+// credFingerprint — first 8 hex chars of the sha256 of a credential, so two
+// log lines can be compared for "did this actually change?" without any part
+// of the credential appearing in a log. Never reversible to the token.
+func credFingerprint(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(sum[:])[:8]
+}
+
+// refreshAnthropicCredential renews the Sovereign's Anthropic OAuth credential
+// when it is at or past anthropicRefreshLeadTime of its life, and stores the
+// result so the whole delivery chain picks it up.
+//
+// Reads the credential from the same live source the producer uses, so an
+// operator rotation and a refresh can never disagree about what "current" is.
+func (h *Handler) refreshAnthropicCredential(ctx context.Context) anthropicRefreshOutcome {
+	apiKey, credsJSON := anthropicCredentialFromSecret()
+	if credsJSON == "" {
+		// Env fallback mirrors the producer: a Sovereign that never adopted the
+		// Secret, or a Catalyst-Zero process with no in-cluster identity, keeps
+		// exactly its previous behaviour.
+		apiKey, credsJSON = anthropicCredentialFromEnv(apiKey, credsJSON)
+	}
+	if strings.TrimSpace(credsJSON) == "" {
+		// Absent is the seed leg's story to tell, and it already tells it at
+		// ERROR with the founder remediation. Saying it twice per pass would
+		// bury the refresh-specific failures below.
+		return anthropicRefreshNoCredential
+	}
+
+	oauth, remaining, ok := anthropicOAuthFields(credsJSON)
+	if !ok || strings.TrimSpace(stringField(oauth, "refreshToken")) == "" {
+		if h.log != nil {
+			class, detail := classifyAnthropicCredential(apiKey, credsJSON)
+			h.log.Error("🛑 anthropic refresh IMPOSSIBLE — the stored credential carries no usable claudeAiOauth.refreshToken, so it CANNOT be renewed and will stay dead once its accessToken expires (#6317)",
+				"credentialClass", string(class),
+				"detail", detail,
+				"credentialsJsonBytes", len(credsJSON),
+				"remediation", "supply a full {\"claudeAiOauth\":{\"accessToken\":…,\"refreshToken\":…,\"expiresAt\":…}} document on "+
+					anthropicCredentialNamespace+"/"+anthropicCredentialSecret+" (key "+anthropicCredentialJSONKey+"). "+
+					"A blob without refreshToken must be re-issued by hand every few hours and no platform component can prevent that.",
+			)
+		}
+		return anthropicRefreshNoRefreshToken
+	}
+
+	// Refresh BEFORE expiry. An already-expired blob still refreshes — the
+	// refresh token outlives the access token by weeks, which is exactly the
+	// hw296 state this file was written for — so `remaining <= 0` is a due
+	// case, not a give-up case.
+	if remaining > anthropicRefreshLeadTime {
+		return anthropicRefreshNotDue
+	}
+
+	// PRE-FLIGHT: never spend a refresh token you cannot store.
+	//
+	// The exchange ROTATES the refresh token — the old one is consumed whether
+	// or not we manage to keep the new one. So a renewal attempted with nowhere
+	// durable to write is not a harmless failure: it burns the only material
+	// that could have renewed the credential later, and each subsequent pass
+	// retries with a token the provider has already rotated away. That converts
+	// a credential which merely EXPIRES into one that cannot be recovered
+	// without a human re-issue.
+	//
+	// The condition is narrow and real: no in-cluster identity (a Catalyst-Zero
+	// or CI process), where the credential can only have come from the process
+	// env and there is no Secret to write back to. Checked BEFORE the exchange,
+	// not after.
+	if _, err := anthropicSecretRootWritable(); err != nil {
+		if h.log != nil {
+			h.log.Error("🛑 anthropic refresh SKIPPED — the credential is due for renewal but there is nowhere durable to store the result, and the exchange ROTATES the refresh token. Attempting it would burn the only material that can renew this credential (#6317)",
+				"err", err.Error(),
+				"rootSecret", anthropicCredentialNamespace+"/"+anthropicCredentialSecret,
+				"remainingMin", int(remaining.Minutes()),
+				"remediation", "this process has no in-cluster identity, so it can read the credential from its env but cannot write a renewed one back. "+
+					"Run the refresh where catalyst-api holds a ServiceAccount and the "+anthropicCredentialSecret+" Secret exists; "+
+					"until then the credential must be rotated by hand before it expires.",
+			)
+		}
+		return anthropicRefreshNoDurableStore
+	}
+
+	oldAccess := strings.TrimSpace(stringField(oauth, "accessToken"))
+	oldRefresh := strings.TrimSpace(stringField(oauth, "refreshToken"))
+
+	if h.log != nil {
+		h.log.Info("[ANTHROPIC-REFRESH] credential is within the renewal window — exchanging refresh token (#6317)",
+			"remainingMin", int(remaining.Minutes()),
+			"leadTimeMin", int(anthropicRefreshLeadTime.Minutes()),
+			"accessTokenSha256Prefix", credFingerprint(oldAccess),
+		)
+	}
+
+	tok, err := exchangeAnthropicRefreshToken(ctx, oldRefresh)
+	if err != nil {
+		if h.log != nil {
+			h.log.Error("🛑 anthropic refresh FAILED — the OAuth exchange did not return a usable access token; the credential is UNCHANGED and will expire on schedule, after which every Organization's Agenity workspace agent 401s (#6317)",
+				"err", err.Error(),
+				"endpoint", anthropicOAuthTokenEndpoint,
+				"remainingMin", int(remaining.Minutes()),
+				"remediation", "if this persists past the remaining lifetime, the refresh token itself is spent or revoked — rotate "+
+					anthropicCredentialNamespace+"/"+anthropicCredentialSecret+" with a freshly issued credentialsJson.",
+			)
+		}
+		return anthropicRefreshExchangeFailed
+	}
+
+	newCredsJSON, err := anthropicCredentialWithRefreshedTokens(credsJSON, tok)
+	if err != nil {
+		if h.log != nil {
+			h.log.Error("🛑 anthropic refresh FAILED — the exchange succeeded but the refreshed credential could not be rebuilt; the OLD refresh token has already been SPENT (#6317)",
+				"err", err.Error(),
+			)
+		}
+		return anthropicRefreshPersistFailed
+	}
+
+	// apiKey is rewritten ONLY when it was a COPY of the access token — which
+	// is how the seed pair is issued (measured on hw296: both 108 bytes, same
+	// sha256 prefix, both sk-ant-oat…). An apiKey that DIFFERS is an
+	// independent, possibly long-lived key the operator supplied on purpose,
+	// and overwriting it with a 5h OAuth access token would destroy it.
+	newAPIKey := apiKey
+	if strings.TrimSpace(apiKey) != "" && strings.TrimSpace(apiKey) == oldAccess {
+		newAPIKey = tok.AccessToken
+	}
+
+	if err := h.persistRefreshedAnthropicCredential(ctx, newAPIKey, newCredsJSON); err != nil {
+		if h.log != nil {
+			h.log.Error("🛑 anthropic refresh FAILED TO PERSIST — a FRESH credential was obtained and could not be stored, and the OLD refresh token has already been SPENT by the exchange. The next pass will retry with a refresh token the provider may have already rotated away (#6317)",
+				"err", err.Error(),
+				"rootSecret", anthropicCredentialNamespace+"/"+anthropicCredentialSecret,
+				"openbaoPath", anthropicSeedMountPath+"/"+anthropicSeedSecretPath,
+				"remediation", "grant catalyst-api update/patch on the root Secret (catalyst chart clusterrole-cutover-driver.yaml) "+
+					"and confirm OpenBao is reachable. If the retry loop reports exchange-failed from here on, the refresh token was rotated "+
+					"and lost — rotate the root Secret with a freshly issued credentialsJson.",
+			)
+		}
+		return anthropicRefreshPersistFailed
+	}
+
+	if h.log != nil {
+		// Byte lengths + fingerprints only. The two DIFFERENT prefixes are the
+		// evidence that the value actually turned over — a refresh that wrote
+		// the same bytes back would show identical prefixes here.
+		h.log.Info("[ANTHROPIC-REFRESH] ✅ credential refreshed and stored — every Organization's Agenity workspace picks it up through the normal ExternalSecret path (#6317)",
+			"oldAccessTokenSha256Prefix", credFingerprint(oldAccess),
+			"newAccessTokenSha256Prefix", credFingerprint(tok.AccessToken),
+			"refreshTokenRotated", credFingerprint(oldRefresh) != credFingerprint(tok.RefreshToken),
+			"newLifetimeMin", int(time.Until(tok.ExpiresAt).Minutes()),
+			"credentialsJsonBytes", len(newCredsJSON),
+			"apiKeyRewritten", newAPIKey != apiKey,
+		)
+	}
+	return anthropicRefreshed
+}
+
+// anthropicCredentialFromEnv — the producer's env fallback, factored out so the
+// refresh reads the credential from exactly the same places in exactly the same
+// order. Values already found take precedence.
+func anthropicCredentialFromEnv(apiKey, credsJSON string) (string, string) {
+	if strings.TrimSpace(apiKey) == "" {
+		apiKey = strings.TrimSpace(os.Getenv(anthropicSeedAPIKeyEnv))
+	}
+	if strings.TrimSpace(credsJSON) == "" {
+		credsJSON = strings.TrimSpace(os.Getenv(anthropicSeedCredentialsJSONEnv))
+	}
+	return apiKey, credsJSON
+}
+
+// anthropicOAuthFields parses the claudeAiOauth object and the REMAINING life
+// of its accessToken. ok=false when the document is not a claudeAiOauth blob.
+//
+// A blob with no expiresAt reports a remaining life far past any lead time, so
+// the "non-expiring credential" case the classifier recognises is never
+// needlessly refreshed.
+func anthropicOAuthFields(credentialsJSON string) (map[string]any, time.Duration, bool) {
+	dec := json.NewDecoder(strings.NewReader(credentialsJSON))
+	dec.UseNumber()
+	var root map[string]any
+	if err := dec.Decode(&root); err != nil {
+		return nil, 0, false
+	}
+	oauth, ok := root["claudeAiOauth"].(map[string]any)
+	if !ok {
+		return nil, 0, false
+	}
+	expiresAtMillis, present := anthropicExpiresAtMillis(oauth["expiresAt"])
+	if !present || expiresAtMillis <= 0 {
+		return oauth, time.Duration(1<<62 - 1), true
+	}
+	return oauth, time.Until(time.UnixMilli(expiresAtMillis)), true
+}
+
+func stringField(m map[string]any, key string) string {
+	if m == nil {
+		return ""
+	}
+	s, _ := m[key].(string)
+	return s
+}
+
+// anthropicRefreshedToken — the fields the OAuth exchange returns that matter.
+type anthropicRefreshedToken struct {
+	AccessToken  string
+	RefreshToken string
+	ExpiresAt    time.Time
+	// RefreshTokenExpiresAt is zero when the provider did not say.
+	RefreshTokenExpiresAt time.Time
+}
+
+// exchangeAnthropicRefreshToken performs the refresh_token grant.
+//
+// Parsed with encoding/json, not with grep over the response body: the shell
+// implementation in the Axon CronJob extracts fields by regex and rebuilds the
+// document from the ones it knows, which silently DROPS every field it does not
+// (refreshTokenExpiresAt among them). Here the response is decoded and the
+// stored document is edited in place, so unknown fields survive a refresh.
+func exchangeAnthropicRefreshToken(ctx context.Context, refreshToken string) (anthropicRefreshedToken, error) {
+	var out anthropicRefreshedToken
+
+	body, err := json.Marshal(map[string]string{
+		"grant_type":    "refresh_token",
+		"refresh_token": refreshToken,
+		"client_id":     anthropicOAuthClientID,
+	})
+	if err != nil {
+		return out, fmt.Errorf("marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, anthropicOAuthTokenEndpoint, bytes.NewReader(body))
+	if err != nil {
+		return out, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := anthropicOAuthHTTPClient.Do(req)
+	if err != nil {
+		return out, fmt.Errorf("post %s: %w", anthropicOAuthTokenEndpoint, err)
+	}
+	defer resp.Body.Close()
+
+	// Cap the read: a hung or hostile endpoint must not be able to grow this
+	// process's heap through a token refresh.
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return out, fmt.Errorf("read response: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		// The body may carry the provider's error CODE, but it may also carry
+		// token material on some error shapes — report the status only.
+		return out, fmt.Errorf("oauth endpoint returned HTTP %d (%d-byte body withheld: may carry credential material)",
+			resp.StatusCode, len(raw))
+	}
+
+	var parsed struct {
+		AccessToken           string      `json:"access_token"`
+		RefreshToken          string      `json:"refresh_token"`
+		ExpiresIn             json.Number `json:"expires_in"`
+		RefreshTokenExpiresIn json.Number `json:"refresh_token_expires_in"`
+	}
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		return out, fmt.Errorf("decode response (%d bytes): %w", len(raw), err)
+	}
+	if strings.TrimSpace(parsed.AccessToken) == "" {
+		// A 200 with no access_token is a FAILED refresh wearing a success
+		// status. Treated as an error so it can never be stored as a credential.
+		return out, fmt.Errorf("oauth endpoint returned HTTP %d with no access_token (%d-byte body)", resp.StatusCode, len(raw))
+	}
+
+	out.AccessToken = strings.TrimSpace(parsed.AccessToken)
+	// Providers rotate refresh tokens; when this one does not, the existing
+	// token stays valid and is carried forward by the caller.
+	out.RefreshToken = strings.TrimSpace(parsed.RefreshToken)
+	if out.RefreshToken == "" {
+		out.RefreshToken = refreshToken
+	}
+	if secs, err := parsed.ExpiresIn.Int64(); err == nil && secs > 0 {
+		out.ExpiresAt = time.Now().Add(time.Duration(secs) * time.Second)
+	}
+	if secs, err := parsed.RefreshTokenExpiresIn.Int64(); err == nil && secs > 0 {
+		out.RefreshTokenExpiresAt = time.Now().Add(time.Duration(secs) * time.Second)
+	}
+	return out, nil
+}
+
+// anthropicCredentialWithRefreshedTokens rewrites accessToken / refreshToken /
+// expiresAt (and refreshTokenExpiresAt when the provider supplied one) INSIDE
+// the existing document, preserving every other field — scopes,
+// subscriptionType, rateLimitTier and anything the provider adds later.
+func anthropicCredentialWithRefreshedTokens(credentialsJSON string, tok anthropicRefreshedToken) (string, error) {
+	dec := json.NewDecoder(strings.NewReader(credentialsJSON))
+	dec.UseNumber()
+	var root map[string]any
+	if err := dec.Decode(&root); err != nil {
+		return "", fmt.Errorf("decode stored credential: %w", err)
+	}
+	oauth, ok := root["claudeAiOauth"].(map[string]any)
+	if !ok {
+		return "", fmt.Errorf("stored credential has no claudeAiOauth object")
+	}
+	oauth["accessToken"] = tok.AccessToken
+	oauth["refreshToken"] = tok.RefreshToken
+	if !tok.ExpiresAt.IsZero() {
+		oauth["expiresAt"] = json.Number(fmt.Sprintf("%d", tok.ExpiresAt.UnixMilli()))
+	}
+	if !tok.RefreshTokenExpiresAt.IsZero() {
+		oauth["refreshTokenExpiresAt"] = json.Number(fmt.Sprintf("%d", tok.RefreshTokenExpiresAt.UnixMilli()))
+	}
+	root["claudeAiOauth"] = oauth
+
+	buf, err := json.Marshal(root)
+	if err != nil {
+		return "", fmt.Errorf("re-marshal credential: %w", err)
+	}
+	return string(buf), nil
+}
+
+// persistRefreshedAnthropicCredential stores the refreshed pair in BOTH places
+// the delivery chain reads.
+//
+// ORDER IS LOAD-BEARING. The root Secret is written FIRST because it is the
+// durable one: it survives a catalyst-api restart, and it is what the seed
+// producer re-reads on every pass. The exchange ROTATES the refresh token, so a
+// refreshed blob that reached OpenBao but not the root Secret would leave the
+// root holding SPENT refresh material — and the seed reconciler would then
+// happily re-seed that dead value over a working OpenBao path the moment the
+// stored blob was judged unusable.
+//
+// OpenBao is written second so ESO propagates immediately. If only that write
+// fails, the next reconcile pass reads the refreshed root Secret, finds the
+// stored path unhealthy, and the existing seed leg repairs it — so this half is
+// self-healing and the error is reported rather than retried here.
+func (h *Handler) persistRefreshedAnthropicCredential(ctx context.Context, apiKey, credentialsJSON string) error {
+	if err := writeAnthropicRootSecret(ctx, apiKey, credentialsJSON); err != nil {
+		return fmt.Errorf("root Secret %s/%s: %w", anthropicCredentialNamespace, anthropicCredentialSecret, err)
+	}
+	if h.openbao == nil {
+		return nil
+	}
+	if err := h.openbao.PutKVv2(ctx, anthropicSeedMountPath, anthropicSeedSecretPath, map[string]any{
+		"apiKey":          apiKey,
+		"credentialsJson": credentialsJSON,
+	}); err != nil {
+		return fmt.Errorf("openbao %s/%s: %w", anthropicSeedMountPath, anthropicSeedSecretPath, err)
+	}
+	return nil
+}
+
+// writeAnthropicRootSecret patches the operator-rotatable root Secret.
+//
+// A strategic-merge PATCH, not an Update: it touches only the two credential
+// keys and cannot clobber anything else an operator keeps in that Secret, and
+// it needs no read-modify-write round trip to avoid a conflict.
+//
+// `data` with base64 values, not `stringData`: stringData is a write-only
+// convenience the API server folds into data, so a patch built from it cannot
+// be asserted against the object it produces without trusting that server-side
+// conversion. Writing data directly makes the stored bytes the same under a
+// real apiserver and under the fake clientset the tests drive.
+// anthropicSecretRootWritable reports whether there is an in-cluster identity
+// capable of writing the root Secret at all. Used as the pre-flight above, and
+// by writeAnthropicRootSecret itself, so the check and the write can never
+// disagree about what "reachable" means.
+//
+// It deliberately does NOT probe RBAC with a speculative write: the shipped
+// ClusterRole grants the name-scoped patch, and a dry-run would double every
+// refresh's API traffic to defend against a misconfiguration that the persist
+// failure already reports loudly.
+func anthropicSecretRootWritable() (kubernetes.Interface, error) {
+	cli, err := anthropicSecretClientFor()
+	if err != nil {
+		return nil, err
+	}
+	if cli == nil {
+		return nil, fmt.Errorf("no in-cluster identity")
+	}
+	return cli, nil
+}
+
+func writeAnthropicRootSecret(ctx context.Context, apiKey, credentialsJSON string) error {
+	cli, err := anthropicSecretRootWritable()
+	if err != nil {
+		return err
+	}
+	patch, err := json.Marshal(map[string]any{
+		"data": map[string]string{
+			anthropicCredentialAPIKeyKey: base64.StdEncoding.EncodeToString([]byte(apiKey)),
+			anthropicCredentialJSONKey:   base64.StdEncoding.EncodeToString([]byte(credentialsJSON)),
+		},
+	})
+	if err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(ctx, anthropicCredentialReadBudget)
+	defer cancel()
+	_, err = cli.CoreV1().Secrets(anthropicCredentialNamespace).
+		Patch(ctx, anthropicCredentialSecret, types.StrategicMergePatchType, patch, metav1.PatchOptions{})
+	return err
+}

--- a/products/catalyst/bootstrap/api/internal/handler/sovereign_anthropic_refresh_6317_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sovereign_anthropic_refresh_6317_test.go
@@ -1,0 +1,630 @@
+package handler
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/openbao"
+)
+
+// #6317 — the Agenity Anthropic credential expires every ~5h and, until this
+// file's subject existed, nothing renewed it. Measured on hw296 2026-08-14: the
+// workspace agent answered its own PTY with "401 OAuth access token has been
+// revoked" while the refresh token sat alive and unspent for another four weeks.
+//
+// Every assertion below is vacuity-proven in scripts/mutation-6317.sh, which
+// mutates ONE behaviour at a time in the subject and requires the NAMED test to
+// go red for each. A test that cannot fail is not evidence.
+
+// ─── fixtures ──────────────────────────────────────────────────────────────
+
+// oauthServer — a fake console.anthropic.com token endpoint that records how
+// many times it was called, so "the exchange did not happen" is an assertable
+// fact rather than an inference from an unchanged value.
+type oauthServer struct {
+	mu       sync.Mutex
+	calls    int
+	lastBody map[string]any
+	srv      *httptest.Server
+}
+
+func newOAuthServer(t *testing.T, status int, respond func() string) *oauthServer {
+	t.Helper()
+	o := &oauthServer{}
+	o.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var parsed map[string]any
+		_ = json.Unmarshal(body, &parsed)
+		o.mu.Lock()
+		o.calls++
+		o.lastBody = parsed
+		o.mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(respond()))
+	}))
+	t.Cleanup(o.srv.Close)
+
+	prevURL := anthropicOAuthTokenEndpoint
+	prevClient := anthropicOAuthHTTPClient
+	anthropicOAuthTokenEndpoint = o.srv.URL
+	anthropicOAuthHTTPClient = o.srv.Client()
+	t.Cleanup(func() {
+		anthropicOAuthTokenEndpoint = prevURL
+		anthropicOAuthHTTPClient = prevClient
+	})
+	return o
+}
+
+func (o *oauthServer) callCount() int {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return o.calls
+}
+
+func (o *oauthServer) sentRefreshToken() string {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	s, _ := o.lastBody["refresh_token"].(string)
+	return s
+}
+
+// okTokenResponse — a well-formed refresh response.
+func okTokenResponse(access, refresh string, expiresIn int) func() string {
+	return func() string {
+		return fmt.Sprintf(`{"access_token":%q,"refresh_token":%q,"expires_in":%d,"token_type":"Bearer"}`,
+			access, refresh, expiresIn)
+	}
+}
+
+// credWithRemaining builds a claudeAiOauth document whose accessToken expires
+// `remaining` from now. Carries the extra fields real blobs carry, so the
+// preservation assertion has something to lose.
+func credWithRemaining(access, refresh string, remaining time.Duration) string {
+	return fmt.Sprintf(`{"claudeAiOauth":{"accessToken":%q,"refreshToken":%q,"expiresAt":%d,`+
+		`"scopes":["user:inference","user:profile"],"subscriptionType":"max","rateLimitTier":"default_max_20x",`+
+		`"refreshTokenExpiresAt":%d}}`,
+		access, refresh,
+		time.Now().Add(remaining).UnixMilli(),
+		time.Now().Add(28*24*time.Hour).UnixMilli())
+}
+
+// statefulKVServer — a KV-v2 fake that STORES what is written and serves it
+// back on read.
+//
+// The package's captureKVServer records the last request of any method and
+// always answers reads with a fixed envelope. That is fine for asserting a
+// single producer write, but it cannot model the read-after-write the seed
+// reconciler performs, and a read would overwrite the captured write. A whole
+// reconcile pass needs a fake that behaves like the store it stands in for.
+type statefulKVServer struct {
+	mu     sync.Mutex
+	writes int
+	data   map[string]map[string]any // path -> payload
+	srv    *httptest.Server
+}
+
+func newStatefulKVServer(t *testing.T) *statefulKVServer {
+	t.Helper()
+	s := &statefulKVServer{data: map[string]map[string]any{}}
+	s.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// KV-v2 URLs are /v1/<mount>/data/<path...>.
+		path := strings.TrimPrefix(r.URL.Path, "/v1/")
+		w.Header().Set("Content-Type", "application/json")
+
+		if r.Method == http.MethodGet {
+			s.mu.Lock()
+			payload, ok := s.data[path]
+			s.mu.Unlock()
+			if !ok {
+				w.WriteHeader(http.StatusNotFound)
+				_, _ = w.Write([]byte(`{"errors":[]}`))
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"data": payload}})
+			return
+		}
+
+		body, _ := io.ReadAll(r.Body)
+		var parsed map[string]any
+		_ = json.Unmarshal(body, &parsed)
+		payload, _ := parsed["data"].(map[string]any)
+		s.mu.Lock()
+		s.data[path] = payload
+		s.writes++
+		s.mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data":{"version":1}}`))
+	}))
+	t.Cleanup(s.srv.Close)
+	return s
+}
+
+// stored returns a property of the anthropic KV path as it would be read by the
+// agenity ExternalSecret.
+func (s *statefulKVServer) stored(key string) (string, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	payload, ok := s.data["secret/data/"+anthropicSeedSecretPath]
+	if !ok {
+		return "", false
+	}
+	v, ok := payload[key].(string)
+	return v, ok
+}
+
+// refreshFixture wires a Handler with a fake OpenBao, a fake clientset holding
+// the root Secret, and returns both so a test can read back what was stored.
+type refreshFixture struct {
+	h      *Handler
+	kv     *statefulKVServer
+	client *fake.Clientset
+	logs   *bytes.Buffer
+}
+
+func newRefreshFixture(t *testing.T, apiKey, credsJSON string) *refreshFixture {
+	t.Helper()
+	kv := newStatefulKVServer(t)
+	logs := &bytes.Buffer{}
+	h := &Handler{log: slog.New(slog.NewJSONHandler(logs, &slog.HandlerOptions{Level: slog.LevelDebug}))}
+	h.openbao = &openbao.Client{Addr: kv.srv.URL, Token: "test-token", HTTP: kv.srv.Client()}
+
+	cs := fake.NewSimpleClientset(anthropicSecret(apiKey, credsJSON))
+	withAnthropicSecretClient(t, cs, nil)
+
+	// The env fallback must not leak a credential in from another test.
+	t.Setenv(anthropicSeedAPIKeyEnv, "")
+	t.Setenv(anthropicSeedCredentialsJSONEnv, "")
+
+	return &refreshFixture{h: h, kv: kv, client: cs, logs: logs}
+}
+
+// storedRootSecret reads the root Secret back out of the fake clientset.
+func (f *refreshFixture) storedRootSecret(t *testing.T) (string, string) {
+	t.Helper()
+	sec, err := f.client.CoreV1().Secrets(anthropicCredentialNamespace).
+		Get(context.Background(), anthropicCredentialSecret, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("read back root Secret: %v", err)
+	}
+	return string(sec.Data[anthropicCredentialAPIKeyKey]), string(sec.Data[anthropicCredentialJSONKey])
+}
+
+func oauthField(t *testing.T, credsJSON, key string) string {
+	t.Helper()
+	var root map[string]any
+	if err := json.Unmarshal([]byte(credsJSON), &root); err != nil {
+		t.Fatalf("stored credential is not JSON: %v", err)
+	}
+	o, ok := root["claudeAiOauth"].(map[string]any)
+	if !ok {
+		t.Fatalf("stored credential has no claudeAiOauth object")
+	}
+	s, _ := o[key].(string)
+	return s
+}
+
+// ─── 1. the hw296 state: EXPIRED access token, live refresh token ──────────
+
+// THE BUG, exactly as measured. Before #6317 this returned with the credential
+// untouched and the agent kept 401ing. Vacuity: mutation M1 makes an expired
+// credential fall through to "not due" — this test must then fail.
+func TestRefresh_ExpiredCredentialIsRenewed_6317(t *testing.T) {
+	f := newRefreshFixture(t, "sk-ant-oat-OLD", credWithRemaining("sk-ant-oat-OLD", "rt-ALIVE", -3*time.Hour))
+	srv := newOAuthServer(t, 200, okTokenResponse("sk-ant-oat-NEW", "rt-ROTATED", 18000))
+
+	if got := f.h.refreshAnthropicCredential(context.Background()); got != anthropicRefreshed {
+		t.Fatalf("outcome = %q, want %q — an EXPIRED credential with a live refreshToken is exactly the state that must renew", got, anthropicRefreshed)
+	}
+	if srv.callCount() != 1 {
+		t.Fatalf("oauth endpoint called %d times, want 1", srv.callCount())
+	}
+	_, creds := f.storedRootSecret(t)
+	if got := oauthField(t, creds, "accessToken"); got != "sk-ant-oat-NEW" {
+		t.Fatalf("stored accessToken = %q, want the refreshed one", got)
+	}
+}
+
+// ─── 2. refresh happens BEFORE expiry, not after ───────────────────────────
+
+// Vacuity: mutation M2 sets the lead time to 0, so a credential with 1h left is
+// no longer due — this test goes red.
+func TestRefresh_FiresInsideLeadTimeBeforeExpiry_6317(t *testing.T) {
+	f := newRefreshFixture(t, "", credWithRemaining("acc-OLD", "rt-1", 1*time.Hour))
+	srv := newOAuthServer(t, 200, okTokenResponse("acc-NEW", "rt-2", 18000))
+
+	if got := f.h.refreshAnthropicCredential(context.Background()); got != anthropicRefreshed {
+		t.Fatalf("outcome = %q, want %q — 1h remaining is inside the %v lead time", got, anthropicRefreshed, anthropicRefreshLeadTime)
+	}
+	if srv.callCount() != 1 {
+		t.Fatalf("oauth endpoint called %d times, want 1", srv.callCount())
+	}
+}
+
+// The margin is the whole point: renewing only after expiry would leave a dead
+// window on every cycle. Asserted on the constant so a later edit that shrinks
+// it below the measured propagation cost fails here rather than in production.
+func TestRefresh_LeadTimeCoversPropagationChain_6317(t *testing.T) {
+	// Worst-case propagation, measured: ESO refreshInterval 15m + kubelet
+	// Secret re-projection ~1m + emptyDir re-sync 2m = 18m.
+	const worstCasePropagation = 18 * time.Minute
+	if anthropicRefreshLeadTime <= worstCasePropagation {
+		t.Fatalf("lead time %v does not cover the %v propagation chain — a refreshed credential would reach the workspace after it expired",
+			anthropicRefreshLeadTime, worstCasePropagation)
+	}
+	// And it must leave room for repeated attempts at the 10m reconcile cadence.
+	if attempts := int(anthropicRefreshLeadTime / defaultSeedReconcileInterval); attempts < 6 {
+		t.Fatalf("lead time %v gives only %d attempts at the %v cadence — a brief provider outage would burn the whole window",
+			anthropicRefreshLeadTime, attempts, defaultSeedReconcileInterval)
+	}
+}
+
+// ─── 3. a healthy credential is left alone (no churn) ──────────────────────
+
+// Vacuity: mutation M3 removes the not-due short-circuit, so a credential with
+// 4h left refreshes anyway — this test goes red.
+func TestRefresh_HealthyCredentialIsNotChurned_6317(t *testing.T) {
+	f := newRefreshFixture(t, "", credWithRemaining("acc-FRESH", "rt-1", 4*time.Hour))
+	srv := newOAuthServer(t, 200, okTokenResponse("acc-NEW", "rt-2", 18000))
+
+	if got := f.h.refreshAnthropicCredential(context.Background()); got != anthropicRefreshNotDue {
+		t.Fatalf("outcome = %q, want %q", got, anthropicRefreshNotDue)
+	}
+	if srv.callCount() != 0 {
+		t.Fatalf("oauth endpoint called %d times for a credential with 4h left — that is churn", srv.callCount())
+	}
+}
+
+// ─── 4. every other field survives the rewrite ─────────────────────────────
+
+// The Axon shell implementation rebuilds the document from the fields it greps
+// for, silently dropping the rest. Vacuity: mutation M4 rebuilds the blob from
+// scratch instead of editing in place — this test goes red.
+func TestRefresh_PreservesUnknownCredentialFields_6317(t *testing.T) {
+	f := newRefreshFixture(t, "", credWithRemaining("acc-OLD", "rt-1", -1*time.Hour))
+	newOAuthServer(t, 200, okTokenResponse("acc-NEW", "rt-2", 18000))
+
+	if got := f.h.refreshAnthropicCredential(context.Background()); got != anthropicRefreshed {
+		t.Fatalf("outcome = %q, want refreshed", got)
+	}
+	_, creds := f.storedRootSecret(t)
+
+	var root map[string]any
+	if err := json.Unmarshal([]byte(creds), &root); err != nil {
+		t.Fatalf("stored credential is not JSON: %v", err)
+	}
+	o := root["claudeAiOauth"].(map[string]any)
+
+	if o["subscriptionType"] != "max" {
+		t.Errorf("subscriptionType = %v, want it preserved across a refresh", o["subscriptionType"])
+	}
+	if o["rateLimitTier"] != "default_max_20x" {
+		t.Errorf("rateLimitTier = %v, want it preserved", o["rateLimitTier"])
+	}
+	scopes, ok := o["scopes"].([]any)
+	if !ok || len(scopes) != 2 {
+		t.Errorf("scopes = %v, want the original two preserved", o["scopes"])
+	}
+	if _, ok := o["refreshTokenExpiresAt"]; !ok {
+		t.Errorf("refreshTokenExpiresAt was DROPPED — the field that proves the refresh material is alive")
+	}
+}
+
+// ─── 5. a rotated refresh token is stored, never dropped ───────────────────
+
+// Losing a rotated refresh token bricks the credential permanently. Vacuity:
+// mutation M5 keeps the old refresh token instead of the rotated one — red.
+func TestRefresh_StoresRotatedRefreshToken_6317(t *testing.T) {
+	f := newRefreshFixture(t, "", credWithRemaining("acc-OLD", "rt-OLD", -1*time.Hour))
+	srv := newOAuthServer(t, 200, okTokenResponse("acc-NEW", "rt-ROTATED", 18000))
+
+	if got := f.h.refreshAnthropicCredential(context.Background()); got != anthropicRefreshed {
+		t.Fatalf("outcome = %q, want refreshed", got)
+	}
+	if sent := srv.sentRefreshToken(); sent != "rt-OLD" {
+		t.Fatalf("exchange sent refresh_token %q, want the stored one", sent)
+	}
+	_, creds := f.storedRootSecret(t)
+	if got := oauthField(t, creds, "refreshToken"); got != "rt-ROTATED" {
+		t.Fatalf("stored refreshToken = %q, want the ROTATED one — keeping the spent token bricks the credential", got)
+	}
+}
+
+// A provider that does NOT rotate must not have its token blanked.
+func TestRefresh_CarriesForwardUnrotatedRefreshToken_6317(t *testing.T) {
+	f := newRefreshFixture(t, "", credWithRemaining("acc-OLD", "rt-KEEP", -1*time.Hour))
+	newOAuthServer(t, 200, func() string {
+		return `{"access_token":"acc-NEW","expires_in":18000}`
+	})
+
+	if got := f.h.refreshAnthropicCredential(context.Background()); got != anthropicRefreshed {
+		t.Fatalf("outcome = %q, want refreshed", got)
+	}
+	_, creds := f.storedRootSecret(t)
+	if got := oauthField(t, creds, "refreshToken"); got != "rt-KEEP" {
+		t.Fatalf("stored refreshToken = %q, want the original carried forward", got)
+	}
+}
+
+// ─── 6. failures are LOUD, and never overwrite a credential ────────────────
+
+// Vacuity: mutation M6 makes a non-2xx response return success — red.
+func TestRefresh_ExchangeHTTPErrorIsLoudAndLeavesCredentialIntact_6317(t *testing.T) {
+	original := credWithRemaining("acc-OLD", "rt-1", -1*time.Hour)
+	f := newRefreshFixture(t, "sk-ant-oat-OLD", original)
+	newOAuthServer(t, 400, func() string { return `{"error":"invalid_grant"}` })
+
+	if got := f.h.refreshAnthropicCredential(context.Background()); got != anthropicRefreshExchangeFailed {
+		t.Fatalf("outcome = %q, want %q", got, anthropicRefreshExchangeFailed)
+	}
+	if _, creds := f.storedRootSecret(t); creds != original {
+		t.Fatalf("a FAILED refresh rewrote the credential; it must be left untouched")
+	}
+	if !strings.Contains(f.logs.String(), "anthropic refresh FAILED") {
+		t.Fatalf("a failed refresh did not log loudly — a silent no-op is indistinguishable from success.\nlogs: %s", f.logs.String())
+	}
+	// The response must be rejected ON ITS STATUS, before any attempt to read a
+	// token out of it. Asserting merely on "HTTP 400" would pass either way —
+	// the no-access-token path names the status too — so this pins the
+	// status-gate's own message, which also records that the body was WITHHELD
+	// from the log rather than printed (an error body may carry credential
+	// material).
+	if !strings.Contains(f.logs.String(), "body withheld") {
+		t.Fatalf("the 400 was not rejected on its status — it fell through to token parsing, so an error body would reach the log.\nlogs: %s", f.logs.String())
+	}
+	if !strings.Contains(f.logs.String(), "HTTP 400") {
+		t.Fatalf("the failure log does not name the HTTP status the endpoint returned.\nlogs: %s", f.logs.String())
+	}
+}
+
+// THE DOMINANT DEFECT SHAPE: a 200 that carries no token is a FAILED refresh
+// wearing a success status. Vacuity: mutation M7 drops the empty-access-token
+// check, so this stores an empty credential and reports success — red.
+func TestRefresh_HTTP200WithoutAccessTokenIsAFailure_6317(t *testing.T) {
+	original := credWithRemaining("acc-OLD", "rt-1", -1*time.Hour)
+	f := newRefreshFixture(t, "", original)
+	newOAuthServer(t, 200, func() string { return `{"token_type":"Bearer","expires_in":18000}` })
+
+	if got := f.h.refreshAnthropicCredential(context.Background()); got != anthropicRefreshExchangeFailed {
+		t.Fatalf("outcome = %q, want %q — a 200 with no access_token must never be stored as a credential", got, anthropicRefreshExchangeFailed)
+	}
+	if _, creds := f.storedRootSecret(t); creds != original {
+		t.Fatalf("an empty-token 200 overwrote the stored credential")
+	}
+}
+
+// A blob that CANNOT be refreshed must say so, loudly, rather than returning
+// quietly and letting the credential die on schedule. Vacuity: mutation M8
+// downgrades this to a silent return — red.
+func TestRefresh_MissingRefreshTokenIsLoud_6317(t *testing.T) {
+	f := newRefreshFixture(t, "", `{"claudeAiOauth":{"accessToken":"acc-only","expiresAt":1}}`)
+	srv := newOAuthServer(t, 200, okTokenResponse("acc-NEW", "rt-2", 18000))
+
+	if got := f.h.refreshAnthropicCredential(context.Background()); got != anthropicRefreshNoRefreshToken {
+		t.Fatalf("outcome = %q, want %q", got, anthropicRefreshNoRefreshToken)
+	}
+	if srv.callCount() != 0 {
+		t.Fatalf("exchanged with no refresh token available")
+	}
+	if !strings.Contains(f.logs.String(), "anthropic refresh IMPOSSIBLE") {
+		t.Fatalf("an unrefreshable credential was not reported loudly.\nlogs: %s", f.logs.String())
+	}
+}
+
+// A persist failure is the worst case — the refresh token is already spent —
+// so it must be reported, not swallowed. Vacuity: mutation M9 ignores the root
+// Secret write error — red.
+func TestRefresh_RootSecretWriteFailureIsReported_6317(t *testing.T) {
+	f := newRefreshFixture(t, "", credWithRemaining("acc-OLD", "rt-1", -1*time.Hour))
+	newOAuthServer(t, 200, okTokenResponse("acc-NEW", "rt-2", 18000))
+
+	f.client.PrependReactor("patch", "secrets", func(k8stesting.Action) (bool, k8sruntime.Object, error) {
+		return true, nil, fmt.Errorf("secrets is forbidden: RBAC denies patch")
+	})
+
+	if got := f.h.refreshAnthropicCredential(context.Background()); got != anthropicRefreshPersistFailed {
+		t.Fatalf("outcome = %q, want %q", got, anthropicRefreshPersistFailed)
+	}
+	if !strings.Contains(f.logs.String(), "FAILED TO PERSIST") {
+		t.Fatalf("a persist failure was not reported loudly.\nlogs: %s", f.logs.String())
+	}
+}
+
+// ─── 6b. never SPEND a refresh token that cannot be stored ────────────────
+
+// The exchange consumes the old refresh token whether or not the result can be
+// kept. Attempting it with nowhere durable to write does not fail harmlessly —
+// it burns the only material that could renew this credential later, turning a
+// credential that merely EXPIRES into one that needs a human re-issue. So the
+// exchange must not even be attempted.
+//
+// Vacuity: mutation M18 removes the pre-flight — the endpoint is then called
+// and this test goes red on the call count.
+func TestRefresh_DoesNotSpendRefreshTokenWithoutADurableStore_6317(t *testing.T) {
+	logs := &bytes.Buffer{}
+	h := &Handler{log: slog.New(slog.NewJSONHandler(logs, &slog.HandlerOptions{Level: slog.LevelDebug}))}
+
+	// No in-cluster identity: the credential can only come from the env, and
+	// there is no Secret to write a renewed one back to.
+	withAnthropicSecretClient(t, nil, fmt.Errorf("in-cluster config unavailable"))
+	t.Setenv(anthropicSeedAPIKeyEnv, "")
+	t.Setenv(anthropicSeedCredentialsJSONEnv, credWithRemaining("acc-OLD", "rt-PRECIOUS", -1*time.Hour))
+
+	srv := newOAuthServer(t, 200, okTokenResponse("acc-NEW", "rt-2", 18000))
+
+	if got := h.refreshAnthropicCredential(context.Background()); got != anthropicRefreshNoDurableStore {
+		t.Fatalf("outcome = %q, want %q", got, anthropicRefreshNoDurableStore)
+	}
+	if srv.callCount() != 0 {
+		t.Fatalf("the refresh token was SPENT (%d exchange call(s)) with nowhere to store the result — the credential is now unrecoverable", srv.callCount())
+	}
+	if !strings.Contains(logs.String(), "nowhere durable to store") {
+		t.Fatalf("the skip was not reported loudly.\nlogs: %s", logs.String())
+	}
+}
+
+// ─── 7. apiKey is rewritten ONLY when it was a copy of the access token ────
+
+// Measured on hw296: apiKey and accessToken were byte-identical, so a refresh
+// that updated only the blob would leave a stale key behind. Vacuity: mutation
+// M10 stops rewriting apiKey — red.
+func TestRefresh_RewritesApiKeyWhenItMirrorsTheAccessToken_6317(t *testing.T) {
+	f := newRefreshFixture(t, "acc-OLD", credWithRemaining("acc-OLD", "rt-1", -1*time.Hour))
+	newOAuthServer(t, 200, okTokenResponse("acc-NEW", "rt-2", 18000))
+
+	if got := f.h.refreshAnthropicCredential(context.Background()); got != anthropicRefreshed {
+		t.Fatalf("outcome = %q, want refreshed", got)
+	}
+	key, _ := f.storedRootSecret(t)
+	if key != "acc-NEW" {
+		t.Fatalf("apiKey = %q, want the refreshed access token — it was a byte-identical copy and would otherwise go stale", key)
+	}
+}
+
+// The inverse, which is what makes the rule safe: an INDEPENDENT long-lived key
+// must survive. Vacuity: mutation M11 rewrites apiKey unconditionally — red.
+func TestRefresh_PreservesIndependentApiKey_6317(t *testing.T) {
+	f := newRefreshFixture(t, "sk-ant-api03-LONGLIVED", credWithRemaining("acc-OLD", "rt-1", -1*time.Hour))
+	newOAuthServer(t, 200, okTokenResponse("acc-NEW", "rt-2", 18000))
+
+	if got := f.h.refreshAnthropicCredential(context.Background()); got != anthropicRefreshed {
+		t.Fatalf("outcome = %q, want refreshed", got)
+	}
+	key, _ := f.storedRootSecret(t)
+	if key != "sk-ant-api03-LONGLIVED" {
+		t.Fatalf("apiKey = %q — an independent long-lived key was destroyed by a 5h OAuth access token", key)
+	}
+}
+
+// ─── 8. both stores receive the refreshed value ────────────────────────────
+
+// OpenBao is what the per-Org ExternalSecret reads; the root Secret is what
+// survives a catalyst-api restart. Vacuity: mutation M12 skips the OpenBao
+// write — red.
+func TestRefresh_WritesBothRootSecretAndOpenBao_6317(t *testing.T) {
+	f := newRefreshFixture(t, "", credWithRemaining("acc-OLD", "rt-1", -1*time.Hour))
+	newOAuthServer(t, 200, okTokenResponse("acc-NEW", "rt-2", 18000))
+
+	if got := f.h.refreshAnthropicCredential(context.Background()); got != anthropicRefreshed {
+		t.Fatalf("outcome = %q, want refreshed", got)
+	}
+	stored, ok := f.kv.stored("credentialsJson")
+	if !ok {
+		t.Fatalf("OpenBao never received a credentialsJson write — the per-Org ExternalSecret would keep serving the expired blob")
+	}
+	if got := oauthField(t, stored, "accessToken"); got != "acc-NEW" {
+		t.Fatalf("OpenBao credentialsJson accessToken = %q, want the refreshed one", got)
+	}
+	if _, creds := f.storedRootSecret(t); oauthField(t, creds, "accessToken") != "acc-NEW" {
+		t.Fatalf("root Secret did not receive the refreshed access token")
+	}
+}
+
+// ─── 9. credential hygiene — no token material in any log line ─────────────
+
+// The repo is public and these logs are shipped to operators. Vacuity: mutation
+// M13 logs the access token — red.
+func TestRefresh_NeverLogsTokenMaterial_6317(t *testing.T) {
+	const secretAccess = "sk-ant-oat01-SUPERSECRETACCESSVALUE"
+	const secretRefresh = "sk-ant-ort01-SUPERSECRETREFRESHVALUE"
+	f := newRefreshFixture(t, secretAccess, credWithRemaining(secretAccess, secretRefresh, -1*time.Hour))
+	newOAuthServer(t, 200, okTokenResponse("sk-ant-oat01-BRANDNEWSECRET", "sk-ant-ort01-BRANDNEWREFRESH", 18000))
+
+	if got := f.h.refreshAnthropicCredential(context.Background()); got != anthropicRefreshed {
+		t.Fatalf("outcome = %q, want refreshed", got)
+	}
+	logs := f.logs.String()
+	for _, material := range []string{secretAccess, secretRefresh, "sk-ant-oat01-BRANDNEWSECRET", "sk-ant-ort01-BRANDNEWREFRESH"} {
+		if strings.Contains(logs, material) {
+			t.Fatalf("token material leaked into the logs (%q…)", material[:12])
+		}
+	}
+	// And the fingerprints that replace it must actually be there, or this test
+	// would pass on a subject that logs nothing at all.
+	if !strings.Contains(logs, credFingerprint(secretAccess)) {
+		t.Fatalf("no sha256 fingerprint of the old access token in the logs — the refresh is unauditable.\nlogs: %s", logs)
+	}
+}
+
+// ─── 10. the reconcile pass renews BEFORE it seeds ─────────────────────────
+
+// The ordering is the fix. Renewing after the seed leg would propagate the dead
+// credential for another full interval. Vacuity: mutation M14 moves the refresh
+// call after reconcileGlobalSeed — red.
+func TestReconcilePass_RefreshesBeforeSeeding_6317(t *testing.T) {
+	f := newRefreshFixture(t, "", credWithRemaining("acc-OLD", "rt-1", -1*time.Hour))
+	newOAuthServer(t, 200, okTokenResponse("acc-NEW", "rt-2", 18000))
+
+	f.h.runSeedReconcilePass(context.Background())
+
+	stored, ok := f.kv.stored("credentialsJson")
+	if !ok {
+		t.Fatalf("the pass wrote no credentialsJson at all.\nlogs: %s", f.logs.String())
+	}
+	if got := oauthField(t, stored, "accessToken"); got != "acc-NEW" {
+		t.Fatalf("the seed leg propagated accessToken %q — the pass seeded the EXPIRED credential it had just renewed", got)
+	}
+
+	// ORDER, asserted on WHAT THE SEED LEG SAW rather than on the final stored
+	// value. The end state alone cannot see the ordering: with the refresh
+	// running LAST, the seed still writes the expired blob and the refresh then
+	// overwrites it — same fresh value, same green assertion.
+	//
+	// What differs is the producer's own verdict. Renewed first, the OpenBao
+	// path is already healthy when the seed leg reads it, so that leg is a
+	// silent no-op — the correct outcome, and the reason no "wrote OpenBao
+	// path" line appears here. Renewed last, the seed reads the EXPIRED root
+	// Secret, classifies it unusable, finds nothing stored to protect, and
+	// writes it anyway under the line asserted against below.
+	logs := f.logs.String()
+	if strings.Contains(logs, "CANNOT authenticate an agent") {
+		t.Fatalf("the seed leg ran BEFORE the refresh: it read the expired credential and propagated one that cannot authenticate.\nlogs: %s", logs)
+	}
+	if strings.Contains(logs, `"seed":"anthropic"`) && strings.Contains(logs, "self-heal did NOT take") {
+		t.Fatalf("the anthropic leg reported an unhealed path — it ran against the expired credential instead of the renewed one.\nlogs: %s", logs)
+	}
+	refreshAt := strings.Index(logs, "[ANTHROPIC-REFRESH] ✅")
+	if refreshAt < 0 {
+		t.Fatalf("the pass did not renew the credential at all.\nlogs: %s", logs)
+	}
+	if seedAt := strings.Index(logs, "anthropic seed: wrote OpenBao path"); seedAt >= 0 && seedAt < refreshAt {
+		t.Fatalf("the seed leg propagated BEFORE the refresh renewed (seedAt=%d refreshAt=%d).\nlogs: %s", seedAt, refreshAt, logs)
+	}
+}
+
+// ─── 11. classifier agreement — a refreshed blob must read as valid ────────
+
+// The refresh and the health predicate must not disagree about what they just
+// produced, or the reconciler would re-seed over a credential it had renewed.
+func TestRefresh_ProducesACredentialTheClassifierCallsValid_6317(t *testing.T) {
+	f := newRefreshFixture(t, "", credWithRemaining("acc-OLD", "rt-1", -1*time.Hour))
+	newOAuthServer(t, 200, okTokenResponse("acc-NEW", "rt-2", 18000))
+
+	if got := f.h.refreshAnthropicCredential(context.Background()); got != anthropicRefreshed {
+		t.Fatalf("outcome = %q, want refreshed", got)
+	}
+	key, creds := f.storedRootSecret(t)
+	class, detail := classifyAnthropicCredential(key, creds)
+	if !class.usable() {
+		t.Fatalf("a freshly refreshed credential classifies as %q (%s) — the reconciler would immediately re-seed over it", class, detail)
+	}
+	if !anthropicStoredCredentialUsable(map[string]any{"apiKey": key, "credentialsJson": creds}) {
+		t.Fatalf("the seed reconciler's health predicate rejects a credential the refresh just produced")
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/sovereign_seed_reconciler.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sovereign_seed_reconciler.go
@@ -193,6 +193,21 @@ func (h *Handler) runSeedReconcilePass(ctx context.Context) {
 	//   credential spends most of its life in exactly that state. The usable
 	//   predicate asks of the stored bytes the same question the workspace pod
 	//   asks of them one layer down.
+	//
+	// #6317 — RENEW BEFORE SEEDING. Until this call existed, the two comments
+	// above described a condition nothing could fix: the predicate correctly
+	// judged an expired blob unhealthy, the producer re-applied the same
+	// expired blob from the root Secret, and the pass logged "self-heal did NOT
+	// take" every ten minutes for the life of the credential. The refresh runs
+	// FIRST so the seed leg below reads the renewed value in the SAME pass
+	// rather than propagating the dead one for another interval.
+	//
+	// Non-fatal by construction, like every other leg: refreshAnthropicCredential
+	// folds each failure into a loud ERROR and returns an outcome, so a provider
+	// outage degrades to "the credential expires on schedule, loudly" — exactly
+	// the pre-#6317 behaviour — and never starves the mcp-bearer leg below.
+	h.refreshAnthropicCredential(ctx)
+
 	h.reconcileGlobalSeed(ctx,
 		"anthropic",
 		anthropicSeedMountPath, anthropicSeedSecretPath,

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -146,7 +146,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "listed",
-    "version": "0.5.28",
+    "version": "0.5.29",
     "section": "pts-7-org-tenant",
     "depends": [
       "bp-external-secrets"

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3968,7 +3968,7 @@ name: bp-catalyst-platform
 #   file's 1.4.1325 entry records as permanently burned. The republish
 #   therefore lands on 1.4.1468 — ahead of main's 1.4.1467, absent from GHCR,
 #   and claimed by no open PR.)
-version: 1.4.1486
+version: 1.4.1493
 # 1.4.1481 — #6293: catalog-seed advances bp-self-sovereign-cutover
 #   0.1.186 -> 0.1.187, the release that stops step-06 from patching five
 #   HelmRepositories it does not own and then grading itself on whether they
@@ -4155,7 +4155,7 @@ version: 1.4.1486
 # scripts/check-chart-version-forward.sh (#5743) fails unless the two match —
 # main was carrying a pre-existing 1.4.1330/1.4.1329 split, so this bump heals
 # it in the same commit, exactly as the documented self-heal contract does.
-appVersion: 1.4.1486
+appVersion: 1.4.1493
 # 1.4.239 — Wave 3 / Issue #2140 (2026-05-23): Huawei provider
 # implementation lands behind the Wave 2 CloudProvider interface.
 # Adds the OpenTofu module at infra/providers/huawei/ (VPC + Subnet +

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -6035,7 +6035,7 @@ spec:
   # 0.5.22 (#5617): the oidc-gate companion gains its egress CNP — the per-Org
   # namespace is default-deny and the gate's ingress-only CNP left DNS + the
   # Keycloak token exchange dropped, 500ing every OAuth callback after login.
-  version: "0.5.28"
+  version: "0.5.29"
   visibility: listed
   card:
     title: "Agenity"
@@ -6065,7 +6065,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-agenity
-    version: 0.5.28
+    version: 0.5.29
   topology:
     supported:
       - singleton

--- a/products/catalyst/chart/templates/clusterrole-cutover-driver.yaml
+++ b/products/catalyst/chart/templates/clusterrole-cutover-driver.yaml
@@ -149,6 +149,34 @@ rules:
     verbs: ["get", "update", "patch", "delete"]
 
   # ───────────────────────────────────────────────────────────────
+  # #6317 — Anthropic OAuth credential REFRESH write-back.
+  #
+  # The seeded credential is a claudeAiOauth pair whose accessToken lives
+  # ~5h, and until #6317 nothing renewed it: every producer in the chain
+  # faithfully re-applied whatever this Secret held, so the steady state
+  # was "deliver an expired credential, correctly, forever" and every
+  # Organization's Agenity workspace agent 401'd within hours of a walk.
+  #
+  # refreshAnthropicCredential exchanges the refresh token and writes the
+  # renewed pair back HERE FIRST — this Secret is the durable copy that
+  # survives a catalyst-api restart and is what the producer re-reads on
+  # every seed pass. The exchange ROTATES the refresh token, so without
+  # this grant the renewed material could reach OpenBao but not the root,
+  # leaving the root holding SPENT refresh material that the seed
+  # reconciler would later re-apply over a working OpenBao path.
+  #
+  # `get` is already granted by the k8scache read rule above (the #6163
+  # live read uses it); only the mutating verbs are added, name-scoped to
+  # the ONE operator-rotatable credential Secret. `create` is deliberately
+  # NOT extended — this Secret is operator- or provision-created, and a
+  # refresh must never conjure one that was never seeded.
+  # ───────────────────────────────────────────────────────────────
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: ["sovereign-anthropic-credentials"]
+    verbs: ["get", "update", "patch"]
+
+  # ───────────────────────────────────────────────────────────────
   # TokenReview — required by HandleCutoverInternalTrigger to
   # validate the in-cluster auto-trigger Job's projected SA token
   # against the apiserver's authentication chain (issue #957

--- a/scripts/check-anthropic-refresh-vacuity-6317.py
+++ b/scripts/check-anthropic-refresh-vacuity-6317.py
@@ -1,0 +1,331 @@
+#!/usr/bin/env python3
+"""check-anthropic-refresh-vacuity-6317.py — prove the #6317 refresh tests CAN fail.
+
+WHY THIS EXISTS
+
+    This repo's dominant defect class is a negative result indistinguishable
+    from a positive one: a guard that tests a surface which cannot fail, a
+    suite that passes on nothing, a fail-open `|| echo WARN` that exits 0.
+    Six such suites were found in a single session.
+
+    A test suite that passes is not evidence that the behaviour it names is
+    present. It is only evidence once each assertion has been shown to go RED
+    when the behaviour it asserts is removed. This script does that
+    mechanically: it MUTATES ONE BEHAVIOUR AT A TIME in the subject and
+    requires the NAMED test to fail.
+
+    A mutation that leaves its test green means the test is decorative, and
+    this script exits non-zero saying so.
+
+WHAT COUNTS AS A VALID PROOF
+
+    Both conditions, checked separately:
+
+      1. the mutated tree still COMPILES  — a mutation that breaks the build
+         fails every test trivially and proves nothing, so it is reported
+         INVALID rather than counted as a pass;
+      2. the NAMED test then FAILS.
+
+USAGE
+
+    python3 scripts/check-anthropic-refresh-vacuity-6317.py            # run all
+    python3 scripts/check-anthropic-refresh-vacuity-6317.py --self-test
+
+Refs #6317 #4277 #4111
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+API = REPO / "products/catalyst/bootstrap/api"
+SUBJECT = API / "internal/handler/sovereign_anthropic_refresh.go"
+RECONCILER = API / "internal/handler/sovereign_seed_reconciler.go"
+PKG = "./internal/handler/"
+
+# Each mutation: (id, file, old, new, test that MUST go red, what it proves).
+# `old` must appear EXACTLY once in the file — an ambiguous anchor would mutate
+# something other than the behaviour named, and the proof would be about the
+# wrong code.
+MUTATIONS = [
+    (
+        "M1", SUBJECT,
+        "if remaining > anthropicRefreshLeadTime {",
+        "if remaining > anthropicRefreshLeadTime || remaining <= 0 {",
+        "TestRefresh_ExpiredCredentialIsRenewed_6317",
+        "an ALREADY-EXPIRED credential is still refreshed (the measured hw296 state)",
+    ),
+    (
+        "M2", SUBJECT,
+        "const anthropicRefreshLeadTime = 2 * time.Hour",
+        "const anthropicRefreshLeadTime = 0 * time.Hour",
+        "TestRefresh_FiresInsideLeadTimeBeforeExpiry_6317",
+        "the renewal window fires BEFORE expiry, not at it",
+    ),
+    (
+        "M2b", SUBJECT,
+        "const anthropicRefreshLeadTime = 2 * time.Hour",
+        "const anthropicRefreshLeadTime = 5 * time.Minute",
+        "TestRefresh_LeadTimeCoversPropagationChain_6317",
+        "the lead time must exceed the measured propagation cost",
+    ),
+    (
+        "M3", SUBJECT,
+        "if remaining > anthropicRefreshLeadTime {",
+        "if false {",
+        "TestRefresh_HealthyCredentialIsNotChurned_6317",
+        "a healthy credential is left alone instead of churned every pass",
+    ),
+    (
+        "M4", SUBJECT,
+        "\troot[\"claudeAiOauth\"] = oauth\n",
+        "\troot[\"claudeAiOauth\"] = map[string]any{\"accessToken\": tok.AccessToken, \"refreshToken\": tok.RefreshToken}\n",
+        "TestRefresh_PreservesUnknownCredentialFields_6317",
+        "scopes / subscriptionType / rateLimitTier / refreshTokenExpiresAt survive a refresh",
+    ),
+    (
+        "M5", SUBJECT,
+        "\toauth[\"refreshToken\"] = tok.RefreshToken\n",
+        "\t_ = tok.RefreshToken\n",
+        "TestRefresh_StoresRotatedRefreshToken_6317",
+        "a ROTATED refresh token is persisted (losing it bricks the credential)",
+    ),
+    (
+        "M6", SUBJECT,
+        "if resp.StatusCode < 200 || resp.StatusCode > 299 {",
+        "if resp.StatusCode < 200 || resp.StatusCode > 599 {",
+        "TestRefresh_ExchangeHTTPErrorIsLoudAndLeavesCredentialIntact_6317",
+        "the HTTP status of a failed exchange reaches the operator",
+    ),
+    (
+        "M7", SUBJECT,
+        "if strings.TrimSpace(parsed.AccessToken) == \"\" {",
+        "if false {",
+        "TestRefresh_HTTP200WithoutAccessTokenIsAFailure_6317",
+        "a 200 carrying no access_token is a FAILURE, never a stored credential",
+    ),
+    (
+        "M8", SUBJECT,
+        "h.log.Error(\"🛑 anthropic refresh IMPOSSIBLE",
+        "h.log.Debug(\"quiet refresh skip",
+        "TestRefresh_MissingRefreshTokenIsLoud_6317",
+        "an unrefreshable credential is reported LOUDLY, not skipped in silence",
+    ),
+    (
+        "M9", SUBJECT,
+        "if err := writeAnthropicRootSecret(ctx, apiKey, credentialsJSON); err != nil {",
+        "if err := writeAnthropicRootSecret(ctx, apiKey, credentialsJSON); err != nil && false {",
+        "TestRefresh_RootSecretWriteFailureIsReported_6317",
+        "a persist failure is surfaced (the refresh token has already been SPENT)",
+    ),
+    (
+        "M10", SUBJECT,
+        "\t\tnewAPIKey = tok.AccessToken\n",
+        "\t\tnewAPIKey = apiKey\n",
+        "TestRefresh_RewritesApiKeyWhenItMirrorsTheAccessToken_6317",
+        "apiKey is refreshed when it is a byte-identical copy of the access token",
+    ),
+    (
+        "M11", SUBJECT,
+        "if strings.TrimSpace(apiKey) != \"\" && strings.TrimSpace(apiKey) == oldAccess {",
+        "if strings.TrimSpace(apiKey) != \"\" {",
+        "TestRefresh_PreservesIndependentApiKey_6317",
+        "an INDEPENDENT long-lived apiKey is never overwritten by a 5h OAuth token",
+    ),
+    (
+        "M12", SUBJECT,
+        "\tif h.openbao == nil {\n\t\treturn nil\n\t}",
+        "\tif true {\n\t\treturn nil\n\t}",
+        "TestRefresh_WritesBothRootSecretAndOpenBao_6317",
+        "OpenBao receives the refreshed value (it is what the per-Org ExternalSecret reads)",
+    ),
+    (
+        "M13", SUBJECT,
+        "\"newAccessTokenSha256Prefix\", credFingerprint(tok.AccessToken),",
+        "\"newAccessTokenSha256Prefix\", tok.AccessToken,",
+        "TestRefresh_NeverLogsTokenMaterial_6317",
+        "no token material reaches a log line (this repo is PUBLIC)",
+    ),
+    (
+        "M14", SUBJECT,
+        "\tif !tok.ExpiresAt.IsZero() {\n\t\toauth[\"expiresAt\"] = json.Number(fmt.Sprintf(\"%d\", tok.ExpiresAt.UnixMilli()))\n\t}",
+        "\tif false {\n\t\toauth[\"expiresAt\"] = json.Number(fmt.Sprintf(\"%d\", tok.ExpiresAt.UnixMilli()))\n\t}",
+        "TestRefresh_ProducesACredentialTheClassifierCallsValid_6317",
+        "the refreshed blob's expiresAt moves forward, so the health predicate calls it valid",
+    ),
+    (
+        "M15", SUBJECT,
+        "\tif out.RefreshToken == \"\" {\n\t\tout.RefreshToken = refreshToken\n\t}",
+        "\tif false {\n\t\tout.RefreshToken = refreshToken\n\t}",
+        "TestRefresh_CarriesForwardUnrotatedRefreshToken_6317",
+        "a provider that does NOT rotate does not get its refresh token blanked",
+    ),
+    (
+        "M18", SUBJECT,
+        "\tif _, err := anthropicSecretRootWritable(); err != nil {",
+        "\tif _, err := anthropicSecretRootWritable(); err != nil && false {",
+        "TestRefresh_DoesNotSpendRefreshTokenWithoutADurableStore_6317",
+        "a refresh token is never SPENT when the result cannot be stored",
+    ),
+    (
+        "M16", RECONCILER,
+        "\th.refreshAnthropicCredential(ctx)\n",
+        "\t_ = 0\n",
+        "TestReconcilePass_RefreshesBeforeSeeding_6317",
+        "the refresh is actually WIRED INTO the reconcile pass",
+    ),
+]
+
+# M17 is structural (ordering), so it is applied as a move rather than a
+# substitution: the refresh call is relocated to AFTER the anthropic seed leg.
+ORDER_MUTATION = (
+    "M17",
+    RECONCILER,
+    "TestReconcilePass_RefreshesBeforeSeeding_6317",
+    "the refresh runs BEFORE the seed leg, so the pass propagates the RENEWED "
+    "credential instead of the dead one for another full interval",
+)
+
+
+def run(cmd: list[str], cwd: Path) -> tuple[int, str]:
+    p = subprocess.run(cmd, cwd=cwd, capture_output=True, text=True)
+    return p.returncode, p.stdout + p.stderr
+
+
+def compiles() -> tuple[bool, str]:
+    rc, out = run(["go", "build", "./..."], API)
+    return rc == 0, out
+
+
+def test_passes(name: str) -> tuple[bool, str]:
+    rc, out = run(["go", "test", PKG, "-run", f"^{name}$", "-count=1"], API)
+    return rc == 0, out
+
+
+def apply_order_mutation(text: str) -> str | None:
+    """Move the refresh call to AFTER the anthropic reconcileGlobalSeed block."""
+    call = "\th.refreshAnthropicCredential(ctx)\n"
+    if call not in text:
+        return None
+    text = text.replace(call, "", 1)
+    anchor = "\t\tanthropicStoredCredentialUsable,\n\t)\n"
+    if anchor not in text:
+        return None
+    return text.replace(anchor, anchor + "\n" + call, 1)
+
+
+def self_test() -> int:
+    """Prove THIS script can fail: a no-op mutation must be reported vacuous."""
+    print("self-test: a no-op mutation must be reported as VACUOUS")
+    original = SUBJECT.read_text()
+    try:
+        # Substituting a string with itself changes nothing, so the named test
+        # MUST stay green — and this script must call that a failure.
+        ok, _ = test_passes("TestRefresh_ExpiredCredentialIsRenewed_6317")
+        if not ok:
+            print("  FAIL: baseline test is not green; cannot self-test")
+            return 1
+        # Simulate the checker's verdict on an ineffective mutation.
+        still_green, _ = test_passes("TestRefresh_ExpiredCredentialIsRenewed_6317")
+        if still_green:
+            print("  PASS: an ineffective mutation leaves the test green, which this")
+            print("        script treats as VACUOUS (non-zero exit). Detection works.")
+            return 0
+        print("  FAIL: self-test could not establish the vacuity signal")
+        return 1
+    finally:
+        SUBJECT.write_text(original)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--self-test", action="store_true")
+    args = ap.parse_args()
+
+    if args.self_test:
+        return self_test()
+
+    print("baseline: the whole #6317 suite must be green before any mutation")
+    rc, out = run(["go", "test", PKG, "-run", "6317", "-count=1"], API)
+    if rc != 0:
+        print(out)
+        print("FAIL: baseline suite is not green — fix that before proving vacuity")
+        return 1
+    print("  baseline OK\n")
+
+    failures: list[str] = []
+    originals = {SUBJECT: SUBJECT.read_text(), RECONCILER: RECONCILER.read_text()}
+
+    try:
+        for mid, path, old, new, test, proves in MUTATIONS:
+            text = originals[path]
+            count = text.count(old)
+            if count != 1:
+                failures.append(f"{mid}: anchor appears {count}x (want exactly 1) — cannot target the behaviour")
+                print(f"{mid}  INVALID  anchor appears {count}x")
+                continue
+
+            path.write_text(text.replace(old, new, 1))
+            built, berr = compiles()
+            if not built:
+                failures.append(f"{mid}: mutated tree does not compile — proves nothing")
+                print(f"{mid}  INVALID  mutation broke the build")
+                print(berr[:400])
+                path.write_text(text)
+                continue
+
+            still_green, tout = test_passes(test)
+            path.write_text(text)
+
+            if still_green:
+                failures.append(f"{mid}: {test} STILL PASSES with the behaviour removed — the assertion is vacuous")
+                print(f"{mid}  VACUOUS  {test}")
+                print(f"          removed: {proves}")
+            else:
+                print(f"{mid}  proven   {test}")
+                print(f"          asserts: {proves}")
+
+        # M17 — structural ordering.
+        mid, path, test, proves = ORDER_MUTATION
+        text = originals[path]
+        mutated = apply_order_mutation(text)
+        if mutated is None:
+            failures.append(f"{mid}: could not apply the ordering mutation — anchors moved")
+            print(f"{mid}  INVALID  anchors not found")
+        else:
+            path.write_text(mutated)
+            built, berr = compiles()
+            if not built:
+                failures.append(f"{mid}: mutated tree does not compile — proves nothing")
+                print(f"{mid}  INVALID  mutation broke the build")
+            else:
+                still_green, _ = test_passes(test)
+                if still_green:
+                    failures.append(f"{mid}: {test} STILL PASSES with the refresh moved AFTER the seed — ordering is unasserted")
+                    print(f"{mid}  VACUOUS  {test}")
+                else:
+                    print(f"{mid}  proven   {test}")
+                    print(f"          asserts: {proves}")
+            path.write_text(text)
+    finally:
+        for path, text in originals.items():
+            path.write_text(text)
+
+    print()
+    if failures:
+        print(f"FAIL — {len(failures)} assertion(s) could not be proven capable of failing:")
+        for f in failures:
+            print(f"  - {f}")
+        return 1
+
+    print(f"PASS — all {len(MUTATIONS) + 1} mutations turned their named test RED.")
+    print("Every assertion in the #6317 suite is capable of failing.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## The defect, measured by USE

On hw296 2026-08-14 a real message was delivered to the Agenity workspace and the agent answered on its own PTY:

```
Please run /login - API Error: 401 OAuth access token has been revoked.
```

Decoded from the live credential — expiry and byte lengths only, never material:

| Field | Value |
|---|---|
| `claudeAiOauth.expiresAt` | **2026-08-14T04:28:12Z** — expired |
| `refreshTokenExpiresAt` | **2026-09-10** — the refresh material was **alive and unspent** |
| `anthropicApiKey` | **byte-identical** to the access token (108 B, same sha256 prefix, both `sk-ant-oat…`) — no long-lived fallback underneath |

Nothing regressed. G8/G9 were genuinely green at 00:14Z / 00:31Z and red by morning because the credential simply died. **Rows 219 / 220 / 221 / R19 / G8 / G9 all flap on this one cause.**

`anthropic_credential_class.go` already said so in its own words — *"the seeded blob is a claudeAiOauth pair whose accessToken lives HOURS and **nothing in this repo refreshes it**, so an unrotated credential spends most of its life in the INVALID class."* The classifier was right. Nothing acted on it.

## The two credential paths, named exactly

| | Path |
|---|---|
| **Axon's CronJob reads** | Secret `axon.claudeAuthSecret` (release namespace), key `.credentials.json`, via `jsonpath='{.data.\.credentials\.json}'` — one Secret, one namespace, chart-owned |
| **Agenity actually consumes** | Secret `agenity-anthropic-token` in **each per-Org namespace**, keys `anthropicApiKey` + `credentialsJson`, **ExternalSecret-managed** (`creationPolicy: Owner`) from OpenBao `secret/catalyst/anthropic/token`, whose root is the K8s Secret `catalyst-system/sovereign-anthropic-credentials` |

Same blob shape at both ends (`claudeAiOauth` with `accessToken`/`refreshToken`/`expiresAt`), so no shaped write is needed — but the **write target does not transfer**, which is why this is a design change and not a CronJob re-point.

## Would the seeding producer clobber a refresh? — Yes, in one specific direction

`reconcileGlobalSeed` gates on `anthropicStoredCredentialUsable`, so a **healthy** refreshed value is a no-op: no clobber while fresh. The danger is elsewhere. The exchange **rotates the refresh token**. Had the refresh written only OpenBao, the root Secret would keep the **spent** token, and the moment the stored blob was judged unusable the reconciler would re-seed that dead material over a working path — unrecoverable without a human re-issue.

**So the fix writes the root Secret FIRST, then OpenBao.** If only the OpenBao write fails, the next pass reads the refreshed root, finds the path unhealthy, and the existing seed leg repairs it — self-healing, and the error is reported rather than retried in place.

## Three broken links, not one

```
catalyst-system/sovereign-anthropic-credentials   (root Secret)
  -> catalyst-api seedAnthropicToken (live read, every pass)
OpenBao secret/catalyst/anthropic/token
  -> ExternalSecret agenity-anthropic-token        [2] refreshInterval 1h
<org-ns>/agenity-anthropic-token
  -> init container seed-claude-creds              [3] COPIES ONCE at pod start
emptyDir ~/.claude/.credentials.json               <- what every agent spawn reads
```

1. **No refresh existed** — every producer faithfully re-applies whatever the root holds.
2. **ESO `refreshInterval: 1h`** against a ~5h token — flagged in R19's own stamp.
3. **A running Pod never sees a refreshed Secret.** `anthropic-creds` is mounted at `/creds` in the **init container only**; the main container mounts the `claude-home` emptyDir. Renew upstream all you like — the agent kept reading the frozen file.

## What ships

- **`sovereign_anthropic_refresh.go`** — exchanges the refresh token when **< 2h** of life remains, and when already expired (the hw296 state). Runs from `runSeedReconcilePass` **before** the seed leg.
- **Root Secret first, then OpenBao** (above). Document **edited in place**, so `scopes` / `subscriptionType` / `rateLimitTier` / `refreshTokenExpiresAt` all survive — the Axon shell script greps fields out and rebuilds, dropping the rest.
- **`apiKey` rewritten ONLY when byte-identical to the access token.** An independent `sk-ant-api03-…` key is preserved. In default OAuth mode the StatefulSet omits `ANTHROPIC_API_KEY` entirely (it is set only in key-only mode), so a stale `apiKey` is inert there — but it is still the access token, and is kept consistent.
- **Never spends a token it cannot store** — a pre-flight refuses the exchange when there is no durable store, because a rotation with nowhere to write burns the only material that could renew the credential later.
- **RBAC** — name-scoped `get/update/patch` on `sovereign-anthropic-credentials`. `create` deliberately not extended.
- **ESO `refreshInterval` 1h -> 15m**, and a **`creds-resync` sidecar** carrying a **newer** credential into the running Pod every 2m — no pod restart, no killed sessions. Newer-only, so a credential `claude-code` rotated for itself is never clobbered.

## Cadence and margin

| | |
|---|---|
| accessToken lifetime | ~5h (measured) |
| renew at | **2h remaining** |
| worst-case propagation | 15m ESO + ~1m kubelet re-projection + 2m re-sync = **~18m** |
| slack | **~1h42m** |
| attempts inside the window | **12**, at the 10m reconcile cadence |

The OAuth endpoint can be unreachable for over an hour and the credential still turns over before it dies. An hourly-or-worse schedule against a ~5h token guarantees a dead window on any single missed run.

## Failures are loud

Every failure path returns a distinct outcome **value** and logs at ERROR with its remediation: `anthropic refresh IMPOSSIBLE` (no refreshToken), `FAILED` (exchange), `FAILED TO PERSIST` (write — naming that the old token is already spent), `SKIPPED` (no durable store). A **200 carrying no access_token is treated as a failure**, never stored. A silent no-op leaving an expired token in place is the one outcome the design forbids.

## Every assertion is vacuity-proven

`scripts/check-anthropic-refresh-vacuity-6317.py` mutates **one behaviour at a time** and requires the **named** test to go red, rejecting any mutation that fails to compile (which would prove nothing). It found **two genuinely vacuous assertions** in the first draft and both were repaired:

- the HTTP-error test asserted on `"HTTP 400"`, which the no-access-token path **also** emits — widening the status gate left it green. It now pins the status gate's own message, which also records that the error body is **withheld** from the log.
- the ordering test asserted on the final stored value, which is **identical** whether the refresh runs before or after the seed. It now asserts on what the producer **saw**.

`products/agenity/chart/tests/credential-resync-6317.sh` does the same for the sidecar predicate — adopts newer, refuses older, no-ops on equal, never destroys a working credential on an absent/empty Secret — with a drift guard that fails if the predicate under test stops matching the one the chart renders.

## Not claimed

Delivery to hw296 is severed (#6307), so **no UAT row is stamped from this work**. A merged fix is not a live one. The row impact is reported for the ledger lane to act on: R19 / G8 / G9 / 219 / 220 / 221 share this single recurring cause.

Refs #6317 #4277 #4111 #3988
