### PR TITLE
fix(cutover): step-06 pivots the THIRD GitOps repo class — every live Org's catalyst-tenant repo — and proves the pivot survives its owning reconciler (#6309)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -1074,7 +1074,7 @@ spec:
       # chart/tests/ left the package via .helmignore: 757,264 bytes, 72.2%.
       # The rendered manifest is byte-identical modulo comments — no step,
       # value or RBAC change, still 11 steps.
-      version: 0.1.187
+      version: 0.1.188
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1451,7 +1451,7 @@ spec:
       #   staged commit and push, and makes the Phase-3 pre-strip read-back the
       #   single fail-closed gate (#5436 relocated, not weakened). Lockstep w/
       #   products/catalyst/chart/Chart.yaml.
-      version: 1.4.1492
+      version: 1.4.1496
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.187
+  version: 0.1.188
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -3868,7 +3868,120 @@ name: bp-self-sovereign-cutover
 # push-target assertions. Slot-06a pin + blueprint.yaml + catalog-seed
 # spec.version + source.version + the API blueprints.json + the generated UI
 # catalog move to 0.1.187 in lockstep (Inviolable Principle #13).
-version: 0.1.187
+#
+# 0.1.188 (#6309) — THE CUTOVER PIVOTED TWO OF THE THREE GITOPS REPO CLASSES
+# THAT HOLD HelmRepository URLs, SO G11 (#3379) COULD NOT CLOSE EVEN ON A
+# SOVEREIGN THAT RECEIVED 0.1.187. Confirmed two ways before a line was written:
+# `grep -rn catalyst-tenant platform/self-sovereign-cutover/` returned 0 hits
+# across the entire chart, and `git show 5447fa8e7 | grep catalyst-tenant` (the
+# 0.1.187 commit itself) returned 0 hits.
+#
+#   class                          writer                     pivoted by
+#   ─────────────────────────────  ─────────────────────────  ─────────────────
+#   clusters/_template/bootstrap-  committed in this repo     step-05 / step-06
+#     kit slots
+#   clusters/<fqdn>/org-tenants    catalyst-api               Phase 2b (#6293)
+#     (branch org-tenants)           writeParentTenantsIndex
+#   <slug>/catalyst-tenant@main    org-services/provisioning  NOTHING
+#
+# Live on hw296 AFTER 0.1.187 pivoted the org-tenants class at source, step-11's
+# #3526 pre-hold assert still failed on exactly two offenders — down from six,
+# never to zero:
+#
+#   walkfour/bp-stalwart-tenant = oci://ghcr.io/openova-io
+#   walkfive/bp-stalwart-tenant = oci://ghcr.io/openova-io
+#
+# whose durable source is the third class:
+#
+#   walkfour/catalyst-tenant@main : vcluster/host-apps/app-stalwart-mail.yaml:20
+#   walkfive/catalyst-tenant@main : vcluster/apps/app-stalwart-mail.yaml:20
+#
+# Region B was clean, 65/65 on the local registry, so this is not a per-region
+# split — it is a repo class nothing walked.
+#
+# THE COUNT SCALES WITH THE NUMBER OF ORGANIZATIONS. One `catalyst-tenant` repo
+# exists per Org, written by GeneratePerOrgAppsTree into `vcluster/apps/` and
+# `vcluster/host-apps/` and reconciled onto the host `<slug>` namespace by the
+# org-controller's `catalyst-tenant-<slug>-apps` / `-host-apps` Kustomizations.
+# The more the platform is used, the more offenders a cutover inherits — which
+# is why the fix is a cutover step and not a repair, and why Phase-2d's scan is
+# driven from the LIVE Organization list (Organization CRs UNION the live
+# `catalyst-tenant-*` Flux GitRepositories) rather than any curated set. A
+# hardcoded list is wrong the moment the next Org is created; that is the same
+# drift #4573 F4 already fixed for the Phase-1 name list.
+#
+# WHY assert_region_a_pivot COULD NOT SEE THEM. The generated HelmRepository doc
+# says `namespace: flux-system`, but the per-Org Kustomization carries
+# `targetNamespace: <slug>`, which wins — so these objects live in the Org's own
+# namespace. assert_region_a_pivot is scoped to HELMREPO_NAMESPACE and is
+# therefore structurally blind to them; step-11's cluster-wide `-A` scan is what
+# found them. Phase-2d's read-back enumerates `-A` and narrows to the Orgs it
+# pivoted.
+#
+# THE READ-BACK DOES NOT REPEAT 0.1.186. That release's Phase-1.5 read-back
+# logged `ok=6` and `read-back OK`, and all six HelmRepositories reverted within
+# 60s under a 1m/prune=true Kustomization. It could pass because it sampled ONCE,
+# right after the write, with no requirement that the actor which would revert
+# the write had run at all. Phase-2d is two-stage:
+#   Stage 1 CONVERGE — poll to zero offenders across the pivoted Orgs, re-poking
+#     each cycle. A durable rewrite has to be fetched and re-applied before the
+#     live objects settle, so this stage may start dirty; never reaching zero is
+#     FATAL and names its offenders.
+#   Stage 2 SURVIVE — mint a token AFTER Stage 1 is clean, poke every per-Org
+#     HR-owning Kustomization with it, and refuse to certify an Org until one of
+#     ITS Kustomizations reports `status.lastHandledReconcileAt` EQUAL to that
+#     token. That field means the re-apply HAPPENED, not that a reconcile was
+#     requested. Offenders must be zero on EVERY sample in that window.
+# So the gate cannot return green until the exact reconciler that reverted the
+# 0.1.186 pivot has run against the rewritten source and left it standing. Two
+# exemptions, both EXPLICIT and both logged (the #5596 discipline): an Org with
+# no per-Org Kustomization has nothing that re-applies its HelmRepositories, and
+# a SUSPENDED Kustomization never handles a reconcile request and can never
+# re-apply — so neither can revert the pivot, and requiring either to handle the
+# token would time the assert out on a healthy Sovereign. The suite's D9b control
+# runs the identical fixture WITHOUT suspension and requires it to FAIL, so the
+# exemption cannot widen into "durability is never actually required".
+#
+# FAIL-CLOSED ENUMERATION. A FAILED GitRepository listing is not an empty Org
+# list (FATAL). The Organization CRD being INSTALLED but unlistable — the shape a
+# missing RBAC grant produces — is FATAL, never "this Sovereign has no Orgs". CRD
+# ABSENCE must be established from a NotFound, because `kubectl get crd` exits
+# non-zero for both "not installed" and "forbidden". Repo existence is decided by
+# an HTTP status code (404 = absent, anything else non-200 = FATAL), because
+# `git ls-remote` fails identically for a missing repo and a bad credential.
+# A repo that EXISTS but carries no branch yet is a real, benign state — the
+# org-controller creates the per-Org repo before anything seeds a tree into it,
+# so an Org created shortly before the cutover is legitimately empty and
+# `git clone --branch main` fails there. That is separated from a credential
+# fault the same way: ls-remote SUCCEEDING with no matching ref is an absent
+# branch and skips; ls-remote FAILING against a repo the API just reported
+# present is fatal. Without that split, one fresh Organization would stop the
+# whole cutover.
+#
+# GUARDS. chart/tests/step06-perorg-tenant-source.sh — 47 assertions, exit 0 —
+# runs the RENDERED phase2d.sh bytes against REAL local git repositories and
+# reads every verdict out of the BARE origin. Section L is the property that
+# matters beyond hw296: the fixture carries an Org present ONLY as an
+# Organization CR (no Flux source), one present ONLY as a Flux source (no CR),
+# and one introduced by the fixture and named nowhere in the chart — all three
+# must be scanned, so a suite that fed the code the list the code already knows
+# would fail. Ten single-behaviour mutants prove each case individually; M6 is
+# the headline — deleting Stage 2 makes the D2 revert fixture PASS, which is what
+# turns D2 into a proof of the anti-race property rather than a lucky sample. The
+# new `orgs.openova.io/organizations` grant is asserted DIRECTLY against the
+# rendered ClusterRole with no stub in the path (a stubbed kubectl can never be
+# RBAC-refused — the #6280 blind spot) and R4b deletes the rule to prove the
+# assertion can go red. Slot-06a pin + blueprint.yaml + catalog-seed
+# spec.version + source.version + the API blueprints.json + the generated UI
+# catalog move to 0.1.188 in lockstep (Inviolable Principle #13).
+#
+# NOT FIXED HERE, RECORDED: step 11 has ~8 further gates that have never executed
+# on hw296 — catalyst-api CATALYST_GITOPS_REPO_URL, offline-mirror completeness,
+# workload image-host lint, per-region Flux source-host lint, source convergence
+# on gitrepositories/ocirepositories, Crossplane provider-package host lint, and
+# org-tenants Kustomization Ready. Clearing these offenders unblocks step-11's
+# #3526 pre-hold assert; it does not imply the step passes.
+version: 0.1.188
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/06-helmrepository-patches-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/06-helmrepository-patches-job.yaml
@@ -215,6 +215,470 @@ data:
     fi
     # ---- end Phase 2b (#6293) ----
   {{- /*
+   #6309 — Phase 2d, the THIRD GitOps repo class. Same `.`-source discipline and
+   the same reason to live in its own ConfigMap key as phase2b/phase2c: step-06
+   renders within a few hundred bytes of the 110000-byte MAX_ARG_STRLEN budget
+   (#5593), and chart/tests/step06-perorg-tenant-source.sh awk-slices this region
+   out of the RENDERED manifest and runs THESE bytes against real git
+   repositories — never a copy kept in the test.
+
+   WHAT IT FIXES. There are THREE repo classes carrying HelmRepository URLs on a
+   Sovereign, and before this the cutover knew about two:
+
+     class                          writer                     pivoted by
+     ─────────────────────────────  ─────────────────────────  ────────────
+     clusters/_template/bootstrap-  committed in this repo     step-05/06
+       kit slots
+     clusters/<fqdn>/org-tenants    catalyst-api               Phase 2b
+       (branch org-tenants)           writeParentTenantsIndex    (#6293)
+     <slug>/catalyst-tenant@main    org-services/provisioning  NOTHING
+
+   The third is written by GeneratePerOrgAppsTree into `vcluster/apps/` and
+   `vcluster/host-apps/` of a per-Org Gitea repo, one repo PER ORGANIZATION, and
+   reconciled onto the host `<slug>` namespace by the org-controller's
+   `catalyst-tenant-<slug>-apps` / `-host-apps` Kustomizations (per_org_flux.go).
+   Measured on hw296 after Phase-2b landed: step-11's #3526 pre-hold assert still
+   failed on exactly two offenders — walkfour/bp-stalwart-tenant and
+   walkfive/bp-stalwart-tenant, both oci://ghcr.io/openova-io — whose durable
+   source is walkfour/catalyst-tenant@main:vcluster/host-apps/app-stalwart-mail.yaml
+   and walkfive/catalyst-tenant@main:vcluster/apps/app-stalwart-mail.yaml.
+
+   THE OFFENDER COUNT SCALES WITH THE NUMBER OF ORGANIZATIONS, which is why the
+   scan below is driven from the LIVE Organization list (Organization CRs UNION
+   the live per-Org Flux GitRepositories) and never from a curated set. A
+   hardcoded list is silently wrong the moment the next Org is created — the
+   exact drift #4573 F4 already fixed for the Phase-1 name list.
+
+   WHY NOT A LIVE `kubectl patch`. The per-Org HelmRepositories are owned by a
+   Kustomization with prune=true. A live patch is reverted on its next reconcile
+   — that is the whole #6293 finding, restated one class down. This leg is
+   durable-source-then-verify: rewrite the repo, then prove the rewrite survived
+   the owning reconciler actually running.
+
+   NB the generator is already correct (#5629 / #5527 resolveCatalogOCIBase reads
+   the step-07 CATALYST_LOCAL_REGISTRY_URL stamp first), so every tree written
+   AFTER the cutover is born pivoted. This leg exists for the trees written
+   BEFORE it, whose only other trigger is a day-2 app install.
+  */}}
+  phase2d.sh: |
+    {{- /* The `# ----` markers stay `#` comments ON PURPOSE — they are the
+    region delimiters chart/tests/step06-perorg-tenant-source.sh awk-slices out
+    of the render. Prose lives in Helm block comments so it is stripped before
+    the release Secret (#6004); a marker a test navigates by is not prose. */}}
+    # ---- Phase 2d (#6309): per-Org catalyst-tenant durable-source pivot ----
+    if [ "${PERORG_PIVOT_ENABLED:-true}" != "true" ]; then
+      echo "[helmrepository-patches] Phase-2d SKIP: helmRepositories.perOrgTenantSource.enabled=false"
+    else
+      pd_repo="${PERORG_TENANT_REPO:-catalyst-tenant}"
+      pd_branch="${PERORG_BRANCH:-main}"
+      pd_ns="${PERORG_FLUX_NAMESPACE:-flux-system}"
+      pd_api_base="${GITEA_INTERNAL_URL%/}/api/v1/repos"
+      pd_slugs=/tmp/.pd-slugs.txt
+      pd_touched=/tmp/.pd-touched.txt
+      : > "${pd_slugs}"
+      : > "${pd_touched}"
+
+      {{- /*
+       ── SOURCE 1 (mandatory): the live per-Org Flux GitRepositories ──
+       per_org_flux.go creates exactly one `catalyst-tenant-<slug>` GitRepository
+       per Organization, pointing at that Org's Gitea repo. It is the object that
+       FEEDS the reverting Kustomization, so it is the most direct live evidence
+       that a per-Org tree exists and is reconciled. A FAILED listing is not an
+       empty one: an unreadable API is the "verdict from absent evidence" shape,
+       and here it would silently under-scan every Org on the Sovereign.
+      */}}
+      if kubectl get gitrepositories.source.toolkit.fluxcd.io -n "${pd_ns}" \
+          -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' \
+          > /tmp/.pd-grs.txt 2>/tmp/.pd-grs.err; then
+        awk -v p="${pd_repo}-" 'index($0,p)==1 && length($0)>length(p) {print substr($0,length(p)+1)}' \
+          /tmp/.pd-grs.txt >> "${pd_slugs}"
+      else
+        echo "[helmrepository-patches] FATAL: Phase-2d: listing GitRepositories in ${pd_ns} FAILED — the live Organization list cannot be built, and scanning a PARTIAL list would leave an unknown number of per-Org HelmRepositories on ${UPSTREAM_PREFIX} while this step recorded success (#6309)" >&2
+        sed 's/^/  KUBECTL-STDERR /' /tmp/.pd-grs.err >&2 || true
+        exit 1
+      fi
+
+      {{- /*
+       ── SOURCE 2 (union): the live Organization CRs ──
+       Catches an Org whose per-Org Flux source has not been created yet. ABSENCE
+       of the CRD is a real state (a Catalyst-Zero / pre-org-controller cluster)
+       and must be established by POSITIVE evidence — `kubectl get crd` exits
+       non-zero for BOTH "not installed" and "forbidden", so the NotFound string
+       is required before absence may be concluded. Without that, a missing RBAC
+       grant would read as "this Sovereign has no Organizations" and this whole
+       leg would no-op on the environments that need it most.
+      */}}
+      pd_org_crd="${PERORG_ORG_CRD:-organizations.orgs.openova.io}"
+      pd_org_present=0
+      if kubectl get customresourcedefinitions "${pd_org_crd}" >/dev/null 2>/tmp/.pd-crd.err; then
+        pd_org_present=1
+      elif grep -q 'NotFound' /tmp/.pd-crd.err; then
+        echo "[helmrepository-patches] Phase-2d: ${pd_org_crd} is not installed on this Sovereign — the live Org list comes from the per-Org Flux sources alone"
+      else
+        echo "[helmrepository-patches] FATAL: Phase-2d: could not determine whether ${pd_org_crd} exists — that is NOT the same as it being absent, and treating it as absent silently drops every Organization from the scan (#6309)" >&2
+        sed 's/^/  KUBECTL-STDERR /' /tmp/.pd-crd.err >&2 || true
+        exit 1
+      fi
+      if [ "${pd_org_present}" -eq 1 ]; then
+        if kubectl get organizations.orgs.openova.io \
+            -o jsonpath='{range .items[*]}{.spec.slug}{"\n"}{end}' \
+            > /tmp/.pd-orgs.txt 2>/tmp/.pd-orgs.err; then
+          awk 'NF' /tmp/.pd-orgs.txt >> "${pd_slugs}"
+        else
+          echo "[helmrepository-patches] FATAL: Phase-2d: the ${pd_org_crd} CRD IS installed but listing Organizations failed — refusing to scan a partial Organization list (#6309)" >&2
+          sed 's/^/  KUBECTL-STDERR /' /tmp/.pd-orgs.err >&2 || true
+          exit 1
+        fi
+      fi
+
+      awk 'NF' "${pd_slugs}" | sort -u > /tmp/.pd-slugs.sorted
+      mv /tmp/.pd-slugs.sorted "${pd_slugs}"
+      pd_total=$(grep -c . "${pd_slugs}" || true)
+      echo "[helmrepository-patches] Phase-2d: ${pd_total} live Organization slug(s) (Organization CRs ∪ ${pd_repo}-* Flux sources)"
+
+      pd_absent=0
+      pd_pushed=0
+      pd_nodiff=0
+      for pd_slug in $(awk 'NF' "${pd_slugs}"); do
+        {{- /*
+         Existence is decided by an HTTP STATUS CODE, not by whether a git
+         command failed: `git ls-remote` against a repo that does not exist and
+         against a repo we cannot authenticate to both exit non-zero, and
+         collapsing those two is how a credential fault presents as "this Org
+         simply has no repo" — the #6293 shape one class down. 404 is absent
+         (legitimate: the Org was created but never installed an app); anything
+         that is neither 200 nor 404 is unreadable and fails closed.
+        */}}
+        pd_code=$(curl -s -o /tmp/.pd-repo.json -w '%{http_code}' \
+          -u "${GITEA_USERNAME}:${GITEA_PASSWORD}" \
+          "${pd_api_base}/${pd_slug}/${pd_repo}" 2>/dev/null || echo "000")
+        case "${pd_code}" in
+          200) : ;;
+          404)
+            echo "[helmrepository-patches] Phase-2d ${pd_slug}: no ${pd_repo} repo (HTTP 404) — this Org has no per-Org gitops tree, so nothing re-applies HelmRepositories from one"
+            pd_absent=$((pd_absent+1))
+            continue
+            ;;
+          *)
+            echo "[helmrepository-patches] FATAL: Phase-2d ${pd_slug}: HTTP ${pd_code} probing ${pd_slug}/${pd_repo} — an unreadable repo is NOT an absent repo, and guessing leaves this Org's HelmRepositories on ${UPSTREAM_PREFIX} (#6309)" >&2
+            exit 1
+            ;;
+        esac
+
+        pd_url=$(printf '%s' "${GITEA_INTERNAL_URL}" | sed -E "s,^(https?://),\1${GITEA_USERNAME}:${GITEA_PASSWORD}@,")"/${pd_slug}/${pd_repo}.git"
+
+        {{- /*
+         A repo that EXISTS (the probe above returned 200) but carries no branch
+         yet is a real, benign state: the org-controller creates the per-Org repo
+         before anything seeds a tree into it, so an Org created shortly before
+         the cutover can legitimately be empty. `git clone --branch main` against
+         it fails with "Remote branch main not found", and treating that as fatal
+         would stop the whole cutover on a Sovereign whose only sin is a fresh
+         Organization. It is separated from an AUTH failure the same way the repo
+         probe separates 404 from 500: ls-remote SUCCEEDING with no matching ref
+         is an absent branch; ls-remote FAILING against a repo we just proved
+         exists is a credential fault and stays fatal.
+        */}}
+        if ! git ls-remote --heads "${pd_url}" "${pd_branch}" > /tmp/.pd-heads.txt 2>/tmp/.pd-heads.err; then
+          echo "[helmrepository-patches] FATAL: Phase-2d ${pd_slug}: git ls-remote ${pd_branch} failed against a repo the API just reported present — that is a credential fault, not an empty repo, and guessing leaves this Org's HelmRepositories on ${UPSTREAM_PREFIX} (#6309)" >&2
+          sed -e 's,://[^@]*@,://***@,g' /tmp/.pd-heads.err >&2 || true
+          exit 1
+        fi
+        if ! grep -q "refs/heads/${pd_branch}" /tmp/.pd-heads.txt; then
+          echo "[helmrepository-patches] Phase-2d ${pd_slug}: ${pd_repo} exists but has no ${pd_branch} branch — the per-Org tree has not been seeded yet, so nothing re-applies HelmRepositories from one"
+          pd_absent=$((pd_absent+1))
+          continue
+        fi
+
+        cd /tmp
+        rm -rf repo-perorg
+        if ! git clone --depth 1 --branch "${pd_branch}" "${pd_url}" repo-perorg >/dev/null 2>/tmp/.pd-clone.err; then
+          echo "[helmrepository-patches] FATAL: Phase-2d ${pd_slug}: clone of ${pd_slug}/${pd_repo} branch ${pd_branch} failed (#6309)" >&2
+          sed -e 's,://[^@]*@,://***@,g' /tmp/.pd-clone.err >&2 || true
+          exit 1
+        fi
+        cd repo-perorg
+
+        {{- /*
+         Scoped to the trees the org-controller's per-Org Kustomizations actually
+         reconcile (vcluster/apps + vcluster/host-apps, gitops/perorg_apps_tree.go
+         PerOrgAppsDir / PerOrgHostAppsDir). Anything else in the repo is not
+         re-applied by a per-Org Kustomization, so rewriting it would be
+         divergence with no reconciler behind it.
+        */}}
+        pd_list=/tmp/.pd-targets.txt
+        : > "${pd_list}"
+        for pd_tree in ${PERORG_TREES:-vcluster}; do
+          [ -d "${pd_tree}" ] || continue
+          grep -rlE "^[[:space:]]*url:[[:space:]]*${UPSTREAM_PREFIX}[[:space:]]*$" "${pd_tree}" 2>/dev/null >> "${pd_list}" || true
+        done
+        pd_edited=0
+        for pdf in $(awk 'NF' "${pd_list}" | sort -u); do
+          sed -i -E "s,^([[:space:]]*url:[[:space:]]*)${UPSTREAM_PREFIX}([[:space:]]*)$,\1${local_prefix}\2," "${pdf}"
+          pd_edited=$((pd_edited+1))
+          echo "[helmrepository-patches] Phase-2d edited ${pd_slug}/${pd_repo}@${pd_branch}:${pdf}"
+        done
+
+        {{- /*
+         Same certSecretRef durability the bootstrap-kit and org-tenants files
+         get, via the SHARED injector defined in the step args — never a second
+         copy (#5646: two copies drift and only one gets fixed).
+        */}}
+        if [ -n "${trust_secret}" ]; then
+          pd_trust_list=/tmp/.pd-trust-targets.txt
+          : > "${pd_trust_list}"
+          for pd_tree in ${PERORG_TREES:-vcluster}; do
+            [ -d "${pd_tree}" ] || continue
+            grep -rlE "^[[:space:]]*url:[[:space:]]*${local_prefix}([[:space:]]*|/.*)$" "${pd_tree}" 2>/dev/null >> "${pd_trust_list}" || true
+          done
+          for pdf in $(awk 'NF' "${pd_trust_list}" | sort -u); do
+            inject_trust_ref "${pdf}"
+            pd_edited=$((pd_edited+1))
+            echo "[helmrepository-patches] Phase-2d trust-injected certSecretRef -> ${pd_slug}:${pdf}"
+          done
+        fi
+
+        {{- /*
+         Post-condition on the FILES before anything is committed — the result of
+         the rewrite, never the count of loop iterations that were supposed to
+         produce it (#5436's discipline applied to a working tree).
+        */}}
+        pd_left_file=/tmp/.pd-left.txt
+        : > "${pd_left_file}"
+        for pd_tree in ${PERORG_TREES:-vcluster}; do
+          [ -d "${pd_tree}" ] || continue
+          grep -rlE "^[[:space:]]*url:[[:space:]]*${UPSTREAM_PREFIX}[[:space:]]*$" "${pd_tree}" 2>/dev/null >> "${pd_left_file}" || true
+        done
+        pd_left=$(grep -c . "${pd_left_file}" || true)
+        if [ "${pd_left}" -ne 0 ]; then
+          echo "[helmrepository-patches] FATAL: Phase-2d ${pd_slug}: ${pd_left} file(s) still declare ${UPSTREAM_PREFIX} after the rewrite — pushing now would record a durable pivot that does not exist (#6309)" >&2
+          sed 's,^,  STILL-UPSTREAM ,' "${pd_left_file}" >&2 || true
+          exit 1
+        fi
+
+        {{- /*
+         Commit on ACTUAL tree state, never on ${pd_edited}: the trust injector is
+         idempotent, so a re-run legitimately reports edits and produces no diff.
+         Gating on the counter turns that no-op into a hard failure every second
+         run (the #6293 Phase-2b lesson).
+        */}}
+        if git diff --quiet; then
+          echo "[helmrepository-patches] Phase-2d ${pd_slug}: already pivoted (${pd_edited} file-visit(s), no diff) — nothing to push"
+          pd_nodiff=$((pd_nodiff+1))
+        else
+          git add -A .
+          if git diff --staged --quiet; then
+            echo "[helmrepository-patches] FATAL: Phase-2d ${pd_slug}: the working tree has changes but the index is empty — \`git add\` is mis-scoped and this push would carry none of the rewrite (#6309)" >&2
+            exit 1
+          fi
+          git commit -m "cutover: pivot ${pd_edited} per-Org HelmRepository URL(s) to local Harbor" >/dev/null
+          if ! pd_push_err=$(git push origin "HEAD:${pd_branch}" 2>&1); then
+            echo "[helmrepository-patches] FATAL: Phase-2d ${pd_slug}: push to ${pd_branch} failed — this Org's HelmRepositories keep reverting to ${UPSTREAM_PREFIX} on every reconcile (#6309)" >&2
+            printf '%s\n' "${pd_push_err}" >&2
+            exit 1
+          fi
+          echo "[helmrepository-patches] Phase-2d OK: pushed ${pd_edited} edit(s) to ${pd_slug}/${pd_repo} branch ${pd_branch}"
+          pd_pushed=$((pd_pushed+1))
+        fi
+        printf '%s\n' "${pd_slug}" >> "${pd_touched}"
+        cd /tmp/repo
+      done
+
+      echo "[helmrepository-patches] Phase-2d: orgs=${pd_total} with-repo=$(grep -c . "${pd_touched}" || true) pushed=${pd_pushed} already-pivoted=${pd_nodiff} no-repo=${pd_absent}"
+
+      {{- /*
+       ── The read-back ──────────────────────────────────────────────────────
+       #6309 — WHY THIS IS NOT THE PHASE-1.5 SHAPE. Step-06's 0.1.186 read-back
+       logged `ok=6` and `read-back OK` and all six HelmRepositories reverted
+       within 60s under a 1m/prune=true Kustomization. It could pass because it
+       sampled ONCE, immediately after the write, with no requirement that the
+       actor which would revert the write had run at all. Step-11's cluster-wide
+       scan is what caught it; #6303 moved the gate after the durable rewrite.
+
+       This assert is two-stage and neither stage can be satisfied by a lucky
+       sample:
+
+         Stage 1 CONVERGE — poll until zero offenders across the pivoted Orgs'
+           namespaces, re-poking each cycle. A durable rewrite has to be fetched
+           and re-applied before the live objects settle, so this stage is
+           allowed to start dirty. Never reaching zero is FATAL.
+
+         Stage 2 SURVIVE — mint a token AFTER stage 1 is clean, poke every
+           per-Org HR-owning Kustomization with it, and refuse to certify an Org
+           until one of ITS Kustomizations reports
+           status.lastHandledReconcileAt == that token. That field means the
+           re-apply HAPPENED, not that a reconcile was requested. Offenders must
+           be zero on EVERY sample taken during that window. So the gate cannot
+           return green until the exact reconciler that reverted the 0.1.186
+           pivot has run against the rewritten source and left it standing.
+
+       An Org with no per-Org Kustomization has nothing that re-applies its
+       HelmRepositories from a durable source; it is exempted EXPLICITLY and the
+       exemption is logged, rather than being an unremarked hole (#5596).
+      */}}
+      perorg_offenders() {
+        {{- /*
+         `-A` because per-Org HelmRepositories land in the Org's OWN namespace:
+         the docs the generator emits say `namespace: flux-system`, and the
+         per-Org Kustomization's `targetNamespace: <slug>` overrides it. That is
+         why assert_region_a_pivot — scoped to HELMREPO_NAMESPACE — structurally
+         cannot see these, and why hw296 needed step-11's `-A` scan to find them.
+         Scope is then narrowed to the Orgs THIS leg pivoted, so an unrelated
+         namespace is never this leg's failure.
+        */}}
+        if ! kubectl get helmrepositories.source.toolkit.fluxcd.io -A \
+            -o jsonpath='{range .items[*]}{.metadata.namespace}/{.metadata.name}={.spec.url}{"\n"}{end}' \
+            > /tmp/.pd-hrs.txt 2>/tmp/.pd-hrs.err; then
+          return 1
+        fi
+        : > /tmp/.pd-offenders.txt
+        while IFS= read -r po_line; do
+          [ -n "${po_line}" ] || continue
+          po_key="${po_line%%=*}"
+          po_url="${po_line#*=}"
+          po_ns="${po_key%%/*}"
+          po_name="${po_key#*/}"
+          case "${po_url}" in
+            "${UPSTREAM_PREFIX}"*) : ;;
+            *) continue ;;
+          esac
+          {{- /*
+           Same toleration set as assert_region_a_pivot and step-08's
+           count_offenders, so this gate is never STRICTER than the step it
+           unblocks — a cutover that step-08 would pass must not die here.
+          */}}
+          case ",${HELMREPO_READBACK_EXCLUDE:-}," in
+            *",${po_name},"*) continue ;;
+          esac
+          if grep -qx "${po_ns}" /tmp/.pd-touched.txt; then
+            printf '%s=%s\n' "${po_key}" "${po_url}" >> /tmp/.pd-offenders.txt
+          fi
+        done < /tmp/.pd-hrs.txt
+        return 0
+      }
+
+      perorg_poke() {
+        {{- /*
+         $1 = token. Pokes each pivoted Org's GitRepository + every HR-owning
+         Kustomization that EXISTS, and (re)writes /tmp/.pd-ks.txt as
+         `<slug> <kustomization>` rows. Only existing objects are listed: an
+         absence must never be something the assert then waits forever on.
+        */}}
+        pk_token="$1"
+        : > /tmp/.pd-ks.txt
+        for pk_slug in $(awk 'NF' /tmp/.pd-touched.txt); do
+          kubectl annotate --overwrite gitrepository "${pd_repo}-${pk_slug}" -n "${pd_ns}" \
+            "reconcile.fluxcd.io/requestedAt=${pk_token}" >/dev/null 2>&1 || true
+          for pk_sfx in ${PERORG_KS_SUFFIXES:-apps host-apps}; do
+            pk_ks="${pd_repo}-${pk_slug}-${pk_sfx}"
+            if kubectl get kustomization "${pk_ks}" -n "${pd_ns}" >/dev/null 2>&1; then
+              {{- /*
+               A SUSPENDED Kustomization never handles a reconcile request, so
+               requiring it to would time the assert out on a Sovereign whose
+               only sin is a paused per-Org reconciler. It also cannot re-apply,
+               which means it cannot revert this pivot — the same reason an
+               ABSENT Kustomization is exempt. Recorded as an explicit exemption
+               with a log line rather than an unremarked hole (#5596).
+              */}}
+              pk_susp=$(kubectl get kustomization "${pk_ks}" -n "${pd_ns}" \
+                -o jsonpath='{.spec.suspend}' 2>/dev/null || echo "")
+              if [ "${pk_susp}" = "true" ]; then
+                echo "[helmrepository-patches] Phase-2d ${pk_slug}: Kustomization ${pk_ks} is SUSPENDED — it cannot re-apply, so it cannot revert this pivot; not requiring it to handle the poke"
+              else
+                printf '%s %s\n' "${pk_slug}" "${pk_ks}" >> /tmp/.pd-ks.txt
+                kubectl annotate --overwrite kustomization "${pk_ks}" -n "${pd_ns}" \
+                  "reconcile.fluxcd.io/requestedAt=${pk_token}" >/dev/null 2>&1 || true
+              fi
+            fi
+          done
+        done
+      }
+
+      assert_perorg_pivot_durable() {
+        pa_budget="${PERORG_READBACK_BUDGET_SECONDS:-300}"
+        pa_samples="${PERORG_READBACK_SETTLE_SAMPLES:-2}"
+        pa_interval="${PERORG_READBACK_INTERVAL_SECONDS:-10}"
+        pa_want=$(grep -c . /tmp/.pd-touched.txt || true)
+
+        pa_deadline=$(( $(date +%s) + pa_budget ))
+        while : ; do
+          if ! perorg_offenders; then
+            echo "[helmrepository-patches] FATAL: Phase-2d: cannot enumerate HelmRepositories cluster-wide — an unreadable cluster is NOT a pivoted one; refusing to record success (#6309)" >&2
+            sed 's/^/  KUBECTL-STDERR /' /tmp/.pd-hrs.err >&2 || true
+            return 1
+          fi
+          pa_left=$(grep -c . /tmp/.pd-offenders.txt || true)
+          if [ "${pa_left}" -eq 0 ]; then break; fi
+          if [ "$(date +%s)" -ge "${pa_deadline}" ]; then
+            echo "[helmrepository-patches] FATAL: Phase-2d Stage-1: ${pa_left} per-Org HelmRepository(ies) are STILL on ${UPSTREAM_PREFIX} after ${pa_budget}s — the durable rewrite did not reach the live objects, so step-11's #3526 pre-hold assert would fail on exactly these (#6309)" >&2
+            sed 's/^/  STILL-UPSTREAM /' /tmp/.pd-offenders.txt >&2 || true
+            return 1
+          fi
+          echo "[helmrepository-patches] Phase-2d Stage-1: ${pa_left} per-Org HelmRepository(ies) still on ${UPSTREAM_PREFIX}; re-poking their sources + Kustomizations, re-checking in ${pa_interval}s"
+          perorg_poke "$(date +%s)"
+          sleep "${pa_interval}"
+        done
+        echo "[helmrepository-patches] Phase-2d Stage-1 OK: zero per-Org HelmRepositories on ${UPSTREAM_PREFIX} across ${pa_want} Org(s)"
+
+        pa_token=$(date +%s)
+        perorg_poke "${pa_token}"
+        : > /tmp/.pd-handled.txt
+        for pa_slug in $(awk 'NF' /tmp/.pd-touched.txt); do
+          pa_n=$(awk -v s="${pa_slug}" '$1==s' /tmp/.pd-ks.txt | wc -l | tr -d ' ')
+          if [ "${pa_n}" -eq 0 ]; then
+            echo "[helmrepository-patches] Phase-2d ${pa_slug}: no HR-owning Kustomization exists (${PERORG_KS_SUFFIXES:-apps host-apps}) — nothing re-applies its HelmRepositories from a durable source, so the read-back alone is the whole truth here"
+            printf '%s\n' "${pa_slug}" >> /tmp/.pd-handled.txt
+          fi
+        done
+        echo "[helmrepository-patches] Phase-2d Stage-2: poked $(grep -c . /tmp/.pd-ks.txt || true) per-Org Kustomization(s) with reconcile token ${pa_token}; the pivot must survive their re-apply"
+
+        pa_clean=0
+        pa_deadline=$(( $(date +%s) + pa_budget ))
+        while : ; do
+          if ! perorg_offenders; then
+            echo "[helmrepository-patches] FATAL: Phase-2d Stage-2: cannot enumerate HelmRepositories cluster-wide — refusing to certify a cluster this Job could not read (#6309)" >&2
+            sed 's/^/  KUBECTL-STDERR /' /tmp/.pd-hrs.err >&2 || true
+            return 1
+          fi
+          pa_left=$(grep -c . /tmp/.pd-offenders.txt || true)
+          if [ "${pa_left}" -ne 0 ]; then
+            echo "[helmrepository-patches] FATAL: Phase-2d Stage-2: ${pa_left} per-Org HelmRepository(ies) went BACK to ${UPSTREAM_PREFIX} while their owning Kustomization re-applied — the rewrite did not reach the durable source Flux actually consumes, which is precisely the 0.1.186 revert this stage exists to catch (#6309 #6293)" >&2
+            sed 's/^/  REVERTED /' /tmp/.pd-offenders.txt >&2 || true
+            return 1
+          fi
+          pa_clean=$((pa_clean+1))
+          while IFS= read -r pa_row; do
+            [ -n "${pa_row}" ] || continue
+            pa_s="${pa_row%% *}"
+            pa_k="${pa_row#* }"
+            if grep -qx "${pa_s}" /tmp/.pd-handled.txt; then continue; fi
+            pa_h=$(kubectl get kustomization "${pa_k}" -n "${pd_ns}" \
+              -o jsonpath='{.status.lastHandledReconcileAt}' 2>/dev/null || echo "")
+            if [ "${pa_h}" = "${pa_token}" ]; then
+              printf '%s\n' "${pa_s}" >> /tmp/.pd-handled.txt
+              echo "[helmrepository-patches] Phase-2d ${pa_s}: Kustomization ${pa_k} handled reconcile token ${pa_token} — its re-apply has run and the pivot is still standing"
+            fi
+          done < /tmp/.pd-ks.txt
+          pa_got=$(sort -u /tmp/.pd-handled.txt | grep -c . || true)
+          if [ "${pa_got}" -ge "${pa_want}" ] && [ "${pa_clean}" -ge "${pa_samples}" ]; then
+            echo "[helmrepository-patches] Phase-2d DURABLE: ${pa_want} Org(s) clean across ${pa_clean} sample(s) spanning their own re-apply (tolerated: ${HELMREPO_READBACK_EXCLUDE:-<none>})"
+            return 0
+          fi
+          if [ "$(date +%s)" -ge "${pa_deadline}" ]; then break; fi
+          sleep "${pa_interval}"
+        done
+        echo "[helmrepository-patches] FATAL: Phase-2d Stage-2: the pivot read back CLEAN but could not be proven DURABLE within ${pa_budget}s — only ${pa_got:-0} of ${pa_want} Org(s) had a Kustomization handle reconcile token ${pa_token}, so their next re-apply lands AFTER this Job exits and nothing downstream re-reads them. A read-back that can pass before the owning reconciler has run is not a read-back (#6309 #6293)" >&2
+        return 1
+      }
+
+      if [ "$(grep -c . "${pd_touched}" || true)" -eq 0 ]; then
+        echo "[helmrepository-patches] Phase-2d: no Organization on this Sovereign has a ${pd_repo} repo — nothing re-applies per-Org HelmRepositories from one (${pd_total} Org(s) scanned, ${pd_absent} without a repo)"
+      else
+        assert_perorg_pivot_durable || exit 1
+      fi
+    fi
+    # ---- end Phase 2d (#6309) ----
+  {{- /*
    #5593 — Phase 2c of the step script, mounted and exec (`.`-sourced) FROM
    FILE. Step-06 renders within a few hundred bytes of the 110000-byte inline
    arg budget, so this block MUST NOT move back into podSpec.args. Its
@@ -788,6 +1252,35 @@ data:
           - name: ORG_TENANTS_GITREPO_NAMESPACE
             value: {{ .Values.helmRepositories.orgTenantsSource.gitRepositoryNamespace | quote }}
           {{- /*
+           #6309 — Phase-2d per-Org `<slug>/catalyst-tenant` durable-source pivot.
+           `repoName` MUST track the org-controller's perOrgTenantRepoName
+           constant (per_org_flux.go) and org-services/provisioning's
+           TENANT_GITOPS_REPO; `kustomizationSuffixes` MUST track the per-Org
+           Kustomization names the same file derives (`-apps` / `-host-apps`).
+           They are one naming decision seen from three sides, and a mismatch
+           degrades this leg into the silent no-op #6309 exists to remove.
+          */}}
+          - name: PERORG_PIVOT_ENABLED
+            value: {{ eq (toString .Values.helmRepositories.perOrgTenantSource.enabled) "true" | quote }}
+          - name: PERORG_TENANT_REPO
+            value: {{ .Values.helmRepositories.perOrgTenantSource.repoName | quote }}
+          - name: PERORG_BRANCH
+            value: {{ .Values.helmRepositories.perOrgTenantSource.branch | quote }}
+          - name: PERORG_FLUX_NAMESPACE
+            value: {{ .Values.helmRepositories.perOrgTenantSource.fluxNamespace | quote }}
+          - name: PERORG_TREES
+            value: {{ join " " .Values.helmRepositories.perOrgTenantSource.treePaths | quote }}
+          - name: PERORG_KS_SUFFIXES
+            value: {{ join " " .Values.helmRepositories.perOrgTenantSource.kustomizationSuffixes | quote }}
+          - name: PERORG_ORG_CRD
+            value: {{ .Values.helmRepositories.perOrgTenantSource.organizationCRD | quote }}
+          - name: PERORG_READBACK_BUDGET_SECONDS
+            value: {{ .Values.helmRepositories.perOrgTenantSource.readbackBudgetSeconds | quote }}
+          - name: PERORG_READBACK_SETTLE_SAMPLES
+            value: {{ .Values.helmRepositories.perOrgTenantSource.readbackSettleSamples | quote }}
+          - name: PERORG_READBACK_INTERVAL_SECONDS
+            value: {{ .Values.helmRepositories.perOrgTenantSource.readbackIntervalSeconds | quote }}
+          {{- /*
            #5596 — SECONDARY-region DURABLE pivot assert inputs. The #5359
            read-back was single-shot and fired seconds after the patch loop,
            so it measured the PATCH and never the PIVOT: region-B's own
@@ -848,6 +1341,10 @@ data:
           {{- /* #6293 — Phase 2b of the step script, `.`-sourced from here. */}}
           - name: phase2b-script
             mountPath: /phase2b
