### PR TITLE
fix(quota): model the bp-newapi POD, not one container, in both per-Org quota guards

### DIFF
--- a/.github/workflows/test-bootstrap-api.yaml
+++ b/.github/workflows/test-bootstrap-api.yaml
@@ -8,15 +8,34 @@ name: Test — Bootstrap API (Go)
 #
 # The job is fast and runs on every push that touches the bootstrap module.
 
+# TRIGGERS MUST COVER WHAT THE TESTS READ, not only where they live (#6324).
+# The #6324 Pod-quota guard in internal/handler derives its assertions from
+# files OUTSIDE this module. Scoped to this module's own path, a chart-only PR
+# would move a term the guard asserts on and never run the guard — green by
+# absence of measurement, the same fail-open shape as the go-test cache trap
+# #6235 closes. The added paths are the ones that guard reads:
+#   platform/newapi/chart/**                          sidecar + CNPG limits
+#   platform/openclaw/chart/**                        the controller's 250m term
+#   core/controllers/organization/internal/gitops/**  planQuotaTable["s"] — the cap
+#   core/services/provisioning/gitops/**              the OTHER per-Org producer,
+#                                                     cross-checked door-to-door
 on:
   push:
     paths:
       - 'products/catalyst/bootstrap/api/**'
+      - 'platform/newapi/chart/**'
+      - 'platform/openclaw/chart/**'
+      - 'core/controllers/organization/internal/gitops/**'
+      - 'core/services/provisioning/gitops/**'
       - '.github/workflows/test-bootstrap-api.yaml'
     branches: [main]
   pull_request:
     paths:
       - 'products/catalyst/bootstrap/api/**'
+      - 'platform/newapi/chart/**'
+      - 'platform/openclaw/chart/**'
+      - 'core/controllers/organization/internal/gitops/**'
+      - 'core/services/provisioning/gitops/**'
       - '.github/workflows/test-bootstrap-api.yaml'
   workflow_dispatch:
 

--- a/.github/workflows/test-provisioning-service.yaml
+++ b/.github/workflows/test-provisioning-service.yaml
@@ -24,10 +24,18 @@ name: Test — Provisioning Service (Go)
 # That is the same fail-open shape as the go-test cache trap #6235 closes, one
 # level up, and it is exactly how a sidecar's limits could ship invisibly.
 #
-# The paths below are the ones the #6324 Pod-quota guards read:
+# PROVEN, not theorised: on 2026-08-14 f7961510f bumped bp-openclaw to 0.2.19 in
+# the catalog seed and left DefaultHRAppChartVersions at 0.2.18. hrAppPinSeedDrift
+# exists to catch exactly that and never ran, because the seed is not under this
+# workflow's paths — main went red and stayed red until an unrelated PR happened
+# to touch this module. That is the gap, with a live example.
+#
+# The paths below are the ones this module's guards read:
 #   platform/newapi/chart/**                     sidecar + CNPG limits, the DSN gate
 #   platform/openclaw/chart/**                   the controller's 250m neighbour term
 #   core/controllers/organization/internal/gitops/**  planQuotaTable["s"] — the cap
+#   products/catalyst/chart/templates/catalog-seed/**  the delivery pins
+#   scripts/lib/parse-catalog-seed-pins.awk      the shared seed parser
 on:
   push:
     paths:
@@ -35,6 +43,8 @@ on:
       - 'platform/newapi/chart/**'
       - 'platform/openclaw/chart/**'
       - 'core/controllers/organization/internal/gitops/**'
+      - 'products/catalyst/chart/templates/catalog-seed/**'
+      - 'scripts/lib/parse-catalog-seed-pins.awk'
       - '.github/workflows/test-provisioning-service.yaml'
     branches: [main]
   pull_request:
@@ -43,6 +53,8 @@ on:
       - 'platform/newapi/chart/**'
       - 'platform/openclaw/chart/**'
       - 'core/controllers/organization/internal/gitops/**'
+      - 'products/catalyst/chart/templates/catalog-seed/**'
+      - 'scripts/lib/parse-catalog-seed-pins.awk'
       - '.github/workflows/test-provisioning-service.yaml'
   workflow_dispatch:
 

--- a/.github/workflows/test-provisioning-service.yaml
+++ b/.github/workflows/test-provisioning-service.yaml
@@ -16,15 +16,33 @@ name: Test — Provisioning Service (Go)
 # (core/services/provisioning/go.mod); sibling services under core/services/
 # still need their own gates and are deliberately NOT claimed here.
 
+# TRIGGERS MUST COVER WHAT THE TESTS READ, not only where they live (#6324).
+# Several guards in this module derive their assertions from files OUTSIDE it —
+# the bp-newapi and bp-openclaw charts, and the org-controller's planQuotaTable.
+# Scoped to this module's own path, a chart-only PR would change a term the
+# guard asserts on and never run the guard: green by absence of measurement.
+# That is the same fail-open shape as the go-test cache trap #6235 closes, one
+# level up, and it is exactly how a sidecar's limits could ship invisibly.
+#
+# The paths below are the ones the #6324 Pod-quota guards read:
+#   platform/newapi/chart/**                     sidecar + CNPG limits, the DSN gate
+#   platform/openclaw/chart/**                   the controller's 250m neighbour term
+#   core/controllers/organization/internal/gitops/**  planQuotaTable["s"] — the cap
 on:
   push:
     paths:
       - 'core/services/provisioning/**'
+      - 'platform/newapi/chart/**'
+      - 'platform/openclaw/chart/**'
+      - 'core/controllers/organization/internal/gitops/**'
       - '.github/workflows/test-provisioning-service.yaml'
     branches: [main]
   pull_request:
     paths:
       - 'core/services/provisioning/**'
+      - 'platform/newapi/chart/**'
+      - 'platform/openclaw/chart/**'
+      - 'core/controllers/organization/internal/gitops/**'
       - '.github/workflows/test-provisioning-service.yaml'
   workflow_dispatch:
 

--- a/core/services/provisioning/gitops/helmrelease_apps.go
+++ b/core/services/provisioning/gitops/helmrelease_apps.go
@@ -527,6 +527,26 @@ spec:
     # request far below the limit would let this pod in and then starve its
     # neighbours out of the quota it is not accounted against.
     #
+    # ── WHAT THIS BLOCK DOES *NOT* SIZE (#6324) ─────────────────────────────
+    # It pins ONE of the THREE quota-counted containers in this release's Pod,
+    # and a ResourceQuota admits the POD:
+    #
+    #   sandbox-bridge    200m  chart default; a NATIVE sidecar (initContainers
+    #                           entry with restartPolicy: Always, #3374), so its
+    #                           limits count toward the Pod on k8s 1.29+
+    #   newapi            500m  pinned below
+    #   metering-sidecar  500m  chart default
+    #   ------------------------
+    #   POD limits.cpu   1200m
+    #
+    # So the Org bundle is 1200m + openclaw 250m + CNPG 500m = 1950m of the
+    # 2000m smallest-plan cap: 50m of real headroom, not the 750m the
+    # single-container reading suggests. Raising EITHER sidecar by 100m puts the
+    # Org over the cap. The two guards now compute this Pod-level total from the
+    # chart rather than from the one term pinned here — see
+    # newapi_pod_quota_arithmetic_6324_test.go. Sizing the Pod itself is a
+    # plan-capacity decision and belongs to #5393; nothing here changes a value.
+    #
     # Overridden HERE rather than in the chart so the Sovereign-level default is
     # untouched — no chart bump, no five-site lockstep.
     newapi:

--- a/core/services/provisioning/gitops/helmrelease_apps.go
+++ b/core/services/provisioning/gitops/helmrelease_apps.go
@@ -709,7 +709,14 @@ spec:
 // Living here rather than as a literal in main.go is what makes the guard test
 // the value main.go actually ships — a copy in the test would pass while the
 // binary shipped something else.
-const DefaultHRAppChartVersions = "openclaw=0.2.18,stalwart-mail=0.1.15,newapi=1.4.153"
+// 2026-08-14: openclaw 0.2.18 -> 0.2.19. f7961510f bumped platform/openclaw/
+// chart/Chart.yaml and the catalog seed to 0.2.19 and did not bump this pin, so
+// main went red on hrAppPinSeedDrift. The guard was already correct; what let
+// the drift LAND is that its workflow was path-scoped to
+// core/services/provisioning/** while the value it asserts on lives in
+// products/catalyst/chart/templates/catalog-seed/ — the guard never ran on the
+// commit that broke it. Those paths are now in the trigger (#6324).
+const DefaultHRAppChartVersions = "openclaw=0.2.19,stalwart-mail=0.1.15,newapi=1.4.153"
 
 // ParseHRAppVersions parses the CATALYST_HR_APP_CHART_VERSIONS wire format
 // ("slug=version,slug=version") into the HelmReleaseAppVersions map (#4706).

--- a/core/services/provisioning/gitops/newapi_plan_quota_fit_row232_test.go
+++ b/core/services/provisioning/gitops/newapi_plan_quota_fit_row232_test.go
@@ -69,6 +69,11 @@ func cpuToMillis(v string) (int, error) {
 // smallestPlanCPUMillis mirrors planQuotaTable["s"].CPU ("2") from
 // core/controllers/organization/internal/gitops/manifests.go:121, which is the
 // cap an Org gets when its plan slug is empty or unknown (planQuota(), :132).
+//
+// It is a MIRROR, and a mirror can go stale: a LOWERED cap would leave this
+// guard asserting against a ceiling the platform no longer grants, and pass.
+// TestNewAPIHR_Row232_VacuityCheck_HelperSeesTheChartDefault therefore pins it
+// against the real table via smallestPlanCPUMillisFromController (#6324).
 const smallestPlanCPUMillis = 2000
 
 // TestNewAPIHR_Row232_FitsSmallestPlanQuota is the RED test: the per-Org
@@ -125,15 +130,24 @@ func TestNewAPIHR_Row232_FitsSmallestPlanQuota(t *testing.T) {
 					req, reqMillis, limit, limitMillis)
 			}
 
