### PR TITLE
fix(cutover): pivot the per-Organization vCluster HelmRelease off mothership Harbor

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -1074,7 +1074,7 @@ spec:
       # chart/tests/ left the package via .helmignore: 757,264 bytes, 72.2%.
       # The rendered manifest is byte-identical modulo comments — no step,
       # value or RBAC change, still 11 steps.
-      version: 0.1.189
+      version: 0.1.190
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1451,7 +1451,7 @@ spec:
       #   staged commit and push, and makes the Phase-3 pre-strip read-back the
       #   single fail-closed gate (#5436 relocated, not weakened). Lockstep w/
       #   products/catalyst/chart/Chart.yaml.
-      version: 1.4.1503
+      version: 1.4.1504
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.189
+  version: 0.1.190
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -4061,7 +4061,99 @@ name: bp-self-sovereign-cutover
 # Slot-06a pin + blueprint.yaml + catalog-seed spec.version + source.version +
 # the API blueprints.json + the generated UI catalog move to 0.1.189 in lockstep
 # (Inviolable Principle #13).
-version: 0.1.189
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# 0.1.190 (#5439) — THE PER-ORGANIZATION vCLUSTER KEPT THE MOTHERSHIP REGISTRY
+# THROUGH A CUTOVER THAT REPORTED SUCCESS.
+#
+# Step-09 (vcluster-registry-pivot) pivoted exactly FOUR named HelmReleases in
+# ONE namespace: bp-mgmt-vcluster, bp-rtz-vcluster, bp-dmz-vcluster and
+# bp-sso-bridge, all in flux-system. The per-Organization vCluster HelmRelease is
+# a FIFTH shape those four patches structurally cannot reach — it is named
+# `vcluster`, it lives in the Organization's OWN namespace, there is one PER
+# ORGANIZATION, and its durable source is a THIRD repo class,
+# `<slug>/catalyst-tenant@main:vcluster/vcluster.yaml`, written by
+# core/controllers/organization/internal/gitops Render() and reconciled by the
+# `catalyst-tenant-<slug>-vcluster` Kustomization (prune=true).
+#
+# Live on hw292, cutoverComplete=true since 2026-08-03T08:12:04Z:
+#
+#   kubectl -n uatco get hr vcluster -o json | jq -r .spec.values
+#     "image":{"registry":"harbor.openova.io"
+#     "statefulSet":{"image":{"registry":"harbor.openova.io"
+#     "coredns":{...:"harbor.openova.io/proxy-dockerhub/coredns/..."}
+#
+# WHY NOTHING WENT RED — the part that makes this worse than an ordinary miss.
+# Step-11's pod-spec ref-host lint EXEMPTS harbor.openova.io as a host step-04's
+# containerd redirect covers (true of the PULL, silent about the DECLARATION),
+# and the Flux source lint reads only HelmRepository / GitRepository /
+# OCIRepository spec.url — a HelmRelease's spec.values is never examined. So the
+# tether and the green coexisted. This defect never blocked cutoverComplete=true;
+# that is precisely why it mattered. A green that overstates is worse than a red.
+#
+# WHAT LANDS. Step-09 gains Phase 3: enumerate Organizations LIVE (Organization
+# CRs UNION the live `catalyst-tenant-*` Flux GitRepositories — the SAME two
+# sources step-06 Phase-2d uses, deliberately, so the two legs can never disagree
+# about which Organizations exist), clone each `<slug>/catalyst-tenant`, rewrite
+# the mothership host out of the reconciled `vcluster/` tree, push, and then POLL
+# the live per-Org HelmReleases until the owning reconciler has fetched and
+# re-applied the rewrite. Pushed is not pivoted until something applied it.
+#
+# WHY ORDER 9 AND NOT STEP-06 (order 6). The generator is made cutover-aware by
+# step-07 Phase 3e (order 7), which stamps CATALYST_LOCAL_IMAGE_REGISTRY_HOST on
+# the org-controller / provisioning / catalyst-api Deployments and rolls them.
+# Rewriting the repos BEFORE that stamp lands races the org-controller: any
+# Organization reconcile in between re-renders the mothership literal straight
+# back into the Flux-owned source. At order 9 the stamp is already in the pod
+# template, so a regeneration after this leg reproduces the same local host.
+# chart/tests/perorg-vcluster-registry-pivot.sh Section B pins that ordering off
+# the RENDER's own cutover-order labels, so the durability argument cannot
+# silently regress into a no-op with good logs.
+#
+# WHY A HOST-LITERAL REWRITE AND NOT THREE NAMED YAML PATHS. The generator
+# renders every image reference off ONE variable but in TWO shapes — a bare
+# `registry:` scalar for the distro and syncer images, a fully-qualified
+# host/path:tag for coredns — and it has GAINED fields before; #5439 exists one
+# field over from #5527 for exactly that reason. Replacing the host wherever it
+# appears in the reconciled tree covers the shapes that exist, the shapes that
+# get added, and the app manifests beside them, while preserving every path and
+# tag. Idempotent by construction: after a run the literal is gone.
+#
+# DETECTION. Step-11 gains a pre-hold lint: no HelmRelease belonging to an
+# Organization may name a mothership registry host anywhere in spec.values.
+# Membership is decided by `openova.io/organization` — on the HelmRelease or on
+# its namespace — the selector the org-controller already stamps and
+# org_namespace_invariant_4292_test.go already pins, so nothing new is invented
+# and there is nothing to keep in sync. It runs PER REGION through the existing
+# #5359 driver, and an unreadable region is a FAIL, never a skip.
+#
+# TWO ANTI-VACUITY WITNESSES, because "nothing to do" and "I could not look"
+# render identically and this whole issue is an instance of that. Phase-3: a
+# GitRepository listing that EXITS 0 and returns ZERO objects is FATAL — this
+# step annotates gitrepository/openova in that same namespace moments earlier, so
+# zero is not a state a Sovereign can be in, and a "no Organizations" verdict
+# drawn from it would be a fabrication. The lint: zero HelmReleases from a
+# SUCCEEDING listing is FATAL for the same reason. Both are proven able to fail
+# by mutants (Section G) that neuter only the witness and re-run the identical
+# fixture.
+#
+# RBAC: no new grant. Phase-3 reads gitrepositories, customresourcedefinitions,
+# organizations and helmreleases; the lint adds namespaces and helmreleases. All
+# six are already in the runner ClusterRole's READ rules, and no rule in the
+# create or update/patch groups needed widening — the leg never patches a live
+# per-Org HelmRelease, by design (a prune=true Kustomization reverts that).
+# chart/tests/rbac-coverage.sh re-derives this from the render.
+#
+# GUARDS. chart/tests/perorg-vcluster-registry-pivot.sh — 33 assertions, exit 0 —
+# executes the RENDERED Phase-3 bytes against REAL local git repositories and
+# reads every verdict out of the BARE origin, and drives the RENDERED lint under
+# a programmable stub. Watched red first: on `git archive origin/main` it exits 1
+# naming the absent pivot region, and on a half-fix tree carrying Phase-3 but no
+# lint it exits 1 naming the absent lint — so both halves are independently
+# load-bearing. Slot-06a pin + blueprint.yaml + catalog-seed spec.version +
+# source.version + the API blueprints.json + the generated UI catalog move to
+# 0.1.190 in lockstep (Inviolable Principle #13).
+version: 0.1.190
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/08-egress-block-test-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/08-egress-block-test-job.yaml
@@ -258,6 +258,33 @@ data:
           - name: FLUX_SOURCE_HEALTH_LINT
             value: {{ eq (toString .Values.egressTest.fluxSourceHealthLint.enabled) "true" | quote }}
           {{- /*
+           #5439 — pre-hold per-Organization HelmRelease VALUES registry lint.
+           The THIRD blind spot in the same family, and the one that let a live
+           mothership tether coexist with cutoverComplete=true on hw292:
+
+             PODSPEC_REFHOST_LINT   walks pod specs, and EXEMPTS
+                                    harbor.openova.io as step-04-redirect-
+                                    covered. True of the pull; silent about the
+                                    declaration that produced it.
+             FLUX_SOURCE_HOST_LINT  walks spec.url on HelmRepository /
+                                    GitRepository / OCIRepository. A
+                                    HelmRelease's spec.values is not a source
+                                    URL and is never read.
+
+           So `uatco/vcluster` sat there with
+           spec.values.controlPlane.statefulSet.image.registry =
+           harbor.openova.io, re-applied by its own Kustomization on every
+           reconcile, and passed both. Step-09 Phase-3 pivots it; this is what
+           proves the pivot held — and what catches the NEXT Organization
+           created by a control-plane that somehow lost the stamp.
+          */}}
+          - name: PERORG_HR_VALUES_LINT
+            value: {{ eq (toString .Values.egressTest.perOrgHelmReleaseValuesLint.enabled) "true" | quote }}
+          - name: PERORG_HR_MOTHERSHIP_HOSTS
+            value: {{ .Values.egressTest.perOrgHelmReleaseValuesLint.mothershipHosts | default (list) | join " " | quote }}
+          - name: PERORG_HR_ALLOW_RELEASES
+            value: {{ .Values.egressTest.perOrgHelmReleaseValuesLint.allowReleases | default (list) | join " " | quote }}
+          {{- /*
            #5650 — pre-hold Crossplane Provider PACKAGE host lint. Same class
            as FLUX_SOURCE_HOST_LINT, different controller: Crossplane's
            package manager fetches `Provider.spec.package` directly from the
@@ -1233,6 +1260,140 @@ data:
               return 0
             }
             {{- /*
+             ── #5439 PRE-HOLD PER-ORG HELMRELEASE VALUES REGISTRY LINT ────
+
+             WHAT IT ASSERTS: no per-Organization HelmRelease may carry a
+             MOTHERSHIP registry host anywhere in spec.values.
+
+             WHY spec.values AND NOT THE RENDERED POD. A pod is a snapshot; the
+             HelmRelease is the DECLARATION, re-applied by its owning
+             Kustomization forever. On hw292 the pods were fine — they pulled
+             through the step-04 containerd redirect — while
+             `uatco/vcluster` spec.values kept naming harbor.openova.io. Delete
+             the redirect, or roll the pod after the mothership is gone, and the
+             Organization's whole vCluster stops. That is a live dependency, and
+             it is invisible to a lint that reads pod specs (which exempts the
+             host) or Flux source URLs (which never reads values).
+
+             WHY IT IS SCOPED TO PER-ORG RELEASES. The four PLATFORM image HRs
+             are asserted by step-09's own Phase-1c residual check against a
+             FIXED list, which is adequate precisely because that list is fixed.
+             The per-Org shape has no fixed list — one HelmRelease per
+             Organization, in the Organization's own namespace — so it needs a
+             LIVE predicate, and `openova.io/organization` is the one the
+             org-controller already stamps (pinned by
+             org_namespace_invariant_4292_test.go, and the same selector
+             step-03 Phase A0 and the provisioning kubeconfig reconciler use).
+             Nothing new is invented here and there is nothing to keep in sync.
+
+             ARGS: $1 = region label, $2 = kubeconfig path ("" = this Job's own
+             in-cluster context). The `_pv_kubectl` shim is written on ONE line
+             on purpose — chart/tests/perorg-vcluster-registry-pivot.sh extracts
+             this function out of the RENDER with an awk range that terminates
+             on the first bare `}` line, so a nested multi-line function would
+             silently truncate the function under test (#5646).
+            */}}
+            run_perorg_hr_values_registry_lint() {
+              _pv_region="${1:-primary}"
+              _PV_KUBECONFIG="${2:-}"
+              _pv_kubectl() { if [ -n "${_PV_KUBECONFIG:-}" ]; then kubectl --kubeconfig="${_PV_KUBECONFIG}" "$@"; else kubectl "$@"; fi; }
+              echo "[egress-block-test] #5439: PRE-HOLD per-Org HelmRelease values lint [region=${_pv_region}] — no HelmRelease belonging to an Organization may name a mothership registry host (${PERORG_HR_MOTHERSHIP_HOSTS:-}) anywhere in spec.values. Neither the pod-spec ref-host lint (which EXEMPTS that host as redirect-covered) nor the Flux source lint (which reads only source URLs) can see this."
+              {{- /*
+               The `: >` MUST be checked. If the scratch file cannot be created
+               every later append silently no-ops, `-s` is false, and the lint
+               returns PASS having examined nothing — the fail-OPEN shape this
+               whole family of lints exists to eliminate.
+              */}}
+              _pv_off="${WORK_DIR:-/work}/perorghr-offenders.$$"
+              if ! : > "${_pv_off}" 2>/dev/null; then
+                echo "  FAIL — cannot create ${_pv_off}; refusing to report PASS from a lint that cannot record an offender (fail-closed)"
+                return 1
+              fi
+              _pv_raw="${WORK_DIR:-/work}/perorghr-raw.$$"
+              _pv_err="${WORK_DIR:-/work}/perorghr-err.$$"
+              _pv_ns="${WORK_DIR:-/work}/perorghr-ns.$$"
+              {{- /*
+               The Organization-namespace set. A FAILED listing is not an empty
+               one: unreadable here would shrink the per-Org predicate to "the HR
+               carries the label itself" and silently under-scan. Fail closed.
+              */}}
+              if ! _pv_kubectl get namespaces -l openova.io/organization \
+                -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' >"${_pv_ns}" 2>"${_pv_err}"; then
+                echo "  FAIL — region ${_pv_region}: cannot list Organization namespaces ($(head -1 "${_pv_err}" 2>/dev/null)). Refusing to report PASS for an estate that could not be measured (fail-closed)"
+                rm -f "${_pv_off}" "${_pv_ns}" "${_pv_err}"
+                return 1
+              fi
+              if ! _pv_kubectl get helmreleases.helm.toolkit.fluxcd.io -A \
+                -o jsonpath='{range .items[*]}{.metadata.namespace}{"|"}{.metadata.name}{"|"}{.metadata.labels.openova\.io/organization}{"|"}{.spec.values}{"\n"}{end}' >"${_pv_raw}" 2>"${_pv_err}"; then
+                {{- /*
+                 A kind that is not INSTALLED is zero rows, not a tether. Any
+                 other failure (auth, TLS, connection) means the region was not
+                 measured and the verdict must be FAIL.
+                */}}
+                if grep -qiE "server doesn't have a resource type|could not find the requested resource|no matches for kind|the server could not find the requested resource" "${_pv_err}" 2>/dev/null; then
+                  echo "  PASS — region ${_pv_region}: the HelmRelease kind is not installed here; there are no per-Org HelmReleases to tether (positive absence, not an unread list)"
+                  rm -f "${_pv_off}" "${_pv_raw}" "${_pv_err}" "${_pv_ns}"
+                  return 0
+                fi
+                echo "  FAIL — region ${_pv_region}: cannot enumerate helmreleases ($(head -1 "${_pv_err}" 2>/dev/null)). Refusing to report PASS for a region that could not be measured (fail-closed, #5359)"
+                rm -f "${_pv_off}" "${_pv_raw}" "${_pv_err}" "${_pv_ns}"
+                return 1
+              fi
+              {{- /*
+               ── THE ANTI-VACUITY WITNESS ──────────────────────────────────
+               The enumeration EXITED 0 and returned zero rows. On a Catalyst
+               cluster in any region that cannot be true: the bootstrap-kit
+               installs dozens of HelmReleases and this Job is running inside
+               the result. Zero total therefore means the reader is not looking
+               at the cluster it believes it is, and "no offenders" drawn from it
+               would be a verdict from absent evidence — the exact shape #5359
+               fixed for a FAILING read, here for a SUCCEEDING but empty one.
+              */}}
+              _pv_total=$(grep -c . "${_pv_raw}" || true)
+              if [ "${_pv_total}" -eq 0 ]; then
+                echo "  FAIL — region ${_pv_region}: the HelmRelease CRD is installed and the listing succeeded, but it returned ZERO HelmReleases. A Catalyst region always carries the bootstrap-kit's releases, so this is an unread estate, not a clean one; refusing to certify 'no per-Org tether' from it (#5439)"
+                rm -f "${_pv_off}" "${_pv_raw}" "${_pv_err}" "${_pv_ns}"
+                return 1
+              fi
+              _pv_scanned=0
+              while IFS='|' read -r _pvns _pvname _pvlabel _pvvals; do
+                [ -n "${_pvns}" ] && [ -n "${_pvname}" ] || continue
+                {{- /*
+                 PER-ORG predicate: the HelmRelease's own label, OR its namespace
+                 being an Organization namespace. Either is sufficient; the union
+                 keeps a generator that stops stamping the label on the HR (but
+                 still lands it in the Org namespace) inside the scope.
+                */}}
+                _pvperorg=0
+                [ -n "${_pvlabel}" ] && _pvperorg=1
+                if [ "${_pvperorg}" = "0" ] && grep -qx "${_pvns}" "${_pv_ns}" 2>/dev/null; then
+                  _pvperorg=1
+                fi
+                [ "${_pvperorg}" = "1" ] || continue
+                _pv_scanned=$((_pv_scanned+1))
+                _pvex=0
+                for _pva in ${PERORG_HR_ALLOW_RELEASES:-}; do
+                  [ "${_pvns}/${_pvname}" = "${_pva}" ] && { _pvex=1; break; }
+                done
+                [ "${_pvex}" = "1" ] && continue
+                for _pvh in ${PERORG_HR_MOTHERSHIP_HOSTS:-}; do
+                  case "${_pvvals}" in
+                    *"${_pvh}"*) printf '%s/%s (host:%s)\n' "${_pvns}" "${_pvname}" "${_pvh}" >> "${_pv_off}" ;;
+                  esac
+                done
+              done <"${_pv_raw}"
+              rm -f "${_pv_raw}" "${_pv_err}" "${_pv_ns}"
+              if [ -s "${_pv_off}" ]; then
+                echo "  FAIL — region ${_pv_region}: these per-Organization HelmReleases still name a mothership registry host in spec.values. Each is a Flux-owned DECLARATION, re-applied on every reconcile long after the 600s hold is torn down, so the hold cannot see it and a containerd redirect does not remove the dependency (fix = re-run step-09's vcluster-registry-pivot Phase-3, which rewrites the durable <slug>/catalyst-tenant source, or declare a reviewed exception in egressTest.perOrgHelmReleaseValuesLint.allowReleases):"
+                sort -u "${_pv_off}" | while IFS= read -r _o; do echo "    PERORG-MOTHERSHIP-REGISTRY [${_pv_region}] ${_o}"; done
+                rm -f "${_pv_off}"
+                return 1
+              fi
+              rm -f "${_pv_off}"
+              echo "  PASS — region ${_pv_region}: ${_pv_scanned} per-Organization HelmRelease(s) examined out of ${_pv_total} total; none names a mothership registry host in spec.values (#5439)"
+              return 0
+            }
+            {{- /*
              ── #5359 PER-REGION DRIVER ────────────────────────────────────
              Every region is evaluated — no short-circuit — so one run names
              every offender in the fleet instead of stopping at the first. The
@@ -1241,7 +1402,7 @@ data:
              unable to be set while ANY region has an off-Sovereign or
              unconverged Flux source.
             */}}