+            readOnly: true
+          {{- /* #6309 — Phase 2d of the step script, `.`-sourced from here. */}}
+          - name: phase2d-script
+            mountPath: /phase2d
             readOnly: true
           {{- /* #5593 — Phase 2c of the step script, `.`-sourced from here. */}}
           - name: phase2c-script
@@ -2021,6 +2518,23 @@ data:
             . /phase2b/phase2b.sh
 
             {{- /*
+             Phase 2d (#6309) — the THIRD repo class: every live Organization's
+             `<slug>/catalyst-tenant` repo. Sourced (not `sh`) for the same
+             reason as 2b/2c: ${GITEA_INTERNAL_URL}, ${UPSTREAM_PREFIX},
+             ${local_prefix}, ${trust_secret} and inject_trust_ref() are in
+             scope, and its `exit 1` FATALs the whole step.
+
+             It runs AFTER Phase-2b and BEFORE the secondary-region legs and
+             Phase 3. Before 2b would be wrong: both legs clone into /tmp and
+             `cd /tmp/repo` on the way out, and interleaving them buys nothing.
+             After Phase 3 would be catastrophic — Phase 3 strips the mothership
+             auth, and the per-Org HelmRepositories this leg pivots must be
+             pullable from local Harbor before that fallback is removed (the
+             hw139 half-pivot lesson).
+            */}}
+            . /phase2d/phase2d.sh
+
+            {{- /*
              ====================================================================
              #5359 — SECONDARY-REGION HelmRepository pivot legs
              ====================================================================
@@ -2993,6 +3507,13 @@ data:
           items:
             - key: phase2b.sh
               path: phase2b.sh
+      {{- /* #6309 — the same step-06 ConfigMap, exposing ONLY the phase2d.sh key. */}}
+      - name: phase2d-script
+        configMap:
+          name: cutover-step-06-helmrepository-patches
+          items:
+            - key: phase2d.sh
+              path: phase2d.sh
       {{- /* #5593 — the same step-06 ConfigMap, exposing ONLY the phase2c.sh key. */}}
       - name: phase2c-script
         configMap:

