### PR TITLE
fix(ci): close the fail-open test-gate class outside the cutover harness (#6235)

### DIFF
--- a/.github/workflows/build-openova-mcp.yaml
+++ b/.github/workflows/build-openova-mcp.yaml
@@ -49,7 +49,11 @@ jobs:
         run: |
           set -euo pipefail
           cd products/openova-mcp
-          go test ./...
+          # -count=1 — Refs #6235. This repo has no root go.mod, and Go's test
+          # cache keys on a package's OWN inputs only, so any test that reads a
+          # file outside its module can report a stale `ok (cached)` forever.
+          # Enforced repo-wide by scripts/check-go-test-count1.sh.
+          go test -count=1 ./...
 
       - name: Set short SHA + chart appVersion
         id: vars

--- a/.github/workflows/chart-tests-pr.yaml
+++ b/.github/workflows/chart-tests-pr.yaml
@@ -44,14 +44,33 @@ name: Chart tests (PR)
 # charts whose tests changed, under the SAME toolchain versions the release
 # workflow installs.
 #
-# PATH FILTER — `platform/*/chart/tests/**` + `products/*/chart/tests/**` and
-# nothing else. Not `platform/*/chart/**`: 191 test scripts across 63 charts
-# already run on the release path for a chart edit, and re-running every touched
-# chart's suite at PR time would multiply an Actions queue that is already
-# saturated. A change that doubles CI load becomes its own defect. This fires
-# only when a test script itself changes — which is precisely the edit that had
-# no execution at all. The single `*` mirrors blueprint-release.yaml's own
-# `platform/*/chart/**` shape (one Blueprint folder per directory).
+# PATH FILTER — `platform/*/chart/**` + `products/*/chart/**`, byte-for-byte the
+# chart half of blueprint-release.yaml's own filter.
+#
+# 🛑 THIS WAS NARROWER AND THAT WAS ITS OWN DEFECT — Refs #6235.
+# Until 2026-08-14 the filter read `platform/*/chart/tests/**` +
+# `products/*/chart/tests/**`, on the reasoning that only a tests-only edit had
+# gone unexecuted and that widening would multiply a saturated Actions queue.
+# The load argument was real; the conclusion was not. A PR that changed chart
+# TEMPLATES without touching a test file ran NO chart suite at PR time, so the
+# gate could not fire on the change it exists to gate — the same class as the
+# fail-open predicate in #6235 and as the `check-*.sh` nothing invokes. Measured
+# on the last 600 non-deploy commits of main: 8 commits changed a chart that HAS
+# a tests/ suite without touching a single test file, and not one of them ran
+# that suite before merging.
+#
+# The load concern is answered where it actually bites rather than by refusing
+# to fire: `scripts/chart-tests-pr-matrix.sh` drops a chart whose ONLY changed
+# file is `chart/Chart.yaml` with a version-only diff. That is exactly and only
+# what `scripts/bump-chart-version.sh` writes, and it is what the deploy-bots put
+# on essentially every open PR (41 carried the umbrella bump when this was
+# written) — so the umbrella suite no longer fires on a bump that cannot change a
+# render, while every template/values edit now does fire. The predicate lives in
+# that script rather than in a `run:` block so it can be mutation-tested; its
+# `--self-test` carries 8 git-fixture cases and every one of them is proven able
+# to go red.
+#
+# The single `*` mirrors blueprint-release.yaml (one Blueprint folder per dir).
 #
 # This workflow's OWN path is deliberately NOT in the filter. Adding it would
 # fire the workflow on every edit to this file while changing nothing under
@@ -73,8 +92,8 @@ name: Chart tests (PR)
 on:
   pull_request:
     paths:
-      - 'platform/*/chart/tests/**'
-      - 'products/*/chart/tests/**'
+      - 'platform/*/chart/**'
+      - 'products/*/chart/**'
   workflow_dispatch:
     inputs:
       blueprint:
@@ -94,7 +113,7 @@ concurrency:
 
 jobs:
   detect:
-    name: which charts changed a test script
+    name: which charts changed
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
@@ -105,7 +124,13 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Detect charts with changed test scripts
+      # The matrix predicate self-tests BEFORE it is trusted. It is the thing
+      # that decides whether this gate runs at all, so a silent regression in it
+      # is indistinguishable from "no chart needed testing" — a green.
+      - name: Matrix predicate self-test (git fixtures, no cluster)
+        run: bash scripts/chart-tests-pr-matrix.sh --self-test
+
+      - name: Detect charts to test
         id: changed
         env:
           BASE_REF: ${{ github.base_ref }}
@@ -124,19 +149,11 @@ jobs:
           # diff is exactly the PR's own changes.
           git fetch --no-tags --quiet origin "${BASE_REF}"
           echo "Diffing origin/${BASE_REF}...HEAD"
-          changed=$(git diff --name-only "origin/${BASE_REF}...HEAD" \
-                    | grep -E '^(platform|products)/[^/]+/chart/tests/' \
-                    | awk -F/ '{print $1"/"$2}' | sort -u || true)
+          matrix="$(bash scripts/chart-tests-pr-matrix.sh --base "origin/${BASE_REF}" --head HEAD)"
 
-          echo "Charts with changed test scripts:"
-          echo "${changed:-(none)}"
-
-          if [ -z "$changed" ]; then
-            echo "matrix={\"include\":[]}" >> "$GITHUB_OUTPUT"
-          else
-            include=$(printf '%s\n' "$changed" | jq -R -s -c 'split("\n") | map(select(length > 0)) | map({path: .})')
-            echo "matrix={\"include\":$include}" >> "$GITHUB_OUTPUT"
-          fi
+          echo "Charts selected:"
+          printf '%s\n' "$matrix" | jq -r '.include[].path' | sed 's/^/  /'
+          echo "matrix=${matrix}" >> "$GITHUB_OUTPUT"
 
   chart-tests:
     name: "chart/tests/*.sh — ${{ matrix.path }}"

--- a/.github/workflows/check-guard-selftests.yaml
+++ b/.github/workflows/check-guard-selftests.yaml
@@ -29,11 +29,13 @@ on:
     paths:
       - 'scripts/check-*.sh'
       - 'scripts/uat-pivot.py'
+      - 'scripts/chart-tests-pr-matrix.sh'
       - '.github/workflows/**'
   pull_request:
     paths:
       - 'scripts/check-*.sh'
       - 'scripts/uat-pivot.py'
+      - 'scripts/chart-tests-pr-matrix.sh'
       - '.github/workflows/**'
   workflow_dispatch:
 
@@ -143,3 +145,27 @@ jobs:
       # the same reason (#6272).
       - name: convergence pivot — per-cycle keying + reconciliation (#6114)
         run: python3 scripts/uat-pivot.py --self-test
+
+      # #6235 — `go test` caches on a package's OWN inputs, so a test that reads
+      # a chart template / blueprint.yaml / .tf module from outside its module
+      # can print `ok (cached)` over a file that was just mutated. Measured:
+      # mutating platform/openclaw/chart/templates/oidc-client-secret.yaml left
+      # core/services/provisioning `ok (cached)` and only went FAIL under
+      # -count=1. This guard is a `check-*.sh` so the meta-gate DOES see it —
+      # but the meta-gate only asserts it is invoked somewhere, which is this
+      # line.
+      - name: every workflow's go test passes -count=1 (#6235)
+        run: bash scripts/check-go-test-count1.sh
+
+      - name: go-test -count=1 guard self-test (#6235)
+        run: bash scripts/check-go-test-count1.sh --self-test
+
+      # #6235 — the chart-tests-pr matrix predicate. Wired HERE BY HAND for the
+      # same reason as the two python entries above: check-guards-are-wired.sh
+      # globs `scripts/check-*.sh`, and this is not a `check-` script, so the
+      # meta-gate cannot see it. It decides whether the PR-time chart gate runs
+      # at all, so a silent regression in it looks exactly like "no chart needed
+      # testing". chart-tests-pr.yaml runs this same self-test, but only when a
+      # chart changed — this entry runs it whenever the predicate itself does.
+      - name: chart-tests-pr matrix predicate (#6235)
+        run: bash scripts/chart-tests-pr-matrix.sh --self-test

--- a/.github/workflows/openclaw-controller.yaml
+++ b/.github/workflows/openclaw-controller.yaml
@@ -72,7 +72,10 @@ jobs:
         run: |
           set -euo pipefail
           go vet ./...
-          go test ./...
+          # -count=1 — Refs #6235. Go's test cache cannot see a file read from
+          # outside the module, so a cached `ok` can stand over a mutated chart
+          # template indefinitely. Enforced by scripts/check-go-test-count1.sh.
+          go test -count=1 ./...
 
       - name: Login to GHCR
         uses: docker/login-action@v3

--- a/.github/workflows/pool-domain-manager-build.yaml
+++ b/.github/workflows/pool-domain-manager-build.yaml
@@ -53,7 +53,10 @@ jobs:
         # (store_test.go round-trip against CNPG) lives in
         # test-bootstrap-api.yaml.
         run: |
-          go test ./internal/pdns/... \
+          # -count=1 — Refs #6235. Go's test cache keys on the package's own
+          # inputs; a test reading outside its module can report a stale
+          # `ok (cached)` forever. Enforced by scripts/check-go-test-count1.sh.
+          go test -count=1 ./internal/pdns/... \
                   ./internal/allocator/... \
                   ./internal/dynadot/... \
                   ./internal/reserved/... \

--- a/platform/crossplane-claims/chart/tests/composition-validate.sh
+++ b/platform/crossplane-claims/chart/tests/composition-validate.sh
@@ -135,7 +135,14 @@ fi
 # Strip comment lines (the plain-CRD template's own history note names the
 # retired type in prose) before asserting the composite type is gone —
 # match only real manifest declarations of the XUserAccess composite.
-if grep -vE '^\s*#' "$TMP/render.yaml" | grep -Eq 'kind: XUserAccess|xuseraccesses'; then
+# `grep -Ec … >/dev/null` — NOT `grep -Eq`. Refs #6235: `-q` exits on the FIRST
+# match, so the producer's next write hits a pipe with no reader (SIGPIPE 141
+# locally; EPIPE -> rc 1 on the GitHub runner, where SIGPIPE is SIG_IGN). Under
+# `set -o pipefail` that poisons the pipeline status, and a PRESENT XUserAccess
+# reads as absent — the `if` goes false and this fail-open assertion reports a
+# pass. `-c` counts, so it reads to EOF and the producer always finishes. This
+# producer emits 492,746 bytes; the earliest offending line is near the top.
+if grep -vE '^\s*#' "$TMP/render.yaml" | grep -Ec 'kind: XUserAccess|xuseraccesses' >/dev/null; then
   echo "FAIL: XUserAccess / xuseraccesses composite type still present — the XR-spawning layer must be gone (Refs #4773)" >&2
   grep -vE '^\s*#' "$TMP/render.yaml" | grep -nE 'kind: XUserAccess|xuseraccesses' >&2
   exit 1

--- a/platform/openbao/chart/tests/auto-unseal-toggle.sh
+++ b/platform/openbao/chart/tests/auto-unseal-toggle.sh
@@ -169,7 +169,12 @@ echo "[auto-unseal-toggle] Case 6: #5146 reconciler captures bao's REAL rc (seal
 REC="$TMP/autounseal.yaml"
 # 6a — the buggy `if ! bao status` wrapper must be ABSENT from executable code
 # (strip comment lines — the fix's own doc-comment names the antipattern).
-if grep -vE '^[[:space:]]*#' "$REC" | grep -qE 'if ! bao status'; then
+# `grep -cE … >/dev/null` — NOT `grep -qE`. Refs #6235: `-q` exits on the first
+# match and SIGPIPEs the producer, which `set -o pipefail` turns into a non-zero
+# pipeline status indistinguishable from "not found" — so a PRESENT `if ! bao
+# status` would read as absent and this fail-open assertion would report a pass.
+# `-c` reads to EOF. Measured producer output here: 87,744 bytes.
+if grep -vE '^[[:space:]]*#' "$REC" | grep -cE 'if ! bao status' >/dev/null; then
   echo "FAIL: reconciler wraps 'bao status' in 'if !' — the negation clobbers \$? (1.2.61 bug)." >&2
   exit 1
 fi

--- a/scripts/chart-tests-pr-matrix.sh
+++ b/scripts/chart-tests-pr-matrix.sh
@@ -1,0 +1,232 @@
+#!/usr/bin/env bash
+# chart-tests-pr-matrix.sh — which charts must run chart/tests/*.sh on THIS PR.
+#
+# WHY THIS IS A SCRIPT AND NOT INLINE YAML — Refs #6235
+# ------------------------------------------------------
+# `.github/workflows/chart-tests-pr.yaml` used to compute its matrix inline, and
+# its trigger was `platform/*/chart/tests/**` ONLY. A PR that changed chart
+# TEMPLATES without touching a test file therefore ran no chart suite at PR
+# time: the gate could not fire on the change it exists to gate, which is the
+# same class as the fail-open predicate that motivated #6235. The trigger now
+# mirrors blueprint-release.yaml (`platform/*/chart/**`, `products/*/chart/**`),
+# so the PR gate covers exactly the edits the post-merge gate covers.
+#
+# Widening the trigger alone would have multiplied CI load: the deploy-bots bump
+# `products/catalyst/chart/Chart.yaml` on essentially every PR (41 open PRs carry
+# the umbrella at the time of writing), so `products/*/chart/**` would fire the
+# 10-script catalyst suite on all of them for a change that cannot alter a
+# render. So a chart is dropped from the matrix when its ONLY changed file is
+# `chart/Chart.yaml` AND that file's diff touches nothing but `version:` /
+# `appVersion:` — which is exactly and only what `scripts/bump-chart-version.sh`
+# writes. Any other Chart.yaml edit (a dependency pin, a rename, an annotation)
+# keeps the chart in the matrix.
+#
+# Living in a script rather than in a `run:` block is what makes the predicate
+# testable: `--self-test` builds real git fixtures and asserts the three cases
+# against THIS code, not against a re-implementation of it.
+#
+# Usage:
+#   chart-tests-pr-matrix.sh --base <ref-or-sha> [--head <ref-or-sha>] [--root <dir>]
+#   chart-tests-pr-matrix.sh --self-test
+#
+# Prints the GitHub Actions matrix JSON on stdout, e.g.
+#   {"include":[{"path":"platform/gitea"}]}
+# Exit: 0 = computed (possibly empty), 2 = usage/setup error.
+
+set -euo pipefail
+
+BASE=""
+HEAD_REF="HEAD"
+ROOT="${ROOT:-.}"
+SELF_TEST=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --base)      BASE="$2"; shift 2 ;;
+    --head)      HEAD_REF="$2"; shift 2 ;;
+    --root)      ROOT="$2"; shift 2 ;;
+    --self-test) SELF_TEST=1; shift ;;
+    *) echo "Unknown arg: $1" >&2
+       echo "Usage: $0 --base <ref> [--head <ref>] [--root <dir>] | $0 --self-test" >&2
+       exit 2 ;;
+  esac
+done
+
+# ── The predicates, factored out so --self-test exercises the SAME code the
+#    real run uses. A self-test over a re-implementation proves nothing.
+
+# changed_chart_files <root> <base> <head> — PR-owned changes under a chart dir.
+#
+# NOTE: `git diff --name-only ... | grep -E ...` and NOT `grep -qE`. Refs #6235:
+# `grep -q` exits on the first match and SIGPIPEs the producer, which under
+# `set -o pipefail` reports a FOUND match as non-zero. `grep -E` without `-q`
+# reads to EOF, so the producer always finishes.
+changed_chart_files() {
+  local root="$1" base="$2" head="$3"
+  git -C "$root" diff --name-only "${base}...${head}" \
+    | grep -E '^(platform|products)/[^/]+/chart/' || true
+}
+
+# version_only_chart_yaml <root> <base> <head> <path> — is this Chart.yaml diff
+# nothing but a version bump? Content lines only: the +++/--- headers and the
+# @@ hunk markers are not content, and a rename/mode change is not either.
+version_only_chart_yaml() {
+  local root="$1" base="$2" head="$3" path="$4" line
+  local saw=0
+  while IFS= read -r line; do
+    case "$line" in
+      '+++'*|'---'*) continue ;;
+      '+'*|'-'*)
+        saw=1
+        # strip the leading +/- then require the key to be version/appVersion
+        case "${line#?}" in
+          version:*|appVersion:*) ;;
+          *) return 1 ;;
+        esac
+        ;;
+    esac
+  done < <(git -C "$root" diff -U0 "${base}...${head}" -- "$path")
+  [ "$saw" -eq 1 ]
+}
+
+# compute_matrix <root> <base> <head> — the whole decision, one function.
+compute_matrix() {
+  local root="$1" base="$2" head="$3" f chart
+  local -a files=()
+  while IFS= read -r f; do [ -n "$f" ] && files+=("$f"); done < <(changed_chart_files "$root" "$base" "$head")
+
+  local -a charts=()
+  for f in "${files[@]+"${files[@]}"}"; do
+    chart="$(printf '%s' "$f" | cut -d/ -f1-2)"
+    case " ${charts[*]-} " in *" $chart "*) ;; *) charts+=("$chart") ;; esac
+  done
+
+  local -a keep=()
+  for chart in "${charts[@]+"${charts[@]}"}"; do
+    # this chart's own changed files
+    local -a own=()
+    for f in "${files[@]+"${files[@]}"}"; do
+      case "$f" in "$chart"/chart/*) own+=("$f") ;; esac
+    done
+    if [ "${#own[@]}" -eq 1 ] && [ "${own[0]}" = "$chart/chart/Chart.yaml" ] \
+       && version_only_chart_yaml "$root" "$base" "$head" "${own[0]}"; then
+      # A pure version bump cannot change a render. Skip.
+      continue
+    fi
+    # Nothing to run if the chart has no tests/ directory.
+    [ -d "$root/$chart/chart/tests" ] || continue
+    keep+=("$chart")
+  done
+
+  if [ "${#keep[@]}" -eq 0 ]; then
+    printf '{"include":[]}\n'
+  else
+    printf '%s\n' "${keep[@]}" | jq -R -s -c '{include: (split("\n") | map(select(length>0)) | map({path: .}))}'
+  fi
+}
+
+# ── Self-test — real git fixtures, no network, no cluster ────────────────────
+if [ "$SELF_TEST" -eq 1 ]; then
+  command -v jq >/dev/null 2>&1 || { echo "SELF-TEST SETUP: jq is required" >&2; exit 2; }
+  T="$(mktemp -d)"
+  trap 'rm -rf "$T"' EXIT
+  RC=0
+  chk() { # <label> <want> <got>
+    if [ "$2" = "$3" ]; then echo "  ok   $1"
+    else echo "  FAIL $1"; echo "         want: $2"; echo "         got : $3"; RC=1; fi
+  }
+
+  g() { git -C "$T" "$@" >/dev/null 2>&1; }
+  g init -q -b main
+  g config user.email t@t.t
+  g config user.name t
+  mkdir -p "$T/platform/alpha/chart/templates" "$T/platform/alpha/chart/tests" \
+           "$T/products/umbrella/chart/templates" "$T/products/umbrella/chart/tests" \
+           "$T/platform/notests/chart/templates"
+  printf 'version: 1.0.0\nappVersion: 1.0.0\nname: alpha\n'    > "$T/platform/alpha/chart/Chart.yaml"
+  printf 'kind: Deployment\n'                                  > "$T/platform/alpha/chart/templates/d.yaml"
+  printf '#!/usr/bin/env bash\n'                               > "$T/platform/alpha/chart/tests/t.sh"
+  printf 'version: 1.4.1400\nappVersion: 1.4.1400\nname: u\n'  > "$T/products/umbrella/chart/Chart.yaml"
+  printf 'kind: Service\n'                                     > "$T/products/umbrella/chart/templates/s.yaml"
+  printf '#!/usr/bin/env bash\n'                               > "$T/products/umbrella/chart/tests/t.sh"
+  printf 'version: 0.1.0\nname: notests\n'                     > "$T/platform/notests/chart/Chart.yaml"
+  printf 'kind: ConfigMap\n'                                   > "$T/platform/notests/chart/templates/c.yaml"
+  g add -A; g commit -qm base
+  BASE_SHA="$(git -C "$T" rev-parse HEAD)"
+
+  echo "== chart-tests-pr-matrix self-test (git fixtures, no cluster) =="
+
+  # (a) THE DEFECT THIS FIXES: a template-only change must produce a matrix.
+  g checkout -q -b a
+  printf 'kind: Deployment\n# edited\n' > "$T/platform/alpha/chart/templates/d.yaml"
+  g add -A; g commit -qm tmpl
+  chk "template-only edit selects the chart" \
+      '{"include":[{"path":"platform/alpha"}]}' "$(compute_matrix "$T" "$BASE_SHA" HEAD)"
+
+  # (b) the load carve-out: a pure version bump selects nothing.
+  g checkout -q main; g checkout -q -b b
+  printf 'version: 1.4.1401\nappVersion: 1.4.1401\nname: u\n' > "$T/products/umbrella/chart/Chart.yaml"
+  g add -A; g commit -qm bump
+  chk "version-only Chart.yaml bump selects nothing" \
+      '{"include":[]}' "$(compute_matrix "$T" "$BASE_SHA" HEAD)"
+
+  # (c) CONTROL for (b) — the carve-out must not swallow a real Chart.yaml edit.
+  #     Without this, (b) would also pass for a guard that ignored Chart.yaml
+  #     entirely, which is a different and much worse rule.
+  g checkout -q main; g checkout -q -b c
+  printf 'version: 1.4.1402\nappVersion: 1.4.1402\nname: u\ndependencies:\n  - name: x\n' \
+      > "$T/products/umbrella/chart/Chart.yaml"
+  g add -A; g commit -qm dep
+  chk "Chart.yaml edit beyond version: still selects the chart" \
+      '{"include":[{"path":"products/umbrella"}]}' "$(compute_matrix "$T" "$BASE_SHA" HEAD)"
+
+  # (c2) TIGHTER CONTROL for (c). Case (c) adds `dependencies:` AND its child
+  #      `  - name: x`; the child alone keeps the chart in the matrix, so (c)
+  #      still passes for a carve-out that had been widened to allow
+  #      `dependencies:` itself. This case changes exactly ONE other key, on one
+  #      line, so nothing but the key test can decide it. Without (c2) the
+  #      allow-list could be widened key-by-key and every case above stays green.
+  g checkout -q main; g checkout -q -b c2
+  printf 'version: 1.4.1404\nappVersion: 1.4.1404\nname: u\ndependencies: []\n' \
+      > "$T/products/umbrella/chart/Chart.yaml"
+  g add -A; g commit -qm dep-oneline
+  chk "one-line non-version key in Chart.yaml still selects the chart" \
+      '{"include":[{"path":"products/umbrella"}]}' "$(compute_matrix "$T" "$BASE_SHA" HEAD)"
+
+  # (d) CONTROL for (a) — a version bump RIDING ALONG with a template edit must
+  #     still select. The carve-out keys on "Chart.yaml is the ONLY change".
+  g checkout -q main; g checkout -q -b d
+  printf 'version: 1.4.1403\nappVersion: 1.4.1403\nname: u\n' > "$T/products/umbrella/chart/Chart.yaml"
+  printf 'kind: Service\n# edited\n' > "$T/products/umbrella/chart/templates/s.yaml"
+  g add -A; g commit -qm both
+  chk "template edit + version bump still selects the chart" \
+      '{"include":[{"path":"products/umbrella"}]}' "$(compute_matrix "$T" "$BASE_SHA" HEAD)"
+
+  # (e) a tests-only change — the case the OLD filter covered — must still work.
+  g checkout -q main; g checkout -q -b e
+  printf '#!/usr/bin/env bash\n# edited\n' > "$T/platform/alpha/chart/tests/t.sh"
+  g add -A; g commit -qm tests
+  chk "tests-only edit still selects the chart (no regression)" \
+      '{"include":[{"path":"platform/alpha"}]}' "$(compute_matrix "$T" "$BASE_SHA" HEAD)"
+
+  # (f) a chart with NO tests/ dir has nothing to run.
+  g checkout -q main; g checkout -q -b f
+  printf 'kind: ConfigMap\n# edited\n' > "$T/platform/notests/chart/templates/c.yaml"
+  g add -A; g commit -qm notests
+  chk "chart without tests/ selects nothing" \
+      '{"include":[]}' "$(compute_matrix "$T" "$BASE_SHA" HEAD)"
+
+  # (g) non-chart change selects nothing.
+  g checkout -q main; g checkout -q -b g
+  mkdir -p "$T/docs"; printf 'x\n' > "$T/docs/x.md"
+  g add -A; g commit -qm docs
+  chk "non-chart change selects nothing" \
+      '{"include":[]}' "$(compute_matrix "$T" "$BASE_SHA" HEAD)"
+
+  if [ "$RC" -eq 0 ]; then echo "SELF-TEST PASS (8 cases, git fixtures only — no cluster, no network)"
+  else echo "SELF-TEST FAIL"; fi
+  exit "$RC"
+fi
+
+[ -n "$BASE" ] || { echo "--base is required (or use --self-test)" >&2; exit 2; }
+compute_matrix "$ROOT" "$BASE" "$HEAD_REF"

--- a/scripts/chart-tests-pr-matrix.sh
+++ b/scripts/chart-tests-pr-matrix.sh
@@ -140,6 +140,11 @@ if [ "$SELF_TEST" -eq 1 ]; then
   g init -q -b main
   g config user.email t@t.t
   g config user.name t
+  # A global commit.gpgsign=true would make every fixture commit fail on a
+  # machine that has one, and the self-test would read as a code defect rather
+  # than an environment difference. Pin it off for the fixture repo only.
+  g config commit.gpgsign false
+  g config tag.gpgsign false
   mkdir -p "$T/platform/alpha/chart/templates" "$T/platform/alpha/chart/tests" \
            "$T/products/umbrella/chart/templates" "$T/products/umbrella/chart/tests" \
            "$T/platform/notests/chart/templates"

--- a/scripts/check-go-test-count1.sh
+++ b/scripts/check-go-test-count1.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+# check-go-test-count1.sh — every `go test` in a workflow must pass `-count=1`.
+#
+# WHY THIS EXISTS — Refs #6235
+# ----------------------------
+# `go test` caches a package's result under a key computed from that package's
+# own inputs: its source files, its build flags, its environment, and files it
+# opens through the test binary's own tracked paths. This repo has no root
+# `go.mod` — every component is its own module — and ~25 test files deliberately
+# read files OUTSIDE their module: chart templates, `blueprint.yaml`s, `.tf`
+# modules, `clusters/_template/**`, even other trees' TypeScript. Those reads are
+# INVISIBLE to the cache key. Mutate the external file and the cached verdict
+# still stands.
+#
+# Measured on this repo, 2026-08-14, against
+# core/services/provisioning/gitops/openclaw_secret_producer_6114_test.go, which
+# reads ../../../../platform/openclaw/chart/templates/ :
+#
+#   $ python3 -c "...s.replace('kind: Secret','kind: ConfigMap',1)..."   # producer gone
+#   $ go test ./gitops/
+#   ok  github.com/openova-io/openova/core/services/provisioning/gitops  (cached)
+#   $ go test -count=1 ./gitops/
+#   FAIL github.com/openova-io/openova/core/services/provisioning/gitops 0.028s
+#
+# A clean pass that never read the mutated file. This is the purest form of the
+# fail-open family in #6235: not a gate that fires for the wrong reason, but one
+# that can report a stale green indefinitely and never execute at all.
+#
+# `-count=1` is the documented idiom for disabling test caching. It costs one
+# re-run of an already-fast suite; a stale green costs a released artifact.
+#
+# WHY A BLANKET RULE RATHER THAN "ONLY THE CROSS-MODULE ONES"
+# -----------------------------------------------------------
+# Scoping this to the modules that read outside themselves today would need a
+# list, and the list rots the moment a new test adds an `os.ReadFile("../../..")`
+# — silently, because the symptom is a PASS. Every compliant step in this repo
+# already passes `-count=1` (24 of 27 when this guard was written), so the rule
+# is not a new burden; it is the existing convention, enforced.
+#
+# Usage:  scripts/check-go-test-count1.sh [--root <repo-root>] [--self-test]
+# Exit:   0 = every `go test` carries -count=1
+#         1 = at least one does not
+#         2 = usage / setup error
+
+set -euo pipefail
+
+ROOT="${ROOT:-.}"
+SELF_TEST=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --root)      ROOT="$2"; shift 2 ;;
+    --self-test) SELF_TEST=1; shift ;;
+    *) echo "Unknown arg: $1" >&2
+       echo "Usage: $0 [--root <repo-root>] [--self-test]" >&2; exit 2 ;;
+  esac
+done
+
+# ── The predicate, factored out so --self-test exercises the SAME code the real
+#    run uses. A self-test over a re-implementation proves nothing.
+#
+# offenders <workflow-dir> — prints `file:line: <command>` for every `go test`
+# invocation that does not carry -count=1.
+#
+# Shapes that must NOT be reported:
+#   * a YAML comment mentioning `go test` (openclaw-controller.yaml has one in
+#     its header, and test-ungated-trees.yaml has several in `echo "::error"`
+#     strings) — comments run nothing;
+#   * a step name / echo string containing the words "go test";
+#   * `go test` split across a backslash continuation with `-count=1` on a later
+#     physical line (pool-domain-manager's suite list is written that way).
+offenders() {
+  local wfdir="$1" f
+  [ -d "$wfdir" ] || return 0
+  local files=()
+  for f in "$wfdir"/*.yml "$wfdir"/*.yaml; do [ -f "$f" ] && files+=("$f"); done
+  [ "${#files[@]}" -gt 0 ] || return 0
+  for f in "${files[@]}"; do
+    awk -v FNAME="$f" '
+      # Join backslash continuations so a multi-line invocation is one record,
+      # remembering the line number the invocation STARTED on.
+      {
+        line = $0
+        sub(/^[ \t]*/, "", line)
+        if (pending != "") { buf = buf " " line } else { buf = line; start = NR }
+        if (buf ~ /\\$/) { sub(/\\$/, "", buf); pending = 1; next }
+        pending = ""
+        rec = buf; buf = ""
+
+        # Drop YAML comments — they execute nothing.
+        if (rec ~ /^#/) next
+        # Drop step names / keys — `- name: go test (…)`, `name: go test`.
+        if (rec ~ /^-?[ \t]*name:[ \t]/) next
+        # Drop echo/printf lines that merely mention it.
+        if (rec ~ /^(echo|printf)[ \t]/) next
+
+        # A real invocation: `go test` at the start of a command position.
+        if (rec !~ /(^|[ \t;&|(])go[ \t]+test([ \t]|$)/) next
+        if (rec ~ /-count[= \t]+?1([ \t]|$)/) next
+        if (rec ~ /-count=1([ \t]|$)/) next
+        printf "%s:%d: %s\n", FNAME, start, rec
+      }
+    ' "$f"
+  done
+}
+
+# ── Self-test — fixtures only, no repo state, no cluster ────────────────────
+if [ "$SELF_TEST" -eq 1 ]; then
+  T="$(mktemp -d)"; trap 'rm -rf "$T"' EXIT
+  W="$T/.github/workflows"; mkdir -p "$W"
+  RC=0
+  chk() { if [ "$2" = "$3" ]; then echo "  ok   $1"; else echo "  FAIL $1 (want '$2', got '$3')"; RC=1; fi; }
+
+  cat > "$W/compliant.yaml" <<'YAML'
+      - name: go test
+        run: go test -count=1 -race ./...
+YAML
+  cat > "$W/offender.yaml" <<'YAML'
+      - name: unit
+        run: go test ./...
+YAML
+  cat > "$W/comment.yaml" <<'YAML'
+# This header explains that `go test ./...` exits 0 on a module with no tests.
+      - name: unit
+        run: go test -count=1 ./...
+YAML
+  cat > "$W/stepname.yaml" <<'YAML'
+      - name: go test (race + count=1)
+        run: go test -count=1 -race ./...
+YAML
+  cat > "$W/echoed.yaml" <<'YAML'
+      - name: unit
+        run: |
+          echo "go test ./... exits 0 with no test files, so this check exists"
+          go test -count=1 ./...
+YAML
+  cat > "$W/continuation.yaml" <<'YAML'
+      - name: unit
+        run: |
+          go test -count=1 ./internal/a/... \
+                  ./internal/b/...
+YAML
+  cat > "$W/continuation-bad.yaml" <<'YAML'
+      - name: unit
+        run: |
+          go test ./internal/a/... \
+                  ./internal/b/...
+YAML
+  cat > "$W/spaced.yaml" <<'YAML'
+      - name: unit
+        run: go test -count 1 ./...
+YAML
+
+  got="$(offenders "$W" | sed "s#$W/##" | cut -d: -f1 | sort -u | tr '\n' ' ' | sed 's/ $//')"
+  echo "== check-go-test-count1 self-test (fixtures only, no cluster) =="
+  chk "flags a bare 'go test ./...' and nothing else" \
+      "continuation-bad.yaml offender.yaml" "$got"
+
+  # Each control on its own, so a broadened matcher cannot hide behind the set.
+  one() { offenders "$W" | grep -c "/$1:" || true; }
+  chk "compliant -count=1 not flagged"          0 "$(one compliant.yaml)"
+  chk "comment mentioning go test not flagged"  0 "$(one comment.yaml)"
+  chk "step NAME containing 'go test' not flagged" 0 "$(one stepname.yaml)"
+  chk "echoed 'go test' string not flagged"     0 "$(one echoed.yaml)"
+  chk "backslash continuation with -count=1 not flagged" 0 "$(one continuation.yaml)"
+  chk "'-count 1' (space form) not flagged"     0 "$(one spaced.yaml)"
+  chk "bare invocation IS flagged"              1 "$(one offender.yaml)"
+  chk "bare multi-line invocation IS flagged"   1 "$(one continuation-bad.yaml)"
+
+  # VACUITY: an empty workflow dir must yield nothing, and the guard must not
+  # mistake "found nothing because I read nothing" for a pass.
+  E="$T/empty/.github/workflows"; mkdir -p "$E"
+  chk "empty workflow dir yields no offenders" "" "$(offenders "$E")"
+
+  if [ "$RC" -eq 0 ]; then echo "SELF-TEST PASS (10 cases, fixtures only — no cluster, no network)"
+  else echo "SELF-TEST FAIL"; fi
+  exit "$RC"
+fi
+
+WFDIR="${ROOT}/.github/workflows"
+[ -d "$WFDIR" ] || { echo "FATAL: $WFDIR not found" >&2; exit 2; }
+
+# Refuse to report a pass from an empty read — the guard must have seen work.
+seen="$(ls -1 "$WFDIR"/*.yml "$WFDIR"/*.yaml 2>/dev/null | wc -l)"
+if [ "$seen" -eq 0 ]; then
+  echo "FATAL: no workflow files under $WFDIR — refusing to report a pass on an empty scan." >&2
+  exit 2
+fi
+
+FOUND="$(offenders "$WFDIR" || true)"
+if [ -n "$FOUND" ]; then
+  echo "FAIL: a workflow runs 'go test' without -count=1 (#6235)." >&2
+  echo "" >&2
+  printf '%s\n' "$FOUND" >&2
+  echo "" >&2
+  echo "  This repo has no root go.mod and ~25 test files read chart templates," >&2
+  echo "  blueprint.yaml, .tf modules and clusters/_template/** from OUTSIDE their" >&2
+  echo "  own module. Those reads are invisible to the go test cache key, so a" >&2
+  echo "  cached 'ok' can stand over a mutated external file indefinitely." >&2
+  echo "  Add -count=1 to the invocation." >&2
+  exit 1
+fi
+echo "OK: all ${seen} workflow file(s) scanned; every 'go test' carries -count=1 (#6235)."