-			// The headroom assertion the row actually turns on: openclaw's own
-			// controller (250m) plus bp-newapi's CNPG (500m) must still fit.
-			const openclawControllerMillis = 250
-			const newapiCNPGMillis = 500
-			if limitMillis+openclawControllerMillis+newapiCNPGMillis > smallestPlanCPUMillis {
-				t.Fatalf("newapi %dm + openclaw controller %dm + newapi CNPG %dm = %dm "+
-					"exceeds the smallest-plan cap %dm — row 232's pod is refused at admission",
-					limitMillis, openclawControllerMillis, newapiCNPGMillis,
-					limitMillis+openclawControllerMillis+newapiCNPGMillis, smallestPlanCPUMillis)
+			// The headroom assertion the row actually turns on, at POD
+			// granularity (#6324). It sums the whole bp-newapi Pod — the
+			// container pinned above PLUS the two chart-default containers this
+			// overlay never mentions — because a ResourceQuota admits a Pod,
+			// not a container. Summing only `limitMillis` here understated the
+			// cost by 700m and left this guard green while the live cluster
+			// refused the Pod. See newapi_pod_quota_arithmetic_6324_test.go for
+			// the full derivation, the term list, and the live refusal.
+			pod := newapiPodCPUMillis(t, values)
+			openclawControllerMillis := openclawControllerPodCPUMillis(t)
+			newapiCNPGMillis := newapiCNPGCPUMillis(t)
+			if pod.total+openclawControllerMillis+newapiCNPGMillis > smallestPlanCPUMillis {
+				t.Fatalf("bp-newapi POD %dm + openclaw controller %dm + newapi CNPG %dm = %dm "+
+					"exceeds the smallest-plan cap %dm — row 232's pod is refused at admission.\n"+
+					"(the POD costs %dm; this overlay pins only %dm, on the `newapi` container)\n%s",
+					pod.total, openclawControllerMillis, newapiCNPGMillis,
+					pod.total+openclawControllerMillis+newapiCNPGMillis, smallestPlanCPUMillis,
+					pod.total, limitMillis, pod)
 			}
 		})
 	}
@@ -162,5 +176,17 @@ func TestNewAPIHR_Row232_VacuityCheck_HelperSeesTheChartDefault(t *testing.T) {
 	}
 	if m, err := cpuToMillis("0.5"); err != nil || m != 500 {
 		t.Fatalf("cpuToMillis(\"0.5\") = %dm err=%v, want 500m", m, err)
+	}
+
+	// #6324 — and the ceiling itself must still be the platform's ceiling. A
+	// local mirror that drifted BELOW the real cap would make every assertion
+	// above conservative-but-wrong; one that drifted ABOVE would let a Pod the
+	// cluster refuses pass here.
+	if derived := smallestPlanCPUMillisFromController(t); derived != smallestPlanCPUMillis {
+		t.Fatalf("smallestPlanCPUMillis = %dm but planQuotaTable[\"s\"].CPU in "+
+			"core/controllers/organization/internal/gitops/manifests.go now grants %dm. "+
+			"This guard is asserting against a ceiling the platform no longer has — "+
+			"update the mirror and re-check every headroom number that depends on it.",
+			smallestPlanCPUMillis, derived)
 	}
 }