-            if [ "${FLUX_SOURCE_HOST_LINT}" = "true" ] || [ "${FLUX_SOURCE_HEALTH_LINT}" = "true" ] || [ "${PROVIDER_PACKAGE_HOST_LINT}" = "true" ]; then
+            if [ "${FLUX_SOURCE_HOST_LINT}" = "true" ] || [ "${FLUX_SOURCE_HEALTH_LINT}" = "true" ] || [ "${PROVIDER_PACKAGE_HOST_LINT}" = "true" ] || [ "${PERORG_HR_VALUES_LINT}" = "true" ]; then
               _fs_verdict=0
               for _fs_target in "primary=" $(for _k in /secondary-kubeconfigs/*.yaml; do [ -e "${_k}" ] && printf '%s=%s ' "$(basename "${_k}" .yaml)" "${_k}"; done); do
                 _fs_rlabel="${_fs_target%%=*}"
@@ -1257,11 +1418,22 @@ data:
                 if [ "${PROVIDER_PACKAGE_HOST_LINT}" = "true" ]; then
                   run_provider_package_host_lint "${_fs_rlabel}" "${_fs_rkc}" || { _fs_verdict=1; _pp_rstate="failed"; }
                 fi
+                {{- /*
+                 #5439 — same driver, same AND-across-regions verdict, same
+                 "an unreadable region is a FAIL, not a skip" rule. A per-Org
+                 tether in a secondary region is exactly as live as one in the
+                 primary, and #5359 is the record of what measuring one region
+                 and reporting a fleet property costs.
+                */}}
+                _pv_rstate="pass"
+                if [ "${PERORG_HR_VALUES_LINT}" = "true" ]; then
+                  run_perorg_hr_values_registry_lint "${_fs_rlabel}" "${_fs_rkc}" || { _fs_verdict=1; _pv_rstate="failed"; }
+                fi
                 [ "${_fs_rlabel}" = "primary" ] || kubectl -n "${CUTOVER_NAMESPACE:-catalyst}" patch configmap "${STATUS_CONFIGMAP}" --type=merge \
-                  -p "{\"data\":{\"step.egress-block-test.region.${_fs_rlabel}.fluxSourceLint\":\"${_fs_rstate}\",\"step.egress-block-test.region.${_fs_rlabel}.providerPackageLint\":\"${_pp_rstate}\"}}" >/dev/null 2>&1 || true
+                  -p "{\"data\":{\"step.egress-block-test.region.${_fs_rlabel}.fluxSourceLint\":\"${_fs_rstate}\",\"step.egress-block-test.region.${_fs_rlabel}.providerPackageLint\":\"${_pp_rstate}\",\"step.egress-block-test.region.${_fs_rlabel}.perOrgHelmReleaseLint\":\"${_pv_rstate}\"}}" >/dev/null 2>&1 || true
               done
               if [ "${_fs_verdict}" != "0" ]; then
-                echo "[egress-block-test] Flux source / Provider package lint FAILED before the hold — sovereignty proof FAILED (cutoverComplete stays false). This is the dependency half of Pillar 5: surviving a 600s isolation window is necessary but not sufficient when a source keeps fetching from the public internet on its own interval once the policy is gone (#5650), and it proves nothing at all about a region the hold never measured (#5359)"
+                echo "[egress-block-test] Flux source / Provider package / per-Org HelmRelease lint FAILED before the hold — sovereignty proof FAILED (cutoverComplete stays false). This is the dependency half of Pillar 5: surviving a 600s isolation window is necessary but not sufficient when a source keeps fetching from the public internet on its own interval once the policy is gone (#5650), when a Flux-owned HelmRelease keeps DECLARING a mothership registry the hold's containerd redirect merely papered over (#5439), and it proves nothing at all about a region the hold never measured (#5359)"
                 exit 1
               fi
             fi

--- a/platform/self-sovereign-cutover/chart/templates/10-vcluster-registry-pivot-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/10-vcluster-registry-pivot-job.yaml
@@ -191,6 +191,29 @@ data:
             value: {{ .Values.gitea.repo | quote }}
           - name: IMAGE_TAG
             value: {{ .Values.vclusterRegistryPivot.imageTag | quote }}
+          {{- /*
+           #5439 Phase 3 — the per-Organization `<slug>/catalyst-tenant` leg.
+           Every knob is threaded as env (never re-templated inside the script)
+           so chart/tests/perorg-vcluster-registry-pivot.sh can drive the SAME
+           rendered bytes with its own values — the #5646 discipline: the test
+           executes the shipped block, it does not validate a copy of it.
+          */}}
+          - name: PERORG_PIVOT_ENABLED
+            value: {{ eq (toString .Values.vclusterRegistryPivot.perOrgTenant.enabled) "true" | quote }}
+          - name: PERORG_TENANT_REPO
+            value: {{ .Values.vclusterRegistryPivot.perOrgTenant.repo | quote }}
+          - name: PERORG_BRANCH
+            value: {{ .Values.vclusterRegistryPivot.perOrgTenant.branch | quote }}
+          - name: PERORG_FLUX_NAMESPACE
+            value: {{ .Values.vclusterRegistryPivot.perOrgTenant.fluxNamespace | quote }}
+          - name: PERORG_ORG_CRD
+            value: {{ .Values.vclusterRegistryPivot.perOrgTenant.organizationCRD | quote }}
+          - name: PERORG_TREES
+            value: {{ .Values.vclusterRegistryPivot.perOrgTenant.trees | quote }}
+          - name: PERORG_READBACK_DEADLINE
+            value: {{ .Values.vclusterRegistryPivot.perOrgTenant.readbackDeadlineSeconds | quote }}
+          - name: MOTHERSHIP_HARBOR_HOST
+            value: {{ .Values.vclusterRegistryPivot.perOrgTenant.mothershipHarborHost | quote }}
         volumeMounts:
           - name: tmp
             mountPath: /tmp
@@ -822,32 +845,392 @@ data:
             done
 
             echo "[vcluster-registry-pivot] edited ${edited} files (yq merge / sed fallback)"
+            {{- /*
+             #5439 — these two "nothing to do" outcomes used to `exit 0` and END
+             THE STEP. That was correct while the bootstrap-kit push was the last
+             thing this step did; with Phase 3 below it would mean a Sovereign
+             whose bootstrap-kit slots are ALREADY pivoted (every re-run, and
+             every cutover re-fire) silently skips the per-Org leg entirely. The
+             skip is now scoped to the PUSH, which is what has nothing to do —
+             never to the rest of the step.
+            */}}
             if [ "${edited}" -eq 0 ]; then
-              echo "[vcluster-registry-pivot] no edits required — already pivoted in Gitea or files absent"
-              {{- /* Phase 1 already succeeded; nothing to push. */}}
-              exit 0
-            fi
+              echo "[vcluster-registry-pivot] no bootstrap-kit edits required — already pivoted in Gitea or files absent"
+            else
+              git add "${target_dir}"
+              if git diff --staged --quiet; then
+                echo "[vcluster-registry-pivot] git diff empty after sed — nothing to commit"
+              else
+                git commit -m "cutover: pivot vCluster + sso-bridge image.repository + global.registryMirror to harbor.${SOVEREIGN_FQDN}" >/dev/null
+                push_err=$(git push origin main 2>&1) || {
+                  echo "[vcluster-registry-pivot] FATAL: git push failed" >&2
+                  printf '%s\n' "$push_err" >&2
+                  exit 1
+                }
+                echo "[vcluster-registry-pivot] pushed to ${redacted}"
 
-            git add "${target_dir}"
-            if git diff --staged --quiet; then
-              echo "[vcluster-registry-pivot] git diff empty after sed — nothing to commit"
-              exit 0
+                {{- /*
+                 Trigger an immediate Flux reconciliation so the new YAML
+                 lands without waiting for the polling interval.
+                */}}
+                kubectl annotate --overwrite gitrepository openova \
+                  -n flux-system \
+                  "reconcile.fluxcd.io/requestedAt=$(date +%s)" >/dev/null || true
+              fi
             fi
-            git commit -m "cutover: pivot vCluster + sso-bridge image.repository + global.registryMirror to harbor.${SOVEREIGN_FQDN}" >/dev/null
-            push_err=$(git push origin main 2>&1) || {
-              echo "[vcluster-registry-pivot] FATAL: git push failed" >&2
-              printf '%s\n' "$push_err" >&2
-              exit 1
-            }
-            echo "[vcluster-registry-pivot] pushed to ${redacted}"
 
             {{- /*
-             Trigger an immediate Flux reconciliation so the new YAML
-             lands without waiting for the polling interval.
+             ══ Phase 3 (#5439): per-Organization `<slug>/catalyst-tenant` ══
+                 vCluster image-registry durable pivot.
+
+             Everything above this line pivots FOUR named HelmReleases in ONE
+             namespace. This phase pivots the shape whose count scales with the
+             number of Organizations, and whose durable source is a repo class
+             no cutover step touched: `<slug>/catalyst-tenant@main`, tree
+             `vcluster/` (vcluster.yaml + apps/ + host-apps/), reconciled by the
+             `catalyst-tenant-<slug>-{vcluster,apps,host-apps}` Kustomizations
+             with prune=true.
+
+             THE ENUMERATION IS THE DESIGN. A hardcoded slug list is wrong the
+             moment the next Organization is sold, so the list is built LIVE and
+             from the SAME two sources step-06 Phase-2d already uses (#6309) —
+             deliberately the same, so the two legs can never disagree about
+             which Organizations exist:
+
+               SOURCE 1 (mandatory) the `catalyst-tenant-<slug>` GitRepositories
+                 — per_org_flux.go creates exactly one per Org, and it is the
+                 object that FEEDS the reverting Kustomization.
+               SOURCE 2 (union) the Organization CRs — catches an Org whose Flux
+                 source has not been created yet.
+
+             Neither read may fail quietly: a refused list and an empty estate
+             render identically, and here that would leave an unknown number of
+             Organizations tethered while this step recorded success.
             */}}