### PR DESCRIPTION
Closes the **fail-open test-gate class** outside the cutover harness. `platform/self-sovereign-cutover/` is untouched — Case 40 was already swept in #6323.

Every change below carries a mutation proof: the failing condition is constructed, the gate is shown RED, the mutation is reverted, the gate is shown GREEN. Where a site did **not** reproduce, it was **reverted rather than shipped** — the audited-vs-changed gap is the point of this PR.

---

## Instance 1 — `grep -q` on a pipe under `pipefail`

### What I measured first

The trigger is match **position**, but the threshold is set by the **producer kind**, and my numbers differ from the sizing on the issue. Needle first, N bytes of tail, 30 trials per point, this machine, bash 5.1.16:

```
    tail    printf builtin    grep -v      awk   (false negatives out of 30)
      4K                 0          0        0
     16K                 0          0        0
     32K                 0          0       30
     48K                 0          0       30
     64K                 0          2       29
    128K                30         30       30
    256K                30         30       30
```

A shell **builtin** producer (`printf`/`echo "$var" |`) writes the whole string in one `write()`; if it fits the 64 KB pipe buffer the producer has already finished before `grep -q` can exit, so no `EPIPE` is possible. An external **process** producer (`awk`, `grep -v`, `sed`, `helm`) flushes in blocks and keeps running, so it flips much earlier — awk at 32 KB. The issue's "tail=1024B -> rc=141" does not reproduce here for any of the three; I could not get a false negative below 32 KB.