--- a/core/services/provisioning/gitops/newapi_pod_quota_arithmetic_6324_test.go
+++ b/core/services/provisioning/gitops/newapi_pod_quota_arithmetic_6324_test.go
@@ -1,0 +1,551 @@
+package gitops
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// ─────────────────────────────────────────────────────────────────────────
+// #6324 — THE MODELLED UNIT IS THE POD, NOT ONE CONTAINER.
+//
+// The per-Org bp-newapi sizing override (#6114, UAT row 232) pins exactly one
+// term, `newapi.resources.limits.cpu`, and both of its guards asserted on that
+// one term. A ResourceQuota does not admit a container; it admits a POD. The
+// bp-newapi chart puts two more quota-counted containers in that same Pod and
+// the per-Org overlay overrides neither:
+//
+//	sandbox-bridge     200m   platform/newapi/chart/values.yaml sandboxBridge
+//	newapi             500m   pinned by the per-Org overlay
+//	metering-sidecar   500m   platform/newapi/chart/values.yaml meteringSidecar
+//	                  ─────
+//	POD limits.cpu    1200m
+//
+// sandbox-bridge is the term that is easy to miss by reading, and the reason is
+// structural rather than careless: templates/deployment.yaml renders it as a
+// NATIVE SIDECAR — an `initContainers` entry carrying `restartPolicy: Always`
+// (#3374) — so a reader scanning the `containers:` list sees only newapi and
+// metering-sidecar. Since Kubernetes 1.29 a native sidecar's limits count
+// toward the Pod's effective total exactly like a regular container's, and
+// Sovereigns run k3s v1.31.4. Note the term does NOT depend on which list it
+// lands in: with `sandboxBridge.nativeSidecar: false` the chart renders the
+// same image as a plain container instead, and it still counts. The term is
+// gated on `sandboxBridge.enabled` alone.
+//
+// The plain `wait-for-sql-dsn` initContainer is correctly EXCLUDED, and
+// TestNewAPIPodCPU_6324_PlainInitDoesNotDominate proves the exclusion instead
+// of assuming it: a Pod's effective limit is
+//
+//	max( sum(containers) + sum(native sidecars),
+//	     max over plain init i of ( init_i + sum(sidecars declared before i) ) )
+//
+// so the DSN gate only matters if its own branch overtakes the container sum.
+// Today it does not (100m + the 200m bridge declared before it = 300m against
+// 1200m), and a chart change that inverted that would go red here.
+//
+// MEASURED LIVE, hw296 dep e689e3b34a75fdec, Deployment walkthree/bp-newapi
+// ReplicaFailure=True FailedCreate:
+//
+//	pods "bp-newapi-6867df99bd-..." is forbidden: exceeded quota: plan-quota,
+//	requested: limits.cpu=1200m, used: limits.cpu=3300m, limited: limits.cpu=4
+//
+// `requested: limits.cpu=1200m` is the admission controller's OWN arithmetic
+// over the same Pod, and it matches the sum above term for term. That is what
+// identifies 500m as the WRONG QUANTITY rather than merely a conservative one.
+//
+// WHAT IS DERIVED AND WHAT IS PINNED, deliberately split:
+//
+//   - Every TERM (200m / 500m / 500m, the openclaw controller's 250m, the CNPG
+//     500m, the plan-"s" 2000m cap) is read from the file the platform itself
+//     reads, and a lookup that misses is FATAL, never zero. A guard that
+//     restated these numbers as literals would drift the moment a chart moved
+//     and would go on reporting a total that no longer exists — which is the
+//     defect being closed, one level up.
+//   - The TOTALS (1200m, and the 1950m-of-2000m bundle) are pinned against the
+//     cluster's own admission arithmetic quoted above. That is an INDEPENDENT
+//     measurement, not a restatement of the source, so guard-vs-cluster
+//     disagreement surfaces instead of being defined away.
+//
+// This file changes no quota, request or limit value. It only counts them
+// correctly. Whether 1200m is the right size for an Org boundary is a
+// plan-capacity decision and belongs to #5393, which is founder-gated.
+//
+// Refs #6324 #5393 #3988
+// ─────────────────────────────────────────────────────────────────────────
+
+// repoPath joins a path relative to the repository root. This package lives at
+// core/services/provisioning/gitops, so the root is four levels up.
+func repoPath(parts ...string) string {
+	return filepath.Join(append([]string{"..", "..", "..", ".."}, parts...)...)
+}
+
+// readRepoFile reads a repo-root-relative file. FATAL on a miss: every caller
+// below is deriving a term of an arithmetic, and a term that silently resolves
+// to zero is precisely how the Pod total lost 700m.
+//
+// NOTE FOR ANY FUTURE READER: reads like this one are INVISIBLE to the `go
+// test` cache key (the key covers this module's own files, not
+// platform/newapi/chart/**). Mutate the chart and a cached `ok` still stands.
+// Every proof of this file must run under `-count=1`;
+// scripts/check-go-test-count1.sh enforces that on every workflow (#6235).
+func readRepoFile(t *testing.T, parts ...string) string {
+	t.Helper()
+	p := repoPath(parts...)
+	b, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatalf("read %s: %v", p, err)
+	}
+	return string(b)
+}
+
+func newapiChartValues(t *testing.T) string {
+	t.Helper()
+	return readRepoFile(t, "platform", "newapi", "chart", "values.yaml")
+}
+
+// cpuTerm is one container that counts toward the bp-newapi Pod's effective
+// limits.cpu.
+type cpuTerm struct {
+	container string // the container name as it appears in the rendered Pod
+	block     string // the top-level values key that sizes it
+	enabledAt string // the values path that gates whether it renders ("" = always)
+	native    bool   // true = rendered as a native sidecar (initContainers + restartPolicy: Always)
+}
+
+// newapiPodCPUTerms is the Pod's container inventory, mirroring
+// platform/newapi/chart/templates/deployment.yaml. Adding a container to that
+// template without adding it here leaves the same 700m hole #6324 closed, so
+// TestNewAPIPodCPU_6324_TermsCoverEveryChartContainer cross-checks the list
+// against the template rather than trusting it.
+var newapiPodCPUTerms = []cpuTerm{
+	{container: "sandbox-bridge", block: "sandboxBridge", enabledAt: "sandboxBridge.enabled", native: true},
+	{container: "newapi", block: "newapi", enabledAt: ""},
+	{container: "metering-sidecar", block: "meteringSidecar", enabledAt: "meteringSidecar.enabled"},
+}
+
+// podCPU is a resolved Pod-level CPU model: the per-term breakdown plus the
+// total, so a failure message can name the term that moved.
+type podCPU struct {
+	total     int
+	byTerm    map[string]int
+	fromChart map[string]bool // true = the term took the chart default (overlay did not pin it)
+}
+
+// resolveTermCPU returns one term's limits.cpu in millicores, taking the
+// overlay's pin where it has one and the chart default otherwise — which is
+// exactly what Helm does, and exactly what the single-container model failed to
+// do for the two terms the overlay never mentions.
+func resolveTermCPU(t *testing.T, overlay, chart string, term cpuTerm) (millis int, fromChart bool) {
+	t.Helper()
+	path := term.block + ".resources.limits.cpu"
+	if v, ok := yamlScalar(overlay, path); ok {
+		m, err := cpuToMillis(v)
+		if err != nil {
+			t.Fatalf("overlay %s = %q is not a parseable CPU quantity: %v", path, v, err)
+		}
+		return m, false
+	}
+	v, ok := yamlScalar(chart, path)
+	if !ok {
+		t.Fatalf("neither the per-Org overlay nor platform/newapi/chart/values.yaml resolves %q. "+
+			"The chart was restructured and this guard's Pod arithmetic no longer covers the %q "+
+			"container. RE-POINT the path — do NOT drop the term; a dropped term is #6324.",
+			path, term.container)
+	}
+	m, err := cpuToMillis(v)
+	if err != nil {
+		t.Fatalf("chart %s = %q is not a parseable CPU quantity: %v", path, v, err)
+	}
+	return m, true
+}
+
+// newapiPodCPUMillis models the bp-newapi Pod the way a ResourceQuota admits
+// it: every regular container plus every native sidecar that renders.
+func newapiPodCPUMillis(t *testing.T, overlay string) podCPU {
+	t.Helper()
+	chart := newapiChartValues(t)
+	out := podCPU{byTerm: map[string]int{}, fromChart: map[string]bool{}}
+	for _, term := range newapiPodCPUTerms {
+		if term.enabledAt != "" && !termEnabled(t, overlay, chart, term) {
+			continue
+		}
+		m, fromChart := resolveTermCPU(t, overlay, chart, term)
+		out.byTerm[term.container] = m
+		out.fromChart[term.container] = fromChart
+		out.total += m
+	}
+	return out
+}
+
+// termEnabled reads the term's `enabled` gate — overlay first, chart second. A
+// gate that resolves to NEITHER is fatal rather than defaulted, because
+// guessing "probably on" is how an arithmetic acquires a term it cannot see.
+func termEnabled(t *testing.T, overlay, chart string, term cpuTerm) bool {
+	t.Helper()
+	if v, ok := yamlScalar(overlay, term.enabledAt); ok {
+		return v == "true"
+	}
+	v, ok := yamlScalar(chart, term.enabledAt)
+	if !ok {
+		t.Fatalf("neither the per-Org overlay nor platform/newapi/chart/values.yaml resolves %q, "+
+			"so this guard cannot tell whether the %q container renders. Re-point the gate.",
+			term.enabledAt, term.container)
+	}
+	return v == "true"
+}
+
+// ─── Neighbours in the same Org namespace ────────────────────────────────
+
+// openclawControllerPodCPUMillis derives the openclaw controller Pod's
+// limits.cpu from platform/openclaw/chart/values.yaml. Neither per-Org producer
+// overrides `controller.resources`, so the chart default is what lands in the
+// Org namespace. Its Deployment renders ONE container
+// (platform/openclaw/chart/templates/controller-deployment.yaml), so the Pod
+// total equals that container.
+func openclawControllerPodCPUMillis(t *testing.T) int {
+	t.Helper()
+	chart := readRepoFile(t, "platform", "openclaw", "chart", "values.yaml")
+	v, ok := yamlScalar(chart, "controller.resources.limits.cpu")
+	if !ok {
+		t.Fatalf("platform/openclaw/chart/values.yaml has no controller.resources.limits.cpu — " +
+			"re-point this term; the Org bundle arithmetic is incomplete without it")
+	}
+	m, err := cpuToMillis(v)
+	if err != nil {
+		t.Fatalf("openclaw controller.resources.limits.cpu = %q is not parseable: %v", v, err)
+	}
+	return m
+}
+
+// newapiCNPGCPUMillis derives the per-Org CNPG Postgres cost: the per-instance
+// limits.cpu times the instance count. The instance count is a term in its own
+// right — a chart that moved to `instances: 2` would double this silently, and
+// the operator-injected bootstrap-controller init container inherits the same
+// resources block, so a single instance's Pod total equals one instance's
+// limit.
+func newapiCNPGCPUMillis(t *testing.T) int {
+	t.Helper()
+	chart := newapiChartValues(t)
+	cpu, ok := yamlScalar(chart, "cnpg.cluster.resources.limits.cpu")
+	if !ok {
+		t.Fatalf("platform/newapi/chart/values.yaml has no cnpg.cluster.resources.limits.cpu — re-point this term")
+	}
+	m, err := cpuToMillis(cpu)
+	if err != nil {
+		t.Fatalf("cnpg.cluster.resources.limits.cpu = %q is not parseable: %v", cpu, err)
+	}
+	inst, ok := yamlScalar(chart, "cnpg.cluster.instances")
+	if !ok {
+		t.Fatalf("platform/newapi/chart/values.yaml has no cnpg.cluster.instances — re-point this term")
+	}
+	var n int
+	if _, err := fmt.Sscanf(strings.TrimSpace(inst), "%d", &n); err != nil || n < 1 {
+		t.Fatalf("cnpg.cluster.instances = %q is not a positive integer (%v)", inst, err)
+	}
+	return m * n
+}
+
+// smallestPlanCPUMillisFromController derives the plan-"s" ResourceQuota cap
+// from the ONE table the org-controller drives it off — planQuotaTable in
+// core/controllers/organization/internal/gitops/manifests.go. planQuota()
+// resolves an empty or unknown plan slug to "s", so this is the cap a fresh
+// funnel Org gets. Restating "2000" as a local constant would let a LOWERED cap
+// pass this guard unnoticed.
+func smallestPlanCPUMillisFromController(t *testing.T) int {
+	t.Helper()
+	src := readRepoFile(t, "core", "controllers", "organization", "internal", "gitops", "manifests.go")
+	re := regexp.MustCompile(`"s":\s*\{Slug:\s*"s",\s*CPU:\s*"([^"]*)"`)
+	m := re.FindStringSubmatch(src)
+	if m == nil {
+		t.Fatalf(`planQuotaTable["s"] not found in ` +
+			`core/controllers/organization/internal/gitops/manifests.go — the plan table was ` +
+			`restructured and this guard can no longer see the cap it asserts against. Re-point it.`)
+	}
+	millis, err := cpuToMillis(m[1])
+	if err != nil {
+		t.Fatalf(`planQuotaTable["s"].CPU = %q is not a parseable CPU quantity: %v`, m[1], err)
+	}
+	return millis
+}
+
+// ─── The assertions ──────────────────────────────────────────────────────
+
+// funnelOverlay renders the funnel producer's values block, which is the thing
+// under test on this door.
+func funnelOverlay(t *testing.T) string {
+	t.Helper()
+	return hrValuesBlock(t, generateNewAPIHR(helmReleaseAppOpts{slug: "acme", parentDomain: "omani.homes"}))
+}
+
+// liveAdmissionPodCPUMillis is the quantity the hw296 admission controller
+// itself reported for this Pod (`requested: limits.cpu=1200m`). It is pinned
+// rather than derived ON PURPOSE: it is the independent observation this
+// guard's derived arithmetic is checked against.
+const liveAdmissionPodCPUMillis = 1200
+
+// TestNewAPIPodCPU_6324_PodIsTheModelledUnit is the RED test for #6324: the
+// per-Org bp-newapi Pod costs the sum of its quota-counted containers, not the
+// one container the overlay pins.
+func TestNewAPIPodCPU_6324_PodIsTheModelledUnit(t *testing.T) {
+	pod := newapiPodCPUMillis(t, funnelOverlay(t))
+
+	sum := 0
+	for _, m := range pod.byTerm {
+		if m <= 0 {
+			t.Fatalf("a term resolved to %dm — a zero term means the lookup missed and the Pod "+
+				"total silently collapses toward the single-container model:\n%s", m, pod)
+		}
+		sum += m
+	}
+	if sum != pod.total {
+		t.Fatalf("Pod total %dm != the sum of its terms %dm — the arithmetic lost a term:\n%s",
+			pod.total, sum, pod)
+	}
+
+	// The whole point: the Pod is strictly more than the container the overlay
+	// pins. A regression to the single-container model fails HERE.
+	container, ok := pod.byTerm["newapi"]
+	if !ok {
+		t.Fatalf("the `newapi` container is absent from the Pod model:\n%s", pod)
+	}
+	if pod.total <= container {
+		t.Fatalf("VACUITY: Pod total %dm is not greater than the `newapi` container alone (%dm), "+
+			"so this guard would pass on the exact single-container model #6324 replaces:\n%s",
+			pod.total, container, pod)
+	}
+
+	// Guard-vs-cluster. The hw296 refusal read `requested: limits.cpu=1200m`.
+	if pod.total != liveAdmissionPodCPUMillis {
+		t.Fatalf("Pod total = %dm, but the live hw296 admission refusal for walkthree/bp-newapi "+
+			"read `requested: limits.cpu=%dm`. The guard and the cluster now disagree about what "+
+			"this Pod costs — reconcile them (and re-check #5393's plan sizing) before changing "+
+			"this number:\n%s", pod.total, liveAdmissionPodCPUMillis, pod)
+	}
+}
+
+// TestNewAPIPodCPU_6324_TermsCoverEveryChartContainer cross-checks the term
+// list against templates/deployment.yaml. A container added to the template and
+// not to newapiPodCPUTerms would re-open #6324 exactly as sandbox-bridge did,
+// and no assertion above could see it — the sum would simply be smaller.
+func TestNewAPIPodCPU_6324_TermsCoverEveryChartContainer(t *testing.T) {
+	tmpl := readRepoFile(t, "platform", "newapi", "chart", "templates", "deployment.yaml")
+	rendered := deploymentContainerNames(t, tmpl)
+	if len(rendered) == 0 {
+		t.Fatalf("VACUITY: parsed ZERO container names out of templates/deployment.yaml — the " +
+			"scanner missed, so this cross-check would pass on any term list at all")
+	}
+
+	// wait-for-sql-dsn is a PLAIN initContainer and is excluded by design; see
+	// TestNewAPIPodCPU_6324_PlainInitDoesNotDominate for the proof that the
+	// exclusion is safe rather than assumed.
+	const plainInit = "wait-for-sql-dsn"
+
+	modelled := map[string]bool{}
+	for _, term := range newapiPodCPUTerms {
+		modelled[term.container] = true
+	}
+	for _, name := range rendered {
+		if name == plainInit || modelled[name] {
+			continue
+		}
+		t.Fatalf("templates/deployment.yaml renders a container %q that newapiPodCPUTerms does "+
+			"not model. Every regular container and every native sidecar counts toward the Pod's "+
+			"limits.cpu, so an unmodelled one understates the quota cost — that is #6324. Add the "+
+			"term (or, if it is a PLAIN initContainer, extend the exclusion WITH a proof that it "+
+			"cannot dominate).\nrendered: %v", name, rendered)
+	}
+}
+
+// TestNewAPIPodCPU_6324_PlainInitDoesNotDominate proves the one term this
+// arithmetic deliberately leaves OUT is safe to leave out. A Pod's effective
+// limit is the max of the container branch and the plain-init branch, and the
+// DSN gate only stops being free if its branch overtakes the container sum.
+func TestNewAPIPodCPU_6324_PlainInitDoesNotDominate(t *testing.T) {
+	tmpl := readRepoFile(t, "platform", "newapi", "chart", "templates", "deployment.yaml")
+	gate := initContainerCPULimit(t, tmpl, "wait-for-sql-dsn")
+	if gate <= 0 {
+		t.Fatalf("VACUITY: wait-for-sql-dsn limits.cpu resolved to %dm — the scanner missed, and a "+
+			"zero here would make the comparison below unfalsifiable", gate)
+	}
+
+	pod := newapiPodCPUMillis(t, funnelOverlay(t))
+	// Native sidecars declared BEFORE a plain init are held for its whole run,
+	// so they join its branch. sandbox-bridge is declared first (#3374).
+	bridge := pod.byTerm["sandbox-bridge"]
+	initBranch := gate + bridge
+	if initBranch >= pod.total {
+		t.Fatalf("the plain-init branch (wait-for-sql-dsn %dm + sandbox-bridge %dm held across it "+
+			"= %dm) now MEETS OR EXCEEDS the container branch (%dm), so the Pod's effective "+
+			"limits.cpu is no longer the container sum and this guard's arithmetic is "+
+			"incomplete:\n%s", gate, bridge, initBranch, pod.total, pod)
+	}
+}
+
+// TestNewAPIPodCPU_6324_OrgBundleFitsSmallestPlan is the headroom assertion the
+// row actually turns on, restated at Pod granularity and with every term
+// derived from the file the platform reads.
+func TestNewAPIPodCPU_6324_OrgBundleFitsSmallestPlan(t *testing.T) {
+	pod := newapiPodCPUMillis(t, funnelOverlay(t))
+	openclaw := openclawControllerPodCPUMillis(t)
+	cnpg := newapiCNPGCPUMillis(t)
+	cap := smallestPlanCPUMillisFromController(t)
+
+	bundle := pod.total + openclaw + cnpg
+	if bundle > cap {
+		t.Fatalf("bp-newapi POD %dm + openclaw controller %dm + newapi CNPG %dm = %dm exceeds the "+
+			"smallest-plan cap %dm — the Pod is refused at admission, which is the live hw296 "+
+			"failure verbatim:\n%s", pod.total, openclaw, cnpg, bundle, cap, pod)
+	}
+
+	// The headroom is the number the issue turns on and it is ALARMING: 50m of
+	// a 2000m Org cap for everything else the Org will ever install. Pinning it
+	// means any term that grows — in either chart, or in the plan table — turns
+	// this red instead of quietly consuming the last of the margin.
+	const wantBundle, wantHeadroom = 1950, 50
+	if bundle != wantBundle || cap-bundle != wantHeadroom {
+		t.Fatalf("the Org bundle now totals %dm of the %dm cap (headroom %dm); this guard was "+
+			"written against %dm / %dm headroom, measured from the same files. A term moved — "+
+			"name it and re-derive:\n  bp-newapi POD  %dm\n  openclaw ctrl  %dm\n  newapi CNPG    %dm\n%s",
+			bundle, cap, cap-bundle, wantBundle, wantHeadroom, pod.total, openclaw, cnpg, pod)
+	}
+}
+
+// TestNewAPIPodCPU_6324_VacuityCheck_TheOldModelWouldHavePassed is the proof
+// that this whole file is load-bearing. It reconstructs the PRE-FIX
+// single-container arithmetic from the same derived terms and shows it reported
+// 750m of headroom where the truth is 50m — i.e. the old guard was green over a
+// Pod the cluster was refusing. If a future edit collapses the Pod model back
+// to one container, these two numbers converge and this test fails.
+func TestNewAPIPodCPU_6324_VacuityCheck_TheOldModelWouldHavePassed(t *testing.T) {
+	pod := newapiPodCPUMillis(t, funnelOverlay(t))
+	openclaw := openclawControllerPodCPUMillis(t)
+	cnpg := newapiCNPGCPUMillis(t)
+	cap := smallestPlanCPUMillisFromController(t)
+
+	container := pod.byTerm["newapi"]
+	oldHeadroom := cap - (container + openclaw + cnpg)
+	newHeadroom := cap - (pod.total + openclaw + cnpg)
+
+	if oldHeadroom == newHeadroom {
+		t.Fatalf("VACUITY: the single-container model and the Pod model report the SAME headroom "+
+			"(%dm). Either the sidecar terms have been dropped, or they resolved to zero — in "+
+			"both cases this file no longer models what #6324 is about:\n%s", oldHeadroom, pod)
+	}
+	if oldHeadroom <= newHeadroom {
+		t.Fatalf("VACUITY: the single-container model reports LESS headroom (%dm) than the Pod "+
+			"model (%dm), which is arithmetically impossible while the sidecars cost anything:\n%s",
+			oldHeadroom, newHeadroom, pod)
+	}
+	const wantOld, wantNew = 750, 50
+	if oldHeadroom != wantOld || newHeadroom != wantNew {
+		t.Fatalf("the understatement changed: the single-container model now reports %dm of "+
+			"headroom and the Pod model %dm (this file was written against %dm vs %dm). Re-derive "+
+			"and restate the defect before adjusting these:\n%s",
+			oldHeadroom, newHeadroom, wantOld, wantNew, pod)
+	}
+}
+
+// ─── Template scanners ───────────────────────────────────────────────────
+
+// containerNameRe matches a `- name: <x>` list entry at the indentation
+// templates/deployment.yaml uses for containers and initContainers entries
+// (8 spaces), which is deeper than the `- name:` entries used for volumes and
+// env vars only in that those sit at other depths — hence the anchored indent.
+var containerNameRe = regexp.MustCompile(`(?m)^        - name: ([a-z0-9][a-z0-9-]*)\s*$`)
+
+// deploymentContainerNames returns every container/initContainer name declared
+// in templates/deployment.yaml. It reads the TEMPLATE rather than a render
+// because the render needs Helm; the names are literal in the template, and
+// TestNewAPIPodCPU_6324_TermsCoverEveryChartContainer refuses a zero-length
+// result so a scanner that stopped matching cannot report a pass.
+func deploymentContainerNames(t *testing.T, tmpl string) []string {
+	t.Helper()
+	// Restrict to the Pod spec: everything from `initContainers:` (or
+	// `containers:`) up to the `volumes:` block, so volume entries — which share
+	// the `- name:` shape at other depths — cannot be mistaken for containers.
+	start := strings.Index(tmpl, "\n      initContainers:")
+	if start < 0 {
+		start = strings.Index(tmpl, "\n      containers:")
+	}
+	if start < 0 {
+		t.Fatalf("templates/deployment.yaml has neither an initContainers: nor a containers: block " +
+			"at the expected depth — the template was restructured; re-point this scanner")
+	}
+	end := strings.Index(tmpl[start:], "\n      volumes:")
+	if end < 0 {
+		t.Fatalf("templates/deployment.yaml has no volumes: block after the container lists — the " +
+			"scanner cannot bound the Pod spec; re-point it")
+	}
+	spec := tmpl[start : start+end]
+
+	var out []string
+	seen := map[string]bool{}
+	for _, m := range containerNameRe.FindAllStringSubmatch(spec, -1) {
+		if seen[m[1]] {
+			continue
+		}
+		seen[m[1]] = true
+		out = append(out, m[1])
+	}
+	return out
+}
+
+// initContainerCPULimit pulls a literal `resources.limits.cpu` out of one named
+// container block in templates/deployment.yaml. The DSN gate's resources are
+// written inline in the template rather than in values.yaml, so this is the
+// only place that number exists.
+func initContainerCPULimit(t *testing.T, tmpl, name string) int {
+	t.Helper()
+	marker := "- name: " + name + "\n"
+	i := strings.Index(tmpl, marker)
+	if i < 0 {
+		t.Fatalf("templates/deployment.yaml declares no container %q — re-point this scanner; do "+
+			"NOT drop the check", name)
+	}
+	block := tmpl[i+len(marker):]
+	// Stop at the next sibling list entry so a later container's numbers cannot
+	// be attributed to this one — the same mis-attribution class #6324 is about.
+	if j := strings.Index(block, "\n        - name: "); j >= 0 {
+		block = block[:j]
+	}
+	re := regexp.MustCompile(`(?s)limits:\s*\n\s*cpu:\s*(\S+)`)
+	m := re.FindStringSubmatch(block)
+	if m == nil {
+		t.Fatalf("container %q in templates/deployment.yaml has no literal resources.limits.cpu — "+
+			"if it moved to values.yaml, re-point this lookup; a missing term must never read as "+
+			"zero", name)
+	}
+	v, err := cpuToMillis(m[1])
+	if err != nil {
+		t.Fatalf("container %q limits.cpu = %q is not parseable: %v", name, m[1], err)
+	}
+	return v
+}
+
+// String renders the per-term breakdown for failure messages, so a red test
+// names the term that moved instead of only the total.
+func (p podCPU) String() string {
+	var b strings.Builder
+	b.WriteString("  bp-newapi Pod limits.cpu breakdown:\n")
+	for _, term := range newapiPodCPUTerms {
+		m, ok := p.byTerm[term.container]
+		if !ok {
+			fmt.Fprintf(&b, "    %-18s (not rendered — its enabled gate is false)\n", term.container)
+			continue
+		}
+		src := "per-Org overlay"
+		if p.fromChart[term.container] {
+			src = "chart default"
+		}
+		kind := "container"
+		if term.native {
+			kind = "native sidecar"
+		}
+		fmt.Fprintf(&b, "    %-18s %5dm  (%s, %s)\n", term.container, m, kind, src)
+	}
+	fmt.Fprintf(&b, "    %-18s %5dm\n", "POD TOTAL", p.total)
+	return b.String()
+}