-            kubectl annotate --overwrite gitrepository openova \
-              -n flux-system \
-              "reconcile.fluxcd.io/requestedAt=$(date +%s)" >/dev/null || true
+            # ---- perorg-vcluster-pivot BEGIN (extraction anchor — chart/tests/perorg-vcluster-registry-pivot.sh awk-slices this region out of the render and EXECUTES it under a stubbed kubectl/curl with real git) ----
+            if [ "${PERORG_PIVOT_ENABLED:-true}" != "true" ]; then
+              echo "[vcluster-registry-pivot] Phase-3 SKIP: vclusterRegistryPivot.perOrgTenant.enabled=false"
+            else
+              {{- /*
+               Scratch root. Production keeps /tmp (the Job's emptyDir, the
+               only writable path under readOnlyRootFilesystem). It is a
+               variable so chart/tests/perorg-vcluster-registry-pivot.sh can
+               execute these exact bytes in its own sandbox instead of
+               writing into the runner's real /tmp — a test that has to share
+               mutable global paths cannot run beside another copy of itself.
+              */}}
+              pv_scratch="${PERORG_SCRATCH_DIR:-/tmp}"
+              pv_repo="${PERORG_TENANT_REPO:-catalyst-tenant}"
+              pv_branch="${PERORG_BRANCH:-main}"
+              pv_ns="${PERORG_FLUX_NAMESPACE:-flux-system}"
+              pv_crd="${PERORG_ORG_CRD:-organizations.orgs.openova.io}"
+              pv_api_base="${GITEA_INTERNAL_URL%/}/api/v1/repos"
+              pv_slugs="${pv_scratch}/.pv-slugs.txt"
+              pv_touched="${pv_scratch}/.pv-touched.txt"
+              : > "${pv_slugs}"
+              : > "${pv_touched}"
+
+              {{- /*
+               SOURCE 1 + the ANTI-VACUITY WITNESS.
+
+               `pv_grs_total` is the count of ALL GitRepositories the listing
+               returned, kept separately from the count that MATCHED the
+               `catalyst-tenant-` prefix. It exists because "zero Organizations"
+               and "I read nothing" are the same output otherwise, and the
+               fail-closed branch below only covers the case where kubectl
+               EXITS non-zero. A listing that exits 0 and returns zero rows is
+               the residual hole — and on a Sovereign it cannot be honest: this
+               very step annotates `gitrepository openova -n flux-system` a few
+               lines above, so at least ONE GitRepository is present in this
+               namespace by construction. Zero total therefore means the reader
+               is not looking at the cluster it thinks it is (wrong namespace,
+               wrong context, a stub that answers everything with silence), and
+               a "no Organizations, nothing to do" verdict drawn from it would
+               be a fabrication. It is FATAL, and it is the witness that makes a
+               genuine zero trustworthy.
+              */}}
+              if kubectl get gitrepositories.source.toolkit.fluxcd.io -n "${pv_ns}" \
+                  -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' \
+                  > "${pv_scratch}/.pv-grs.txt" 2>"${pv_scratch}/.pv-grs.err"; then
+                pv_grs_total=$(awk 'NF' "${pv_scratch}/.pv-grs.txt" | grep -c . || true)
+                if [ "${pv_grs_total}" -eq 0 ]; then
+                  echo "[vcluster-registry-pivot] FATAL: Phase-3: listing GitRepositories in ${pv_ns} SUCCEEDED but returned ZERO objects. This step annotated gitrepository/openova in that namespace moments ago, so zero is not a state this Sovereign can be in — the read is hollow (wrong namespace or context), and concluding 'no Organizations' from it would report a pivot over an estate that was never examined (#5439)" >&2
+                  exit 1
+                fi
+                awk -v p="${pv_repo}-" 'index($0,p)==1 && length($0)>length(p) {print substr($0,length(p)+1)}' \
+                  "${pv_scratch}/.pv-grs.txt" >> "${pv_slugs}"
+              else
+                echo "[vcluster-registry-pivot] FATAL: Phase-3: listing GitRepositories in ${pv_ns} FAILED — the live Organization list cannot be built, and pivoting a PARTIAL list would leave an unknown number of per-Org vCluster HelmReleases on the mothership Harbor while this step recorded success (#5439)" >&2
+                sed 's/^/  KUBECTL-STDERR /' "${pv_scratch}/.pv-grs.err" >&2 || true
+                exit 1
+              fi
+
+              {{- /*
+               SOURCE 2. CRD absence must be POSITIVE evidence: `kubectl get crd`
+               exits non-zero for BOTH "not installed" and "forbidden", so the
+               NotFound string is required before absence may be concluded.
+               Without that, a missing RBAC grant reads as "this Sovereign has
+               no Organizations" and the leg no-ops on exactly the environments
+               that need it.
+              */}}
+              pv_org_present=0
+              if kubectl get customresourcedefinitions "${pv_crd}" >/dev/null 2>"${pv_scratch}/.pv-crd.err"; then
+                pv_org_present=1
+                pv_org_state="crd-present"
+              elif grep -q 'NotFound' "${pv_scratch}/.pv-crd.err"; then
+                pv_org_state="crd-absent(NotFound-confirmed)"
+                echo "[vcluster-registry-pivot] Phase-3: ${pv_crd} is not installed on this Sovereign — the live Org list comes from the per-Org Flux sources alone"
+              else
+                echo "[vcluster-registry-pivot] FATAL: Phase-3: could not determine whether ${pv_crd} exists — that is NOT the same as it being absent, and treating it as absent silently drops every Organization from the pivot (#5439)" >&2
+                sed 's/^/  KUBECTL-STDERR /' "${pv_scratch}/.pv-crd.err" >&2 || true
+                exit 1
+              fi
+              if [ "${pv_org_present}" -eq 1 ]; then
+                if kubectl get "${pv_crd}" \
+                    -o jsonpath='{range .items[*]}{.spec.slug}{"\n"}{end}' \
+                    > "${pv_scratch}/.pv-orgs.txt" 2>"${pv_scratch}/.pv-orgs.err"; then
+                  pv_org_state="crd-present,listed=$(awk 'NF' "${pv_scratch}/.pv-orgs.txt" | grep -c . || true)"
+                  awk 'NF' "${pv_scratch}/.pv-orgs.txt" >> "${pv_slugs}"
+                else
+                  echo "[vcluster-registry-pivot] FATAL: Phase-3: the ${pv_crd} CRD IS installed but listing Organizations failed — refusing to pivot a partial Organization list (#5439)" >&2
+                  sed 's/^/  KUBECTL-STDERR /' "${pv_scratch}/.pv-orgs.err" >&2 || true
+                  exit 1
+                fi
+              fi
+
+              awk 'NF' "${pv_slugs}" | sort -u > "${pv_scratch}/.pv-slugs.sorted"
+              mv "${pv_scratch}/.pv-slugs.sorted" "${pv_slugs}"
+              pv_total=$(grep -c . "${pv_slugs}" || true)
+              {{- /*
+               The witness is PRINTED, not merely computed. An operator reading
+               `orgs=0` must be able to see, on the same line, the two positive
+               reads that establish it — never infer it from silence.
+              */}}
+              echo "[vcluster-registry-pivot] Phase-3: ${pv_total} live Organization slug(s) (Organization CRs ∪ ${pv_repo}-* Flux sources) [witness: gitrepositories-read-ok total=${pv_grs_total}, org-crd=${pv_org_state}]"
+
+              pv_absent=0
+              pv_pushed=0
+              pv_nodiff=0
+              for pv_slug in $(awk 'NF' "${pv_slugs}"); do
+                {{- /*
+                 Existence decided by HTTP STATUS, not by whether a git command
+                 failed: `git ls-remote` exits non-zero both for a repo that does
+                 not exist and for one we cannot authenticate to, and collapsing
+                 those is how a credential fault presents as "this Org simply has
+                 no repo". 404 is legitimately absent; anything neither 200 nor
+                 404 is unreadable and fails closed.
+                */}}
+                pv_code=$(curl -s -o "${pv_scratch}/.pv-repo.json" -w '%{http_code}' \
+                  -u "${GITEA_USERNAME}:${GITEA_PAT}" \
+                  "${pv_api_base}/${pv_slug}/${pv_repo}" 2>/dev/null || echo "000")
+                case "${pv_code}" in
+                  200) : ;;
+                  404)
+                    echo "[vcluster-registry-pivot] Phase-3 ${pv_slug}: no ${pv_repo} repo (HTTP 404) — this Org has no per-Org gitops tree, so nothing re-applies a vCluster HelmRelease from one"
+                    pv_absent=$((pv_absent+1))
+                    continue
+                    ;;
+                  *)
+                    echo "[vcluster-registry-pivot] FATAL: Phase-3 ${pv_slug}: HTTP ${pv_code} probing ${pv_slug}/${pv_repo} — an unreadable repo is NOT an absent repo, and guessing leaves this Org's vCluster on the mothership Harbor (#5439)" >&2
+                    exit 1
+                    ;;
+                esac
+
+                pv_url=$(printf '%s' "${GITEA_INTERNAL_URL}" | sed -E "s,^(https?://),\1${GITEA_USERNAME}:${GITEA_PAT}@,")"/${pv_slug}/${pv_repo}.git"
+
+                {{- /*
+                 A repo that EXISTS but carries no branch is a real, benign state
+                 (the org-controller creates the repo before anything seeds it).
+                 Separated from an AUTH failure exactly as the probe separates
+                 404 from 500: ls-remote SUCCEEDING with no matching ref is an
+                 absent branch; ls-remote FAILING against a repo the API just
+                 reported present is a credential fault and stays fatal.
+                */}}
+                if ! git ls-remote --heads "${pv_url}" "${pv_branch}" > "${pv_scratch}/.pv-heads.txt" 2>"${pv_scratch}/.pv-heads.err"; then
+                  echo "[vcluster-registry-pivot] FATAL: Phase-3 ${pv_slug}: git ls-remote ${pv_branch} failed against a repo the API just reported present — that is a credential fault, not an empty repo (#5439)" >&2
+                  sed -e 's,://[^@]*@,://***@,g' "${pv_scratch}/.pv-heads.err" >&2 || true
+                  exit 1
+                fi
+                if ! grep -q "refs/heads/${pv_branch}" "${pv_scratch}/.pv-heads.txt"; then
+                  echo "[vcluster-registry-pivot] Phase-3 ${pv_slug}: ${pv_repo} exists but has no ${pv_branch} branch — the per-Org tree has not been seeded yet"
+                  pv_absent=$((pv_absent+1))
+                  continue
+                fi
+
+                cd "${pv_scratch}"
+                rm -rf repo-perorg-vc
+                if ! git clone --depth 1 --branch "${pv_branch}" "${pv_url}" repo-perorg-vc >/dev/null 2>"${pv_scratch}/.pv-clone.err"; then
+                  echo "[vcluster-registry-pivot] FATAL: Phase-3 ${pv_slug}: clone of ${pv_slug}/${pv_repo} branch ${pv_branch} failed (#5439)" >&2
+                  sed -e 's,://[^@]*@,://***@,g' "${pv_scratch}/.pv-clone.err" >&2 || true
+                  exit 1
+                fi
+                cd repo-perorg-vc
+
+                {{- /*
+                 THE REWRITE is a HOST-literal substitution, not a rewrite of
+                 three named YAML paths. The generator renders every one of its
+                 image references off ONE variable (VClusterImageRegistry), but
+                 it renders them into DIFFERENT shapes — a bare `registry:`
+                 scalar for the distro and syncer images, and a fully-qualified
+                 `host/path:tag` for coredns — and it has gained fields before
+                 (that is how #5439 came to exist one field over from #5527).
+                 Replacing the HOST wherever it appears covers the shapes that
+                 exist, the shapes that will be added, and the app manifests in
+                 the same tree, while preserving every path and tag verbatim.
+                 Idempotent by construction: after a successful run the literal
+                 is gone, so a re-run matches nothing and produces no diff.
+                */}}
+                pv_list="${pv_scratch}/.pv-targets.txt"
+                : > "${pv_list}"
+                for pv_tree in ${PERORG_TREES:-vcluster}; do
+                  [ -d "${pv_tree}" ] || continue
+                  grep -rl "${MOTHERSHIP_HARBOR_HOST}" "${pv_tree}" 2>/dev/null >> "${pv_list}" || true
+                done
+                pv_edited=0
+                for pvf in $(awk 'NF' "${pv_list}" | sort -u); do
+                  sed -i "s,${MOTHERSHIP_HARBOR_HOST},${target_host},g" "${pvf}"
+                  pv_edited=$((pv_edited+1))
+                  echo "[vcluster-registry-pivot] Phase-3 edited ${pv_slug}/${pv_repo}@${pv_branch}:${pvf}"
+                done
+
+                {{- /*
+                 Post-condition on the FILES, before anything is committed — the
+                 RESULT of the rewrite, never the count of loop iterations that
+                 were supposed to produce it.
+                */}}
+                pv_left_file="${pv_scratch}/.pv-left.txt"
+                : > "${pv_left_file}"
+                for pv_tree in ${PERORG_TREES:-vcluster}; do
+                  [ -d "${pv_tree}" ] || continue
+                  grep -rl "${MOTHERSHIP_HARBOR_HOST}" "${pv_tree}" 2>/dev/null >> "${pv_left_file}" || true
+                done
+                pv_left=$(grep -c . "${pv_left_file}" || true)
+                if [ "${pv_left}" -ne 0 ]; then
+                  echo "[vcluster-registry-pivot] FATAL: Phase-3 ${pv_slug}: ${pv_left} file(s) still reference ${MOTHERSHIP_HARBOR_HOST} after the rewrite — pushing now would record a durable pivot that does not exist (#5439)" >&2
+                  sed 's,^,  STILL-MOTHERSHIP ,' "${pv_left_file}" >&2 || true
+                  exit 1
+                fi
+
+                {{- /*
+                 Commit on ACTUAL tree state, never on ${pv_edited}: a re-run
+                 legitimately visits files and produces no diff, and gating on
+                 the counter would turn that no-op into a hard failure on every
+                 second run (the #6293 Phase-2b lesson).
+                */}}
+                if git diff --quiet; then
+                  echo "[vcluster-registry-pivot] Phase-3 ${pv_slug}: already pivoted (${pv_edited} file-visit(s), no diff) — nothing to push"
+                  pv_nodiff=$((pv_nodiff+1))
+                else
+                  git add -A .
+                  if git diff --staged --quiet; then
+                    echo "[vcluster-registry-pivot] FATAL: Phase-3 ${pv_slug}: the working tree has changes but the index is empty — \`git add\` is mis-scoped and this push would carry none of the rewrite (#5439)" >&2
+                    exit 1
+                  fi
+                  git commit -m "cutover: pivot ${pv_edited} per-Org file(s) off ${MOTHERSHIP_HARBOR_HOST} to ${target_host}" >/dev/null
+                  if ! pv_push_err=$(git push origin "HEAD:${pv_branch}" 2>&1); then
+                    echo "[vcluster-registry-pivot] FATAL: Phase-3 ${pv_slug}: push to ${pv_branch} failed — this Org's vCluster keeps reverting to ${MOTHERSHIP_HARBOR_HOST} on every reconcile (#5439)" >&2
+                    printf '%s\n' "${pv_push_err}" | sed -e 's,://[^@]*@,://***@,g' >&2
+                    exit 1
+                  fi
+                  echo "[vcluster-registry-pivot] Phase-3 OK: pushed ${pv_edited} edit(s) to ${pv_slug}/${pv_repo} branch ${pv_branch}"
+                  pv_pushed=$((pv_pushed+1))
+                fi
+                printf '%s\n' "${pv_slug}" >> "${pv_touched}"
+                cd "${pv_scratch}"
+              done
+
+              pv_with_repo=$(grep -c . "${pv_touched}" || true)
+              echo "[vcluster-registry-pivot] Phase-3: orgs=${pv_total} with-repo=${pv_with_repo} pushed=${pv_pushed} already-pivoted=${pv_nodiff} no-repo=${pv_absent}"
+
+              {{- /*
+               ── THE READ-BACK (Stage CONVERGE) ───────────────────────────────
+               A durable rewrite is a CLAIM until the reconciler that owns the
+               object has fetched it and re-applied it. Poll the LIVE per-Org
+               HelmReleases until none carries the mothership host in
+               spec.values, re-poking each cycle. Reaching the deadline with an
+               offender still live is FATAL: a rewrite the owning Kustomization
+               never applied is a pivot that does not exist, and this is exactly
+               the leg where "pushed" would otherwise be mistaken for "pivoted".
+
+               Scoped to the Orgs THIS phase touched, so an unrelated namespace
+               is never this leg's failure. An enumeration that FAILS is not a
+               clean sample — it returns non-zero and the poll keeps waiting,
+               and the deadline then reports honestly that convergence was never
+               OBSERVED rather than silently certifying it.
+              */}}
+              if [ "${pv_with_repo}" -eq 0 ]; then
+                echo "[vcluster-registry-pivot] Phase-3 read-back SKIP: no Organization had a seeded ${pv_repo} tree, so there is no per-Org HelmRelease this phase could have changed (witness above shows the estate WAS read)"
+              else
+                pv_offenders() {
+                  if ! kubectl get helmreleases.helm.toolkit.fluxcd.io -A \
+                      -o jsonpath='{range .items[*]}{.metadata.namespace}{"/"}{.metadata.name}{"="}{.spec.values}{"\n"}{end}' \
+                      > "${pv_scratch}/.pv-hrs.txt" 2>"${pv_scratch}/.pv-hrs.err"; then
+                    return 2
+                  fi
+                  : > "${pv_scratch}/.pv-offenders.txt"
+                  while IFS= read -r pv_line; do
+                    [ -n "${pv_line}" ] || continue
+                    pv_key="${pv_line%%=*}"
+                    pv_vals="${pv_line#*=}"
+                    case "${pv_vals}" in
+                      *"${MOTHERSHIP_HARBOR_HOST}"*) : ;;
+                      *) continue ;;
+                    esac
+                    pv_hrns="${pv_key%%/*}"
+                    {{- /* Only the Orgs this phase pivoted. */}}
+                    if grep -qx "${pv_hrns}" "${pv_touched}"; then
+                      printf '%s\n' "${pv_key}" >> "${pv_scratch}/.pv-offenders.txt"
+                    fi
+                  done < "${pv_scratch}/.pv-hrs.txt"
+                  {{- /*
+                   Explicit if, never `[ -s f ] && return 1`: this whole script
+                   runs under `set -eu`, and an AND-OR list is precisely the
+                   shape whose exit-status semantics people get wrong. Spelling
+                   it out costs two lines and removes the question.
+                  */}}
+                  if [ -s "${pv_scratch}/.pv-offenders.txt" ]; then
+                    return 1
+                  fi
+                  return 0
+                }
+
+                pv_deadline="${PERORG_READBACK_DEADLINE:-300}"
+                pv_start=$(date +%s)
+                pv_converged=0
+                pv_lastrc=9
+                while [ $(($(date +%s) - pv_start)) -lt "${pv_deadline}" ]; do
+                  {{- /*
+                   `set -e` is ON. A bare `pv_offenders` call would TERMINATE the
+                   step the first time it legitimately reports offenders — i.e.
+                   the poll would die on the very state it exists to wait out.
+                   The `&& rc=0 || rc=$?` form keeps the non-zero returns as
+                   DATA, which is what they are here.
+                  */}}
+                  pv_offenders && pv_lastrc=0 || pv_lastrc=$?
+                  if [ "${pv_lastrc}" -eq 0 ]; then
+                    pv_converged=1
+                    break
+                  fi
+                  if [ "${pv_lastrc}" -eq 2 ]; then
+                    echo "  [vcluster-registry-pivot] Phase-3 read-back: HelmRelease enumeration failed ($(head -1 "${pv_scratch}/.pv-hrs.err" 2>/dev/null)) — a failed read is NOT a clean sample; retrying in 15s"
+                  else
+                    echo "  [vcluster-registry-pivot] Phase-3 read-back: $(grep -c . "${pv_scratch}/.pv-offenders.txt" || true) per-Org HelmRelease(s) still on ${MOTHERSHIP_HARBOR_HOST} at $(($(date +%s) - pv_start))s; re-poking the owning sources, re-checking in 15s (bounded ${pv_deadline}s)"
+                  fi
+                  for pv_slug in $(awk 'NF' "${pv_touched}"); do
+                    kubectl annotate --overwrite "gitrepository/${pv_repo}-${pv_slug}" -n "${pv_ns}" \
+                      "reconcile.fluxcd.io/requestedAt=$(date +%s)" >/dev/null 2>&1 || true
+                  done
+                  sleep 15
+                done
+                if [ "${pv_converged}" -ne 1 ]; then
+                  echo "[vcluster-registry-pivot] FATAL: Phase-3 read-back did not converge within ${pv_deadline}s (last enumeration rc=${pv_lastrc}) — the durable rewrite was pushed but the owning Kustomization has not re-applied it, so the per-Org vCluster image registry is still the mothership Harbor. Pillar 5 independence not met (#5439)" >&2
+                  sed 's,^,  RESIDUAL-PERORG-TETHER ,' "${pv_scratch}/.pv-offenders.txt" >&2 2>/dev/null || true
+                  exit 1
+                fi
+                echo "[vcluster-registry-pivot] Phase-3 read-back PASS: 0 per-Org HelmRelease(s) on ${MOTHERSHIP_HARBOR_HOST} across ${pv_with_repo} pivoted Organization(s) — the rewrite was fetched and re-applied by the owning reconciler"
+              fi
+            fi
+            # ---- perorg-vcluster-pivot END ----
 
             echo "[vcluster-registry-pivot] step complete"
         resources:

--- a/platform/self-sovereign-cutover/chart/tests/perorg-vcluster-registry-pivot.sh
+++ b/platform/self-sovereign-cutover/chart/tests/perorg-vcluster-registry-pivot.sh
@@ -1,0 +1,658 @@
+#!/usr/bin/env bash
+# #5439 — step-09 Phase-3 (per-Organization vCluster registry pivot) and the
+# step-11 pre-hold lint that proves it held.
+#
+# THE DEFECT THIS LOCKS OUT
+# ─────────────────────────
+# Step-09 (vcluster-registry-pivot, cutover-order 9) pivoted exactly FOUR named
+# HelmReleases in ONE namespace: bp-mgmt-vcluster, bp-rtz-vcluster,
+# bp-dmz-vcluster, bp-sso-bridge, all in flux-system. The per-Organization
+# vCluster HelmRelease is a fifth shape it structurally could not reach — it is
+# named `vcluster`, it lives in the Org's own namespace, there is one PER
+# ORGANIZATION, and its durable source is a third repo class,
+# `<slug>/catalyst-tenant@main:vcluster/vcluster.yaml`.
+#
+# Measured live on hw292, cutoverComplete=true since 2026-08-03T08:12:04Z:
+#
+#   kubectl -n uatco get hr vcluster -o json | jq -r .spec.values
+#     "image":{"registry":"harbor.openova.io"
+#     "statefulSet":{"image":{"registry":"harbor.openova.io"
+#     "coredns":{...:"harbor.openova.io/proxy-dockerhub/coredns/..."}
+#
+# WHY NOTHING WENT RED, which is the part that matters. The step-11 pod-spec
+# ref-host lint EXEMPTS harbor.openova.io as a host step-04's containerd
+# redirect covers, and the Flux source lint reads only HelmRepository /
+# GitRepository / OCIRepository spec.url — never a HelmRelease's spec.values. So
+# a live mothership tether and `cutoverComplete=true` coexisted. A green that
+# overstates is worse than a red, and that is the class this suite exists for.
+#
+# WHAT IS REAL HERE AND WHAT IS STUBBED, AND WHY
+# ──────────────────────────────────────────────
+# REAL: git, and the shipped bytes. Every case executes the REAL rendered
+# Phase-3 region against REAL local git repositories with real branches, and
+# reads its verdict out of the BARE origin (`git show main:<path>`), never out
+# of a working tree the script left behind — pushed-or-it-did-not-happen. Both
+# the phase and the lint are sliced out of `helm template` output rather than
+# copied into this file: #5646 showed a suite validating a hand-kept copy that
+# had silently drifted from the shipped source and went on passing.
+#
+# STUBBED: kubectl and curl, because the defect classes here are "which
+# Organizations did you enumerate", "did you tell a failed read apart from an
+# empty estate" and "did you wait for the reverting reconciler" — all decided by
+# how the script INTERPRETS the API's answers, not by the API. A stub can be
+# made to FAIL on demand, which a live cluster cannot.
+#
+# `sleep` is stubbed to a fixed 0.2s so the bounded read-back's timing logic
+# still runs (it is wall-clock driven off `date`, not off the sleep) without
+# spending 15s of CI per poll.
+#
+# PROVEN ABLE TO FAIL: Section G re-runs the two verdict-bearing cases against
+# MUTANTS of the shipped bytes — the vacuity witness deleted, the read-back
+# deleted — and requires this suite to go RED on each. A guard that has only
+# ever been observed passing is not yet known to be a guard.
+set -uo pipefail
+
+CHART_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+FQDN="hw292.omani.works"
+TARGET_HOST="harbor.${FQDN}"
+MOTHERSHIP="harbor.openova.io"
+REPO="catalyst-tenant"
+TMP="$(mktemp -d)"
+REAL_GIT="$(command -v git)"
+trap 'rm -rf "${TMP}"' EXIT
+FAILURES=0
+
+bad() { echo "  FAIL — $*"; FAILURES=$((FAILURES + 1)); }
+ok()  { echo "  ok   — $*"; }
+
+echo "== #5439 per-Org vCluster registry pivot (step-09 Phase-3) + step-11 lint =="
+
+helm template ssc "${CHART_DIR}" --set sovereign.fqdn="${FQDN}" >"${TMP}/render.yaml" 2>"${TMP}/render.err" || {
+  echo "helm template failed:"; cat "${TMP}/render.err"; exit 1
+}
+
+# ═══════════════════════════════════════════════════════════════════════════
+# A. Extraction — the shipped bytes, or nothing
+# ═══════════════════════════════════════════════════════════════════════════
+echo
+echo "-- A. the phase and the lint exist in the render --"
+
+awk '/# ---- perorg-vcluster-pivot BEGIN/,/# ---- perorg-vcluster-pivot END/' \
+  "${TMP}/render.yaml" | sed 's/^            //' >"${TMP}/phase3.sh"
+
+if ! grep -q 'perorg-vcluster-pivot BEGIN' "${TMP}/phase3.sh"; then
+  echo "  FAIL — step-09 carries no per-Org catalyst-tenant pivot region."
+  echo "         The four flux-system HelmReleases it pivots cannot reach the"
+  echo "         per-Organization vCluster HelmRelease, whose durable source is"
+  echo "         <slug>/${REPO}@main:vcluster/vcluster.yaml — so every Org keeps"
+  echo "         image.registry=${MOTHERSHIP} through a cutover that reports"
+  echo "         success (#5439, measured on hw292/uatco)."
+  exit 1
+fi
+if ! grep -q 'perorg-vcluster-pivot END' "${TMP}/phase3.sh"; then
+  echo "  FAIL — the Phase-3 region was truncated during extraction (no END marker)."
+  exit 1
+fi
+ok "step-09 Phase-3 region extracted ($(grep -c . "${TMP}/phase3.sh") lines)"
+
+awk '/^ *run_perorg_hr_values_registry_lint\(\) \{/,/^ *\}$/' \
+  "${TMP}/render.yaml" | sed 's/^ *//' >"${TMP}/lint.sh"
+
+if ! grep -q 'run_perorg_hr_values_registry_lint()' "${TMP}/lint.sh"; then
+  echo "  FAIL — step-11 carries no per-Org HelmRelease values lint."
+  echo "         Without it the pivot above has no gate: the pod-spec ref-host"
+  echo "         lint EXEMPTS ${MOTHERSHIP}, and the Flux source lint reads only"
+  echo "         source URLs, so a per-Org spec.values tether passes both and"
+  echo "         cutoverComplete=true is set over a live dependency (#5439)."
+  exit 1
+fi
+# The awk range stops at the first bare `}` line. If a nested multi-line
+# function is ever added inside the lint the range truncates, and a FRAGMENT
+# would still source cleanly and could still return 0 — i.e. the suite would
+# quietly change subject. Pin the tail so truncation is a failure.
+if ! grep -q '^return 0$' "${TMP}/lint.sh"; then
+  echo "  FAIL — the lint was truncated during extraction (no trailing 'return 0')."
+  exit 1
+fi
+ok "step-11 lint extracted ($(grep -c . "${TMP}/lint.sh") lines), tail intact"
+
+sh -n "${TMP}/phase3.sh" 2>"${TMP}/syn.err" && ok "Phase-3 region is valid POSIX sh" \
+  || bad "Phase-3 region is not valid POSIX sh: $(head -1 "${TMP}/syn.err")"
+sh -n "${TMP}/lint.sh" 2>"${TMP}/syn2.err" && ok "lint is valid POSIX sh" \
+  || bad "lint is not valid POSIX sh: $(head -1 "${TMP}/syn2.err")"
+
+# ═══════════════════════════════════════════════════════════════════════════
+# B. The ordering invariant the durability argument rests on
+# ═══════════════════════════════════════════════════════════════════════════
+# Phase-3 rewrites the per-Org repos. The org-controller REGENERATES those repos
+# on every Organization reconcile, so the rewrite only survives if the generator
+# has already been made cutover-aware — which is step-07 Phase 3e stamping
+# CATALYST_LOCAL_IMAGE_REGISTRY_HOST. If step-09 ever sorted BEFORE step-07, any
+# Organization reconcile in between would write ${MOTHERSHIP} straight back into
+# the Flux-owned source and this whole leg would be a no-op with good logs.
+# The orders are read from the RENDER's own labels, not from prose.
+echo
+echo "-- B. step-07 (generator stamp) must run BEFORE step-09 (repo rewrite) --"
+python3 - "${TMP}/render.yaml" >"${TMP}/orders.txt" 2>"${TMP}/orders.err" <<'PY'
+import sys, yaml
+orders = {}
+for doc in yaml.safe_load_all(open(sys.argv[1], encoding="utf-8")):
+    if not isinstance(doc, dict):
+        continue
+    md = doc.get("metadata") or {}
+    labels = md.get("labels") or {}
+    o = labels.get("bp.openova.io/cutover-order")
+    step = (doc.get("data") or {}).get("stepName") if doc.get("kind") == "ConfigMap" else None
+    if o is not None and step:
+        orders[step] = int(o)
+for k, v in sorted(orders.items(), key=lambda kv: kv[1]):
+    print(f"{v} {k}")
+PY
+if [ ! -s "${TMP}/orders.txt" ]; then
+  bad "could not read cutover-order labels from the render: $(head -1 "${TMP}/orders.err")"
+else
+  env_order=$(awk '$2=="catalyst-api-env-patch"{print $1}' "${TMP}/orders.txt")
+  piv_order=$(awk '$2=="vcluster-registry-pivot"{print $1}' "${TMP}/orders.txt")
+  egr_order=$(awk '$2=="egress-block-test"{print $1}' "${TMP}/orders.txt")
+  if [ -z "${env_order}" ] || [ -z "${piv_order}" ] || [ -z "${egr_order}" ]; then
+    bad "missing a cutover-order (env=${env_order:-?} pivot=${piv_order:-?} egress=${egr_order:-?})"
+  elif [ "${env_order}" -lt "${piv_order}" ]; then
+    ok "catalyst-api-env-patch=${env_order} < vcluster-registry-pivot=${piv_order} — the generator carries the local-registry stamp before any repo is rewritten"
+  else
+    bad "catalyst-api-env-patch=${env_order} is NOT before vcluster-registry-pivot=${piv_order}: the org-controller would re-render ${MOTHERSHIP} back into the per-Org source after Phase-3 rewrote it"
+  fi
+  if [ -n "${piv_order}" ] && [ -n "${egr_order}" ] && [ "${piv_order}" -lt "${egr_order}" ]; then
+    ok "vcluster-registry-pivot=${piv_order} < egress-block-test=${egr_order} — the lint observes the estate after the pivot ran"
+  else
+    bad "vcluster-registry-pivot=${piv_order:-?} must run before egress-block-test=${egr_order:-?}, or the lint asserts over an un-pivoted estate"
+  fi
+fi
+
+# ═══════════════════════════════════════════════════════════════════════════
+# C. Harness
+# ═══════════════════════════════════════════════════════════════════════════
+mkdir -p "${TMP}/bin"
+GITEA_ROOT="${TMP}/gitea"
+GITEA_HOST="gitea.invalid"
+
+# kubectl stub. Dispatches on the token after `get`, so a leading
+# `--kubeconfig=` (the lint's secondary-region shim) does not shift the index.
+cat >"${TMP}/bin/kubectl" <<'STUB'
+#!/usr/bin/env sh
+verb=""; kind=""; want=0
+for a in "$@"; do
+  if [ "${want}" = "1" ]; then kind="$a"; want=0; continue; fi
+  case "$a" in
+    get)      verb=get; want=1 ;;
+    annotate) verb=annotate ;;
+  esac
+done
+[ "${verb}" = "annotate" ] && exit 0
+short="${kind%%.*}"
+if [ -n "${STUB_FAIL_KIND:-}" ] && [ "${short}" = "${STUB_FAIL_KIND}" ]; then
+  echo "${STUB_FAIL_MSG:-error: You must be logged in to the server (Unauthorized)}" >&2
+  exit 1
+fi
+if [ "${short}" = "customresourcedefinitions" ]; then
+  case "${STUB_CRD_MODE:-ok}" in
+    ok)       exit 0 ;;
+    notfound) echo 'Error from server (NotFound): customresourcedefinitions.apiextensions.k8s.io "organizations.orgs.openova.io" not found' >&2; exit 1 ;;
+    *)        echo 'Error from server (Forbidden): customresourcedefinitions.apiextensions.k8s.io is forbidden' >&2; exit 1 ;;
+  esac
+fi
+# HelmRelease answers may be a SEQUENCE, so a case can make the estate converge
+# on the Nth poll (or never).
+if [ "${short}" = "helmreleases" ] && [ ! -f "${STUB_DIR}/helmreleases.txt" ]; then
+  n=$(cat "${STUB_DIR}/.hrn" 2>/dev/null || echo 0); n=$((n+1)); echo "${n}" >"${STUB_DIR}/.hrn"
+  f="${STUB_DIR}/helmreleases.${n}.txt"
+  if [ ! -f "${f}" ]; then f=$(ls "${STUB_DIR}"/helmreleases.*.txt 2>/dev/null | sort -V | tail -1); fi
+  [ -n "${f}" ] && [ -f "${f}" ] && cat "${f}"
+  exit 0
+fi
+f="${STUB_DIR}/${short}.txt"
+[ -f "${f}" ] && cat "${f}"
+exit 0
+STUB
+chmod +x "${TMP}/bin/kubectl"
+
+# curl stub — repo existence is an HTTP STATUS, forceable per slug.
+cat >"${TMP}/bin/curl" <<'STUB'
+#!/usr/bin/env sh
+url=""; out="/dev/null"; nexto=0
+for a in "$@"; do
+  if [ "${nexto}" = "1" ]; then out="$a"; nexto=0; continue; fi
+  case "$a" in
+    -o) nexto=1 ;;
+    http*) url="$a" ;;
+  esac
+done
+slug=$(printf '%s' "${url}" | awk -F/ '{print $(NF-1)}')
+repo=$(printf '%s' "${url}" | awk -F/ '{print $NF}')
+: >"${out}" 2>/dev/null || true
+if [ -n "${CURL_FORCE_CODE:-}" ] && [ "${CURL_FORCE_SLUG:-}" = "${slug}" ]; then
+  printf '%s' "${CURL_FORCE_CODE}"; exit 0
+fi
+if [ -d "${GITEA_ROOT}/${slug}/${repo}.git" ]; then printf '200'; else printf '404'; fi
+STUB
+chmod +x "${TMP}/bin/curl"
+
+# git shim — maps http://<creds>@gitea.invalid/<slug>/<repo>.git onto the local
+# bare repo, then execs the REAL git. Branches, commits, pushes and diffs are
+# genuine; only the transport is local.
+cat >"${TMP}/bin/git" <<'STUB'
+#!/usr/bin/env sh
+first=1
+for a in "$@"; do
+  case "$a" in
+    http://*"${GITEA_HOST_FOR_SHIM}"/*)
+      a="${GITEA_ROOT}/${a##*"${GITEA_HOST_FOR_SHIM}"/}" ;;
+  esac
+  if [ "${first}" = 1 ]; then set -- "$a"; first=0; else set -- "$@" "$a"; fi
+done
+exec "${REAL_GIT_BIN}" "$@"
+STUB
+chmod +x "${TMP}/bin/git"
+
+# sleep stub — the read-back's bound is wall-clock (date), so shortening the
+# poll gap changes nothing it asserts and saves 15s per poll in CI.
+cat >"${TMP}/bin/sleep" <<'STUB'
+#!/usr/bin/env sh
+exec /bin/sleep 0.2
+STUB
+chmod +x "${TMP}/bin/sleep"
+
+# The per-Org vcluster/vcluster.yaml as the org-controller renders it — the
+# three image references all resolve off VClusterImageRegistry, in the two
+# DIFFERENT shapes it emits (bare `registry:` scalar, and a fully-qualified
+# host/path:tag for coredns). Both shapes must end up pivoted.
+vcluster_doc() {
+  printf 'apiVersion: helm.toolkit.fluxcd.io/v2\nkind: HelmRelease\nmetadata:\n  name: vcluster\n  namespace: %s\n  labels:\n    openova.io/organization: %s\nspec:\n  values:\n    controlPlane:\n      distro:\n        k8s:\n          image:\n            registry: %s\n            repository: proxy-ghcr/loft-sh/kubernetes\n      coredns:\n        deployment:\n          image: %s/proxy-dockerhub/coredns/coredns:1.11.3\n      statefulSet:\n        image:\n          registry: %s\n          repository: proxy-ghcr/loft-sh/vcluster-oss\n' "$1" "$1" "$2" "$2" "$2"
+}
+
+seed_org_repo() {
+  # $1 = slug   $2 = image registry host to seed with
+  sl="$1"; host="$2"
+  mkdir -p "${GITEA_ROOT}/${sl}"
+  rm -rf "${GITEA_ROOT}/${sl}/${REPO}.git" "${TMP}/seed-${sl}"
+  "${REAL_GIT}" init --bare -q "${GITEA_ROOT}/${sl}/${REPO}.git"
+  "${REAL_GIT}" init -q -b main "${TMP}/seed-${sl}"
+  (
+    cd "${TMP}/seed-${sl}"
+    "${REAL_GIT}" config user.name t; "${REAL_GIT}" config user.email t@example.invalid
+    mkdir -p vcluster/apps legacy
+    vcluster_doc "${sl}" "${host}" >vcluster/vcluster.yaml
+    printf 'image: %s/proxy-dockerhub/library/nginx:1.27\n' "${host}" >vcluster/apps/app-site.yaml
+    # OUTSIDE the reconciled tree, carrying the mothership host — the SCOPING
+    # control. No per-Org Kustomization reconciles this path, so rewriting it
+    # would be divergence with nothing behind it.
+    printf 'image: %s/proxy-dockerhub/library/redis:7\n' "${host}" >legacy/old.yaml
+    "${REAL_GIT}" add -A; "${REAL_GIT}" commit -qm seed
+    "${REAL_GIT}" remote add origin "${GITEA_ROOT}/${sl}/${REPO}.git"
+    "${REAL_GIT}" push -q origin main
+  ) >/dev/null 2>&1
+}
+
+origin_show() { "${REAL_GIT}" --git-dir="${GITEA_ROOT}/$1/${REPO}.git" show "main:$2" 2>/dev/null; }
+origin_commits() { "${REAL_GIT}" --git-dir="${GITEA_ROOT}/$1/${REPO}.git" rev-list --count main 2>/dev/null || echo 0; }
+
+# Runs the extracted Phase-3 region. Echoes its exit code; output in ${TMP}/out.txt
+run_phase3() {
+  local case_dir="$1" script="${2:-${TMP}/phase3.sh}"
+  (
+    set -eu
+    export PATH="${TMP}/bin:${PATH}"
+    export STUB_DIR="${case_dir}"
+    export GITEA_ROOT="${GITEA_ROOT}"
+    export GITEA_HOST_FOR_SHIM="${GITEA_HOST}"
+    export REAL_GIT_BIN="${REAL_GIT}"
+    export GITEA_INTERNAL_URL="http://${GITEA_HOST}"
+    export GITEA_USERNAME="gitea_admin"
+    export GITEA_PAT="stub-token-not-a-secret"
+    export PERORG_PIVOT_ENABLED="${PERORG_PIVOT_ENABLED:-true}"
+    export PERORG_TENANT_REPO="${REPO}"
+    export PERORG_BRANCH="main"
+    export PERORG_FLUX_NAMESPACE="flux-system"
+    export PERORG_ORG_CRD="organizations.orgs.openova.io"
+    export PERORG_TREES="vcluster"
+    export PERORG_READBACK_DEADLINE="${PERORG_READBACK_DEADLINE:-30}"
+    export PERORG_SCRATCH_DIR="${case_dir}/scratch"
+    export MOTHERSHIP_HARBOR_HOST="${MOTHERSHIP}"
+    # Phase-2 runs `git config --global user.{name,email}` unconditionally
+    # before Phase-3 is reached, so in the Job a commit identity always exists.
+    # Driving Phase-3 alone has to supply the same fact; env vars do it without
+    # writing a gitconfig into the runner's HOME.
+    export GIT_AUTHOR_NAME="self-sovereign-cutover" GIT_AUTHOR_EMAIL="cutover@${FQDN}"
+    export GIT_COMMITTER_NAME="self-sovereign-cutover" GIT_COMMITTER_EMAIL="cutover@${FQDN}"
+    mkdir -p "${PERORG_SCRATCH_DIR}"
+    target_host="${TARGET_HOST}"
+    export target_host
+    # shellcheck disable=SC1090
+    . "${script}"
+  ) >"${TMP}/out.txt" 2>&1
+  echo $?
+}
+
+new_case() {
+  # $1 = case name; seeds a stub dir with a believable flux-system estate.
+  local d="${TMP}/case-$1"
+  rm -rf "${d}"; mkdir -p "${d}/scratch"
+  # A real Sovereign always has GitRepositories in flux-system — `openova` at
+  # minimum, which this very step annotates. Included so the vacuity witness
+  # has an honest baseline to pass on.
+  printf 'openova\n' >"${d}/gitrepositories.txt"
+  : >"${d}/organizations.txt"
+  : >"${d}/namespaces.txt"
+  echo "${d}"
+}
+
+# ═══════════════════════════════════════════════════════════════════════════
+# D. Phase-3 — the pivot, proven out of the BARE origin
+# ═══════════════════════════════════════════════════════════════════════════
+echo
+echo "-- D. the durable rewrite --"
+
+D1="$(new_case d1)"
+seed_org_repo walkone "${MOTHERSHIP}"
+seed_org_repo walktwo "${MOTHERSHIP}"
+{ printf 'openova\n'; printf '%s-walkone\n' "${REPO}"; printf '%s-walktwo\n' "${REPO}"; } >"${D1}/gitrepositories.txt"
+# Converged estate: the read-back's first sample is already clean.
+printf 'walkone/vcluster|vcluster|walkone|map[controlPlane:map[statefulSet:map[image:map[registry:%s]]]]\n' "${TARGET_HOST}" >"${D1}/helmreleases.txt"
+rc="$(run_phase3 "${D1}")"
+if [ "${rc}" != "0" ]; then
+  bad "D1 shipped Phase-3 exited ${rc} on a healthy estate: $(tail -3 "${TMP}/out.txt" | tr '\n' ' ')"
+else
+  ok "D1 Phase-3 completed on a two-Organization estate"
+fi
+for sl in walkone walktwo; do
+  body="$(origin_show "${sl}" vcluster/vcluster.yaml)"
+  if printf '%s' "${body}" | grep -q "${MOTHERSHIP}"; then
+    bad "D1 ${sl}: vcluster.yaml in the BARE origin still names ${MOTHERSHIP}"
+  elif [ "$(printf '%s' "${body}" | grep -c "${TARGET_HOST}")" != "3" ]; then
+    bad "D1 ${sl}: expected 3 ${TARGET_HOST} references in the pushed vcluster.yaml, got $(printf '%s' "${body}" | grep -c "${TARGET_HOST}")"
+  else
+    ok "D1 ${sl}: all 3 image references pivoted to ${TARGET_HOST} in the pushed tree"
+  fi
+  if origin_show "${sl}" vcluster/apps/app-site.yaml | grep -q "${TARGET_HOST}"; then
+    ok "D1 ${sl}: the app manifest in the same reconciled tree pivoted too"
+  else
+    bad "D1 ${sl}: vcluster/apps/app-site.yaml was not pivoted"
+  fi
+  if origin_show "${sl}" legacy/old.yaml | grep -q "${MOTHERSHIP}"; then
+    ok "D1 ${sl}: the file OUTSIDE the reconciled tree was left alone (scoping control)"
+  else
+    bad "D1 ${sl}: rewrote legacy/old.yaml — nothing reconciles that path, so this is divergence"
+  fi
+done
+
+# Idempotence, on the SAME origin the previous case pushed to.
+before="$(origin_commits walkone)"
+rc="$(run_phase3 "${D1}")"
+after="$(origin_commits walkone)"
+if [ "${rc}" != "0" ]; then
+  bad "D2 re-run exited ${rc} (a second run must be safe): $(tail -3 "${TMP}/out.txt" | tr '\n' ' ')"
+elif [ "${before}" != "${after}" ]; then
+  bad "D2 re-run added a commit (${before} -> ${after}) — the rewrite is not idempotent"
+else
+  ok "D2 re-run is a no-op: exit 0, commit count unchanged at ${after}"
+fi
+
+# The Organization CR union: an Org with a repo but no Flux source yet.
+D3="$(new_case d3)"
+seed_org_repo walkthree "${MOTHERSHIP}"
+printf 'openova\n' >"${D3}/gitrepositories.txt"
+printf 'walkthree\n' >"${D3}/organizations.txt"
+printf 'walkthree/vcluster|vcluster|walkthree|map[image:map[registry:%s]]\n' "${TARGET_HOST}" >"${D3}/helmreleases.txt"
+rc="$(run_phase3 "${D3}")"
+if [ "${rc}" = "0" ] && ! origin_show walkthree vcluster/vcluster.yaml | grep -q "${MOTHERSHIP}"; then
+  ok "D3 an Organization known only by its CR (no Flux source yet) was still pivoted"
+else
+  bad "D3 the Organization-CR union leg did not pivot walkthree (exit ${rc})"
+fi
+
+# ═══════════════════════════════════════════════════════════════════════════
+# E. Fail-loud — every way the estate can be unknowable
+# ═══════════════════════════════════════════════════════════════════════════
+echo
+echo "-- E. an unreadable estate is never an empty one --"
+
+expect_fatal() {
+  # $1 = label, $2 = case dir, $3 = substring the message must carry
+  local label="$1" d="$2" needle="$3" rc
+  rc="$(run_phase3 "${d}")"
+  if [ "${rc}" = "0" ]; then
+    bad "${label}: exited 0 — the step recorded success over an estate it could not read"
+  elif ! grep -qi "${needle}" "${TMP}/out.txt"; then
+    bad "${label}: failed (exit ${rc}) but the message never names '${needle}': $(grep -i fatal "${TMP}/out.txt" | head -1)"
+  else
+    ok "${label}: FATAL (exit ${rc}), message names what was missing"
+  fi
+}
+
+E1="$(new_case e1)"; export STUB_FAIL_KIND=gitrepositories
+expect_fatal "E1 GitRepository listing REFUSED" "${E1}" "listing GitRepositories"
+unset STUB_FAIL_KIND
+
+# The vacuity witness: the listing SUCCEEDS and returns nothing. On a Sovereign
+# that cannot be true — this step annotates gitrepository/openova in the same
+# namespace — so a "no Organizations, nothing to do" verdict drawn from it is a
+# fabrication. This is the case a fail-closed-on-error guard alone does NOT
+# cover, and the reason the witness exists.
+E2="$(new_case e2)"; : >"${E2}/gitrepositories.txt"
+expect_fatal "E2 GitRepository listing SUCCEEDS but returns zero objects" "${E2}" "ZERO objects"
+
+E3="$(new_case e3)"; export STUB_CRD_MODE=forbidden
+expect_fatal "E3 CRD probe fails with something other than NotFound" "${E3}" "NOT the same as it being absent"
+unset STUB_CRD_MODE
+
+# NotFound is a REAL state and must NOT be fatal.
+E4="$(new_case e4)"; export STUB_CRD_MODE=notfound
+rc="$(run_phase3 "${E4}")"
+if [ "${rc}" = "0" ] && grep -q "not installed on this Sovereign" "${TMP}/out.txt"; then
+  ok "E4 a confirmed-NotFound CRD is a real state, not a failure (exit 0)"
+else
+  bad "E4 a NotFound Organization CRD must not fail the step (exit ${rc})"
+fi
+unset STUB_CRD_MODE
+
+E5="$(new_case e5)"
+seed_org_repo walkfour "${MOTHERSHIP}"
+{ printf 'openova\n'; printf '%s-walkfour\n' "${REPO}"; } >"${E5}/gitrepositories.txt"
+export CURL_FORCE_CODE=500 CURL_FORCE_SLUG=walkfour
+expect_fatal "E5 repo probe returns 500" "${E5}" "unreadable repo is NOT an absent repo"
+unset CURL_FORCE_CODE CURL_FORCE_SLUG
+
+# 404 is legitimately absent — an Org that never installed anything.
+E6="$(new_case e6)"
+{ printf 'openova\n'; printf '%s-ghost\n' "${REPO}"; } >"${E6}/gitrepositories.txt"
+rc="$(run_phase3 "${E6}")"
+if [ "${rc}" = "0" ] && grep -q "HTTP 404" "${TMP}/out.txt"; then
+  ok "E6 an Organization with no per-Org repo (404) is skipped, not fatal (exit 0)"
+else
+  bad "E6 a 404 repo probe must be a benign skip (exit ${rc})"
+fi
+
+# The read-back: pushed is not pivoted until the owning reconciler re-applied it.
+E7="$(new_case e7)"
+seed_org_repo walkfive "${MOTHERSHIP}"
+{ printf 'openova\n'; printf '%s-walkfive\n' "${REPO}"; } >"${E7}/gitrepositories.txt"
+rm -f "${E7}/helmreleases.txt"
+printf 'walkfive/vcluster|vcluster|walkfive|map[image:map[registry:%s]]\n' "${MOTHERSHIP}" >"${E7}/helmreleases.1.txt"
+PERORG_READBACK_DEADLINE=1 expect_fatal "E7 read-back never converges" "${E7}" "has not re-applied it"
+if origin_show walkfive vcluster/vcluster.yaml | grep -q "${TARGET_HOST}"; then
+  ok "E7 the push still happened — the FATAL is about the reconciler, not the rewrite"
+else
+  bad "E7 expected the rewrite to be pushed before the read-back verdict"
+fi
+
+# ...and it converges once the reconciler catches up.
+E8="$(new_case e8)"
+seed_org_repo walksix "${MOTHERSHIP}"
+{ printf 'openova\n'; printf '%s-walksix\n' "${REPO}"; } >"${E8}/gitrepositories.txt"
+rm -f "${E8}/helmreleases.txt"
+printf 'walksix/vcluster|vcluster|walksix|map[image:map[registry:%s]]\n' "${MOTHERSHIP}" >"${E8}/helmreleases.1.txt"
+printf 'walksix/vcluster|vcluster|walksix|map[image:map[registry:%s]]\n' "${MOTHERSHIP}" >"${E8}/helmreleases.2.txt"
+printf 'walksix/vcluster|vcluster|walksix|map[image:map[registry:%s]]\n' "${TARGET_HOST}" >"${E8}/helmreleases.3.txt"
+rc="$(PERORG_READBACK_DEADLINE=30 run_phase3 "${E8}")"
+if [ "${rc}" = "0" ] && grep -q "read-back PASS" "${TMP}/out.txt"; then
+  ok "E8 the read-back waits out a slow reconciler and then passes (exit 0)"
+else
+  bad "E8 expected convergence on the 3rd sample (exit ${rc}): $(tail -2 "${TMP}/out.txt" | tr '\n' ' ')"
+fi
+
+# ═══════════════════════════════════════════════════════════════════════════
+# F. The step-11 lint
+# ═══════════════════════════════════════════════════════════════════════════
+echo
+echo "-- F. the pre-hold lint --"
+
+run_lint() {
+  # $1 = case dir, $2 = allowReleases
+  (
+    export PATH="${TMP}/bin:${PATH}"
+    export STUB_DIR="$1"
+    export WORK_DIR="$1/work"; mkdir -p "${WORK_DIR}"
+    export PERORG_HR_MOTHERSHIP_HOSTS="${MOTHERSHIP}"
+    export PERORG_HR_ALLOW_RELEASES="${2:-}"
+    # shellcheck disable=SC1090
+    . "${TMP}/lint.sh"
+    if run_perorg_hr_values_registry_lint "primary" "" >"${TMP}/lintout.txt" 2>&1; then echo PASS; else echo FAIL; fi
+  )
+}
+
+F1="$(new_case f1)"
+printf 'uatco\n' >"${F1}/namespaces.txt"
+printf 'uatco|vcluster|uatco|map[controlPlane:map[statefulSet:map[image:map[registry:%s]]]]\n' "${MOTHERSHIP}" >"${F1}/helmreleases.txt"
+[ "$(run_lint "${F1}")" = "FAIL" ] \
+  && ok "F1 a per-Org HelmRelease naming ${MOTHERSHIP} in spec.values is caught (the exact hw292/uatco shape)" \
+  || bad "F1 the lint PASSED over the live hw292 tether — it does not measure what it claims"
+
+F2="$(new_case f2)"
+printf 'uatco\n' >"${F2}/namespaces.txt"
+printf 'uatco|vcluster|uatco|map[controlPlane:map[statefulSet:map[image:map[registry:%s]]]]\n' "${TARGET_HOST}" >"${F2}/helmreleases.txt"
+[ "$(run_lint "${F2}")" = "PASS" ] \
+  && ok "F2 a pivoted per-Org HelmRelease passes" \
+  || bad "F2 the lint failed a clean estate: $(tail -1 "${TMP}/lintout.txt")"
+
+# Namespace-derived membership: the HR carries no org label of its own.
+F3="$(new_case f3)"
+printf 'uatco\n' >"${F3}/namespaces.txt"
+printf 'uatco|bp-wordpress-tenant||map[image:map[registry:%s]]\n' "${MOTHERSHIP}" >"${F3}/helmreleases.txt"
+[ "$(run_lint "${F3}")" = "FAIL" ] \
+  && ok "F3 an unlabelled HelmRelease in an Organization namespace is still in scope" \
+  || bad "F3 membership by namespace label is not working — an app HR in an Org ns escaped"
+
+# A PLATFORM HelmRelease is not this lint's business (step-09 Phase-1c owns it).
+F4="$(new_case f4)"
+: >"${F4}/namespaces.txt"
+printf 'flux-system|bp-mgmt-vcluster||map[global:map[registryMirror:%s]]\n' "${MOTHERSHIP}" >"${F4}/helmreleases.txt"
+[ "$(run_lint "${F4}")" = "PASS" ] \
+  && ok "F4 a platform HelmRelease outside any Organization namespace is out of scope, not a false positive" \
+  || bad "F4 the lint claimed a platform HR — scope creep into step-09 Phase-1c's assertion"
+
+F5="$(new_case f5)"
+printf 'uatco\n' >"${F5}/namespaces.txt"
+printf 'uatco|vcluster|uatco|map[image:map[registry:%s]]\n' "${MOTHERSHIP}" >"${F5}/helmreleases.txt"
+[ "$(run_lint "${F5}" "uatco/vcluster")" = "PASS" ] \
+  && ok "F5 a reviewed allowReleases exception is honoured" \
+  || bad "F5 the allowReleases exception was ignored"
+
+F6="$(new_case f6)"; printf 'uatco\n' >"${F6}/namespaces.txt"
+[ "$(STUB_FAIL_KIND=helmreleases run_lint "${F6}")" = "FAIL" ] \
+  && ok "F6 an unreadable HelmRelease list is a FAIL, never a silent PASS" \
+  || bad "F6 the lint reported PASS for a region it could not measure"
+
+F7="$(new_case f7)"; printf 'uatco\n' >"${F7}/namespaces.txt"
+[ "$(STUB_FAIL_KIND=namespaces run_lint "${F7}")" = "FAIL" ] \
+  && ok "F7 an unreadable Organization-namespace list is a FAIL" \
+  || bad "F7 the lint proceeded with a shrunken per-Org predicate"
+
+# The lint's own vacuity witness.
+F8="$(new_case f8)"; printf 'uatco\n' >"${F8}/namespaces.txt"; : >"${F8}/helmreleases.txt"
+[ "$(run_lint "${F8}")" = "FAIL" ] \
+  && ok "F8 zero HelmReleases from a SUCCEEDING listing is an unread estate, not a clean one" \
+  || bad "F8 the lint certified 'no per-Org tether' from an estate with zero objects in it"
+
+# ═══════════════════════════════════════════════════════════════════════════
+# G. Proven able to fail — mutants of the shipped bytes
+# ═══════════════════════════════════════════════════════════════════════════
+echo
+echo "-- G. the guards are guards (mutation controls) --"
+
+# G1 — neuter the vacuity witness (make its condition unreachable rather than
+# deleting the block, which would only prove sh rejects a hole). E2's fixture
+# must then sail through.
+sed 's/\[ "\${pv_grs_total}" -eq 0 \]/[ "${pv_grs_total}" -eq -1 ]/' "${TMP}/phase3.sh" >"${TMP}/mutant-witness.sh"
+if ! grep -q -- '-eq -1' "${TMP}/mutant-witness.sh" || ! sh -n "${TMP}/mutant-witness.sh" 2>/dev/null; then
+  bad "G1 could not build a valid no-witness mutant"
+else
+  G1="$(new_case g1)"; : >"${G1}/gitrepositories.txt"
+  mrc="$(run_phase3 "${G1}" "${TMP}/mutant-witness.sh")"
+  if [ "${mrc}" = "0" ]; then
+    ok "G1 without the witness the SAME empty-read fixture exits 0 (silently 'nothing to do') — the witness is what discriminates"
+  else
+    bad "G1 the no-witness mutant still failed (exit ${mrc}); E2 is not isolating the witness"
+  fi
+fi
+
+# G2 — delete the read-back. E7's never-converging fixture must then pass.
+python3 - "${TMP}/phase3.sh" "${TMP}/mutant-readback.sh" <<'PY'
+import sys
+src, dst = sys.argv[1], sys.argv[2]
+lines = open(src, encoding="utf-8").read().split("\n")
+out, skip = [], False
+for ln in lines:
+    if "pv_offenders() {" in ln:
+        skip = True
+        # The removed region is the whole body of an `else` branch; leave a
+        # no-op behind so the mutant stays syntactically valid and the case
+        # measures the ABSENCE OF THE READ-BACK, not a parse error.
+        out.append(":")
+    if skip and "read-back PASS" in ln:
+        skip = False
+        continue
+    if not skip:
+        out.append(ln)
+open(dst, "w", encoding="utf-8").write("\n".join(out))
+PY
+if grep -q 'read-back PASS' "${TMP}/mutant-readback.sh" || ! sh -n "${TMP}/mutant-readback.sh" 2>/dev/null; then
+  bad "G2 could not build a syntactically valid no-read-back mutant"
+else
+  G2="$(new_case g2)"
+  seed_org_repo walkseven "${MOTHERSHIP}"
+  { printf 'openova\n'; printf '%s-walkseven\n' "${REPO}"; } >"${G2}/gitrepositories.txt"
+  rm -f "${G2}/helmreleases.txt"
+  printf 'walkseven/vcluster|vcluster|walkseven|map[image:map[registry:%s]]\n' "${MOTHERSHIP}" >"${G2}/helmreleases.1.txt"
+  mrc="$(PERORG_READBACK_DEADLINE=1 run_phase3 "${G2}" "${TMP}/mutant-readback.sh")"
+  if [ "${mrc}" = "0" ]; then
+    ok "G2 without the read-back the SAME never-converging fixture exits 0 — the read-back is what turns 'pushed' into 'pivoted'"
+  else
+    bad "G2 the no-read-back mutant still failed (exit ${mrc}); E7 is not isolating the read-back"
+  fi
+fi
+
+# G3 — the lint with its offender test removed must pass F1's fixture.
+sed 's/^                    \*"\${_pvh}"\*).*$/                    *"__never_matches__"*) : ;;/' "${TMP}/lint.sh" >"${TMP}/mutant-lint.sh"
+if ! grep -q '__never_matches__' "${TMP}/mutant-lint.sh"; then
+  # The indentation was stripped at extraction; match on content instead.
+  sed 's/\*"\${_pvh}"\*)/*"__never_matches__")/' "${TMP}/lint.sh" >"${TMP}/mutant-lint.sh"
+fi
+if ! grep -q '__never_matches__' "${TMP}/mutant-lint.sh"; then
+  bad "G3 could not build the blind-lint mutant"
+else
+  mv "${TMP}/lint.sh" "${TMP}/lint.real.sh"; cp "${TMP}/mutant-lint.sh" "${TMP}/lint.sh"
+  res="$(run_lint "${F1}")"
+  mv "${TMP}/lint.real.sh" "${TMP}/lint.sh"
+  if [ "${res}" = "PASS" ]; then
+    ok "G3 with the host test neutered the lint PASSES the hw292 fixture — F1 is isolating the assertion, not the plumbing"
+  else
+    bad "G3 the blind-lint mutant still failed; F1 may be passing for the wrong reason"
+  fi
+fi
+
+echo
+if [ "${FAILURES}" -eq 0 ]; then
+  echo "== #5439 suite PASS =="
+  exit 0
+fi
+echo "== #5439 suite FAILED (${FAILURES}) =="
+exit 1