Separately measured, because ~40 sites use it: a **here-string is not a pipeline**. `cmd <<<"$big"` is a redirect on a simple command, so `pipefail` has no pipeline to inspect — rc=0 at 1 K / 8 K / 64 K / 256 K / 1 M / 4 M where the pipe form was already 141 from 256 K.

### How the audit was done

Static grep is not enough — `||` reads as a pipe, a here-string reads as a pipe, and neither is one. So the corpus was **instrumented and executed**: a drop-in `grep` shim (self-tested first, 9 assertions) drains stdin for every `-q` invocation and reports `matched` / `bytes-after-first-match` / `total`, attributed to the call site through `PS4='+@${BASH_SOURCE}:${LINENO}@ '` xtrace.

- **191** genuine `producer | grep -q` sites, **67** files (after correcting for `||`, which inflated a naive count to 215).
- **33** chart-test files + **25** `scripts/` guards executed under the shim; **106** pipeline sites observed actually running, plus 64 here-string `-q` sites observed and confirmed not exposed.

### Audited 191 → changed 2

| site | producer | size | verdict |
|---|---|---|---|
| `crossplane-claims/.../composition-validate.sh:138` | `grep -vE` (process) | 492,849 B, match at 10,696 B | **fail-open, 30/30 reproduced → FIXED** |
| `openbao/.../auto-unseal-toggle.sh:172` | `grep -vE` (process) | 87,744 B | **fail-open, 29/30 reproduced → FIXED** |