--- a/platform/self-sovereign-cutover/chart/templates/rbac.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/rbac.yaml
@@ -133,6 +133,9 @@ rules:
   - apiGroups: ["catalyst.openova.io"]
     resources: ["blueprints"]   # step 03 (#5443) Phase A2-catalog enumerates the LIVE Blueprint CRs — what the marketplace OFFERS — so harbor-prewarm mirrors the catalog's chart set, not only the charts something already installed. Cluster-scoped CRD; read-only.
     verbs: ["get", "list", "watch"]
+  - apiGroups: ["orgs.openova.io"]
+    resources: ["organizations"]   # step 06 (#6309) Phase 2d builds the LIVE Organization list the per-Org `<slug>/catalyst-tenant` pivot walks — Organization CRs UNIONed with the live `catalyst-tenant-*` Flux GitRepositories, never a curated set, because the offender count scales with the number of Orgs. Cluster-scoped CRD; read-only. WITHOUT this grant the list is REFUSED, and Phase-2d fails closed by design rather than silently scanning nothing (the #6280 shape: a stub kubectl can never be RBAC-refused, so only tests/rbac-coverage.sh sees this class).
+    verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["namespaces"]   # step 03 (#6280) Phase A0 partitions settled-roll offenders by OWNERSHIP: Organization namespaces are read by the openova.io/organization label the org-controller stamps, so a customer's failed Application warns instead of fail-closing the cutover (#6273). Cluster-scoped; read-only. WITHOUT this grant the partition cannot list and the gate — correctly refusing to fail open — stops the cutover at the same step it was meant to unblock.
     verbs: ["get", "list", "watch"]