--- a/platform/self-sovereign-cutover/chart/values.yaml
+++ b/platform/self-sovereign-cutover/chart/values.yaml
@@ -2076,6 +2076,45 @@ egressTest:
   providerPackageHostLint:
     enabled: true
     allowHosts: []
+  # #5439 — PRE-HOLD per-Organization HelmRelease VALUES registry lint.
+  #
+  # THE BLIND SPOT IT CLOSES, stated as the two lints that could not see it:
+  #   * the pod-spec ref-host lint (#5026) EXEMPTS harbor.openova.io outright,
+  #     as a host step-04's containerd redirect covers. For an IMAGE PULL that
+  #     is true. It says nothing about the DECLARATION that produced the ref.
+  #   * the Flux source-host lint (#5650) reads spec.url on HelmRepository /
+  #     GitRepository / OCIRepository. A HelmRelease's spec.values is not a
+  #     source URL and is never examined.
+  # So a per-Org vCluster HelmRelease carrying
+  # `spec.values.controlPlane.statefulSet.image.registry: harbor.openova.io`
+  # passed BOTH, on a Sovereign with cutoverComplete=true (hw292, uatco).
+  #
+  # WHY spec.values AND NOT THE RENDERED POD. Because the declaration outlives
+  # the pod: a mothership host sitting in a Flux-owned HelmRelease is re-applied
+  # on every reconcile and re-resolved on every image pull for the life of the
+  # Sovereign, long after the 600s hold is torn down. That is the same argument
+  # #5650 makes for source URLs, one field over.
+  #
+  # SCOPE. Per-Organization HelmReleases only — the HR itself carrying
+  # `openova.io/organization`, or living in a namespace that does. The four
+  # PLATFORM image HRs are already asserted by step-09's own Phase-1c residual
+  # check, so this lint deliberately does not restate them; it covers the shape
+  # that scales with the number of Organizations and therefore has no fixed
+  # list anywhere to keep in sync.
+  #
+  # allowHosts is EMPTY by default, same rationale as the two lints above: a
+  # mothership host in a Flux-owned declaration is a tether until a human
+  # declares otherwise here, in Git, under review.
+  perOrgHelmReleaseValuesLint:
+    enabled: true
+    # The registry hosts whose presence in a per-Org HelmRelease's spec.values
+    # IS the defect. Space-joined into the Job env; the mothership Harbor is
+    # the only shipped entry, and it is the exact literal every generator in
+    # this program defaults to pre-cutover.
+    mothershipHosts:
+      - "harbor.openova.io"
+    # Reviewed exceptions, by `<namespace>/<helmrelease>`. Empty by default.
+    allowReleases: []
   # #3678 — TRUE deny-egress shape. defaultDenyEgress flips the Step-08
   # CCNP from a SUBTRACTIVE 4-CIDR block (default-allow, deny only the
   # listed hosts — which left console.openova.io + every un-enumerated