**Left alone, with the reason:**

- **~97 fail-loud sites.** `if ! producer \| grep -q X` / `... \|\| fail`. A false negative here raises a spurious failure — noisy, not silent. Per the brief these are not urgent and churning them would bury the two real fixes. This includes `kyverno-policies/nodeport-enforce-5491.sh:20,40` (82 KB producer), whose false negative turns the §854 NodePort-enforcement gate red for no reason. Worth a follow-up; not a fail-open.
- **~64 here-string sites** (`gitea/gitdata-preservation-guard.sh`, `postgres-render.sh`, `newapi/httproute-render.sh`, …). Measured non-exposed at every size to 4 MB. Not pipelines.
- **3 fail-open sites I changed and then REVERTED**, because the pipeline does not reproduce the defect at today's sizes — all three have a **builtin** producer below the 64 KB pipe buffer:
  - `keycloak/.../pin-broker-secret-platform-only-5400.sh:60` — `printf`, 42,455 B → **0/30**. This is the nearest to the line and it is a *vacuity control*; if that render passes ~64 KB it becomes exposed.
  - `check-no-dead-grant-theater.sh:53/58/64/70` — `printf`, `$NC` = 37,318 B → **0/30**.
  - `catalyst/.../baseline-cnp-allowlist.sh:232/242/246` — `printf`, 4,501 B → **0/30**.