--- a/core/services/provisioning/gitops/newapi_pod_quota_arithmetic_6324_test.go
+++ b/core/services/provisioning/gitops/newapi_pod_quota_arithmetic_6324_test.go
@@ -347,6 +347,30 @@ func TestNewAPIPodCPU_6324_TermsCoverEveryChartContainer(t *testing.T) {
 	for _, term := range newapiPodCPUTerms {
 		modelled[term.container] = true
 	}
+
+	// BOTH DIRECTIONS. The check below (rendered ⊆ modelled ∪ {plainInit}) is
+	// satisfied vacuously by a scanner that found only ONE container, so assert
+	// the other inclusion first: every term this file models must actually
+	// appear in the template. That is what makes the len()>0 check above more
+	// than a formality.
+	renderedSet := map[string]bool{}
+	for _, name := range rendered {
+		renderedSet[name] = true
+	}
+	for _, term := range newapiPodCPUTerms {
+		if !renderedSet[term.container] {
+			t.Fatalf("newapiPodCPUTerms models a container %q that the scanner did not find in "+
+				"templates/deployment.yaml. Either the chart dropped it — in which case the Pod "+
+				"total is now overstated — or this scanner stopped matching, in which case the "+
+				"coverage check below is vacuous.\nrendered: %v", term.container, rendered)
+		}
+	}
+	if !renderedSet[plainInit] {
+		t.Fatalf("the scanner did not find the %q plain initContainer, which "+
+			"TestNewAPIPodCPU_6324_PlainInitDoesNotDominate depends on being present.\nrendered: %v",
+			plainInit, rendered)
+	}
+
 	for _, name := range rendered {
 		if name == plainInit || modelled[name] {
 			continue

--- a/products/catalyst/bootstrap/api/internal/handler/organization_gitops.go
+++ b/products/catalyst/bootstrap/api/internal/handler/organization_gitops.go
@@ -1455,6 +1455,23 @@ spec:
     # (core/controllers/organization/internal/gitops/manifests.go:121). A
     # ResourceQuota counts limits, so the chart default reserved the entire cap
     # and every pod rendered beside it was refused at admission.
+    #
+    # ── WHAT THIS BLOCK DOES *NOT* SIZE (#6324) ───────────────────────
+    # It pins ONE of the THREE quota-counted containers in this release's
+    # Pod, and a ResourceQuota admits the POD:
+    #   sandbox-bridge    200m  chart default; a NATIVE sidecar
+    #                           (initContainers + restartPolicy: Always,
+    #                           #3374), counted on k8s 1.29+
+    #   newapi            500m  pinned below
+    #   metering-sidecar  500m  chart default
+    #   ------------------------
+    #   POD limits.cpu   1200m
+    # Org bundle = 1200m + openclaw 250m + CNPG 500m = 1950m of the 2000m
+    # smallest-plan cap — 50m of real headroom, not the 750m a
+    # single-container reading suggests. Raising EITHER sidecar by 100m
+    # puts the Org over the cap. Both guards now compute this Pod total
+    # from the chart; sizing the Pod is #5393, and nothing here changes a
+    # value.
     newapi:
       resources:
         requests:

--- a/products/catalyst/bootstrap/api/internal/handler/orgtenant_newapi_plan_quota_row232_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/orgtenant_newapi_plan_quota_row232_test.go
@@ -88,11 +88,22 @@ func TestOrgTenantBPNewAPI_Row232_PinsCPUInsideThePlanQuota(t *testing.T) {
 			"these must match so the reservation is honest",
 			reqM[1], reqMillis, limM[1], limMillis)
 	}
-	// Headroom for the workloads rendered alongside: openclaw controller 250m
-	// + this release's own CNPG 500m.
-	if limMillis+250+500 > smallestPlanCPUMillisBSS {
-		t.Fatalf("newapi %dm + openclaw 250m + CNPG 500m exceeds the %dm cap",
-			limMillis, smallestPlanCPUMillisBSS)
+	// Headroom for the workloads rendered alongside, at POD granularity
+	// (#6324). It sums the whole bp-newapi Pod — the container pinned above
+	// PLUS the two chart-default containers this overlay never mentions —
+	// because a ResourceQuota admits a Pod, not a container. Summing only
+	// `limMillis` here understated the cost by 700m and left this guard green
+	// while the live cluster refused the Pod. Terms derived in
+	// orgtenant_newapi_pod_quota_arithmetic_6324_test.go.
+	pod := newapiPodCPUMillisBSS(t)
+	openclaw := openclawControllerPodCPUMillisBSS(t)
+	cnpg := newapiCNPGCPUMillisBSS(t)
+	if pod.total+openclaw+cnpg > smallestPlanCPUMillisBSS {
+		t.Fatalf("bp-newapi POD %dm + openclaw controller %dm + newapi CNPG %dm = %dm exceeds "+
+			"the %dm cap.\n(the POD costs %dm; this overlay pins only %dm, on the `newapi` "+
+			"container)\n%s",
+			pod.total, openclaw, cnpg, pod.total+openclaw+cnpg, smallestPlanCPUMillisBSS,
+			pod.total, limMillis, pod)
 	}
 }
 

--- a/products/catalyst/bootstrap/api/internal/handler/orgtenant_newapi_pod_quota_arithmetic_6324_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/orgtenant_newapi_pod_quota_arithmetic_6324_test.go
@@ -1,0 +1,513 @@
+package handler
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// ─────────────────────────────────────────────────────────────────────────
+// #6324, BSS-door half — THE MODELLED UNIT IS THE POD, NOT ONE CONTAINER.
+//
+// Lockstep with core/services/provisioning/gitops/
+// newapi_pod_quota_arithmetic_6324_test.go, which carries the full derivation.
+// Short form: there are TWO producers of a per-Org bp-newapi release — the
+// funnel generator (generateNewAPIHR) and this BSS door (orgTenantBPNewAPI) —
+// and BOTH sized the release by the one container they pin,
+// `newapi.resources.limits.cpu`. A ResourceQuota admits a POD:
+//
+//	sandbox-bridge     200m   chart default, native sidecar (initContainers +
+//	                          restartPolicy: Always, #3374) — counts on k8s 1.29+
+//	newapi             500m   pinned by this overlay
+//	metering-sidecar   500m   chart default
+//	                  ─────
+//	POD limits.cpu    1200m
+//
+// Measured live on hw296 (dep e689e3b34a75fdec), Deployment walkthree/bp-newapi
+// ReplicaFailure=True FailedCreate:
+//
+//	pods "bp-newapi-6867df99bd-..." is forbidden: exceeded quota: plan-quota,
+//	requested: limits.cpu=1200m, used: limits.cpu=3300m, limited: limits.cpu=4
+//
+// WHY THIS IS DUPLICATED RATHER THAN SHARED. The two producers live in two
+// separate Go modules (core/services/provisioning and
+// products/catalyst/bootstrap/api) with no shared package between them, so the
+// arithmetic is written twice. The duplication is made safe by pinning BOTH
+// copies to the same derived totals — 1200m for the Pod, 1950m of the 2000m
+// smallest-plan cap for the Org bundle — so a change that moves one door's
+// number without the other turns exactly one of them red and names it. A fix
+// applied to one producer and not the other is the shape that let UAT row 15
+// render three of seven Org chips for a month behind a green label-only test.
+//
+// Every TERM here is read from the file the platform itself reads and a miss is
+// FATAL, never zero. The TOTALS are pinned against the cluster's own admission
+// arithmetic quoted above — an independent measurement, not a restatement.
+//
+// This file changes no quota, request or limit value; the plan-capacity
+// question belongs to #5393, which is founder-gated.
+//
+// Refs #6324 #5393 #3988
+// ─────────────────────────────────────────────────────────────────────────
+
+// ─── yamlScalar, ported verbatim ─────────────────────────────────────────
+//
+// This is the SAME indentation-aware lookup the funnel-door guard uses
+// (core/services/provisioning/gitops/newapi_hr_installable_5987_test.go),
+// copied because the module boundary forbids importing it. It is a verbatim
+// port ON PURPOSE: re-hand-rolling the predicate as a regex is how a lookup
+// silently crosses out of the block it is scoped to and attributes a
+// neighbouring container's number to this term — the same mis-measurement class
+// this file exists to remove. TestYAMLScalarBSS_SelfCheck below proves the port
+// still refuses to skip a level and still misses what is absent.
+func yamlScalarBSS(block, path string) (string, bool) {
+	segs := strings.Split(path, ".")
+	lines := strings.Split(block, "\n")
+	depth, idx := 0, 0
+	for si, seg := range segs {
+		found := false
+		for ; idx < len(lines); idx++ {
+			raw := lines[idx]
+			trimmed := strings.TrimLeft(raw, " ")
+			if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+				continue
+			}
+			ind := len(raw) - len(trimmed)
+			if ind < depth {
+				return "", false
+			}
+			if ind > depth {
+				continue
+			}
+			if !strings.HasPrefix(trimmed, seg+":") {
+				continue
+			}
+			rest := strings.TrimSpace(strings.TrimPrefix(trimmed, seg+":"))
+			if si == len(segs)-1 {
+				return rest, true
+			}
+			idx++
+			depth += 2
+			found = true
+			break
+		}
+		if !found {
+			return "", false
+		}
+	}
+	return "", false
+}
+
+// TestYAMLScalarBSS_SelfCheck is the port's vacuity guard: a lookup that
+// silently matched nothing would make every assertion below unfalsifiable, and
+// one that flattened the tree would find a term under the wrong parent.
+func TestYAMLScalarBSS_SelfCheck(t *testing.T) {
+	fixture := strings.Join([]string{
+		"sovereignFQDN: acme.omani.homes",
+		"newapi:",
+		"  resources:",
+		"    # a comment that must be skipped",
+		"    requests:",
+		"      cpu: 500m",
+		"    limits:",
+		"      cpu: 500m",
+		"meteringSidecar:",
+		"  enabled: true",
+		"  resources:",
+		"    limits:",
+		"      cpu: 500m",
+	}, "\n")
+
+	for path, want := range map[string]string{
+		"sovereignFQDN":                        "acme.omani.homes",
+		"newapi.resources.limits.cpu":          "500m",
+		"newapi.resources.requests.cpu":        "500m",
+		"meteringSidecar.enabled":              "true",
+		"meteringSidecar.resources.limits.cpu": "500m",
+	} {
+		if got, ok := yamlScalarBSS(fixture, path); !ok || got != want {
+			t.Errorf("yamlScalarBSS(%q) = (%q, %v), want (%q, true)", path, got, ok, want)
+		}
+	}
+
+	// It must MISS what is absent and must NOT skip a level — a flattened
+	// lookup would read `limits.cpu` out of whichever block came first and
+	// attribute it to every term.
+	for _, path := range []string{
+		"sandboxBridge.resources.limits.cpu",
+		"newapi.limits.cpu",
+		"resources.limits.cpu",
+		"newapi.resources.limits.memory",
+	} {
+		if got, ok := yamlScalarBSS(fixture, path); ok {
+			t.Errorf("yamlScalarBSS(%q) = (%q, true), want a miss", path, got)
+		}
+	}
+}
+
+// ─── Repo reads ──────────────────────────────────────────────────────────
+
+// repoFileBSS reads a repo-root-relative file. This package lives at
+// products/catalyst/bootstrap/api/internal/handler — six levels down. FATAL on
+// a miss, because every caller is deriving a term and a term that silently
+// resolves to zero is exactly how the Pod total lost 700m.
+//
+// NOTE: reads like this are INVISIBLE to the `go test` cache key. Mutate the
+// chart and a cached `ok` still stands over it. Every proof of this file must
+// run under `-count=1`; scripts/check-go-test-count1.sh enforces that on every
+// workflow (#6235), and this module's gate already passes it.
+func repoFileBSS(t *testing.T, parts ...string) string {
+	t.Helper()
+	p := filepath.Join(append([]string{"..", "..", "..", "..", "..", ".."}, parts...)...)
+	b, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatalf("read %s: %v", p, err)
+	}
+	return string(b)
+}
+
+func newapiChartValuesBSS(t *testing.T) string {
+	t.Helper()
+	return repoFileBSS(t, "platform", "newapi", "chart", "values.yaml")
+}
+
+// orgTenantBPNewAPIValues returns orgTenantBPNewAPI's `spec.values:` mapping
+// dedented to column 0, so a path reads like a chart values path.
+func orgTenantBPNewAPIValues(t *testing.T) string {
+	t.Helper()
+	var out []string
+	grabbing := false
+	for _, l := range strings.Split(orgTenantBPNewAPI, "\n") {
+		if l == "  values:" {
+			grabbing = true
+			continue
+		}
+		if !grabbing {
+			continue
+		}
+		if strings.TrimSpace(l) == "" {
+			out = append(out, "")
+			continue
+		}
+		if !strings.HasPrefix(l, "    ") {
+			break
+		}
+		out = append(out, l[4:])
+	}
+	if len(out) == 0 {
+		t.Fatalf("orgTenantBPNewAPI carries no spec.values block")
+	}
+	return strings.Join(out, "\n")
+}
+
+// ─── The Pod model ───────────────────────────────────────────────────────
+
+// cpuTermBSS is one container that counts toward the bp-newapi Pod's effective
+// limits.cpu. Mirrors newapiPodCPUTerms on the funnel door.
+type cpuTermBSS struct {
+	container string
+	block     string
+	enabledAt string
+	native    bool
+}
+
+var newapiPodCPUTermsBSS = []cpuTermBSS{
+	{container: "sandbox-bridge", block: "sandboxBridge", enabledAt: "sandboxBridge.enabled", native: true},
+	{container: "newapi", block: "newapi"},
+	{container: "metering-sidecar", block: "meteringSidecar", enabledAt: "meteringSidecar.enabled"},
+}
+
+type podCPUBSS struct {
+	total     int
+	byTerm    map[string]int
+	fromChart map[string]bool
+}
+
+func (p podCPUBSS) String() string {
+	var b strings.Builder
+	b.WriteString("  bp-newapi Pod limits.cpu breakdown:\n")
+	for _, term := range newapiPodCPUTermsBSS {
+		m, ok := p.byTerm[term.container]
+		if !ok {
+			fmt.Fprintf(&b, "    %-18s (not rendered — its enabled gate is false)\n", term.container)
+			continue
+		}
+		src := "per-Org overlay"
+		if p.fromChart[term.container] {
+			src = "chart default"
+		}
+		kind := "container"
+		if term.native {
+			kind = "native sidecar"
+		}
+		fmt.Fprintf(&b, "    %-18s %5dm  (%s, %s)\n", term.container, m, kind, src)
+	}
+	fmt.Fprintf(&b, "    %-18s %5dm\n", "POD TOTAL", p.total)
+	return b.String()
+}
+
+// newapiPodCPUMillisBSS models the Pod the way a ResourceQuota admits it: every
+// regular container plus every native sidecar that renders, taking this
+// overlay's pin where it has one and the chart default otherwise — which is
+// what Helm does, and what the single-container model failed to do for the two
+// terms this overlay never mentions.
+func newapiPodCPUMillisBSS(t *testing.T) podCPUBSS {
+	t.Helper()
+	overlay := orgTenantBPNewAPIValues(t)
+	chart := newapiChartValuesBSS(t)
+	out := podCPUBSS{byTerm: map[string]int{}, fromChart: map[string]bool{}}
+
+	for _, term := range newapiPodCPUTermsBSS {
+		if term.enabledAt != "" {
+			on, ok := yamlScalarBSS(overlay, term.enabledAt)
+			if !ok {
+				on, ok = yamlScalarBSS(chart, term.enabledAt)
+			}
+			if !ok {
+				t.Fatalf("neither orgTenantBPNewAPI nor platform/newapi/chart/values.yaml resolves "+
+					"%q, so this guard cannot tell whether the %q container renders. Re-point the gate.",
+					term.enabledAt, term.container)
+			}
+			if on != "true" {
+				continue
+			}
+		}
+
+		path := term.block + ".resources.limits.cpu"
+		v, ok := yamlScalarBSS(overlay, path)
+		fromChart := false
+		if !ok {
+			v, ok = yamlScalarBSS(chart, path)
+			fromChart = true
+		}
+		if !ok {
+			t.Fatalf("neither orgTenantBPNewAPI nor platform/newapi/chart/values.yaml resolves %q. "+
+				"The chart was restructured and this guard's Pod arithmetic no longer covers the %q "+
+				"container. RE-POINT the path — do NOT drop the term; a dropped term is #6324.",
+				path, term.container)
+		}
+		m, parsed := cpuMillisFromYAML(v)
+		if !parsed {
+			t.Fatalf("%s = %q is not a parseable CPU quantity", path, v)
+		}
+		out.byTerm[term.container] = m
+		out.fromChart[term.container] = fromChart
+		out.total += m
+	}
+	return out
+}
+
+// ─── Neighbours in the same Org namespace ────────────────────────────────
+
+func openclawControllerPodCPUMillisBSS(t *testing.T) int {
+	t.Helper()
+	chart := repoFileBSS(t, "platform", "openclaw", "chart", "values.yaml")
+	v, ok := yamlScalarBSS(chart, "controller.resources.limits.cpu")
+	if !ok {
+		t.Fatalf("platform/openclaw/chart/values.yaml has no controller.resources.limits.cpu — " +
+			"re-point this term; the Org bundle arithmetic is incomplete without it")
+	}
+	m, parsed := cpuMillisFromYAML(v)
+	if !parsed {
+		t.Fatalf("openclaw controller.resources.limits.cpu = %q is not parseable", v)
+	}
+	return m
+}
+
+// newapiCNPGCPUMillisBSS is the per-Org Postgres cost: per-instance limits.cpu
+// times the instance count. The instance count is a term in its own right — a
+// move to `instances: 2` would double this silently.
+func newapiCNPGCPUMillisBSS(t *testing.T) int {
+	t.Helper()
+	chart := newapiChartValuesBSS(t)
+	cpu, ok := yamlScalarBSS(chart, "cnpg.cluster.resources.limits.cpu")
+	if !ok {
+		t.Fatalf("platform/newapi/chart/values.yaml has no cnpg.cluster.resources.limits.cpu — re-point this term")
+	}
+	m, parsed := cpuMillisFromYAML(cpu)
+	if !parsed {
+		t.Fatalf("cnpg.cluster.resources.limits.cpu = %q is not parseable", cpu)
+	}
+	inst, ok := yamlScalarBSS(chart, "cnpg.cluster.instances")
+	if !ok {
+		t.Fatalf("platform/newapi/chart/values.yaml has no cnpg.cluster.instances — re-point this term")
+	}
+	var n int
+	if _, err := fmt.Sscanf(strings.TrimSpace(inst), "%d", &n); err != nil || n < 1 {
+		t.Fatalf("cnpg.cluster.instances = %q is not a positive integer (%v)", inst, err)
+	}
+	return m * n
+}
+
+// smallestPlanCPUMillisFromControllerBSS derives the plan-"s" cap from the ONE
+// table the org-controller drives the ResourceQuota off. Restating "2000" as a
+// local constant would let a LOWERED cap pass unnoticed.
+func smallestPlanCPUMillisFromControllerBSS(t *testing.T) int {
+	t.Helper()
+	src := repoFileBSS(t, "core", "controllers", "organization", "internal", "gitops", "manifests.go")
+	re := regexp.MustCompile(`"s":\s*\{Slug:\s*"s",\s*CPU:\s*"([^"]*)"`)
+	m := re.FindStringSubmatch(src)
+	if m == nil {
+		t.Fatalf(`planQuotaTable["s"] not found in ` +
+			`core/controllers/organization/internal/gitops/manifests.go — the plan table was ` +
+			`restructured and this guard can no longer see the cap it asserts against. Re-point it.`)
+	}
+	millis, ok := cpuMillisFromYAML(m[1])
+	if !ok {
+		t.Fatalf(`planQuotaTable["s"].CPU = %q is not a parseable CPU quantity`, m[1])
+	}
+	return millis
+}
+
+// ─── The assertions ──────────────────────────────────────────────────────
+
+// liveAdmissionPodCPUMillisBSS is the quantity the hw296 admission controller
+// itself reported (`requested: limits.cpu=1200m`). Pinned rather than derived
+// ON PURPOSE: it is the independent observation the derived arithmetic is
+// checked against, and it is what keeps the two doors from drifting apart.
+const liveAdmissionPodCPUMillisBSS = 1200
+
+func TestOrgTenantBPNewAPI_6324_PodIsTheModelledUnit(t *testing.T) {
+	pod := newapiPodCPUMillisBSS(t)
+
+	sum := 0
+	for _, m := range pod.byTerm {
+		if m <= 0 {
+			t.Fatalf("a term resolved to %dm — a zero term means the lookup missed and the Pod "+
+				"total silently collapses toward the single-container model:\n%s", m, pod)
+		}
+		sum += m
+	}
+	if sum != pod.total {
+		t.Fatalf("Pod total %dm != the sum of its terms %dm — the arithmetic lost a term:\n%s",
+			pod.total, sum, pod)
+	}
+
+	container, ok := pod.byTerm["newapi"]
+	if !ok {
+		t.Fatalf("the `newapi` container is absent from the Pod model:\n%s", pod)
+	}
+	if pod.total <= container {
+		t.Fatalf("VACUITY: Pod total %dm is not greater than the `newapi` container alone (%dm), "+
+			"so this guard would pass on the exact single-container model #6324 replaces:\n%s",
+			pod.total, container, pod)
+	}
+
+	if pod.total != liveAdmissionPodCPUMillisBSS {
+		t.Fatalf("Pod total = %dm, but the live hw296 admission refusal for walkthree/bp-newapi "+
+			"read `requested: limits.cpu=%dm`. The BSS door and the cluster now disagree about "+
+			"what this Pod costs — reconcile them, and check the funnel door "+
+			"(core/services/provisioning/gitops) has moved in lockstep:\n%s",
+			pod.total, liveAdmissionPodCPUMillisBSS, pod)
+	}
+}
+
+func TestOrgTenantBPNewAPI_6324_OrgBundleFitsSmallestPlan(t *testing.T) {
+	pod := newapiPodCPUMillisBSS(t)
+	openclaw := openclawControllerPodCPUMillisBSS(t)
+	cnpg := newapiCNPGCPUMillisBSS(t)
+	planCap := smallestPlanCPUMillisFromControllerBSS(t)
+
+	bundle := pod.total + openclaw + cnpg
+	if bundle > planCap {
+		t.Fatalf("bp-newapi POD %dm + openclaw controller %dm + newapi CNPG %dm = %dm exceeds the "+
+			"smallest-plan cap %dm — the Pod is refused at admission, which is the live hw296 "+
+			"failure verbatim:\n%s", pod.total, openclaw, cnpg, bundle, planCap, pod)
+	}
+
+	// 50m of a 2000m Org cap for everything else the Org will ever install.
+	// Pinning it means any term that grows turns this red instead of quietly
+	// consuming the last of the margin.
+	const wantBundle, wantHeadroom = 1950, 50
+	if bundle != wantBundle || planCap-bundle != wantHeadroom {
+		t.Fatalf("the Org bundle now totals %dm of the %dm cap (headroom %dm); this guard was "+
+			"written against %dm / %dm headroom, measured from the same files. A term moved — "+
+			"name it and re-derive:\n  bp-newapi POD  %dm\n  openclaw ctrl  %dm\n  newapi CNPG    %dm\n%s",
+			bundle, planCap, planCap-bundle, wantBundle, wantHeadroom, pod.total, openclaw, cnpg, pod)
+	}
+
+	// The local mirror used by the pre-#6324 assertions in
+	// orgtenant_newapi_plan_quota_row232_test.go must still be the platform's
+	// real ceiling.
+	if planCap != smallestPlanCPUMillisBSS {
+		t.Fatalf("smallestPlanCPUMillisBSS = %dm but planQuotaTable[\"s\"].CPU now grants %dm — "+
+			"this package is asserting against a ceiling the platform no longer has",
+			smallestPlanCPUMillisBSS, planCap)
+	}
+}
+
+// TestOrgTenantBPNewAPI_6324_VacuityCheck_TheOldModelWouldHavePassed proves the
+// file is load-bearing: it reconstructs the PRE-FIX single-container arithmetic
+// from the same derived terms and shows it reported 750m of headroom where the
+// truth is 50m — the old guard was green over a Pod the cluster was refusing.
+// Collapse the Pod model back to one container and these numbers converge.
+func TestOrgTenantBPNewAPI_6324_VacuityCheck_TheOldModelWouldHavePassed(t *testing.T) {
+	pod := newapiPodCPUMillisBSS(t)
+	openclaw := openclawControllerPodCPUMillisBSS(t)
+	cnpg := newapiCNPGCPUMillisBSS(t)
+	planCap := smallestPlanCPUMillisFromControllerBSS(t)
+
+	container := pod.byTerm["newapi"]
+	oldHeadroom := planCap - (container + openclaw + cnpg)
+	newHeadroom := planCap - (pod.total + openclaw + cnpg)
+
+	if oldHeadroom == newHeadroom {
+		t.Fatalf("VACUITY: the single-container model and the Pod model report the SAME headroom "+
+			"(%dm). Either the sidecar terms have been dropped, or they resolved to zero:\n%s",
+			oldHeadroom, pod)
+	}
+	if oldHeadroom <= newHeadroom {
+		t.Fatalf("VACUITY: the single-container model reports LESS headroom (%dm) than the Pod "+
+			"model (%dm), which is arithmetically impossible while the sidecars cost anything:\n%s",
+			oldHeadroom, newHeadroom, pod)
+	}
+	const wantOld, wantNew = 750, 50
+	if oldHeadroom != wantOld || newHeadroom != wantNew {
+		t.Fatalf("the understatement changed: the single-container model now reports %dm of "+
+			"headroom and the Pod model %dm (this file was written against %dm vs %dm). Re-derive "+
+			"and restate the defect before adjusting these:\n%s",
+			oldHeadroom, newHeadroom, wantOld, wantNew, pod)
+	}
+}
+
+// TestOrgTenantBPNewAPI_6324_DoorsAgreeOnTheOverriddenTerm pins the ONE term
+// this door owns against the funnel door's producer, read from source. The two
+// overlays are meant to be identical on sizing; a divergence here is the "fix
+// landed on one producer" shape, and it is invisible to either door's own
+// arithmetic because each is internally consistent.
+func TestOrgTenantBPNewAPI_6324_DoorsAgreeOnTheOverriddenTerm(t *testing.T) {
+	bss, ok := yamlScalarBSS(orgTenantBPNewAPIValues(t), "newapi.resources.limits.cpu")
+	if !ok {
+		t.Fatalf("orgTenantBPNewAPI does not pin newapi.resources.limits.cpu")
+	}
+	bssMillis, parsed := cpuMillisFromYAML(bss)
+	if !parsed {
+		t.Fatalf("orgTenantBPNewAPI newapi.resources.limits.cpu = %q is not parseable", bss)
+	}
+
+	// The funnel producer is a Go source file in another module; read the
+	// literal it stamps. A miss is FATAL — "the other door has no override" is
+	// never a safe silent default.
+	src := repoFileBSS(t, "core", "services", "provisioning", "gitops", "helmrelease_apps.go")
+	re := regexp.MustCompile(`(?s)newapi:\s*\n\s*resources:\s*\n.*?limits:\s*\n\s*cpu:\s*(\S+)`)
+	m := re.FindStringSubmatch(src)
+	if m == nil {
+		t.Fatalf("could not find generateNewAPIHR's newapi.resources.limits.cpu in " +
+			"core/services/provisioning/gitops/helmrelease_apps.go — the funnel producer was " +
+			"restructured; re-point this cross-door check rather than dropping it")
+	}
+	funnelMillis, parsed := cpuMillisFromYAML(m[1])
+	if !parsed {
+		t.Fatalf("funnel newapi.resources.limits.cpu = %q is not parseable", m[1])
+	}
+
+	if bssMillis != funnelMillis {
+		t.Fatalf("the two per-Org bp-newapi producers now size the `newapi` container "+
+			"differently: BSS door %dm vs funnel generator %dm. Both render into the same kind "+
+			"of Org ResourceQuota, so one of them is wrong — and neither door's own arithmetic "+
+			"can see it, because each is internally consistent (#6324).",
+			bssMillis, funnelMillis)
+	}
+}