--- a/platform/self-sovereign-cutover/chart/tests/step06-perorg-tenant-source.sh
+++ b/platform/self-sovereign-cutover/chart/tests/step06-perorg-tenant-source.sh
@@ -1,0 +1,1071 @@
+#!/usr/bin/env bash
+# #6309 — step-06 Phase-2d: the per-Org `<slug>/catalyst-tenant` HelmRepository
+# DURABLE-SOURCE pivot, and the read-back that must survive a reconcile.
+#
+# THE DEFECT THIS LOCKS OUT
+# ─────────────────────────
+# Three GitOps repo classes carry HelmRepository URLs on a Sovereign. Before
+# 0.1.188 the cutover pivoted two:
+#
+#   clusters/_template/bootstrap-kit  committed in-repo    step-05 / step-06
+#   clusters/<fqdn>/org-tenants       catalyst-api         Phase-2b (#6293)
+#   <slug>/catalyst-tenant            org-services/        NOTHING
+#                                       provisioning
+#
+# `grep -rn catalyst-tenant platform/self-sovereign-cutover/` returned zero hits
+# across the entire chart. Measured on hw296 after #6303 (chart 0.1.187) pivoted
+# the org-tenants class at source, step-11's #3526 pre-hold assert still failed
+# on exactly two offenders — down from six, never to zero:
+#
+#   walkfour/bp-stalwart-tenant = oci://ghcr.io/openova-io
+#   walkfive/bp-stalwart-tenant = oci://ghcr.io/openova-io
+#
+# whose durable source is the third class:
+#
+#   walkfour/catalyst-tenant@main : vcluster/host-apps/app-stalwart-mail.yaml:20
+#   walkfive/catalyst-tenant@main : vcluster/apps/app-stalwart-mail.yaml:20
+#
+# THE OFFENDER COUNT SCALES WITH THE NUMBER OF ORGANIZATIONS. A curated list of
+# slugs is therefore wrong the moment the next Org is created, which is why
+# Section L below is not a nice-to-have: it is the property that separates this
+# fix from one that happens to work on hw296.
+#
+# WHY THE 0.1.186 READ-BACK IS NOT A MODEL TO COPY
+# ────────────────────────────────────────────────
+# Step-06's Phase-1.5 read-back logged `ok=6` and `read-back OK`, and all six
+# HelmRepositories reverted within 60s under the org-tenants Kustomization
+# (interval=1m, prune=true). It could pass because it sampled ONCE, immediately
+# after the write, with no requirement that the actor which would revert the
+# write had run at all. Step-11's cluster-wide `-A` scan is what caught it.
+#
+# Phase-2d's read-back is two-stage and Section D proves BOTH stages fire:
+#   Stage 1 CONVERGE — poll to zero offenders across the pivoted Orgs.
+#   Stage 2 SURVIVE  — mint a token AFTER Stage 1 is clean, poke every per-Org
+#                      HR-owning Kustomization, and refuse to certify an Org
+#                      until one of ITS Kustomizations reports
+#                      status.lastHandledReconcileAt == that token, with zero
+#                      offenders on EVERY sample in that window.
+# Case D2 is the 0.1.186 fixture exactly: clean on the first sample, reverted on
+# the next. Mutant M6 deletes Stage 2 and shows that same fixture then passes —
+# which is the whole argument, made mechanically rather than asserted in prose.
+#
+# WHAT IS REAL HERE AND WHAT IS STUBBED, AND WHY
+# ──────────────────────────────────────────────
+# REAL: git. Every case runs the REAL rendered phase2d.sh bytes against REAL
+# local git repositories with real branches, and reads its verdict out of the
+# BARE origin (`git show main:<path>`), never out of a working tree the script
+# left behind. Pushed-or-it-did-not-happen. `git` is reached through a shim that
+# ONLY maps the http URL onto the local bare repo and records whether the URL
+# carried a credential — it then execs the real binary, so branches, commits,
+# pushes and diffs are genuine.
+#
+# STUBBED: kubectl and curl, because the defect classes this suite covers are
+# "which Organizations did you scan" and "did you wait for the reverting
+# reconciler" — both of which are decided by how the script INTERPRETS the API's
+# answers, not by the API. The stubs are programmable per case and answer from
+# fixture files, so a case can make an enumeration FAIL, which a live cluster
+# could not be asked to do on demand.
+#
+# WHAT A STUB CANNOT SEE, AND WHERE THAT IS COVERED INSTEAD
+# ─────────────────────────────────────────────────────────
+# A stubbed kubectl can never be RBAC-refused, so it is structurally blind to a
+# missing ClusterRole grant — the #6280 shape, where Case 95 of the contract
+# suite went green against a stub while the real ServiceAccount was being
+# refused. Phase-2d reads a resource the ClusterRole did not previously grant
+# (organizations.orgs.openova.io). Section R therefore asserts that grant
+# DIRECTLY against the rendered ClusterRole — no stub in the path — and R3b
+# deletes the rule and requires the assertion to go RED.
+#
+# NO `grep -q` ON A PIPE ANYWHERE IN THIS FILE. Under `pipefail` (which this
+# file sets) grep closing the pipe on its first match SIGPIPEs the upstream
+# writer, and on the GitHub runner Node sets SIGPIPE to SIG_IGN so a FOUND match
+# exits 1 — byte-identical to an honest miss. That shape has bitten this repo
+# three times (#5370, #5406, #4969). Producers write to FILES; greps read FILES.
+#
+# EVERY ASSERTION IS VACUITY-PROVED INDIVIDUALLY. Section M re-runs cases
+# against single-behaviour mutants of the real script — one mutation each — and
+# requires the matching case to go RED. Cases with no mutant partner are
+# CONTROLS, and Section M includes mutants that turn controls red too, so the
+# suite cannot be satisfied by deleting, disabling or blanket-widening Phase-2d.
+#
+# Usage: bash tests/step06-perorg-tenant-source.sh [CHART_DIR]
+set -uo pipefail
+
+CHART_DIR="${1:-$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/.." && pwd)}"
+CHART_DIR="$(cd "${CHART_DIR}" && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "${TMP}"' EXIT
+
+FQDN="hw296.omani.works"
+UPSTREAM="oci://ghcr.io/openova-io"
+LOCAL="oci://registry.${FQDN}/openova-io"
+TRUST="cutover-harbor-ca"
+GITEA_HOST="gitea.invalid"
+GITEA_URL="http://${GITEA_HOST}"
+REPO="catalyst-tenant"
+HOSTAPP="vcluster/host-apps/app-stalwart-mail.yaml"
+APPSAPP="vcluster/apps/app-stalwart-mail.yaml"
+OUTSIDE="legacy/app-legacy.yaml"
+
+FIX="${TMP}/fx"
+GITEA_ROOT="${TMP}/gitea"
+REAL_GIT="$(command -v git)"
+
+pass=0; fail=0
+ok()  { echo "  ok   — $1"; pass=$((pass+1)); }
+bad() { echo "  FAIL — $1"; fail=$((fail+1)); }
+
+mkdir -p "${TMP}/bin" "${FIX}"
+
+# ── Render ─────────────────────────────────────────────────────────────────
+helm template ssc "${CHART_DIR}" --set sovereign.fqdn="${FQDN}" \
+  >"${TMP}/render.yaml" 2>"${TMP}/render.err" || {
+  echo "FAIL — helm template failed:"; cat "${TMP}/render.err"; exit 1
+}
+
+# ── Extract the bytes under test straight from the render ──────────────────
+# Plain awk over the render text — the same dependency surface as the Job
+# (sh + awk + git), so this suite cannot skip itself on a runner missing a
+# python module.
+awk '/# ---- Phase 2d \(#6309\)/,/# ---- end Phase 2d \(#6309\) ----/' "${TMP}/render.yaml" \
+  | sed 's/^    //' >"${TMP}/phase2d.orig.sh"
+awk '/# ---- inject_trust_ref \(#3379 #6293\) ----/,/# ---- end inject_trust_ref ----/' "${TMP}/render.yaml" \
+  | sed 's/^            //' >"${TMP}/injector.sh"
+
+if grep -q 'PERORG_TENANT_REPO' "${TMP}/phase2d.orig.sh"; then
+  ok "extracted phase2d.sh from the render"
+else
+  echo "FAIL — phase2d.sh did not extract (marker comments changed?)"; exit 1
+fi
+# Truncation guard: a short extraction would still `sh` cleanly and exit 0 —
+# the fail-open shape this suite exists to eliminate.
+tail -3 "${TMP}/phase2d.orig.sh" >"${TMP}/tail3.txt"
+if ! grep -q 'end Phase 2d' "${TMP}/tail3.txt"; then
+  echo "FAIL — phase2d.sh extraction was truncated"; exit 1
+fi
+if grep -q 'assert_perorg_pivot_durable' "${TMP}/phase2d.orig.sh"; then
+  ok "extraction carries the read-back assert (not just the rewrite half)"
+else
+  echo "FAIL — the read-back assert is missing from the extraction"; exit 1
+fi
+if grep -q 'inject_trust_ref()' "${TMP}/injector.sh"; then
+  ok "extracted the shared inject_trust_ref function from the render"
+else
+  echo "FAIL — inject_trust_ref did not extract"; exit 1
+fi
+sh -n "${TMP}/phase2d.orig.sh" || { echo "FAIL — phase2d.sh is not valid POSIX sh"; exit 1; }
+
+# Relocate the container's literal /tmp paths into the test tmpdir, and assert
+# the substitution applied — a path rename in the template must not silently
+# turn every case below into a no-op.
+tmp_hits=$(grep -c '/tmp' "${TMP}/phase2d.orig.sh" || true)
+if [ "${tmp_hits}" -lt 5 ]; then
+  echo "FAIL — phase2d.sh no longer uses /tmp paths; harness relocation is stale"; exit 1
+fi
+relocate() { sed "s,/tmp,${TMP}/t,g" "$1" >"$2"; }
+relocate "${TMP}/phase2d.orig.sh" "${TMP}/phase2d.sh"
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Stubs. kubectl + curl answer from ${FIX}; git is a URL-mapping shim over the
+# real binary.
+# ═══════════════════════════════════════════════════════════════════════════
+cat >"${TMP}/bin/kubectl" <<'FAKE'
+#!/usr/bin/env sh
+FX="${FIXTURE_DIR}"
+printf 'kubectl %s\n' "$*" >>"${FAKE_KUBECTL_LOG}"
+verb="$1"; shift
+case "${verb}" in
+  annotate)
+    for a in "$@"; do
+      case "$a" in
+        reconcile.fluxcd.io/requestedAt=*) printf '%s' "${a#*=}" >"${FX}/last-token" ;;
+      esac
+    done
+    exit 0 ;;
+  get) : ;;
+  *) exit 0 ;;
+esac
+res="$1"; shift
+case "${res}" in
+  gitrepositories.source.toolkit.fluxcd.io)
+    rc=$(cat "${FX}/gitrepos.rc" 2>/dev/null || echo 0)
+    if [ "${rc}" != "0" ]; then
+      echo 'Error from server (Forbidden): gitrepositories.source.toolkit.fluxcd.io is forbidden' >&2
+      exit "${rc}"
+    fi
+    cat "${FX}/gitrepos.txt" 2>/dev/null || true
+    exit 0 ;;
+  customresourcedefinitions)
+    rc=$(cat "${FX}/crd.rc" 2>/dev/null || echo 0)
+    if [ "${rc}" != "0" ]; then cat "${FX}/crd.err" >&2; exit "${rc}"; fi
+    echo 'organizations.orgs.openova.io   2026-08-14T00:00:00Z'
+    exit 0 ;;
+  organizations.orgs.openova.io)
+    rc=$(cat "${FX}/orgs.rc" 2>/dev/null || echo 0)
+    if [ "${rc}" != "0" ]; then
+      echo 'Error from server (Forbidden): organizations.orgs.openova.io is forbidden: User "system:serviceaccount:catalyst:bp-self-sovereign-cutover-runner" cannot list resource "organizations"' >&2
+      exit "${rc}"
+    fi
+    cat "${FX}/orgs.txt" 2>/dev/null || true
+    exit 0 ;;
+  helmrepositories.source.toolkit.fluxcd.io)
+    n=$(cat "${FX}/hr-seq" 2>/dev/null || echo 0); n=$((n+1)); printf '%s' "${n}" >"${FX}/hr-seq"
+    rc=$(cat "${FX}/hrs.rc" 2>/dev/null || echo 0)
+    if [ "${rc}" != "0" ]; then
+      echo 'Error from server: the server could not list helmrepositories' >&2
+      exit "${rc}"
+    fi
+    if [ -f "${FX}/hrs.${n}.txt" ]; then cat "${FX}/hrs.${n}.txt"
+    else cat "${FX}/hrs.last.txt" 2>/dev/null || true; fi
+    exit 0 ;;
+  kustomization)
+    name="$1"; shift
+    if ! grep -qx "${name}" "${FX}/ks.txt" 2>/dev/null; then
+      echo "Error from server (NotFound): kustomizations.kustomize.toolkit.fluxcd.io \"${name}\" not found" >&2
+      exit 1
+    fi
+    case "$*" in
+      *spec.suspend*)
+        if grep -qx "${name}" "${FX}/suspended-ks.txt" 2>/dev/null; then printf 'true'; fi ;;
+      *lastHandledReconcileAt*)
+        if grep -qx "${name}" "${FX}/handled-ks.txt" 2>/dev/null; then
+          cat "${FX}/last-token" 2>/dev/null || true
+        fi ;;
+    esac
+    exit 0 ;;
+esac
+exit 0
+FAKE
+chmod +x "${TMP}/bin/kubectl"
+
+cat >"${TMP}/bin/curl" <<'FAKE'
+#!/usr/bin/env sh
+out=/dev/null
+url=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -s) shift ;;
+    -o) out="$2"; shift 2 ;;
+    -w) shift 2 ;;
+    -u) shift 2 ;;
+    -*) shift ;;
+    *)  url="$1"; shift ;;
+  esac
+done
+slug=$(printf '%s' "${url}" | awk -F/ '{print $(NF-1)}')
+repo=$(printf '%s' "${url}" | awk -F/ '{print $NF}')
+: >"${out}" 2>/dev/null || true
+if [ -n "${CURL_FORCE_CODE:-}" ] && [ "${CURL_FORCE_SLUG:-}" = "${slug}" ]; then
+  printf '%s' "${CURL_FORCE_CODE}"; exit 0
+fi
+if [ -d "${GITEA_ROOT}/${slug}/${repo}.git" ]; then printf '200'; else printf '404'; fi
+FAKE
+chmod +x "${TMP}/bin/curl"
+
+# git shim — maps http://<creds>@gitea.invalid/<slug>/<repo>.git onto the local
+# bare repo and RECORDS whether the URL carried a credential, then execs the
+# real git. `for a in "$@"` expands the positional params once, so rebuilding
+# them inside the loop is safe.
+cat >"${TMP}/bin/git" <<'FAKE'
+#!/usr/bin/env sh
+first=1
+for a in "$@"; do
+  case "$a" in
+    http://*"${GITEA_HOST_FOR_SHIM}"/*)
+      case "$a" in
+        *"@${GITEA_HOST_FOR_SHIM}/"*) printf 'credentialed %s\n' "${a##*@}" >>"${GIT_URL_LOG}" ;;
+        *) printf 'bare %s\n' "$a" >>"${GIT_URL_LOG}" ;;
+      esac
+      a="${GITEA_ROOT}/${a##*"${GITEA_HOST_FOR_SHIM}"/}"
+      ;;
+  esac
+  if [ "${first}" = 1 ]; then set -- "$a"; first=0; else set -- "$@" "$a"; fi
+done
+exec "${REAL_GIT_BIN}" "$@"
+FAKE
+chmod +x "${TMP}/bin/git"
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Fixtures
+# ═══════════════════════════════════════════════════════════════════════════
+hr_doc() {
+  # $1 = name, $2 = url — the shape gitops/helmrelease_apps.go helmRepoBlock
+  # emits (namespace flux-system in the doc; the per-Org Kustomization's
+  # targetNamespace: <slug> is what actually places it).
+  printf -- 'apiVersion: source.toolkit.fluxcd.io/v1beta2\nkind: HelmRepository\nmetadata:\n  name: %s\n  namespace: flux-system\nspec:\n  type: oci\n  interval: 15m\n  url: %s\n  secretRef:\n    name: ghcr-pull\n' "$1" "$2"
+}
+
+hr_release_doc() {
+  # A HelmRelease that sourceRefs the HR by NAME and carries no url: line.
+  printf -- '---\napiVersion: helm.toolkit.fluxcd.io/v2\nkind: HelmRelease\nmetadata:\n  name: %s\nspec:\n  chart:\n    spec:\n      chart: %s\n      sourceRef:\n        kind: HelmRepository\n        name: %s\n' "$1" "$1" "$1"
+}
+
+seed_org_repo() {
+  # $1 = slug   $2 = tree ("host-apps" | "apps")
+  sl="$1"; tree="$2"
+  mkdir -p "${GITEA_ROOT}/${sl}"
+  rm -rf "${GITEA_ROOT}/${sl}/${REPO}.git" "${TMP}/seed-${sl}"
+  git init --bare -q "${GITEA_ROOT}/${sl}/${REPO}.git"
+  git init -q -b main "${TMP}/seed-${sl}"
+  (
+    cd "${TMP}/seed-${sl}"
+    git config user.name t; git config user.email t@example.invalid
+    mkdir -p "vcluster/${tree}" "vcluster/apps" "legacy"
+    { hr_doc bp-stalwart-tenant "${UPSTREAM}"; hr_release_doc bp-stalwart-tenant; } \
+      >"vcluster/${tree}/app-stalwart-mail.yaml"
+    # A doc with a sourceRef and NO url: — nothing may rewrite it.
+    hr_release_doc bp-wordpress-tenant >"vcluster/apps/app-wordpress.yaml"
+    printf 'resources:\n  - app-wordpress.yaml\n' >"vcluster/apps/kustomization.yaml"
+    # OUTSIDE the reconciled trees, carrying the upstream url — the scoping
+    # CONTROL. No per-Org Kustomization reconciles this path.
+    hr_doc bp-legacy "${UPSTREAM}" >"${OUTSIDE}"
+    git add -A; git commit -qm seed
+    git remote add origin "${GITEA_ROOT}/${sl}/${REPO}.git"
+    git push -q origin main
+  ) >/dev/null 2>&1
+}
+
+origin_show() { "${REAL_GIT}" --git-dir="${GITEA_ROOT}/$1/${REPO}.git" show "main:$2" 2>/dev/null; }
+count_in()    { origin_show "$1" "$2" | grep -c "url: $3\$" || true; }
+count_trust() { origin_show "$1" "$2" | grep -c "name: ${TRUST}\$" || true; }
+
+hr_line() { printf '%s/%s=%s\n' "$1" "$2" "$3"; }
+
+reset_fixture() {
+  rm -rf "${FIX}"; mkdir -p "${FIX}"
+  : >"${FIX}/gitrepos.txt"; : >"${FIX}/orgs.txt"; : >"${FIX}/ks.txt"
+  : >"${FIX}/handled-ks.txt"; : >"${FIX}/hrs.last.txt"; : >"${FIX}/suspended-ks.txt"
+  echo 0 >"${FIX}/gitrepos.rc"; echo 0 >"${FIX}/orgs.rc"
+  echo 0 >"${FIX}/crd.rc"; echo 0 >"${FIX}/hrs.rc"
+  : >"${FIX}/crd.err"
+  printf '0' >"${FIX}/hr-seq"
+}
+
+# The DEFAULT cluster fixture, deliberately asymmetric so the union of the two
+# live sources is load-bearing in BOTH directions:
+#
+#   walkfour  Org CR + Flux GitRepository + a `-host-apps` Kustomization
+#   walkfive  Org CR + Flux GitRepository + an `-apps` Kustomization
+#   newcomer  Org CR ONLY — no Flux source at all. An Organization created
+#             after the per-Org Flux loop last ran; a scan driven only by
+#             GitRepositories would never see it.
+#   fluxonly  Flux GitRepository ONLY — no Org CR. The mirror-image case.
+#   norepo    Org CR, no Gitea repo at all → HTTP 404 → clean skip.
+build_default_cluster() {
+  reset_fixture
+  rm -rf "${GITEA_ROOT}"; mkdir -p "${GITEA_ROOT}"
+  seed_org_repo walkfour host-apps
+  seed_org_repo walkfive apps
+  seed_org_repo newcomer host-apps
+  seed_org_repo fluxonly apps
+  {
+    echo "${REPO}-walkfour"
+    echo "${REPO}-walkfive"
+    echo "${REPO}-fluxonly"
+    # Sources that must NOT be mistaken for a per-Org tenant repo.
+    echo "openova"
+    echo "openova-org-tenants"
+    echo "${REPO}"
+  } >"${FIX}/gitrepos.txt"
+  {
+    echo "walkfour"; echo "walkfive"; echo "newcomer"; echo "norepo"
+  } >"${FIX}/orgs.txt"
+  {
+    echo "${REPO}-walkfour-host-apps"
+    echo "${REPO}-walkfive-apps"
+    echo "${REPO}-newcomer-host-apps"
+    echo "${REPO}-fluxonly-apps"
+  } >"${FIX}/ks.txt"
+  cp "${FIX}/ks.txt" "${FIX}/handled-ks.txt"
+  # Post-pivot live state: every per-Org HR on local Harbor.
+  {
+    hr_line walkfour bp-stalwart-tenant "${LOCAL}"
+    hr_line walkfive bp-stalwart-tenant "${LOCAL}"
+    hr_line newcomer bp-stalwart-tenant "${LOCAL}"
+    hr_line fluxonly bp-stalwart-tenant "${LOCAL}"
+    hr_line flux-system bp-harbor "${LOCAL}"
+  } >"${FIX}/hrs.last.txt"
+}
+
+# ── Runner: execute the real phase2d.sh with the parent-shell contract ────
+run_phase2d() {
+  # $1 = script path   $2 = PERORG_PIVOT_ENABLED   $3.. = extra VAR=VAL env
+  scr="$1"; enabled="$2"; shift 2
+  : >"${TMP}/kubectl.log"; : >"${TMP}/giturl.log"
+  printf '0' >"${FIX}/hr-seq"
+  mkdir -p "${TMP}/t/repo"
+  cat >"${TMP}/driver.sh" <<DRIVER
+# The step container runs the whole script under \`set -eu\` (line 1 of the
+# rendered args). Sourcing phase2d.sh without it would let an unset variable or
+# an unguarded non-zero command pass here and kill the step in production.
+set -eu
+UPSTREAM_PREFIX='${UPSTREAM}'
+local_prefix='${LOCAL}'
+trust_secret='${TRUST}'
+. '${TMP}/injector.sh'
+. '${scr}'
+DRIVER
+  env -i \
+    PATH="${TMP}/bin:${PATH}" \
+    HOME="${TMP}" \
+    FIXTURE_DIR="${FIX}" \
+    FAKE_KUBECTL_LOG="${TMP}/kubectl.log" \
+    GIT_URL_LOG="${TMP}/giturl.log" \
+    GITEA_ROOT="${GITEA_ROOT}" \
+    GITEA_HOST_FOR_SHIM="${GITEA_HOST}" \
+    REAL_GIT_BIN="${REAL_GIT}" \
+    GIT_AUTHOR_NAME=cutover GIT_AUTHOR_EMAIL=cutover@example.invalid \
+    GIT_COMMITTER_NAME=cutover GIT_COMMITTER_EMAIL=cutover@example.invalid \
+    GIT_TERMINAL_PROMPT=0 \
+    GITEA_INTERNAL_URL="${GITEA_URL}" \
+    GITEA_USERNAME=gitea_admin \
+    GITEA_PASSWORD=fixture-not-a-real-password \
+    HELMREPO_READBACK_EXCLUDE="bp-newapi" \
+    PERORG_PIVOT_ENABLED="${enabled}" \
+    PERORG_TENANT_REPO="${REPO}" \
+    PERORG_BRANCH=main \
+    PERORG_FLUX_NAMESPACE=flux-system \
+    PERORG_TREES=vcluster \
+    PERORG_KS_SUFFIXES="apps host-apps" \
+    PERORG_ORG_CRD=organizations.orgs.openova.io \
+    PERORG_READBACK_BUDGET_SECONDS="${PD_BUDGET:-300}" \
+    PERORG_READBACK_SETTLE_SAMPLES=2 \
+    PERORG_READBACK_INTERVAL_SECONDS=1 \
+    "$@" \
+    sh "${TMP}/driver.sh" >"${TMP}/out.log" 2>&1
+  echo $?
+}
+
+# ═══════════════════════════════════════════════════════════════════════════
+echo "== C. the rewrite, against real git repositories =="
+
+build_default_cluster
+rc=$(run_phase2d "${TMP}/phase2d.sh" true)
+
+if [ "${rc}" -eq 0 ]; then ok "C0 happy path exits 0"
+else bad "C0 happy path exit ${rc}"; sed 's/^/      /' "${TMP}/out.log" | tail -25; fi
+
+c1_up=$(count_in walkfour "${HOSTAPP}" "${UPSTREAM}")
+c1_lo=$(count_in walkfour "${HOSTAPP}" "${LOCAL}")
+if [ "${c1_up}" -eq 0 ] && [ "${c1_lo}" -eq 1 ]; then
+  ok "C1 walkfour/${REPO}@main:${HOSTAPP} pivoted to local Harbor IN THE BARE ORIGIN (the hw296 offender)"
+else
+  bad "C1 walkfour still has ${c1_up} on ${UPSTREAM} / ${c1_lo} on local (want 0 / 1)"
+fi
+
+c2_up=$(count_in walkfive "${APPSAPP}" "${UPSTREAM}")
+c2_lo=$(count_in walkfive "${APPSAPP}" "${LOCAL}")
+if [ "${c2_up}" -eq 0 ] && [ "${c2_lo}" -eq 1 ]; then
+  ok "C2 walkfive/${REPO}@main:${APPSAPP} pivoted — BOTH reconciled trees are covered, not just one"
+else
+  bad "C2 walkfive still has ${c2_up} on ${UPSTREAM} / ${c2_lo} on local (want 0 / 1)"
+fi
+
+if [ "$(count_trust walkfour "${HOSTAPP}")" -eq 1 ] && [ "$(count_trust walkfive "${APPSAPP}")" -eq 1 ]; then
+  ok "C3 certSecretRef=${TRUST} injected beside every pivoted url"
+else
+  bad "C3 certSecretRef missing — pivoted per-Org HRs would x509-fail the in-cluster Harbor"
+fi
+
+if [ "$(count_in walkfour "${OUTSIDE}" "${UPSTREAM}")" -eq 1 ]; then
+  ok "C4 CONTROL: ${OUTSIDE} (outside the reconciled trees) is untouched — the vcluster/ scope holds"
+else
+  bad "C4 Phase-2d rewrote a path no per-Org Kustomization reconciles — the tree scope was widened"
+fi
+
+if origin_show walkfour "vcluster/apps/app-wordpress.yaml" \
+   | cmp -s - "${TMP}/seed-walkfour/vcluster/apps/app-wordpress.yaml"; then
+  ok "C5 CONTROL: the sourceRef-only HelmRelease doc is byte-identical (no url: line, nothing to rewrite)"
+else
+  bad "C5 CONTROL: a doc with no url: line was modified"
+fi
+
+if grep -q 'no catalyst-tenant repo (HTTP 404)' "${TMP}/out.log"; then
+  ok "C6 an Org with no ${REPO} repo (HTTP 404) is a clean skip, not a failure"
+else
+  bad "C6 the 404 path did not report a skip"; sed 's/^/      /' "${TMP}/out.log" | tail -10
+fi
+
+if grep -q 'credentialed' "${TMP}/giturl.log"; then
+  ok "C7 the clone URL carries the injected Gitea credential (the push can authenticate)"
+else
+  bad "C7 the clone URL had no credential — every push would 401"
+fi
+
+# ── C8: idempotent re-run ────────────────────────────────────────────────
+rc=$(run_phase2d "${TMP}/phase2d.sh" true)
+if [ "${rc}" -eq 0 ] \
+   && [ "$(count_in walkfour "${HOSTAPP}" "${LOCAL}")" -eq 1 ] \
+   && [ "$(count_trust walkfour "${HOSTAPP}")" -eq 1 ] \
+   && grep -q 'already pivoted' "${TMP}/out.log"; then
+  ok "C8 re-run is idempotent (exit 0, one local url, ONE certSecretRef — no duplicates)"
+else
+  bad "C8 re-run not idempotent: exit ${rc}, $(count_in walkfour "${HOSTAPP}" "${LOCAL}") local, $(count_trust walkfour "${HOSTAPP}") trust refs"
+fi
+
+# ── C9: the disable switch ───────────────────────────────────────────────
+build_default_cluster
+rc=$(run_phase2d "${TMP}/phase2d.sh" false)
+if [ "${rc}" -eq 0 ] && [ "$(count_in walkfour "${HOSTAPP}" "${UPSTREAM}")" -eq 1 ]; then
+  ok "C9 CONTROL: enabled=false is a genuine no-op"
+else
+  bad "C9 enabled=false did not no-op: exit ${rc}"
+fi
+
+# ── C10: an UNREADABLE repo must FATAL, never present as the same 404 skip ─
+build_default_cluster
+rc=$(run_phase2d "${TMP}/phase2d.sh" true CURL_FORCE_CODE=500 CURL_FORCE_SLUG=walkfour)
+if [ "${rc}" -ne 0 ] && grep -q 'unreadable repo is NOT an absent repo' "${TMP}/out.log"; then
+  ok "C10 a non-200/404 repo probe FATALs (an auth fault can never masquerade as an absent repo)"
+else
+  bad "C10 unreadable repo exited ${rc} without the discriminating FATAL"
+fi
+
+# ── C11: a repo that EXISTS but carries no branch yet ─────────────────────
+# The org-controller creates the per-Org repo before anything seeds a tree into
+# it, so an Org created shortly before the cutover is legitimately empty.
+# `git clone --branch main` fails there; failing the cutover on it would stop a
+# Sovereign whose only sin is a fresh Organization.
+build_default_cluster
+rm -rf "${GITEA_ROOT}/emptyorg"
+mkdir -p "${GITEA_ROOT}/emptyorg"
+"${REAL_GIT}" init --bare -q "${GITEA_ROOT}/emptyorg/${REPO}.git"
+printf 'emptyorg\n' >>"${FIX}/orgs.txt"
+rc=$(run_phase2d "${TMP}/phase2d.sh" true)
+if [ "${rc}" -eq 0 ] \
+   && grep -q 'has no main branch' "${TMP}/out.log" \
+   && [ "$(count_in walkfour "${HOSTAPP}" "${LOCAL}")" -eq 1 ]; then
+  ok "C11 a per-Org repo that exists but has no branch yet is a clean skip, and the other Orgs still pivot"
+else
+  bad "C11 the empty-repo case exited ${rc} — a freshly-created Org must not stop the cutover"
+  sed 's/^/      /' "${TMP}/out.log" | tail -10
+fi
+
+# ═══════════════════════════════════════════════════════════════════════════
+echo "== L. the scan is driven by the LIVE Organization list =="
+# THE PROPERTY THAT MATTERS BEYOND hw296. The offender count scales with the
+# number of Organizations, so a scan the code can enumerate from a constant is
+# wrong by construction. These cases use Orgs that appear in ONLY ONE of the two
+# live sources — a suite that fed the code the same list the code already knows
+# would be testing nothing.
+
+build_default_cluster
+rc=$(run_phase2d "${TMP}/phase2d.sh" true)
+
+if [ "$(count_in newcomer "${HOSTAPP}" "${LOCAL}")" -eq 1 ]; then
+  ok "L1 'newcomer' — present ONLY as an Organization CR, with NO Flux source the code could have enumerated — was still scanned and pivoted"
+else
+  bad "L1 an Organization with no per-Org Flux source was NOT scanned — the scan is not driven by the live Org list ($(count_in newcomer "${HOSTAPP}" "${UPSTREAM}") still upstream)"
+fi
+
+if [ "$(count_in fluxonly "${APPSAPP}" "${LOCAL}")" -eq 1 ]; then
+  ok "L2 'fluxonly' — present ONLY as a live ${REPO}-* Flux source, absent from the Organization CR list — was still scanned and pivoted"
+else
+  bad "L2 an Org visible only through its Flux source was NOT scanned — the union is degenerate on that side"
+fi
+
+# L3: an Organization the fixture invents AFTER the suite was written. Nothing
+# in the shipped script or in the cases above names it.
+build_default_cluster
+seed_org_repo lateorg host-apps
+printf 'lateorg\n' >>"${FIX}/orgs.txt"
+printf '%s-lateorg-host-apps\n' "${REPO}" >>"${FIX}/ks.txt"
+cp "${FIX}/ks.txt" "${FIX}/handled-ks.txt"
+hr_line lateorg bp-stalwart-tenant "${LOCAL}" >>"${FIX}/hrs.last.txt"
+rc=$(run_phase2d "${TMP}/phase2d.sh" true)
+if [ "${rc}" -eq 0 ] && [ "$(count_in lateorg "${HOSTAPP}" "${LOCAL}")" -eq 1 ]; then
+  ok "L3 an Organization introduced only by the fixture — named nowhere in the chart — is scanned like any other"
+else
+  bad "L3 a previously-unseen Organization was not scanned: exit ${rc}, $(count_in lateorg "${HOSTAPP}" "${UPSTREAM}") still upstream"
+fi
+
+# L4: zero Organizations is a clean no-op, and must be distinguishable in the
+# log from an enumeration that failed.
+build_default_cluster
+: >"${FIX}/gitrepos.txt"; : >"${FIX}/orgs.txt"
+rc=$(run_phase2d "${TMP}/phase2d.sh" true)
+if [ "${rc}" -eq 0 ] && grep -q '0 live Organization slug' "${TMP}/out.log"; then
+  ok "L4 CONTROL: a Sovereign with zero Organizations is a clean, explicit no-op"
+else
+  bad "L4 zero-Org handling wrong: exit ${rc}"; sed 's/^/      /' "${TMP}/out.log" | tail -8
+fi
+
+# L5: the Flux-source enumeration FAILING is not an empty list.
+build_default_cluster
+echo 1 >"${FIX}/gitrepos.rc"
+rc=$(run_phase2d "${TMP}/phase2d.sh" true)
+if [ "${rc}" -ne 0 ] && grep -q 'scanning a PARTIAL list' "${TMP}/out.log"; then
+  ok "L5 a FAILED GitRepository enumeration FATALs — an unreadable API is not an empty Org list"
+else
+  bad "L5 a failed source enumeration exited ${rc} without a FATAL — a verdict from absent evidence"
+fi
+
+# L6: the Organization CRD is INSTALLED but the list is REFUSED. This is the
+# shape a missing `orgs.openova.io/organizations` grant produces at runtime.
+build_default_cluster
+echo 1 >"${FIX}/orgs.rc"
+rc=$(run_phase2d "${TMP}/phase2d.sh" true)
+if [ "${rc}" -ne 0 ] && grep -q 'CRD IS installed but listing Organizations failed' "${TMP}/out.log"; then
+  ok "L6 CRD installed + list refused FATALs — an RBAC refusal can never read as 'this Sovereign has no Orgs'"
+else
+  bad "L6 a refused Organization list exited ${rc} without a FATAL"
+fi
+
+# L7: the CRD genuinely absent (Catalyst-Zero) — continue on the Flux leg alone.
+build_default_cluster
+echo 1 >"${FIX}/crd.rc"
+printf 'Error from server (NotFound): customresourcedefinitions.apiextensions.k8s.io "organizations.orgs.openova.io" not found\n' >"${FIX}/crd.err"
+rc=$(run_phase2d "${TMP}/phase2d.sh" true)
+if [ "${rc}" -eq 0 ] \
+   && [ "$(count_in walkfour "${HOSTAPP}" "${LOCAL}")" -eq 1 ] \
+   && [ "$(count_in newcomer "${HOSTAPP}" "${UPSTREAM}")" -eq 1 ]; then
+  ok "L7 CONTROL: a genuinely absent Organization CRD falls back to the Flux sources alone (walkfour pivoted; the CR-only newcomer legitimately untouched)"
+else
+  bad "L7 absent-CRD fallback wrong: exit ${rc}"; sed 's/^/      /' "${TMP}/out.log" | tail -8
+fi
+
+# L8: the CRD probe failing for a reason that is NOT NotFound. Absence must be
+# established by POSITIVE evidence, or a refusal silently empties the scan.
+build_default_cluster
+echo 1 >"${FIX}/crd.rc"
+printf 'Error from server (Forbidden): customresourcedefinitions.apiextensions.k8s.io is forbidden\n' >"${FIX}/crd.err"
+rc=$(run_phase2d "${TMP}/phase2d.sh" true)
+if [ "${rc}" -ne 0 ] && grep -q 'NOT the same as it being absent' "${TMP}/out.log"; then
+  ok "L8 a CRD probe that fails for any reason other than NotFound FATALs — absence requires positive evidence"
+else
+  bad "L8 a non-NotFound CRD probe failure exited ${rc} and was treated as absence"
+fi
+
+# ═══════════════════════════════════════════════════════════════════════════
+echo "== D. the read-back must survive the owning reconciler =="
+
+# D1: the happy path already ran above; assert the DURABLE verdict was reached
+# through Stage 2, not merely printed.
+build_default_cluster
+rc=$(run_phase2d "${TMP}/phase2d.sh" true)
+if [ "${rc}" -eq 0 ] \
+   && grep -q 'Phase-2d Stage-1 OK' "${TMP}/out.log" \
+   && grep -q 'handled reconcile token' "${TMP}/out.log" \
+   && grep -q 'Phase-2d DURABLE' "${TMP}/out.log"; then
+  ok "D1 the pivot is certified only after Stage 1 goes clean AND an owning Kustomization HANDLES the Stage-2 token"
+else
+  bad "D1 the DURABLE verdict was not reached through both stages: exit ${rc}"
+  sed 's/^/      /' "${TMP}/out.log" | tail -15
+fi
+
+# D2: THE 0.1.186 FIXTURE. Clean on the first sample, reverted on the next —
+# exactly what step-06's Phase-1.5 read-back saw and passed.
+build_default_cluster
+PD_BUDGET=4
+{
+  hr_line walkfour bp-stalwart-tenant "${LOCAL}"
+  hr_line walkfive bp-stalwart-tenant "${LOCAL}"
+  hr_line newcomer bp-stalwart-tenant "${LOCAL}"
+  hr_line fluxonly bp-stalwart-tenant "${LOCAL}"
+} >"${FIX}/hrs.1.txt"
+{
+  hr_line walkfour bp-stalwart-tenant "${UPSTREAM}"
+  hr_line walkfive bp-stalwart-tenant "${UPSTREAM}"
+  hr_line newcomer bp-stalwart-tenant "${LOCAL}"
+  hr_line fluxonly bp-stalwart-tenant "${LOCAL}"
+} >"${FIX}/hrs.last.txt"
+rc=$(PD_BUDGET=4 run_phase2d "${TMP}/phase2d.sh" true)
+if [ "${rc}" -ne 0 ] && grep -q 'went BACK to' "${TMP}/out.log"; then
+  ok "D2 a pivot that reads CLEAN then reverts under its owning Kustomization is caught (the 0.1.186 shape, one repo class down)"
+else
+  bad "D2 the revert-during-Stage-2 fixture exited ${rc} without the revert FATAL"
+  sed 's/^/      /' "${TMP}/out.log" | tail -12
+fi
+
+# D3: the token is never handled — clean, but durability unproven.
+build_default_cluster
+: >"${FIX}/handled-ks.txt"
+rc=$(PD_BUDGET=3 run_phase2d "${TMP}/phase2d.sh" true)
+if [ "${rc}" -ne 0 ] && grep -q 'could not be proven DURABLE' "${TMP}/out.log"; then
+  ok "D3 clean-but-never-re-applied is REFUSED — a read-back that can pass before the owning reconciler ran is not a read-back"
+else
+  bad "D3 an unproven-durability fixture exited ${rc} without the FATAL"
+fi
+
+# D4: an Org with NO HR-owning Kustomization is exempted EXPLICITLY, not hung on.
+build_default_cluster
+: >"${FIX}/ks.txt"; : >"${FIX}/handled-ks.txt"
+rc=$(PD_BUDGET=6 run_phase2d "${TMP}/phase2d.sh" true)
+if [ "${rc}" -eq 0 ] && grep -q 'no HR-owning Kustomization exists' "${TMP}/out.log"; then
+  ok "D4 CONTROL: an Org with nothing that re-applies its HelmRepositories is exempted, and says so"
+else
+  bad "D4 the no-Kustomization case exited ${rc} — an absence must not be waited on"
+fi
+
+# D5: Stage 1 never converges.
+build_default_cluster
+{
+  hr_line walkfour bp-stalwart-tenant "${UPSTREAM}"
+  hr_line walkfive bp-stalwart-tenant "${LOCAL}"
+  hr_line newcomer bp-stalwart-tenant "${LOCAL}"
+  hr_line fluxonly bp-stalwart-tenant "${LOCAL}"
+} >"${FIX}/hrs.last.txt"
+rc=$(PD_BUDGET=2 run_phase2d "${TMP}/phase2d.sh" true)
+if [ "${rc}" -ne 0 ] && grep -q 'Stage-1' "${TMP}/out.log" && grep -q 'STILL-UPSTREAM' "${TMP}/out.log"; then
+  ok "D5 a pivot that never reaches the live objects FATALs in Stage 1, naming its offenders"
+else
+  bad "D5 the non-converging fixture exited ${rc} without a Stage-1 FATAL"
+fi
+
+# D6: the cluster-wide HelmRepository enumeration FAILING is not zero offenders.
+build_default_cluster
+echo 1 >"${FIX}/hrs.rc"
+rc=$(PD_BUDGET=2 run_phase2d "${TMP}/phase2d.sh" true)
+if [ "${rc}" -ne 0 ] && grep -q 'an unreadable cluster is NOT a pivoted one' "${TMP}/out.log"; then
+  ok "D6 a failed HelmRepository enumeration FATALs — it can never be read as zero offenders"
+else
+  bad "D6 a failed read-back enumeration exited ${rc} without a FATAL"
+fi
+
+# D7: an offender OUTSIDE the pivoted Orgs is not this leg's failure.
+build_default_cluster
+{
+  cat "${FIX}/hrs.last.txt"
+  hr_line unrelated-ns bp-something "${UPSTREAM}"
+} >"${FIX}/hrs.tmp" && mv "${FIX}/hrs.tmp" "${FIX}/hrs.last.txt"
+rc=$(run_phase2d "${TMP}/phase2d.sh" true)
+if [ "${rc}" -eq 0 ]; then
+  ok "D7 CONTROL: an upstream HelmRepository in a namespace this leg did not pivot is not its failure"
+else
+  bad "D7 an unrelated-namespace offender failed this leg: exit ${rc}"
+fi
+
+# D8: the toleration list is honoured, so this gate is never STRICTER than the
+# step-08/step-11 scan it exists to unblock.
+build_default_cluster
+{
+  cat "${FIX}/hrs.last.txt"
+  hr_line walkfour bp-newapi "${UPSTREAM}"
+} >"${FIX}/hrs.tmp" && mv "${FIX}/hrs.tmp" "${FIX}/hrs.last.txt"
+rc=$(run_phase2d "${TMP}/phase2d.sh" true)
+if [ "${rc}" -eq 0 ]; then
+  ok "D8 CONTROL: a HELMREPO_READBACK_EXCLUDE name is tolerated — never stricter than the step it unblocks"
+else
+  bad "D8 a tolerated name failed this leg: exit ${rc} — a cutover step-08 would pass dies here"
+fi
+
+# D9: a SUSPENDED Kustomization can never handle a reconcile request, and can
+# never re-apply either — so it cannot revert the pivot. Requiring it to handle
+# the token would time the assert out on a Sovereign whose only sin is a paused
+# per-Org reconciler. It must be exempted, explicitly.
+build_default_cluster
+cp "${FIX}/ks.txt" "${FIX}/suspended-ks.txt"
+: >"${FIX}/handled-ks.txt"
+rc=$(PD_BUDGET=6 run_phase2d "${TMP}/phase2d.sh" true)
+if [ "${rc}" -eq 0 ] && grep -q 'is SUSPENDED' "${TMP}/out.log"; then
+  ok "D9 CONTROL: a SUSPENDED per-Org Kustomization is exempted and says so — it cannot re-apply, so it cannot revert"
+else
+  bad "D9 a suspended Kustomization exited ${rc} — the assert waited on a reconciler that can never run"
+fi
+
+# D9b: the exemption must be scoped to SUSPENSION alone. The same fixture with
+# the suspension removed and the token still never handled MUST fail — otherwise
+# D9 would be indistinguishable from "durability is never actually required".
+build_default_cluster
+: >"${FIX}/handled-ks.txt"
+rc=$(PD_BUDGET=3 run_phase2d "${TMP}/phase2d.sh" true)
+if [ "${rc}" -ne 0 ] && grep -q 'could not be proven DURABLE' "${TMP}/out.log"; then
+  ok "D9b CONTROL: the identical fixture WITHOUT suspension still fails — the exemption is suspension-only, not a hole in the gate"
+else
+  bad "D9b an un-suspended, never-handled Kustomization exited ${rc} — the D9 exemption leaks"
+fi
+
+# ═══════════════════════════════════════════════════════════════════════════
+# M. VACUITY PROOFS — one mutated behaviour each; the named case must go RED.
+# ═══════════════════════════════════════════════════════════════════════════
+echo "== M. vacuity proofs (single-behaviour mutants must break the named case) =="
+
+mutant() {
+  # $1 = label   $2 = sed expression applied to the ORIGINAL extracted script
+  sed "$2" "${TMP}/phase2d.orig.sh" >"${TMP}/mut.orig.sh"
+  if cmp -s "${TMP}/mut.orig.sh" "${TMP}/phase2d.orig.sh"; then
+    bad "M:$1 mutation matched nothing — the vacuity proof itself is vacuous"
+    return 1
+  fi
+  relocate "${TMP}/mut.orig.sh" "${TMP}/mut.sh"
+  return 0
+}
+
+# M1 — the SHIPPED DEFECT: no per-Org leg at all. Neutering the rewrite loop
+# leaves every per-Org repo upstream, exactly as 0.1.187 does. It must ALSO exit
+# non-zero: the pre-commit post-condition asserts the RESULT of the rewrite, so
+# a rewrite that did nothing can never be pushed as a durable pivot.
+if mutant "no-rewrite" 's,^\( *\)sed -i -E "s\,\^(\[\[:space:\]\]\*url:.*$,\1:,'; then
+  build_default_cluster
+  m1_rc=$(run_phase2d "${TMP}/mut.sh" true)
+  if [ "$(count_in walkfour "${HOSTAPP}" "${UPSTREAM}")" -eq 1 ] \
+     && [ "$(count_in walkfive "${APPSAPP}" "${UPSTREAM}")" -eq 1 ]; then
+    ok "M1 removing the url rewrite leaves both per-Org repos upstream → C1 + C2 go RED (this is the 0.1.187 state)"
+  else
+    bad "M1 C1/C2 still passed with the rewrite removed — they are vacuous"
+  fi
+  if [ "${m1_rc}" -ne 0 ] && grep -q 'still declare' "${TMP}/out.log"; then
+    ok "M1b the same mutant exits ${m1_rc} on the pre-commit post-condition — a rewrite that did nothing cannot be pushed as a pivot"
+  else
+    bad "M1b a no-op rewrite exited ${m1_rc} without the post-condition FATAL"
+  fi
+fi
+
+# M2 — drop the Organization-CR enumeration: the scan collapses to the Flux
+# sources and the CR-only Org is silently missed. This is the mutant a
+# hardcoded list would be indistinguishable from.
+if mutant "no-org-crs" "s,awk 'NF' /tmp/.pd-orgs.txt >> \"\\\${pd_slugs}\",:,"; then
+  build_default_cluster
+  run_phase2d "${TMP}/mut.sh" true >/dev/null
+  if [ "$(count_in newcomer "${HOSTAPP}" "${UPSTREAM}")" -eq 1 ]; then
+    ok "M2 dropping the Organization-CR source misses the CR-only Org → L1 goes RED"
+  else
+    bad "M2 L1 still passed without the Organization-CR source — L1 is vacuous"
+  fi
+fi
+
+# M3 — drop the Flux-source enumeration: the Flux-only Org is missed.
+if mutant "no-flux-srcs" "s,awk -v p=\"\\\${pd_repo}-\",awk -v p=\"__never__\"," ; then
+  build_default_cluster
+  run_phase2d "${TMP}/mut.sh" true >/dev/null
+  if [ "$(count_in fluxonly "${APPSAPP}" "${UPSTREAM}")" -eq 1 ]; then
+    ok "M3 dropping the Flux-source prefix match misses the source-only Org → L2 goes RED"
+  else
+    bad "M3 L2 still passed without the Flux-source enumeration — L2 is vacuous"
+  fi
+fi
+
+# M4 — drop the trust injection.
+if mutant "no-trust" 's,^\( *\)inject_trust_ref "\${pdf}",\1:,'; then
+  build_default_cluster
+  run_phase2d "${TMP}/mut.sh" true >/dev/null
+  if [ "$(count_trust walkfour "${HOSTAPP}")" -eq 0 ]; then
+    ok "M4 removing the injector call drops every certSecretRef → C3 goes RED"
+  else
+    bad "M4 C3 still passed without the injector call — C3 is vacuous"
+  fi
+fi
+
+# M5 — widen the tree scope past the reconciled paths (breaks the C4 control).
+# NB the mutation appends to the LOOP, not to the `:-vcluster` default: the
+# runner passes PERORG_TREES explicitly (that is what the chart renders), so a
+# mutation of the default alone would be inert — and an inert mutant is a
+# vacuity proof that proves nothing.
+if mutant "wide-scope" 's,for pd_tree in \${PERORG_TREES:-vcluster}; do,for pd_tree in ${PERORG_TREES:-vcluster} legacy; do,g'; then
+  build_default_cluster
+  run_phase2d "${TMP}/mut.sh" true >/dev/null
+  if [ "$(count_in walkfour "${OUTSIDE}" "${UPSTREAM}")" -eq 0 ]; then
+    ok "M5 widening the tree scope rewrites a path no Kustomization reconciles → C4 goes RED"
+  else
+    bad "M5 C4 still passed with the scope widened — C4 is vacuous"
+  fi
+fi
+
+# M6 — THE HEADLINE VACUITY PROOF. Delete Stage 2 (return 0 the moment Stage 1
+# reads clean) and re-run the D2 revert fixture. If it now passes, the D2 case
+# is proving that Stage 2 — not luck, not the Stage-1 poll — is what catches the
+# 0.1.186 revert race.
+if mutant "no-stage2" 's,^\( *\)pa_token=.*$,\1return 0,'; then
+  build_default_cluster
+  {
+    hr_line walkfour bp-stalwart-tenant "${LOCAL}"
+    hr_line walkfive bp-stalwart-tenant "${LOCAL}"
+    hr_line newcomer bp-stalwart-tenant "${LOCAL}"
+    hr_line fluxonly bp-stalwart-tenant "${LOCAL}"
+  } >"${FIX}/hrs.1.txt"
+  {
+    hr_line walkfour bp-stalwart-tenant "${UPSTREAM}"
+    hr_line walkfive bp-stalwart-tenant "${UPSTREAM}"
+    hr_line newcomer bp-stalwart-tenant "${LOCAL}"
+    hr_line fluxonly bp-stalwart-tenant "${LOCAL}"
+  } >"${FIX}/hrs.last.txt"
+  rc=$(PD_BUDGET=4 run_phase2d "${TMP}/mut.sh" true)
+  if [ "${rc}" -eq 0 ]; then
+    ok "M6 without Stage 2 the D2 revert fixture PASSES → D2 is proving the anti-race property, not a lucky sample"
+  else
+    bad "M6 the D2 fixture still failed without Stage 2 (exit ${rc}) — D2 does not isolate the race"
+  fi
+fi
+
+# M7 — accept a reconcile REQUEST instead of a HANDLED one. `lastHandledReconcileAt`
+# is the field that means the re-apply ran; comparing against anything else
+# restores the 0.1.186 guarantee (none).
+if mutant "request-not-handled" 's,{.status.lastHandledReconcileAt},{.metadata.name},'; then
+  build_default_cluster
+  rc=$(PD_BUDGET=3 run_phase2d "${TMP}/mut.sh" true)
+  if [ "${rc}" -ne 0 ]; then
+    ok "M7 reading anything but status.lastHandledReconcileAt can no longer prove the re-apply → D1 goes RED"
+  else
+    bad "M7 D1 still passed reading the wrong status field — D1 is vacuous"
+  fi
+fi
+
+# M8 — swallow the repo-probe discrimination (breaks C10).
+if mutant "swallow-probe" 's,^\( *\)echo "\[helmrepository-patches\] FATAL: Phase-2d \${pd_slug}: HTTP,\1continue \# ,'; then
+  build_default_cluster
+  rc=$(run_phase2d "${TMP}/mut.sh" true CURL_FORCE_CODE=500 CURL_FORCE_SLUG=walkfour)
+  if [ "${rc}" -eq 0 ]; then
+    ok "M8 swallowing the repo-probe verdict turns an unreadable repo into a silent skip → C10 goes RED"
+  else
+    bad "M8 C10 still passed with the probe verdict swallowed — C10 is vacuous"
+  fi
+fi
+
+# M10 — swallow the ls-remote verdict. An unreadable remote must not be able to
+# present as the same "no branch yet" skip C11 relies on.
+if mutant "swallow-lsremote" '/ls-remote \${pd_branch} failed against a repo/,+2 s,^\( *\)exit 1,\1:,'; then
+  build_default_cluster
+  rm -rf "${GITEA_ROOT}/emptyorg"; mkdir -p "${GITEA_ROOT}/emptyorg"
+  # A path that is NOT a git repository at all: the API probe is forced to 200,
+  # so ls-remote is the only thing standing between "unreadable" and "empty".
+  printf 'not a repo\n' >"${GITEA_ROOT}/emptyorg/${REPO}.git"
+  printf 'emptyorg\n' >>"${FIX}/orgs.txt"
+  m10_real=$(run_phase2d "${TMP}/phase2d.sh" true CURL_FORCE_CODE=200 CURL_FORCE_SLUG=emptyorg)
+  m10_mut=$(run_phase2d "${TMP}/mut.sh" true CURL_FORCE_CODE=200 CURL_FORCE_SLUG=emptyorg)
+  if [ "${m10_real}" -ne 0 ] && [ "${m10_mut}" -eq 0 ]; then
+    ok "M10 the shipped script FATALs on an unreadable remote (exit ${m10_real}) and the mutant silently skips it (exit ${m10_mut}) → the ls-remote guard is what discriminates"
+  else
+    bad "M10 shipped=${m10_real} mutant=${m10_mut} — the ls-remote discrimination is not isolated"
+  fi
+fi
+
+# M9 — the DIFFERENTIAL control for M1b. M1's mutant (rewrite neutered) exits
+# non-zero; this one neuters the rewrite AND the post-condition. If it now exits
+# 0, the failure M1b observed came from the post-condition and from nothing
+# else — which is what makes M1b a proof rather than a coincidence. Two seds on
+# purpose: isolating a guard requires removing the guard AND the condition that
+# trips it, and saying so beats a single mutation that changes two things.
+sed -e 's,^\( *\)sed -i -E "s\,\^(\[\[:space:\]\]\*url:.*$,\1:,' \
+    -e 's,^\( *\)if \[ "\${pd_left}" -ne 0 \]; then,\1if false; then,' \
+    "${TMP}/phase2d.orig.sh" >"${TMP}/mut9.orig.sh"
+m9_delta=$(diff "${TMP}/phase2d.orig.sh" "${TMP}/mut9.orig.sh" | grep -c '^>' || true)
+relocate "${TMP}/mut9.orig.sh" "${TMP}/mut9.sh"
+if [ "${m9_delta}" -lt 2 ]; then
+  bad "M9 the two-part mutation did not apply (${m9_delta} changed line(s)) — the differential is vacuous"
+else
+  build_default_cluster
+  m9_rc=$(run_phase2d "${TMP}/mut9.sh" true)
+  if [ "${m9_rc}" -eq 0 ] && [ "$(count_in walkfour "${HOSTAPP}" "${UPSTREAM}")" -eq 1 ]; then
+    ok "M9 with the post-condition ALSO removed the same no-op rewrite exits 0 → M1b's failure is the post-condition firing, nothing else"
+  else
+    bad "M9 differential control exited ${m9_rc} — M1b's FATAL cannot be attributed to the post-condition"
+  fi
+fi
+
+# ═══════════════════════════════════════════════════════════════════════════
+echo "== R. render wiring + the grant a stub cannot see =="
+
+python3 - "${TMP}/render.yaml" "${TMP}/args.sh" <<'PY'
+import sys, yaml
+for d in yaml.safe_load_all(open(sys.argv[1])):
+    if not d or d.get("kind") != "ConfigMap":
+        continue
+    if d["metadata"]["name"] != "cutover-step-06-helmrepository-patches":
+        continue
+    spec = yaml.safe_load(d["data"]["podSpec"])
+    c = [x for x in spec["containers"] if x["name"] == "helmrepository-patches"][0]
+    open(sys.argv[2], "w").write(c["args"][0])
+    sys.exit(0)
+sys.exit("step-06 ConfigMap not found")
+PY
+
+p2b_ln=$(awk 'index($0,". /phase2b/phase2b.sh"){print NR; exit}' "${TMP}/args.sh")
+p2d_ln=$(awk 'index($0,". /phase2d/phase2d.sh"){print NR; exit}' "${TMP}/args.sh")
+strip_ln=$(awk 'index($0,"assert_region_a_pivot \"Phase-3 pre-strip read-back\""){print NR; exit}' "${TMP}/args.sh")
+
+if [ -n "${p2b_ln}" ] && [ -n "${p2d_ln}" ] && [ "${p2d_ln}" -gt "${p2b_ln}" ]; then
+  ok "R1 phase2d.sh is sourced (line ${p2d_ln}) AFTER phase2b.sh (line ${p2b_ln})"
+else
+  bad "R1 phase2d source at ${p2d_ln:-<none>} does not follow phase2b at ${p2b_ln:-<none>}"
+fi
+
+# The per-Org HelmRepositories must be pivoted and pullable BEFORE Phase 3
+# removes the mothership auth fallback — the hw139 half-pivot lesson.
+if [ -n "${p2d_ln}" ] && [ -n "${strip_ln}" ] && [ "${p2d_ln}" -lt "${strip_ln}" ]; then
+  ok "R2 phase2d.sh runs (line ${p2d_ln}) BEFORE the Phase-3 pre-strip gate (line ${strip_ln}) — the ghcr fallback is still intact while these HRs pivot"
+else
+  bad "R2 phase2d at ${p2d_ln:-<none>} does not precede the Phase-3 strip at ${strip_ln:-<none>} — the hw139 half-pivot ordering"
+fi
+
+r3=0
+grep -q '^  phase2d.sh: |' "${TMP}/render.yaml" || r3=1
+grep -q 'mountPath: /phase2d' "${TMP}/render.yaml" || r3=1
+grep -q 'key: phase2d.sh' "${TMP}/render.yaml" || r3=1
+if [ "${r3}" -eq 0 ]; then
+  ok "R3 phase2d.sh key + /phase2d mount + volume item are all wired"
+else
+  bad "R3 phase2d.sh is not fully wired — the source would fail at runtime"
+fi
+
+# R4 — the grant. Asserted DIRECTLY against the rendered ClusterRole, with no
+# stub in the path, because a stubbed kubectl can never be RBAC-refused (#6280).
+python3 - "${TMP}/render.yaml" "${TMP}/grants.txt" <<'PY'
+import sys, yaml
+out = []
+for d in yaml.safe_load_all(open(sys.argv[1])):
+    if not d or d.get("kind") not in ("Role", "ClusterRole"):
+        continue
+    for rule in d.get("rules") or []:
+        for g in rule.get("apiGroups") or []:
+            for r in rule.get("resources") or []:
+                for v in rule.get("verbs") or []:
+                    out.append("%s/%s/%s" % (g or "core", r, v))
+open(sys.argv[2], "w").write("\n".join(sorted(set(out))) + "\n")
+PY
+
+r4=0
+for v in get list; do
+  grep -qx "orgs.openova.io/organizations/${v}" "${TMP}/grants.txt" || r4=1
+done
+if [ "${r4}" -eq 0 ]; then
+  ok "R4 the runner ClusterRole grants orgs.openova.io/organizations {get,list} — without it Phase-2d's live Org list is REFUSED"
+else
+  bad "R4 orgs.openova.io/organizations is NOT granted — Phase-2d would fail closed on every Sovereign"
+fi
+
+# R4b — PROVEN ABLE TO FAIL. Delete the rule from the rendered ClusterRole and
+# require R4's check to go RED. A grant check only ever observed passing is not
+# yet known to be a check.
+python3 - "${TMP}/render.yaml" "${TMP}/grants-mut.txt" <<'PY'
+import sys, yaml
+out = []
+for d in yaml.safe_load_all(open(sys.argv[1])):
+    if not d or d.get("kind") not in ("Role", "ClusterRole"):
+        continue
+    for rule in d.get("rules") or []:
+        groups = rule.get("apiGroups") or []
+        res = rule.get("resources") or []
+        if "orgs.openova.io" in groups and "organizations" in res:
+            continue           # the mutation: drop the rule entirely
+        for g in groups:
+            for r in res:
+                for v in rule.get("verbs") or []:
+                    out.append("%s/%s/%s" % (g or "core", r, v))
+open(sys.argv[2], "w").write("\n".join(sorted(set(out))) + "\n")
+PY
+if grep -qx "orgs.openova.io/organizations/list" "${TMP}/grants-mut.txt"; then
+  bad "R4b removing the rule did not remove the grant — R4 is vacuous"
+else
+  ok "R4b mutation control: deleting the organizations rule makes R4's check report it missing"
+fi
+
+# R5 — phase2d must CALL the shared injector, never carry a second copy.
+if grep -q 'inject_trust_ref' "${TMP}/phase2d.orig.sh" \
+   && ! grep -q 'awk -v ref=' "${TMP}/phase2d.orig.sh"; then
+  ok "R5 phase2d calls the shared injector instead of duplicating the awk (#5646)"
+else
+  bad "R5 phase2d carries its own copy of the trust injector — the two will drift"
+fi
+
+# R6 — the read-back must scan cluster-wide. Scoping it to HELMREPO_NAMESPACE is
+# precisely why assert_region_a_pivot could not see these objects: the per-Org
+# Kustomization's targetNamespace places them in the Org's own namespace.
+if grep -q 'helmrepositories.source.toolkit.fluxcd.io -A' "${TMP}/phase2d.orig.sh"; then
+  ok "R6 the read-back enumerates HelmRepositories cluster-wide (-A) — per-Org HRs land in the Org namespace, not flux-system"
+else
+  bad "R6 the read-back is namespace-scoped — it would be blind to exactly the objects this leg pivots"
+fi
+
+echo
+echo "RESULT: ${pass} passed, ${fail} failed"
+[ "${fail}" -eq 0 ]