@@ -2836,6 +2875,87 @@ vclusterRegistryPivot:
   # self-documenting. Override via per-Sovereign overlay if you've
   # pinned a different upstream vCluster version.
   imageTag: "0.20.0"
+
+  # ── Phase 3 (#5439): the per-Organization `<slug>/catalyst-tenant` leg ──
+  #
+  # THE GAP THIS CLOSES. Phases 1/1b/1d/2 above pivot exactly FOUR named
+  # HelmReleases in ONE namespace (bp-mgmt/rtz/dmz-vcluster + bp-sso-bridge,
+  # flux-system). The per-Organization vCluster HelmRelease is a FIFTH shape
+  # they structurally cannot reach: it is named `vcluster`, it lives in the
+  # Org's OWN namespace, there is one PER ORGANIZATION, and its durable source
+  # is a THIRD repo class — `<slug>/catalyst-tenant@main:vcluster/vcluster.yaml`
+  # — written by core/controllers/organization/internal/gitops (Render) and
+  # reconciled by the `catalyst-tenant-<slug>-vcluster` Kustomization
+  # (prune=true). Measured live on hw292 with cutoverComplete=true since
+  # 2026-08-03T08:12:04Z:
+  #
+  #   kubectl -n uatco get hr vcluster -o json | jq -r .spec.values
+  #     "image":{"registry":"harbor.openova.io"
+  #     "statefulSet":{"image":{"registry":"harbor.openova.io"
+  #     "coredns":{...:"harbor.openova.io/proxy-dockerhub/coredns/..."}
+  #
+  # A live tether to the MOTHERSHIP Harbor, surviving a cutover that reported
+  # success. It did not fail the run because nothing looked: step-11's pod-spec
+  # ref-host lint EXEMPTS harbor.openova.io as step-04-redirect-covered, and the
+  # Flux source lint reads only HelmRepository/GitRepository/OCIRepository URLs
+  # — never a HelmRelease's spec.values. `cutoverComplete=true` with a live
+  # mothership tether is worse than a red: it is a green that overstates.
+  #
+  # WHY THIS LEG RUNS AT ORDER 9 AND NOT IN STEP-06 (order 6). The generator is
+  # made cutover-aware by step-07 Phase 3e (order 7), which stamps
+  # CATALYST_LOCAL_IMAGE_REGISTRY_HOST onto the org-controller / provisioning /
+  # catalyst-api Deployments and rolls them. Rewriting the repos BEFORE that
+  # stamp lands would race the org-controller: any Organization reconcile
+  # between the rewrite and the stamp re-renders the mothership literal straight
+  # back into the Flux-owned source. At order 9 the stamp is already in the pod
+  # template, so a regeneration after this leg reproduces the SAME local host
+  # and Flux has nothing to drift-correct.
+  #
+  # WHY NOT A LIVE `kubectl patch` ON THE PER-ORG HR. The per-Org boundary tree
+  # is owned by a prune=true Kustomization; a live patch is reverted on its next
+  # reconcile. That is the #6293/#6309 finding, restated one field over. This
+  # leg is durable-source-then-verify: rewrite the repo, push, then poll the
+  # LIVE HelmReleases until the rewrite has been fetched and re-applied.
+  perOrgTenant:
+    # Default true — on any Sovereign that sold an Organization before the
+    # operator fired the cutover, the tether is present by construction. Set
+    # false only on a Sovereign with no per-Org gitops trees at all.
+    enabled: true
+    # The per-Organization Gitea repo name. Fixed contract with
+    # core/controllers/organization/internal/controller/per_org_flux.go
+    # (perOrgTenantRepoName) — the same literal step-06 Phase-2d walks.
+    repo: "catalyst-tenant"
+    branch: "main"
+    # Namespace holding the per-Org `catalyst-tenant-<slug>` GitRepositories
+    # (SOURCE 1 of the Organization enumeration).
+    fluxNamespace: "flux-system"
+    # The Organization CRD probed for SOURCE 2 of the enumeration. Its ABSENCE
+    # is a real state (a pre-org-controller cluster) but must be established by
+    # POSITIVE NotFound evidence — `kubectl get crd` exits non-zero for BOTH
+    # "not installed" and "forbidden", and collapsing those is how a missing
+    # grant reads as "this Sovereign has no Organizations".
+    organizationCRD: "organizations.orgs.openova.io"
+    # Space-separated top-level directories of the per-Org repo to rewrite.
+    # `vcluster` is the tree the `catalyst-tenant-<slug>-vcluster` /
+    # `-apps` / `-host-apps` Kustomizations reconcile (PerOrgAppsDir /
+    # PerOrgHostAppsDir live under it), so it covers vcluster.yaml AND the app
+    # manifests. Anything outside it has no reconciler behind it, so rewriting
+    # it would be divergence with nothing to apply it.
+    trees: "vcluster"
+    # Bound on the post-push live read-back (Stage CONVERGE). The per-Org
+    # Kustomizations reconcile on the org-controller's FluxIntervalSeconds, so
+    # this must comfortably exceed one interval. Reaching the deadline with
+    # offenders still live is FATAL — a durable rewrite that the owning
+    # reconciler never applied is a pivot that does not exist.
+    readbackDeadlineSeconds: 300
+    # The host literal whose presence in a per-Org tree IS the defect. This is
+    # the bootstrap default every generator in this program ships
+    # (core/controllers/organization/internal/gitops/cutover_aware_vcluster_5439.go
+    # mothershipHarborHost, and the chart env CATALYST_VCLUSTER_IMAGE_REGISTRY
+    # `| default "harbor.openova.io"`), which is why it is the live value on
+    # every Sovereign from birth. Threaded as a value rather than inlined so
+    # the chart test can drive the block with a host of its own.
+    mothershipHarborHost: "harbor.openova.io"
 
 # Step 11 (crossplane-provider-pivot, TBD-V24 MISS-3, issue #2034) —
 # pivot every `pkg.crossplane.io/v1.Provider` CR's `spec.package` host

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-14T10:35:44.440Z",
+  "generatedAt": "2026-08-14T12:17:23.691Z",
   "blueprints": [
     {
       "id": "bp-agenity",
@@ -4640,7 +4640,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "0.1.189",
+      "version": "0.1.190",
       "section": "pts-2-3-per-sovereign-supporting-services",
       "depends": [
         "bp-gitea",

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -4775,7 +4775,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "0.1.189",
+    "version": "0.1.190",
     "section": "pts-2-3-per-sovereign-supporting-services",
     "depends": [
       "bp-gitea",

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3968,7 +3968,7 @@ name: bp-catalyst-platform
 #   file's 1.4.1325 entry records as permanently burned. The republish
 #   therefore lands on 1.4.1468 — ahead of main's 1.4.1467, absent from GHCR,
 #   and claimed by no open PR.)
-version: 1.4.1503
+version: 1.4.1504
 # 1.4.1481 — #6293: catalog-seed advances bp-self-sovereign-cutover
 #   0.1.186 -> 0.1.187, the release that stops step-06 from patching five
 #   HelmRepositories it does not own and then grading itself on whether they
@@ -4155,7 +4155,7 @@ version: 1.4.1503
 # scripts/check-chart-version-forward.sh (#5743) fails unless the two match —
 # main was carrying a pre-existing 1.4.1330/1.4.1329 split, so this bump heals
 # it in the same commit, exactly as the documented self-heal contract does.
-appVersion: 1.4.1503
+appVersion: 1.4.1504
 # 1.4.239 — Wave 3 / Issue #2140 (2026-05-23): Huawei provider
 # implementation lands behind the Wave 2 CloudProvider interface.
 # Adds the OpenTofu module at infra/providers/huawei/ (VPC + Subnet +

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5115,7 +5115,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.1.189"
+  version: "0.1.190"
   visibility: unlisted
   card:
     title: "Self-Sovereignty Cutover"
@@ -5132,7 +5132,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-self-sovereign-cutover
-    version: "0.1.189"
+    version: "0.1.190"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
## The defect

Step-09 (`vcluster-registry-pivot`, cutover-order **9**) pivots exactly **four named HelmReleases in one namespace** — `bp-mgmt-vcluster`, `bp-rtz-vcluster`, `bp-dmz-vcluster`, `bp-sso-bridge`, all in `flux-system`. The **per-Organization** vCluster HelmRelease is a fifth shape those patches structurally cannot reach: it is named `vcluster`, it lives in the Organization's *own* namespace, there is one **per Organization**, and its durable source is a third repo class — `<slug>/catalyst-tenant@main:vcluster/vcluster.yaml`, written by `core/controllers/organization/internal/gitops` `Render()` and reconciled by the `catalyst-tenant-<slug>-vcluster` Kustomization (`prune=true`).

Live on hw292, `cutoverComplete=true` since 2026-08-03T08:12:04Z:

```
kubectl -n uatco get hr vcluster -o json | jq -r .spec.values
  "image":{"registry":"harbor.openova.io"
  "statefulSet":{"image":{"registry":"harbor.openova.io"
  "coredns":{...:"harbor.openova.io/proxy-dockerhub/coredns/..."}
```

**Nothing went red, and that is the point.** Step-11's pod-spec ref-host lint *exempts* `harbor.openova.io` as step-04-redirect-covered (true of the **pull**, silent about the **declaration**), and the Flux source lint reads only `HelmRepository`/`GitRepository`/`OCIRepository` `spec.url` — a HelmRelease's `spec.values` is never examined. So a live mothership tether and a green cutover coexisted. This defect never blocked `cutoverComplete=true`; a green that overstates is worse than a red.

## The enumeration mechanism, and why

Organizations are enumerated **live**, from the **same two sources step-06 Phase-2d (#6309) already uses** — deliberately the same, so the two legs can never disagree about which Organizations exist:

1. **mandatory** — the `catalyst-tenant-<slug>` GitRepositories in `flux-system`. `per_org_flux.go` creates exactly one per Organization, and it is the object that *feeds the reverting Kustomization*.
2. **union** — the Organization CRs, catching an Org whose Flux source has not been created yet.

A hardcoded slug list is wrong the moment the next Organization is sold — the offender count scales with the number of Organizations, which is precisely why this is a cutover step and not a repair. `grep -rn "openova.io/organization" platform/self-sovereign-cutover/chart/templates/` previously hit only `03-harbor-prewarm-job.yaml` and `rbac.yaml`; nothing enumerated per-Org *repos* in this step.

Neither read may fail quietly. A refused list and an empty estate render identically, and here that would leave an unknown number of Organizations tethered while the step recorded success. CRD absence must come from a confirmed `NotFound` (a `kubectl get crd` exits non-zero for both "not installed" and "forbidden"); repo existence is an HTTP status (404 absent, anything else non-200 fatal), because `git ls-remote` fails identically for a missing repo and a bad credential.

## How the change survives a GitOps reconcile — verified, not assumed

Two independent things had to hold, and I checked both rather than reasoning about them.

**1. The repo is the durable source, so a live patch would be pointless.** `per_org_flux.go` creates `catalyst-tenant-<slug>-vcluster` with `prune: true` over the `vcluster/` tree. A `kubectl patch` on the live HR is reverted on its next reconcile — the #6293/#6309 finding, one field over. So Phase-3 rewrites the **repo** and pushes.

**2. The generator must already be cutover-aware, or it re-writes the mothership host straight back.** `Render()` re-emits `vcluster/vcluster.yaml` on *every* Organization reconcile. What makes it emit the local host is step-07 **Phase 3e**, which stamps `CATALYST_LOCAL_IMAGE_REGISTRY_HOST` on the org-controller / provisioning / catalyst-api Deployments and rolls them.

That is exactly why this leg is in **step-09 (order 9)** and **not** in step-06 (order 6): rewriting the repos before the stamp lands races the org-controller. I verified the generator half by running the existing Go tests, not by reading the template:

```
cd core/controllers/organization && go test ./internal/gitops/ -run '5439|Vcluster' -v
--- PASS: TestResolveVClusterImageRegistry/step-07_Phase_3e_stamp_is_authoritative
--- PASS: TestResolveVClusterImageRegistry/step-07_Phase_3e_stamp_normalised_(scheme_+_trailing_slash)
ok  github.com/openova-io/openova/core/controllers/organization/internal/gitops
```

and I pinned the ordering itself in the new suite (Section B), read from the **render's own `cutover-order` labels** so the durability argument cannot silently regress into a no-op with good logs:

```
ok — catalyst-api-env-patch=7 < vcluster-registry-pivot=9
ok — vcluster-registry-pivot=9 < egress-block-test=11
```

**3. And "pushed" is not "pivoted".** Phase-3 ends with a bounded read-back that polls the **live** per-Org HelmReleases until none carries the mothership host, re-poking the owning sources each cycle. Reaching the deadline with an offender still live is FATAL. Case E7 drives a fixture that never converges and requires the step to fail; mutant G2 deletes the read-back and shows that same fixture then exits 0.

## Before / after of a per-Org vCluster HR registry value

Read out of the **bare origin** (`git show main:…`), never a working tree — pushed-or-it-did-not-happen:

| | `vcluster/vcluster.yaml` in `<slug>/catalyst-tenant@main` |
|---|---|
| **before** | `registry: harbor.openova.io` ×2 (distro + syncer), `image: harbor.openova.io/proxy-dockerhub/coredns/coredns:1.11.3` |
| **after** | `registry: harbor.hw292.omani.works` ×2, `image: harbor.hw292.omani.works/proxy-dockerhub/coredns/coredns:1.11.3` |

The rewrite is a **host-literal** substitution scoped to the reconciled `vcluster/` tree, not three named YAML paths. The generator renders every image reference off one variable but in **two shapes** (a bare `registry:` scalar, and a fully-qualified `host/path:tag` for coredns), and it has *gained* fields before — #5439 exists one field over from #5527 for exactly that reason. Replacing the host wherever it appears covers the shapes that exist, the shapes that get added, and the app manifests beside them, while preserving every path and tag. Idempotent by construction. A file **outside** the reconciled tree is left alone (scoping control, asserted).

## Closing the detection gap

Step-11 gains a pre-hold lint: **no HelmRelease belonging to an Organization may name a mothership registry host anywhere in `spec.values`.** Membership uses `openova.io/organization` — on the release or on its namespace — the selector the org-controller already stamps and `org_namespace_invariant_4292_test.go` already pins, so nothing new is invented and there is nothing to keep in sync. It runs **per region** through the existing #5359 driver, and an unreadable region is a FAIL, never a skip. Reviewed exceptions go in `egressTest.perOrgHelmReleaseValuesLint.allowReleases` (empty by default).

## Two anti-vacuity witnesses

"Nothing to do" and "I could not look" render identically, and this issue is an instance of that, so fail-closed-on-error was not enough:

- **Phase-3**: a GitRepository listing that exits 0 and returns **zero objects** is FATAL. This step annotates `gitrepository/openova` in that same namespace moments earlier, so zero is not a state a Sovereign can be in — the read is hollow, and a "no Organizations" verdict from it would be a fabrication. The witness (`total=`, `org-crd=`) is **printed** on the same line as the count, so `orgs=0` always arrives with the two positive reads that establish it.
- **The lint**: zero HelmReleases from a *succeeding* listing is FATAL for the same reason — a Catalyst region always carries the bootstrap-kit's releases.

Both are proven able to fail by mutants that neuter **only** the witness and re-run the identical fixture.

## RBAC

**No new grant needed, and I checked both rule groups.** Phase-3 reads `gitrepositories`, `customresourcedefinitions`, `organizations`, `helmreleases`; the lint adds `namespaces` and `helmreleases`. All six are already in the runner ClusterRole's READ rules. Nothing was needed in the `create` group or the `update/patch` group because the leg **never patches a live per-Org HelmRelease** — by design, since a `prune=true` Kustomization reverts that. `chart/tests/rbac-coverage.sh` re-derives this from the render (it extracts every `kubectl get <resource>` in the rendered scripts and requires each to be granted) and passes.

## Proof: watched red first

The suite was run against the **pre-fix tree** obtained with `git archive origin/main`, not by reverting an edit in place.

**Pre-fix — `git archive origin/main`, TRUE-RC=1:**

```
-- A. the phase and the lint exist in the render --
  FAIL — step-09 carries no per-Org catalyst-tenant pivot region.
         The four flux-system HelmReleases it pivots cannot reach the
         per-Organization vCluster HelmRelease, whose durable source is
         <slug>/catalyst-tenant@main:vcluster/vcluster.yaml — so every Org keeps
         image.registry=harbor.openova.io through a cutover that reports
         success (#5439, measured on hw292/uatco).
```

**Half-fix (Phase-3 present, lint stripped), TRUE-RC=1** — so both halves are independently load-bearing:

```
  ok   — step-09 Phase-3 region extracted (200 lines)
  FAIL — step-11 carries no per-Org HelmRelease values lint.
         Without it the pivot above has no gate: the pod-spec ref-host
         lint EXEMPTS harbor.openova.io, and the Flux source lint reads only
         source URLs, so a per-Org spec.values tether passes both and
         cutoverComplete=true is set over a live dependency (#5439).
```

**This branch — TRUE-RC=0**, 33 assertions. The suite executes the **rendered** Phase-3 bytes against **real local git repositories** (real branches, commits, pushes; only the transport is shimmed) and drives the **rendered** lint under a programmable stub. Three mutation controls prove the guards discriminate rather than merely pass:

```
-- G. the guards are guards (mutation controls) --
  ok — G1 without the witness the SAME empty-read fixture exits 0 — the witness is what discriminates
  ok — G2 without the read-back the SAME never-converging fixture exits 0 — the read-back is what turns 'pushed' into 'pivoted'
  ok — G3 with the host test neutered the lint PASSES the hw292 fixture — F1 is isolating the assertion, not the plumbing
```

*(The task brief pointed at `tests/egress-hold-invariant.sh` as the model; that file did not exist at branch time — it landed on main with 0.1.189 mid-session. I modelled on `tests/step06-perorg-tenant-source.sh`, the true analog, which renders the chart and executes the extracted region under stubs with real git. `egress-hold-invariant.sh` arrived in the rebase and is green.)*

## Guard results — TRUE-RC captured from the guard, never through a pipe

Every run used `out=$(guard 2>&1); rc=$?` so no `tail` exit code could be mistaken for the guard's.

| Guard | TRUE-RC |
|---|---|
| `platform/self-sovereign-cutover/chart/tests/*.sh` — **all 21**, incl. the new suite, `rbac-coverage`, `cutover-contract`, `egress-hold-invariant`, `step06-perorg-tenant-source` | **0** (each) |
| `check-bootstrap-kit-pin-sync.sh` | **0** |
| `check-chart-version-forward.sh 0.1.189 0.1.189 0.1.190 0.1.190 bp-self-sovereign-cutover` | **0** |
| `check-chart-version-forward.sh 1.4.1503 1.4.1503 1.4.1504 1.4.1504 bp-catalyst-platform` | **0** |
| `check-train-coherent.sh` | **1** — see below |
| `go test ./internal/gitops/ -run '5439\|Vcluster'` (organization controller) | **0** |

### `check-train-coherent.sh` is red, and here is exactly what is red

Checks **1, 2 and 4 pass** (versions move forward, no hollow pin, umbrella-republish gate, all five lockstep sites agree and sites 4+5 are byte-identical to a fresh `build-catalog.mjs`). The **2 remaining failures are both in CHECK 3** and name exactly the two versions *this PR introduces*:

```
GHCR MISS bp-self-sovereign-cutover:0.1.190 — tag NOT FOUND on ghcr.io/openova-io/bp-self-sovereign-cutover
GHCR MISS bp-catalyst-platform:1.4.1504    — tag NOT FOUND on ghcr.io/openova-io/bp-catalyst-platform
```

The guard's own classifier files both as **PENDING-MERGE**, not MISSING:

```
· 3 bp-self-sovereign-cutover:0.1.190 PENDING-MERGE — not on main; blueprint-release is on:push→main so it CANNOT be published yet
· 3 bp-catalyst-platform:1.4.1504    PENDING-MERGE — not on main; blueprint-release is on:push→main so it CANNOT be published yet

2 pin(s) are simply NOT PUBLISHED YET — the release run is still in flight, or the
bump has not merged. Nothing is broken; the train is mid-flight.
```

I verified that structural claim in the workflow rather than taking the message's word for it — `.github/workflows/blueprint-release.yaml` is `on: push:` with `branches: [main]` (plus `workflow_dispatch`), so a version introduced on a PR branch **cannot** exist on GHCR before merge. This is unavoidable for any chart-bump PR and resolves itself on merge; there is no third failing item.

**One red this run caught that was a genuine defect of mine, now fixed:** the first `check-train-coherent.sh` run reported `DRIFT bp-catalyst-platform: chart=1.4.1504 pin=1.4.1501`. `scripts/bump-chart-version.sh` writes `Chart.yaml` only — the umbrella's **own** bootstrap-kit slot-13 pin does not move with it. `clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml` is included in this PR, and `check-bootstrap-kit-pin-sync.sh` went from rc=1 to rc=0 on that fix.

## Version and lockstep

`bp-self-sovereign-cutover` **0.1.189 → 0.1.190**. Main advanced to 0.1.189 (PR #6332) during this session, so the branch was rebased onto current main and the version re-derived above every open claim — `check-chart-version-not-claimed-by-open-pr.py --claimed-versions` showed the ceiling at 0.1.189. The cutover chart has `version:` but no `appVersion:`, so `bump-chart-version.sh` exits 1 on it (by design); its sibling-claim enumerator was used instead, and `--allow-unchecked-siblings` was never passed.

All five lockstep sites plus the slot pin and the umbrella republish move in this one commit:

1. `platform/self-sovereign-cutover/chart/Chart.yaml` → 0.1.190
2. `platform/self-sovereign-cutover/blueprint.yaml` → 0.1.190
3. `products/catalyst/chart/templates/catalog-seed/blueprints.yaml` → `spec.version` + `source.version` 0.1.190
4. `products/catalyst/bootstrap/api/internal/catalog/blueprints.json` — **regenerated**
5. `products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts` — **regenerated**
6. `clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml` → 0.1.190 (6-space indent preserved)
7. `products/catalyst/chart/Chart.yaml` 1.4.1503 → **1.4.1504** (`version` + `appVersion`) + slot-13 pin

Sites 4 and 5 come from `node scripts/build-catalog.mjs` run in `products/catalyst/bootstrap/ui/` and were never hand-edited; CHECK 4 confirms they are byte-identical to a fresh regeneration.

## Pillar

Pillar 5 — Sovereign independence post-cutover. UAT rows **G11 / 166 / 227** assert a *complete* cutover; this removes a live mothership-registry tether that survived one, and adds the assertion that stops it recurring silently.

Refs #5439