- **Every `scripts/` guard.** Max measured tail across all of them was **613 B** — the repo-scanning guards (`check-no-nodeports.sh`, `check-no-local-path.sh`, `check-no-banned-words.sh`) match **per line**, so their producer is one line.

### Mutation proof — `composition-validate.sh`

Mutation is an RBAC grant on the retired composite (changes no XRD or Composition count, so no earlier case can mask the result):

```
STATE 1  clean tree,    FIXED test   rc=0   (want 0)
         producer=492849B  first match ends at byte 10696  -> 482153B still to write
STATE 2  mutated chart, FIXED test   rc=1   (want 1 = caught)
         FAIL: XUserAccess / xuseraccesses composite type still present — the XR-spawning layer must be gone (Refs #4773)
STATE 3  mutated chart, PRE-FIX test rc=0   (0 = FAIL-OPEN, the defect)
         last line: [composition-validate] All bp-crossplane Day-2 CRUD Composition gates green.
STATE 4  reverted,      FIXED test   rc=0   (want 0)
         mutation fully reverted (git diff clean on clusterroles.yaml)
```

State 3 is the defect itself: the pre-fix predicate printed **"All bp-crossplane Day-2 CRUD Composition gates green"** over a chart that carried the forbidden composite.

### Mutation proof — `auto-unseal-toggle.sh`