--- a/platform/self-sovereign-cutover/chart/values.yaml
+++ b/platform/self-sovereign-cutover/chart/values.yaml
@@ -1115,6 +1115,79 @@ helmRepositories:
     gitRepositoryName: "openova-org-tenants"
     gitRepositoryNamespace: "flux-system"
 
+  # ── #6309: per-Org `<slug>/catalyst-tenant` DURABLE-SOURCE pivot (Phase-2d) ─
+  #
+  # THE THIRD REPO CLASS. Three kinds of GitOps repo carry HelmRepository URLs
+  # on a Sovereign; before 0.1.188 the cutover pivoted two of them:
+  #
+  #   clusters/_template/bootstrap-kit  committed in-repo    step-05 / step-06
+  #   clusters/<fqdn>/org-tenants       catalyst-api         Phase-2b (#6293)
+  #   <slug>/catalyst-tenant            org-services/        NOTHING
+  #                                       provisioning
+  #
+  # The third is one repo PER ORGANIZATION, written by GeneratePerOrgAppsTree
+  # into `vcluster/apps/` + `vcluster/host-apps/`, and reconciled onto the host
+  # `<slug>` namespace by the org-controller's `catalyst-tenant-<slug>-apps` /
+  # `-host-apps` Kustomizations. Because the per-Org Kustomization carries
+  # `targetNamespace: <slug>`, those HelmRepositories land OUTSIDE
+  # helmRepositories.namespace — which is why assert_region_a_pivot (scoped to
+  # flux-system) structurally cannot see them and step-11's cluster-wide `-A`
+  # scan is what caught them on hw296:
+  #
+  #   walkfour/bp-stalwart-tenant = oci://ghcr.io/openova-io
+  #   walkfive/bp-stalwart-tenant = oci://ghcr.io/openova-io
+  #
+  # THE COUNT SCALES WITH THE NUMBER OF ORGANIZATIONS. That is the whole reason
+  # this must be a cutover step and not a manual repair: the more the platform
+  # is used, the more offenders a cutover inherits. The scan is therefore driven
+  # from the LIVE Organization list — Organization CRs UNION the live
+  # `catalyst-tenant-*` Flux GitRepositories — and never from a curated set. An
+  # Org created five minutes before the cutover is scanned like any other.
+  #
+  # The generator itself is already correct: #5629/#5527 resolveCatalogOCIBase
+  # reads the step-07 CATALYST_LOCAL_REGISTRY_URL stamp as its FIRST branch, so
+  # every per-Org tree written after the cutover is born pivoted. This leg is for
+  # the trees written before it, whose only other trigger is a day-2 app install.
+  perOrgTenantSource:
+    enabled: true
+    # MUST track the org-controller's perOrgTenantRepoName constant
+    # (core/controllers/organization/internal/controller/per_org_flux.go) and
+    # org-services/provisioning's TENANT_GITOPS_REPO. One naming decision seen
+    # from three sides; a mismatch is a silent no-op.
+    repoName: "catalyst-tenant"
+    branch: "main"
+    # Where the per-Org GitRepository + Kustomizations live (per_org_flux.go
+    # creates them in flux-system, not in the Org namespace).
+    fluxNamespace: "flux-system"
+    # The trees the per-Org Kustomizations actually reconcile
+    # (gitops/perorg_apps_tree.go PerOrgAppsDir + PerOrgHostAppsDir). Both sit
+    # under `vcluster/`, so one entry covers them; rewriting anything outside a
+    # reconciled path would be divergence with no reconciler behind it.
+    treePaths:
+      - "vcluster"
+    # Suffixes of the HR-owning per-Org Kustomizations, appended to
+    # `<repoName>-<slug>-`. These are the objects whose re-apply the Stage-2
+    # read-back waits to OBSERVE (status.lastHandledReconcileAt == the poked
+    # token) before certifying the pivot durable.
+    kustomizationSuffixes:
+      - "apps"
+      - "host-apps"
+    # Presence is probed before listing, and ABSENCE must be established from a
+    # NotFound — `kubectl get crd` exits non-zero for both "not installed" and
+    # "forbidden", and treating a refusal as an absence would silently drop
+    # every Organization from the scan.
+    organizationCRD: "organizations.orgs.openova.io"
+    # Read-back budget, per stage. Stage 1 waits for the durable rewrite to
+    # reach the live objects; Stage 2 waits for the owning Kustomization to
+    # HANDLE a token minted after Stage 1 went clean. Both are inside
+    # stepTimeouts.helmRepositoryPatchesSeconds (2400s) alongside the region-A
+    # read-back and the Phase-3a strip-readiness worst case.
+    readbackBudgetSeconds: 300
+    # Consecutive clean samples required in Stage 2, the last of which must land
+    # at or after the observed re-apply.
+    readbackSettleSamples: 2
+    readbackIntervalSeconds: 10
+
   # ── #5650: vcluster loft chart-source pivot (step-06 Phase-2c) ──────────
   #
   # The ONE Flux source the URL-pivot above cannot reach. The

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -4640,7 +4640,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "0.1.187",
+      "version": "0.1.188",
       "section": "pts-2-3-per-sovereign-supporting-services",
       "depends": [
         "bp-gitea",

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -4775,7 +4775,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "0.1.187",
+    "version": "0.1.188",
     "section": "pts-2-3-per-sovereign-supporting-services",
     "depends": [
       "bp-gitea",

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3968,7 +3968,7 @@ name: bp-catalyst-platform
 #   file's 1.4.1325 entry records as permanently burned. The republish
 #   therefore lands on 1.4.1468 — ahead of main's 1.4.1467, absent from GHCR,
 #   and claimed by no open PR.)
-version: 1.4.1492
+version: 1.4.1496
 # 1.4.1481 — #6293: catalog-seed advances bp-self-sovereign-cutover
 #   0.1.186 -> 0.1.187, the release that stops step-06 from patching five
 #   HelmRepositories it does not own and then grading itself on whether they
@@ -4155,7 +4155,7 @@ version: 1.4.1492
 # scripts/check-chart-version-forward.sh (#5743) fails unless the two match —
 # main was carrying a pre-existing 1.4.1330/1.4.1329 split, so this bump heals
 # it in the same commit, exactly as the documented self-heal contract does.
-appVersion: 1.4.1492
+appVersion: 1.4.1496
 # 1.4.239 — Wave 3 / Issue #2140 (2026-05-23): Huawei provider
 # implementation lands behind the Wave 2 CloudProvider interface.
 # Adds the OpenTofu module at infra/providers/huawei/ (VPC + Subnet +

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5115,7 +5115,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.1.187"
+  version: "0.1.188"
   visibility: unlisted
   card:
     title: "Self-Sovereignty Cutover"
@@ -5132,7 +5132,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-self-sovereign-cutover
-    version: "0.1.187"
+    version: "0.1.188"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
## The gap

Three GitOps repo classes carry HelmRepository URLs on a Sovereign. The cutover pivoted two. Confirmed two ways before a line was written:

```
grep -rn "catalyst-tenant" platform/self-sovereign-cutover/        -> 0 hits (entire chart)
git show 5447fa8e7 (#6303, chart 0.1.187) | grep catalyst-tenant   -> 0 hits
```

| class | writer | pivoted by |
|---|---|---|
| `clusters/_template/bootstrap-kit` slots | committed in this repo | step-05 / step-06 |
| `clusters/<fqdn>/org-tenants` | catalyst-api `writeParentTenantsIndex` | Phase 2b (#6293) |
| **`<slug>/catalyst-tenant@main`** | **org-services/provisioning** | **NOTHING** |

Live on hw296 **after** 0.1.187 pivoted the `org-tenants` class at source, step-11's `#3526` pre-hold assert still failed on exactly two offenders — down from six, never to zero:

```
walkfour/bp-stalwart-tenant = oci://ghcr.io/openova-io
walkfive/bp-stalwart-tenant = oci://ghcr.io/openova-io
```

whose durable source is the third class:

```
walkfour/catalyst-tenant@main : vcluster/host-apps/app-stalwart-mail.yaml:20
walkfive/catalyst-tenant@main : vcluster/apps/app-stalwart-mail.yaml:20
```

Region B was clean, 65/65 on the local registry, so this is not a per-region split — it is a repo class nothing walked. The plan of record was "deliver 0.1.187 and G11 closes"; that was false.

## Why it must be a cutover step

**The offender count scales with the number of Organizations.** One `catalyst-tenant` repo exists per Org, written by `GeneratePerOrgAppsTree` into `vcluster/apps/` and `vcluster/host-apps/`, reconciled onto the host `<slug>` namespace by the org-controller's `catalyst-tenant-<slug>-apps` / `-host-apps` Kustomizations. The more the platform is used, the more offenders a cutover inherits.

So **the scan is driven from the LIVE Organization list** — Organization CRs **UNION** the live `catalyst-tenant-*` Flux GitRepositories — never a curated set. A hardcoded list is wrong the moment the next Org is created; that is the same drift #4573 F4 already fixed for the Phase-1 name list.

## Why `assert_region_a_pivot` could not see them

The generated doc says `namespace: flux-system`, but the per-Org Kustomization's `targetNamespace: <slug>` wins — so these objects live in the Org's **own** namespace. `assert_region_a_pivot` is scoped to `HELMREPO_NAMESPACE` and is structurally blind to them; step-11's cluster-wide `-A` scan is what found them. Phase-2d's read-back enumerates `-A` and narrows to the Orgs it pivoted (asserted by case R6).

## The read-back does not repeat 0.1.186

0.1.186's Phase-1.5 read-back logged `ok=6` and `read-back OK`, and all six HelmRepositories reverted within 60s under a 1m/`prune=true` Kustomization. It could pass because it **sampled once, right after the write, with no requirement that the actor which would revert the write had run at all.**

Phase-2d is two-stage:

- **Stage 1 CONVERGE** — poll to zero offenders across the pivoted Orgs, re-poking each cycle. A durable rewrite has to be fetched and re-applied before the live objects settle, so this stage may start dirty. Never reaching zero is FATAL and names its offenders.
- **Stage 2 SURVIVE** — mint a token **after** Stage 1 is clean, poke every per-Org HR-owning Kustomization with it, and refuse to certify an Org until one of **its** Kustomizations reports `status.lastHandledReconcileAt` **equal to that token**. That field means the re-apply *happened*, not that a reconcile was requested. Offenders must be zero on **every** sample in that window.

The gate therefore cannot return green until the exact reconciler that reverted the 0.1.186 pivot has run against the rewritten source and left it standing.

Two exemptions, both **explicit** and both logged (the #5596 discipline): an Org with no per-Org Kustomization, and a **suspended** Kustomization — neither can re-apply, so neither can revert, and requiring either to handle the token would time the assert out on a healthy Sovereign. Control **D9b** runs the identical fixture *without* suspension and requires it to **fail**, so the exemption cannot widen into "durability is never actually required".

## Fail-closed enumeration

- A **failed** GitRepository listing is not an empty Org list → FATAL.
- The Organization CRD **installed but unlistable** — the shape a missing RBAC grant produces — is FATAL, never "this Sovereign has no Orgs".
- CRD **absence** must be established from a `NotFound`, because `kubectl get crd` exits non-zero for both "not installed" and "forbidden".
- Repo existence is decided by an **HTTP status code** (404 absent, any other non-200 FATAL), because `git ls-remote` fails identically for a missing repo and a bad credential.
- A repo that **exists but carries no branch yet** is a real, benign state — the org-controller creates the per-Org repo before anything seeds a tree into it. `ls-remote` succeeding with no matching ref is an absent branch and skips; `ls-remote` failing against a repo the API just reported present is fatal. Without that split, one freshly-created Organization would stop the whole cutover (case C11, mutant M10).

## RBAC

The runner ClusterRole gains `orgs.openova.io/organizations {get,list,watch}` — read-only, cluster-scoped. Without it Phase-2d fails closed by design rather than silently scanning nothing.

## Guards — `chart/tests/step06-perorg-tenant-source.sh`, 51 assertions, exit 0

Runs the **rendered** `phase2d.sh` bytes against **real local git repositories** and reads every verdict out of the **bare origin**, never a working tree the script left behind.

**Section L is the property that matters beyond hw296.** The fixture carries an Org present only as an Organization CR with no Flux source (`newcomer`), one present only as a Flux source with no CR (`fluxonly`), and one introduced by the fixture and named nowhere in the chart (`lateorg`). All three must be scanned — so a suite that fed the code the list the code already knows would fail.

Eleven single-behaviour mutants prove each case individually. **M6 is the headline:** deleting Stage 2 makes the D2 revert fixture **PASS**, which is what turns D2 into a proof of the anti-race property rather than a lucky sample.

The new grant is asserted **directly against the rendered ClusterRole with no stub in the path** — a stubbed kubectl can never be RBAC-refused, the #6280 blind spot — and R4b deletes the rule to prove that assertion can go red.

Deliberately avoided, both named in the issue: no `kubectl` stub is used to certify a grant, and there is no `grep -q` on a pipe anywhere in the suite (producers write to files, greps read files).

<details>
<summary>Full local run — 51/51, every mutant firing</summary>

```
  ok   — extracted phase2d.sh from the render
  ok   — extraction carries the read-back assert (not just the rewrite half)
  ok   — extracted the shared inject_trust_ref function from the render
== C. the rewrite, against real git repositories ==
  ok   — C0 happy path exits 0
  ok   — C1 walkfour/catalyst-tenant@main:vcluster/host-apps/app-stalwart-mail.yaml pivoted to local Harbor IN THE BARE ORIGIN (the hw296 offender)
  ok   — C2 walkfive/catalyst-tenant@main:vcluster/apps/app-stalwart-mail.yaml pivoted — BOTH reconciled trees are covered, not just one
  ok   — C3 certSecretRef=cutover-harbor-ca injected beside every pivoted url
  ok   — C4 CONTROL: legacy/app-legacy.yaml (outside the reconciled trees) is untouched — the vcluster/ scope holds
  ok   — C5 CONTROL: the sourceRef-only HelmRelease doc is byte-identical (no url: line, nothing to rewrite)
  ok   — C6 an Org with no catalyst-tenant repo (HTTP 404) is a clean skip, not a failure
  ok   — C7 the clone URL carries the injected Gitea credential (the push can authenticate)
  ok   — C8 re-run is idempotent (exit 0, one local url, ONE certSecretRef — no duplicates)
  ok   — C9 CONTROL: enabled=false is a genuine no-op
  ok   — C10 a non-200/404 repo probe FATALs (an auth fault can never masquerade as an absent repo)
  ok   — C11 a per-Org repo that exists but has no branch yet is a clean skip, and the other Orgs still pivot
== L. the scan is driven by the LIVE Organization list ==
  ok   — L1 'newcomer' — present ONLY as an Organization CR, with NO Flux source the code could have enumerated — was still scanned and pivoted
  ok   — L2 'fluxonly' — present ONLY as a live catalyst-tenant-* Flux source, absent from the Organization CR list — was still scanned and pivoted
  ok   — L3 an Organization introduced only by the fixture — named nowhere in the chart — is scanned like any other
  ok   — L4 CONTROL: a Sovereign with zero Organizations is a clean, explicit no-op
  ok   — L5 a FAILED GitRepository enumeration FATALs — an unreadable API is not an empty Org list
  ok   — L6 CRD installed + list refused FATALs — an RBAC refusal can never read as 'this Sovereign has no Orgs'
  ok   — L7 CONTROL: a genuinely absent Organization CRD falls back to the Flux sources alone (walkfour pivoted; the CR-only newcomer legitimately untouched)
  ok   — L8 a CRD probe that fails for any reason other than NotFound FATALs — absence requires positive evidence
== D. the read-back must survive the owning reconciler ==
  ok   — D1 the pivot is certified only after Stage 1 goes clean AND an owning Kustomization HANDLES the Stage-2 token
  ok   — D2 a pivot that reads CLEAN then reverts under its owning Kustomization is caught (the 0.1.186 shape, one repo class down)
  ok   — D3 clean-but-never-re-applied is REFUSED — a read-back that can pass before the owning reconciler ran is not a read-back
  ok   — D4 CONTROL: an Org with nothing that re-applies its HelmRepositories is exempted, and says so
  ok   — D5 a pivot that never reaches the live objects FATALs in Stage 1, naming its offenders
  ok   — D6 a failed HelmRepository enumeration FATALs — it can never be read as zero offenders
  ok   — D7 CONTROL: an upstream HelmRepository in a namespace this leg did not pivot is not its failure
  ok   — D8 CONTROL: a HELMREPO_READBACK_EXCLUDE name is tolerated — never stricter than the step it unblocks
  ok   — D9 CONTROL: a SUSPENDED per-Org Kustomization is exempted and says so — it cannot re-apply, so it cannot revert
  ok   — D9b CONTROL: the identical fixture WITHOUT suspension still fails — the exemption is suspension-only, not a hole in the gate
== M. vacuity proofs (single-behaviour mutants must break the named case) ==
  ok   — M1 removing the url rewrite leaves both per-Org repos upstream → C1 + C2 go RED (this is the 0.1.187 state)
  ok   — M1b the same mutant exits 1 on the pre-commit post-condition — a rewrite that did nothing cannot be pushed as a pivot
  ok   — M2 dropping the Organization-CR source misses the CR-only Org → L1 goes RED
  ok   — M3 dropping the Flux-source prefix match misses the source-only Org → L2 goes RED
  ok   — M4 removing the injector call drops every certSecretRef → C3 goes RED
  ok   — M5 widening the tree scope rewrites a path no Kustomization reconciles → C4 goes RED
  ok   — M6 without Stage 2 the D2 revert fixture PASSES → D2 is proving the anti-race property, not a lucky sample
  ok   — M7 reading anything but status.lastHandledReconcileAt can no longer prove the re-apply → D1 goes RED
  ok   — M8 swallowing the repo-probe verdict turns an unreadable repo into a silent skip → C10 goes RED
  ok   — M10 the shipped script FATALs on an unreadable remote (exit 1) and the mutant silently skips it (exit 0) → the ls-remote guard is what discriminates
  ok   — M9 with the post-condition ALSO removed the same no-op rewrite exits 0 → M1b's failure is the post-condition firing, nothing else
== R. render wiring + the grant a stub cannot see ==
  ok   — R1 phase2d.sh is sourced (line 449) AFTER phase2b.sh (line 448)
  ok   — R2 phase2d.sh runs (line 449) BEFORE the Phase-3 pre-strip gate (line 708) — the ghcr fallback is still intact while these HRs pivot
  ok   — R3 phase2d.sh key + /phase2d mount + volume item are all wired
  ok   — R4 the runner ClusterRole grants orgs.openova.io/organizations {get,list} — without it Phase-2d's live Org list is REFUSED
  ok   — R4b mutation control: deleting the organizations rule makes R4's check report it missing
  ok   — R5 phase2d calls the shared injector instead of duplicating the awk (#5646)
  ok   — R6 the read-back enumerates HelmRepositories cluster-wide (-A) — per-Org HRs land in the Org namespace, not flux-system
RESULT: 51 passed, 0 failed
```
</details>

Every other step-06 / cutover suite re-run green on this branch, with the true exit code checked rather than a piped tail: `step06-org-tenants-source` 24/24, `step06-pivot-readback` 18/18, `step06-secondary-durable` 11/11, `rbac-coverage` PASS, `arg-strlen-guard` PASS (13 step containers, every inline arg under 110000 B), `cutover-contract` all gates green through Case 95, plus `catalog-chart-set`, `daytwo-*`, `flux-source-host-lint`, `image-registry-coverage`, `loft-pivot-regions`, `offline-mirror-host-projects`, `provider-package-host-lint`, `single-platform-copy`, `step05-secondary-chain`.

Repo guards: `check-cutover-version-floor` PASS (7/7 pins at 0.1.188), `check-catalog-seed-lockstep` PASS, `check-bootstrap-kit-pin-sync` PASS, `check-no-conflict-markers` PASS, `check-helm-release-payload-size` PASS (77.85% of the Secret ceiling, 127415 B under budget — unchanged by this PR). `check-chart-annotations` certifies `platform/self-sovereign-cutover/chart` on both guards; its two render failures are `platform/syft-grype` and `platform/velero-hcs`, pre-existing on main and untouched here.

## The generator was already right — only the trigger was missing

`resolveCatalogOCIBase` (#5629 / #5527) reads the step-07 `CATALYST_LOCAL_REGISTRY_URL` stamp as its **first** branch, so every per-Org tree written after the cutover is born pivoted. This leg is for the trees written **before** it, whose only other trigger is a day-2 app install. The internal `appChangeData.Apps` list is deliberately **not** synthesized — fabricating it risks dropping a live app from those Orgs' trees; the repo contents are rewritten directly instead.

## Versions

Chart `0.1.187 -> 0.1.188` across all 7 pins / 5 lockstep sites (Chart.yaml, blueprint.yaml, catalog-seed `spec.version` + `source.version`, the API `blueprints.json`, the generated UI catalog, bootstrap-kit slot 06a) plus the catalyst umbrella `1.4.1492 -> 1.4.1496` and its slot-13 pin, all in one commit. Rebased onto current main.

**The umbrella number is derived, never typed.** `scripts/bump-chart-version.sh` reads the baseline from a freshly fetched `origin/main` and takes the max over every open PR head carrying that `Chart.yaml`. It has been re-derived three times here, because the race is structural rather than anyone's error and runs in **both** directions: the deploy-bot auto-bumps the umbrella on merges to main independently of any PR, so a number goes stale **downward** while its own CI runs; and two PRs re-deriving in the same window compute the **same** next-free number deterministically, since each takes ceiling+1 over an identical view — #6320 and this PR both landed on `1.4.1494`, then both on `1.4.1495`. Neither failure is visible to a version that is merely "above main".

**Two guards, two different questions, both gated on exit codes in one `&&` chain — never piped to `tail`:**

| guard | question |
|---|---|
| `check-chart-version-forward.sh` (vs freshly fetched `origin/main`) | is it strictly **above main**? |
| `check-chart-version-not-claimed-by-open-pr.py --pr 6323` | does a **sibling PR** already claim it? |

The claims checker compares only against open PR **heads** — it never looks at main — so it returns exit 0 on a version that has already regressed below main. Gating on it alone, as its name invites, lets a regression through behind a green guard. Both are green against the **pushed head** (not a local tree): umbrella `1.4.1492 -> 1.4.1496` forward, cutover `0.1.187 -> 0.1.188` forward, and no claim collision across 40 open PRs.

The cutover chart's `0.1.188` does not move — it is the correct successor to the published `0.1.187` and no open PR competes with it. `catalog.generated.ts` and `blueprints.json` were regenerated with `build-catalog.mjs`, never hand-edited. `0.1.188` was re-verified free against ghcr and against every open PR head immediately before push.

`ghcr-pin-existence` is expected to fail naming **only** `bp-self-sovereign-cutover:0.1.188` and `bp-catalyst-platform:1.4.1496` — `blueprint-release.yaml` is `on: push -> branches:[main]`, so a new tag structurally cannot exist pre-merge. Any other name in that check's tally is a real failure.

## Recorded, not fixed

Step 11 has ~8 further gates that have **never executed** on hw296 — catalyst-api `CATALYST_GITOPS_REPO_URL`, offline-mirror completeness, workload image-host lint, per-region Flux source-host lint, source convergence on `gitrepositories`/`ocirepositories`, Crossplane provider-package host lint, and org-tenants Kustomization Ready. Clearing these offenders unblocks step-11's `#3526` pre-hold assert; it does **not** imply the step passes.

Not verified on a live Sovereign: hw296 is severed from delivery post-cutover-step-05 (#6307) — step-01 `gitea-mirror` is suppressed by `snapshotRerunSuppressedBy` (#5437) once the chain passes step-05, so re-firing does not restore delivery and merged code cannot reach that env. This lands for the next fresh prov. G11 is **not** stamped here; a row stamped green from merged-but-undelivered code is a false verdict.

Refs #6309 #3379 #6303 #5629