### PR DESCRIPTION
## The defect

The per-Org `bp-newapi` sizing override (#6114, UAT row 232) pins one term — `newapi.resources.limits.cpu` — and **both** of its guards asserted on that one term. A `ResourceQuota` admits a **Pod**. The chart puts two more quota-counted containers in the same Pod and neither producer overrides either one:

| container | limits.cpu | how it renders |
|---|---|---|
| `sandbox-bridge` | 200m | **native sidecar** — `initContainers` entry with `restartPolicy: Always` (#3374) |
| `newapi` | 500m | pinned by the per-Org overlay |
| `metering-sidecar` | 500m | chart default |
| **POD** | **1200m** | |

`sandbox-bridge` is the term that reads as absent, and the reason is structural rather than careless: a reviewer scanning the `containers:` list never sees it. It counts either way — with `nativeSidecar: false` the same image renders as a plain container — so the term is gated on `sandboxBridge.enabled` alone.

Measured live on hw296 (dep `e689e3b34a75fdec`), `Deployment walkthree/bp-newapi` `ReplicaFailure=True FailedCreate`:

```
pods "bp-newapi-6867df99bd-..." is forbidden: exceeded quota: plan-quota,
requested: limits.cpu=1200m, used: limits.cpu=3300m, limited: limits.cpu=4
```

`requested: limits.cpu=1200m` is admission control's own arithmetic over the same Pod and matches the sum term for term — which is what identifies 500m as the **wrong quantity** rather than merely a conservative one.

The knock-on the guards could not report: the Org bundle is **1200m + openclaw 250m + CNPG 500m = 1950m of the 2000m smallest-plan cap** — **50m** of real headroom for the Org's entire remaining estate, where the guard reported 750m. A 100m rise in *either* sidecar puts the Org over the cap.

## What changed

- **Both guards model the Pod**, summing every container plus every native sidecar, taking the overlay's pin where there is one and the chart default otherwise. A term that resolves to neither is **FATAL, never zero** — a silently-zeroed term is how the total lost 700m.
- **Every term is derived from the file the platform actually reads**: the three Pod terms and the CNPG instance count from `platform/newapi/chart`, the openclaw controller from `platform/openclaw/chart`, the plan-`s` cap from `planQuotaTable` in the org-controller. The **totals** (1200m; 1950m of 2000m) are pinned against the cluster's own admission arithmetic — an independent observation, not a restatement of the source.
- **Term coverage is cross-read from `templates/deployment.yaml`**, so a container added to the chart and not to the model cannot understate the Pod silently — the failure mode `sandbox-bridge` itself had.
- **The excluded plain init is proven, not assumed.** A Pod's effective limit is `max(sum(containers)+sum(sidecars), max over plain init i of (init_i + sidecars before i))`. `wait-for-sql-dsn`'s branch (100m + the 200m bridge held across it = 300m) must stay below the container sum; a chart change that inverted that goes red.
- **A cross-door check** pins both producers to the same sized term. A fix landing on one and not the other is invisible to either door's own arithmetic, because each is internally consistent.
- **Both CI workflows now trigger on the paths their guards READ.** Scoped to their own module, a chart-only PR moved a term the guard asserts on and never ran the guard — green by absence of measurement, the same fail-open shape as the cache trap.

## Mutation proof

Every assertion driven RED under `-count=1`, with the **pre-fix guards driven GREEN under the same mutation** as the control.

The control, from a real run:

```
PRE-FIX guards (origin/main) + sandboxBridge 200m -> 300m
  $ go test -count=1 -run Row232 ./gitops/
  --- PASS: TestNewAPIHR_Row232_FitsSmallestPlanQuota (0.00s)
  --- PASS: TestNewAPIHR_Row232_VacuityCheck_HelperSeesTheChartDefault (0.00s)
  ok  github.com/openova-io/openova/core/services/provisioning/gitops  0.002s
  exit=0  ->  GREEN: the pre-fix guard CANNOT see a sidecar bump (this is #6324)
```

Same mutation, same command, post-fix:

```
--- FAIL: TestNewAPIHR_Row232_FitsSmallestPlanQuota (0.00s)
    bp-newapi POD 1300m + openclaw controller 250m + newapi CNPG 500m = 2050m
    exceeds the smallest-plan cap 2000m — row 232's pod is refused at admission.
```

The full matrix (each mutation applied alone, file restored byte-for-byte after):

| mutation | verdict | evidence |
|---|---|---|
| `sandboxBridge` 200m→300m | **RED** | POD 1300m, bundle 2050m > 2000m cap |
| `meteringSidecar` 500m→400m | **RED** | headroom 150m ≠ 50m |
| `sandboxBridge.enabled`→false | **RED** | POD 1000m, headroom 250m |
| openclaw controller 250m→350m | **RED** | bundle 2050m > cap |
| `cnpg.cluster.instances` 1→2 | **RED** | bundle 2450m > cap |
| `planQuotaTable["s"].CPU` "2"→"1" | **RED** | 1950m > 1000m cap |
| `wait-for-sql-dsn` 100m→2 | **RED** | plain-init branch dominates |
| rename a rendered container | **RED** | term coverage |
| per-Org override 500m→2 | **RED** | both doors; POD 2700m |
| BSS door 500m→450m (doors diverge) | **RED** | cross-door check |

Each verdict is backed by a real `--- FAIL` line. The harness demands that positive evidence: a build error, setup failure or full disk now reports **CANNOT READ (exit 2)**, never RED — self-tested by deliberately breaking the build, which correctly reported `CANNOT READ — the suite never ran: ['[build failed]']`. That branch earned its place: an earlier run scored a disk-full `[setup failed]` as RED.

### The cache trap, reproduced on this PR's own guard

```
1. warm the cache with a GREEN run:  go test ./gitops/   -> ok (cached)
2. MUTATE platform/newapi/chart/values.yaml:1218  200m -> 300m
3. go test ./gitops/          -> exit=0  ok  (cached)     <- never read the mutation
4. go test -count=1 ./gitops/ -> exit=1  FAIL
```

Both workflows already pass `-count=1`, and `scripts/check-go-test-count1.sh` passes (self-test 10/10, 113 workflow files scanned).

## No value changed

Both producer edits are **comment-only** — filtering the diff for non-comment lines returns nothing:

```
$ git diff -U0 <both producers> | grep '^[+-]' | grep -v '^+\s*#'
(empty)
```

No chart file is in the change set, no chart version is bumped, no `Chart.yaml` is touched. Sizing the Pod itself is #5393 and stays untouched.

## A third commit: `main` was already red, and the trigger gap is why

CI on the first push failed — **not on this PR's change**. Named, reproduced on a clean checkout of `origin/main` `dabd24907` with no local edits:

```
--- FAIL: TestDefaultHRAppPins_MatchCatalogSeed/openclaw
    PIN DRIFT for "openclaw": the funnel installs bp-openclaw@0.2.18 but the
    catalog seed delivers bp-openclaw@0.2.19.
```

`f7961510f` bumped `platform/openclaw/chart/Chart.yaml` and the catalog seed to `0.2.19` and left `DefaultHRAppChartVersions` at `0.2.18`. Verified `0.2.19` is real: `origin/main` `Chart.yaml` says `version: 0.2.19` and the OCI artifact exists (`bp-openclaw` tags `["0.2.19","0.2.18","0.2.17",…]`). A funnel Org installs the older chart while the seed says the newer one shipped.

**`hrAppPinSeedDrift` exists to catch exactly this, and it never ran.** Its workflow is path-scoped to `core/services/provisioning/**`, while the value it asserts on lives in `products/catalyst/chart/templates/catalog-seed/blueprints.yaml`. The bump touched only the seed, so no run fired — the last `main` run of `test-provisioning-service.yaml` is `2026-08-13T19:54`, *before* the bump. `main` went red silently and stayed red until this PR, an unrelated change that happened to touch the module, surfaced it.

That is the same fail-open shape this PR fixes for the Pod guards — now with a live example rather than a hypothesis. So the trigger list also gained `products/catalyst/chart/templates/catalog-seed/**` and `scripts/lib/parse-catalog-seed-pins.awk`. **With those in place, the commit that broke `main` would have failed its own PR.**

This commit aligns a *consumer pin* to the already-published seed value. No chart version is bumped and no quota, request or limit is touched.

## Verification

- `core/services/provisioning`: `go vet ./...` clean, `go test -count=1 ./...` exit 0
- `products/catalyst/bootstrap/api`: `go vet ./...` clean, `go test -count=1 ./...` exit 0
- `scripts/check-go-test-count1.sh` exit 0 (after `--self-test` PASS)
- `scripts/check-no-banned-words.sh` exit 0

Not walked live: hw296 is severed from delivery (#6307), so this proves out on the next fresh prov. `docs/ledger/UAT.md` is deliberately not stamped. Rows 219/220/221/222 fail today for this reason and are the intended beneficiaries.

Refs #6324 #5393 #3988

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HvMZTDx7W6EPZMmjyXmYh1