```
  1 clean,   FIXED  rc=0   (want 0)
      mutation present in render: 2
  2 mutated, FIXED  rc=1   (want 1)
      FAIL: reconciler wraps 'bao status' in 'if !' — the negation clobbers $? (1.2.61 bug).
  4 reverted,FIXED  rc=0   (want 0)
```

Faithful pipeline replay of the pre-fix line: **29/30 false negatives**.

---

## Instance 2 — `chart-tests-pr.yaml` could not fire on a template change

Its filter was `platform|products/*/chart/tests/**`, so a PR editing chart templates ran **no chart suite at PR time**. Measured on the last 600 non-deploy commits of `main`: **8 commits** changed a chart that has a `tests/` suite without touching a single test file, and none of them ran that suite before merging.

Widened to `platform/*/chart/**` + `products/*/chart/**` — byte-for-byte the chart half of `blueprint-release.yaml`'s own filter, so the PR gate now covers exactly the edits the post-merge gate covers.

**The load argument in the old comment was real and is answered, not ignored.** The deploy-bots bump `products/catalyst/chart/Chart.yaml` on essentially every PR (41 open PRs carry the umbrella), so a naive widening would fire the 10-script catalyst suite on all of them for a change that cannot alter a render. `scripts/chart-tests-pr-matrix.sh` drops a chart whose **only** changed file is `chart/Chart.yaml` with a **version-only** diff — exactly and only what `scripts/bump-chart-version.sh` writes.

### Proof the new filter would have fired on real template-only commits

GitHub `paths:` glob semantics implemented exactly (`*` does not cross `/`, `**` does), self-tested with 5 assertions before use, then run against already-merged commits:

```
── 0daba6c581a6  fix(catalyst-ui): a 1-replica Deployment cannot roll on a full node (#6152)
   OLD filter platform|products/*/chart/tests/** -> DOES NOT FIRE
   NEW filter platform|products/*/chart/**       -> FIRES  matched 3: .../chart/templates/ui-deployment.yaml, ...
   matrix for that diff: {"include":[{"path":"products/catalyst"}]}

── 4bec42e56f14  fix(openova-mcp, catalyst-api): the MCP verified ONE key while the Sovereign signs…
   OLD -> DOES NOT FIRE ; NEW -> FIRES
   matrix for that diff: {"include":[{"path":"products/catalyst"},{"path":"products/openova-mcp"}]}

── 2472dcaec8b1  fix(agenity): the credential init container WAITS instead of reading once
   OLD -> DOES NOT FIRE ; NEW -> FIRES
   matrix for that diff: {"include":[{"path":"products/agenity"},{"path":"products/catalyst"}]}

── 6749aff83313  fix(delivery): the per-Organization console pin had no writer for 3.5 months (#6139)
   OLD -> DOES NOT FIRE ; NEW -> FIRES
   matrix for that diff: {"include":[{"path":"products/catalyst"}]}
```

And the load control — the deploy-bot's version-only bump fires the workflow but selects **nothing**, so the `if:` guard skips the test job and adds zero runner time:

```
── 705b977a11f4  deploy(bp-catalyst-platform): bump chart version -> 1.4.1484 (auto, Refs #5743)
   NEW filter -> FIRES  matched 1: products/catalyst/chart/Chart.yaml
   matrix for that diff: {"include":[]}
```

### Vacuity proof of the matrix predicate

The predicate lives in a script rather than a `run:` block precisely so it can be mutation-tested. Its `--self-test` passed **on the first try**, which is suspect, so every case was regressed:

```
== vacuity: every mutant must turn the self-test RED ==
  M1 rc=1 RED (good)   drop the has-tests/ requirement
  M2 rc=1 RED (good)   widen the version-only carve-out to swallow dependency edits
  M3 rc=1 RED (good)   drop the ONLY-changed-file condition
  M4 rc=1 RED (good)   revert the trigger to tests-only (the original defect)
  M5 rc=1 RED (good)   treat any Chart.yaml diff as version-only
  restored rc=0 (want 0)
```

**M2 initially came back GREEN** — a real coverage hole. Case (c) added `dependencies:` *and* its child `- name: x`, and the child alone kept the chart selected, so (c) would also have passed for a carve-out widened to allow `dependencies:`. Case (c2) was added — a Chart.yaml diff changing exactly **one** other key on **one** line, which nothing but the key test can decide. The suite is 8 cases and all five mutants now go red.

---

## Instance 3 — a cross-module Go guard is invisible to the test cache

This repo has no root `go.mod`, and ~25 test files deliberately read outside their module (chart templates, `blueprint.yaml`, `.tf` modules, `clusters/_template/**`, other trees' TypeScript). Those reads are not in the cache key.

### Mutation proof — reproduced directly

`core/services/provisioning/gitops/openclaw_secret_producer_6114_test.go` reads `../../../../platform/openclaw/chart/templates/`. Retyping the CONTROL's producer `kind: Secret` → `kind: ConfigMap` removes the producer the guard requires:

```
== 0. warm the cache (must be green first, or a later red proves nothing) ==
ok  github.com/openova-io/openova/core/services/provisioning/gitops  (cached)

== mutated platform/openclaw/chart/templates/oidc-client-secret.yaml: kind: Secret -> kind: ConfigMap ==

== A. plain 'go test ./gitops/'  (what 3 CI workflows run today) ==
ok  github.com/openova-io/openova/core/services/provisioning/gitops  (cached)

== B. 'go test -count=1 ./gitops/' ==
FAIL github.com/openova-io/openova/core/services/provisioning/gitops  0.028s
```

A clean pass that never read the mutated file.

### Cross-module Go guards, and their `-count=1` status

Surveyed every `go.mod` and every `*_test.go` reading a path outside its module. **23 test files across 6 modules** do so:

| module | example guard | external tree read | workflow | `-count=1` |
|---|---|---|---|---|
| `core/controllers` | `placement_vocabulary_drift_test.go` | `products/catalyst/chart/crds/`, `bootstrap/ui/src/**` | build-blueprint-controller | was already ✅ |
| `core/controllers` | `crossregion_seed_lockstep_test.go` | `platform/*/chart/values.yaml` | build-application-controller | was already ✅ |
| `core/services/provisioning` | `openclaw_secret_producer_6114_test.go` | `platform/openclaw/chart/templates/` | test-provisioning-service | was already ✅ |
| `core/services/provisioning` | `helmrelease_apps_pin_seed_drift_test.go` | `scripts/lib/*.awk`, catalog-seed | test-provisioning-service | was already ✅ |
| `products/catalyst/bootstrap/api` | 10 files (cutover chart, `infra/providers/hetzner/main.tf`, `platform/cilium/chart/**`, `clusters/_template/**`) | — | test-bootstrap-api | was already ✅ |
| `tests/e2e/bootstrap-kit` | 5 files (whole chart tree + `helm template` subprocesses) | — | test-bootstrap-kit | was already ✅ |
| `tests/e2e/hetzner-provisioning` | `main_test.go` | `infra/hetzner/**` | test-hetzner-e2e | was already ✅ |

**Three workflows ran `go test` with no `-count=1`** and are fixed here — `build-openova-mcp.yaml`, `openclaw-controller.yaml`, `pool-domain-manager-build.yaml`. None of those three modules reads outside itself *today*, so this is prophylaxis; the class is closed by the guard, not by the list.

`scripts/check-go-test-count1.sh` enforces it repo-wide. It refuses to report a pass on an empty scan, and its self-test carries the false-positive controls that matter (a header comment mentioning `go test`, a step **name** containing "go test", an `echo` string containing it, and backslash-continued invocations — all four shapes exist in this repo and none is flagged).

```
STATE 1  clean repo   rc=0   (want 0)
STATE 2  -count=1 removed from ONE workflow   rc=1   (want 1)
         ./.github/workflows/build-openova-mcp.yaml:56: go test ./...
STATE 3  reverted     rc=0   (want 0)
         OK: all 113 workflow file(s) scanned; every 'go test' carries -count=1 (#6235).
```

### Measured but not fixed here — the sibling trigger gap

Every cross-module guard runs with `-count=1`, but several are **not triggered by the tree they read**. `test-provisioning-service.yaml` fires only on `core/services/provisioning/**`, so a PR editing `platform/openclaw/chart/templates/` never runs the guard that reads it; same for `build-blueprint-controller.yaml` vs `bootstrap/ui/src/**`, and `test-bootstrap-api.yaml` vs `platform/self-sovereign-cutover/chart/**` and `infra/providers/hetzner/main.tf`. `test-bootstrap-kit.yaml` already lists its external trees and is the model. Not changed here because widening a **build-and-push** workflow's triggers is a different risk profile and belongs on its own; recorded on #6235 rather than filed as new issues.

---

## Wiring

`scripts/check-go-test-count1.sh` is a `check-*.sh`, so `check-guards-are-wired.sh` sees it — and that meta-gate only asserts a guard is *invoked* somewhere, so it is invoked from `check-guard-selftests.yaml` (both the real run and the self-test).

`scripts/chart-tests-pr-matrix.sh` is **not** a `check-` script and is therefore invisible to that meta-gate's glob — the same blind spot the two Python entries in `check-guard-selftests.yaml` already document. It is **wired by hand** into `check-guard-selftests.yaml`, and its path added to that workflow's `paths:` filter so an edit to the predicate runs its own self-test. `chart-tests-pr.yaml` also runs the self-test before trusting the matrix.

`scripts/check-guards-are-wired.sh` → `OK — all 22 self-test-capable guard(s) are invoked by at least one workflow.`

## Verification run locally

- `check-go-test-count1.sh` → OK (113 workflow files) · `--self-test` → PASS (10 cases)
- `chart-tests-pr-matrix.sh --self-test` → PASS (8 cases), all 5 mutants RED
- `check-guards-are-wired.sh` → OK (22 guards) · `check-no-banned-words.sh` → OK
- `composition-validate.sh` → rc=0 · `auto-unseal-toggle.sh` → rc=0
- `shellcheck -S error` clean on both new scripts; `yaml.safe_load` clean on all 5 edited workflows

No chart version bumped, so no claim on `1.4.1487` / `1.4.1488` / `1.4.1489`. No NodePorts. No secrets. Live clusters untouched — every measurement is local `helm template`, `go test` and git fixtures.

Refs #6235
