### PR TITLE
fix(cloud-init): give the bootstrap GitRepository a clone budget it can finish in

### DIFF
--- a/.github/workflows/test-bootstrap-kit.yaml
+++ b/.github/workflows/test-bootstrap-kit.yaml
@@ -21,6 +21,7 @@ on:
       - 'scripts/check-umbrella-republish-gate.py'
       - 'scripts/sync-catalog-seed-pin.py'
       - 'scripts/check-cloudinit-kustomization-deps.sh'
+      - 'scripts/check-gitrepository-clone-timeout.sh'
       - 'scripts/expected-bootstrap-deps.yaml'
       - 'scripts/expected-cloudinit-kustomization-deps.yaml'
       - 'scripts/render-slot-placement.py'
@@ -42,6 +43,7 @@ on:
       - 'scripts/check-umbrella-republish-gate.py'
       - 'scripts/sync-catalog-seed-pin.py'
       - 'scripts/check-cloudinit-kustomization-deps.sh'
+      - 'scripts/check-gitrepository-clone-timeout.sh'
       - 'scripts/expected-bootstrap-deps.yaml'
       - 'scripts/expected-cloudinit-kustomization-deps.yaml'
       - 'scripts/render-slot-placement.py'
@@ -112,6 +114,23 @@ jobs:
         # back. This pins them to scripts/expected-cloudinit-kustomization-
         # deps.yaml; any drift fails here.
         run: bash scripts/check-cloudinit-kustomization-deps.sh
+
+      - name: GitRepository clone-budget self-test (#6336)
+        # Prove the guard below CAN fail before trusting the verdict it gives.
+        # The fixture suite asserts each must-fail case (no timeout / 60s / 5m /
+        # 2h / no such GitRepository) actually returns non-zero.
+        run: bash scripts/check-gitrepository-clone-timeout.sh --self-test
+
+      - name: GitRepository clone-budget guard (#6336)
+        # The bootstrap GitRepository/openova carried no spec.timeout, so the
+        # source-controller CRD default of 60s applied. A depth-1 clone of this
+        # repo measured 651s on hw297 (2026-08-14) — every reconcile died
+        # "context deadline exceeded", no artifact was ever built, and the
+        # fresh prov converged to ZERO HelmReleases. There is no shallow-clone
+        # knob to reach for (source-controller v1.4.1 already shallow-clones
+        # and the v1 CRD has no depth field), so the deadline is the only lever
+        # and must not drift back under the measured clone.
+        run: bash scripts/check-gitrepository-clone-timeout.sh
 
       - name: Placement-as-data drift gate (#3373 DoD-6)
         # placement.yaml is THE single placement source of truth; a

--- a/infra/providers/_shared/cloudinit-control-plane.tftpl
+++ b/infra/providers/_shared/cloudinit-control-plane.tftpl
@@ -513,6 +513,49 @@ write_files:
         namespace: flux-system
       spec:
         interval: 1m
+        # CLONE BUDGET (issue #6336) — this is source-controller's whole-reconcile
+        # deadline, NOT the kustomize-controller revision-lock knob issue #492
+        # governs. Never "harmonise" it down to 5m by analogy: a GitRepository
+        # holds no revision lock, so a longer deadline costs nothing on the happy
+        # path, while a short one produces ZERO HelmReleases forever.
+        #
+        # Measured on hw297 region-b, 2026-08-14: with the field ABSENT the CRD
+        # default of 60s applies (source-controller v1.4.1 CRD:
+        # `spec.timeout` default "60s"), and every reconcile died at
+        #   `failed to checkout and determine revision: unable to clone
+        #    'https://github.com/openova-io/openova': context deadline exceeded`
+        # -> bootstrap-kit / bootstrap-kit-crs / sovereign-tls all stuck on
+        # `Source artifact not found` -> `kubectl get helmrelease -A` empty ->
+        # the Phase-1 watch reported 0 HelmReleases and the prov froze.
+        # Patching ONLY this field to 10m on the live cluster produced
+        # `13:41:33Z building artifact` -> `13:52:24Z ready=True
+        # rev=main@sha1:e050028da1634e` — 651s (10m51s) for one clone.
+        #
+        # WHY THE CLONE IS THAT EXPENSIVE, and why `ignore:` below does not help:
+        # source-controller v1.4.1 ALREADY shallow-clones unconditionally
+        # (internal/controller/gitrepository_controller.go: `cloneOpts :=
+        # repository.CloneConfig{... ShallowClone: true}`) and the v1 CRD exposes
+        # NO depth / shallow / sparse-checkout knob to tune — so the history is
+        # already excluded and cannot be excluded any further from here. What
+        # crosses the wire is the depth-1 tree at HEAD: 449 MB, of which
+        # docs/ is 373 MB (docs/sessions alone 338 MB). `ignore:` is an
+        # ARTIFACT-BUILD filter applied AFTER checkout, so it never shrinks the
+        # transfer. 449 MB / 651 s => ~0.69 MB/s effective on that link.
+        #
+        # 20m = 1.84x the measured 651s. Floor: it must clear a real observed
+        # clone with room for the tree to grow (docs/sessions grows every walk)
+        # or the link to halve. Ceiling: it must stay well inside the 60m
+        # DefaultWatchTimeout of the Phase-1 HelmRelease watch so a genuinely
+        # unreachable origin still fails visibly INSIDE the watch window rather
+        # than in one endless attempt. A retry cannot rescue a slow clone (each
+        # attempt re-clones from scratch at the same speed), so single-attempt
+        # headroom is what matters; retry count is not.
+        #
+        # This moves the cliff, it does not remove it: at a fixed timeout, repo
+        # growth eventually crosses any value. The durable removal is to stop
+        # carrying hundreds of MB of walk evidence in the reconciled tree.
+        # Guarded by scripts/check-gitrepository-clone-timeout.sh.
+        timeout: 20m
         url: ${gitops_repo_url}
         ref:
           branch: ${gitops_branch}

--- a/products/catalyst/bootstrap/api/internal/provisioner/kustomization_timeout_test.go
+++ b/products/catalyst/bootstrap/api/internal/provisioner/kustomization_timeout_test.go
@@ -36,7 +36,53 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
+
+// operativeTimeout is one non-comment `timeout:` line in the cloud-init
+// template, tagged with the kind + metadata.name of the document that owns it.
+// Ownership matters because the two controllers that read a `timeout:` field
+// mean completely different things by it (see classifyTimeouts).
+type operativeTimeout struct {
+	line int
+	text string // trimmed, e.g. "timeout: 5m"
+	kind string // owning document kind, e.g. "Kustomization"
+	name string // owning document metadata.name
+}
+
+// classifyTimeouts walks the cloud-init template and returns every operative
+// `timeout:` declaration tagged with its owning document.
+//
+// Ownership tracking mirrors TestKustomizationTimeout_WaitTrueRetained: the
+// document kind comes from a `kind:` line, and metadata.name is the `name:`
+// line whose previous non-comment line is `metadata:` (so sourceRef.name /
+// dependsOn[].name / substituteFrom[].name never shadow it).
+func classifyTimeouts(tpl string) []operativeTimeout {
+	var out []operativeTimeout
+	kind, name, prevNonComment := "", "", ""
+	for i, line := range strings.Split(tpl, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "#") {
+			continue // comment — never operative
+		}
+		if strings.HasPrefix(trimmed, "kind:") {
+			// A `kind:` under sourceRef (previous line is `sourceRef:`) names the
+			// REFERENT, not this document. Only a top-of-document `kind:` re-tags.
+			if prevNonComment != "sourceRef:" {
+				kind = strings.TrimSpace(strings.TrimPrefix(trimmed, "kind:"))
+				name = ""
+			}
+		}
+		if strings.HasPrefix(trimmed, "name:") && prevNonComment == "metadata:" {
+			name = strings.TrimSpace(strings.TrimPrefix(trimmed, "name:"))
+		}
+		if strings.HasPrefix(trimmed, "timeout:") {
+			out = append(out, operativeTimeout{line: i + 1, text: trimmed, kind: kind, name: name})
+		}
+		prevNonComment = trimmed
+	}
+	return out
+}
 
 // TestKustomizationTimeout_AllAtFiveMinutes locks the bootstrap Flux
 // Kustomization timeouts. The two health-gating (`wait: true`)
@@ -51,32 +97,36 @@ import (
 // #492 deadlock pathology this test guards simply does not apply to it —
 // it has no operative `timeout:` line and is excluded from the count.
 //
-// Implementation note: we don't bother locating each Kustomization by
-// name and inspecting the next `timeout:` line beneath it. The
-// cloud-init template is small and the only operative `timeout:` lines
-// outside commentary are the two health-gating Kustomization timeouts. We
-// assert presence of two `timeout: 5m` lines AND absence of any
-// `timeout: 30m` lines (the pre-issue-492 form).
+// #6336 — the operative `timeout:` lines are no longer Kustomization-only.
+// The bootstrap `GitRepository/openova` now declares one too, and it means the
+// OPPOSITE thing: source-controller's clone deadline, on an object that holds
+// no revision lock. Conflating the two is exactly how a well-meaning "make the
+// timeouts consistent" edit would re-break a fresh prov, so this test buckets
+// timeouts BY OWNING KIND (classifyTimeouts) and pins each bucket to its own
+// canonical value. An operative `timeout:` owned by neither kind fails: a newly
+// inlined resource must be promoted into this spec, not absorbed silently.
 func TestKustomizationTimeout_AllAtFiveMinutes(t *testing.T) {
 	tpl := readCloudInit(t)
 
-	// Walk lines and bucket the operative `timeout:` declarations.
-	// "Operative" means the line, after trimming whitespace, starts
-	// with `timeout:` (no leading `#`). Comments that quote the
-	// previous form for explanatory purposes are allowed.
+	all := classifyTimeouts(tpl)
 	var operativeTimeouts []string
-	for i, line := range strings.Split(tpl, "\n") {
-		trimmed := strings.TrimSpace(line)
-		if strings.HasPrefix(trimmed, "#") {
-			continue // comment — allowed to reference old/new form
-		}
-		if strings.HasPrefix(trimmed, "timeout:") {
-			operativeTimeouts = append(operativeTimeouts, trimmed)
-			t.Logf("line %d: %s", i+1, trimmed)
+	for _, ot := range all {
+		t.Logf("line %d: %s (owner: %s/%s)", ot.line, ot.text, ot.kind, ot.name)
+		switch ot.kind {
+		case "Kustomization":
+			operativeTimeouts = append(operativeTimeouts, ot.text)
+		case "GitRepository":
+			// Asserted by TestGitRepositoryCloneTimeout_HasHeadroom below.
+		default:
+			t.Errorf("line %d: operative `timeout:` on an unclassified document (kind=%q name=%q): %s\n"+
+				"Every operative timeout must be promoted into this test's spec — a new inlined resource "+
+				"carrying a timeout nobody pinned is how issue #492 and issue #6336 both happened.",
+				ot.line, ot.kind, ot.name, ot.text)
 		}
 	}
 
-	// Expect exactly ONE operative timeout line in cloud-init: bootstrap-kit.
+	// Expect exactly ONE Kustomization-owned timeout line in cloud-init:
+	// bootstrap-kit.
 	// #4521 moved the `infrastructure-config` Kustomization OUT of the inline
 	// cloud-init into a COMMITTED Flux Kustomization CR
 	// (clusters/_template/infrastructure/providers/{,hetzner}/
@@ -262,5 +312,74 @@ func TestKustomizationTimeout_CommittedInfrastructureConfig(t *testing.T) {
 		if !strings.Contains(body, "- name: infrastructure-providers") {
 			t.Errorf("#4521: committed infrastructure-config CR %s must `dependsOn: [infrastructure-providers]` (the atomic-dry-run ordering fix)", f)
 		}
+	}
+}
+
+// gitRepositoryCloneTimeoutFloor / Ceiling — the same bounds
+// scripts/check-gitrepository-clone-timeout.sh enforces, restated here so the
+// Go suite fails on its own without the shell guard present.
+//
+// Floor: a depth-1 clone of this repo measured 651s (10m51s) on hw297 region-b
+// on 2026-08-14 — `13:41:33Z building artifact` -> `13:52:24Z ready=True`.
+// Ceiling: helmwatch's DefaultWatchTimeout (60m); a clone budget larger than
+// the Phase-1 watch window turns an unreachable origin into one silent endless
+// attempt instead of a failure the watch can classify.
+const (
+	gitRepositoryCloneTimeoutFloor   = 15 * time.Minute
+	gitRepositoryCloneTimeoutCeiling = 60 * time.Minute
+)
+
+// TestGitRepositoryCloneTimeout_HasHeadroom is the issue #6336 guard: the
+// bootstrap `GitRepository/openova` cloud-init writes MUST declare an operative
+// `spec.timeout`, and it must sit inside [floor, ceiling].
+//
+// Absence is the defect, not a neutral default. With the field absent, the
+// source-controller v1.4.1 CRD default of 60s applies; on hw297 region-b every
+// reconcile then died with `failed to checkout and determine revision: unable
+// to clone 'https://github.com/openova-io/openova': context deadline exceeded`,
+// so bootstrap-kit / bootstrap-kit-crs / sovereign-tls all sat on `Source
+// artifact not found`, `kubectl get helmrelease -A` returned nothing, and the
+// prov froze at `phase1-watching` with 0 HelmReleases.
+//
+// There is no shallow-clone lever to reach for instead: source-controller
+// v1.4.1 already sets `repository.CloneConfig{... ShallowClone: true}`
+// unconditionally, and `source.toolkit.fluxcd.io/v1` exposes no depth /
+// sparse-checkout field. `spec.ignore` filters at artifact-build time, AFTER
+// checkout, so it never shrinks the transfer either. The deadline is the only
+// knob, which is precisely why it must not drift back down.
+func TestGitRepositoryCloneTimeout_HasHeadroom(t *testing.T) {
+	tpl := readCloudInit(t)
+
+	var found []operativeTimeout
+	for _, ot := range classifyTimeouts(tpl) {
+		if ot.kind == "GitRepository" {
+			found = append(found, ot)
+		}
+	}
+
+	if len(found) != 1 {
+		t.Fatalf("#6336: expected exactly 1 operative GitRepository `timeout:` in the cloud-init template, got %d: %+v\n"+
+			"Zero means the 60s CRD default applies and a fresh Sovereign converges to ZERO HelmReleases.",
+			len(found), found)
+	}
+	got := found[0]
+
+	if got.name != "openova" {
+		t.Errorf("#6336: the timed GitRepository is named %q, want \"openova\" (the bootstrap source every Kustomization sourceRefs)", got.name)
+	}
+
+	raw := strings.TrimSpace(strings.TrimPrefix(got.text, "timeout:"))
+	d, err := time.ParseDuration(raw)
+	if err != nil {
+		t.Fatalf("#6336: GitRepository/%s timeout %q is not a parseable duration: %v", got.name, raw, err)
+	}
+	if d < gitRepositoryCloneTimeoutFloor {
+		t.Errorf("#6336: GitRepository/%s timeout %v is below the %v floor. A depth-1 clone of this repo measured 10m51s on hw297; anything under the floor reproduces the 0-HelmRelease wedge.\n"+
+			"NOTE: the 5m of issue #492 is the kustomize-controller REVISION-LOCK budget. A GitRepository holds no revision lock — do not harmonise this down to match it.",
+			got.name, d, gitRepositoryCloneTimeoutFloor)
+	}
+	if d > gitRepositoryCloneTimeoutCeiling {
+		t.Errorf("#6336: GitRepository/%s timeout %v exceeds the %v ceiling (helmwatch DefaultWatchTimeout) — an unreachable origin would never surface inside the Phase-1 watch window.",
+			got.name, d, gitRepositoryCloneTimeoutCeiling)
 	}
 }

--- a/scripts/check-gitrepository-clone-timeout.sh
+++ b/scripts/check-gitrepository-clone-timeout.sh
@@ -1,0 +1,373 @@
+#!/usr/bin/env bash
+# check-gitrepository-clone-timeout.sh — the bootstrap GitRepository must
+# declare a clone budget that a real clone of THIS repo can actually finish in
+# (issue #6336).
+#
+# THE DEFECT THIS LOCKS OUT
+# ------------------------
+# `infra/providers/_shared/cloudinit-control-plane.tftpl` writes the Flux
+# `GitRepository/openova` in `flux-system` that every fresh Sovereign bootstraps
+# from. It carried NO `spec.timeout`, so the source-controller CRD default of
+# 60s applied. Measured on hw297 region-b (2026-08-14) every reconcile died:
+#
+#   failed to checkout and determine revision: unable to clone
+#   'https://github.com/openova-io/openova': context deadline exceeded
+#
+# -> bootstrap-kit / bootstrap-kit-crs / sovereign-tls all `Source artifact not
+# found` -> `kubectl get helmrelease -A` empty -> Phase-1 watch saw 0
+# HelmReleases -> the prov froze at `phase1-watching`. Patching ONLY this field
+# to 10m produced `ready=True` after 651s (10m51s). The clone needed ~11
+# minutes and had been given 60 seconds.
+#
+# WHY A TIMEOUT AND NOT A SHALLOW-CLONE KNOB
+# ------------------------------------------
+# source-controller v1.4.1 (the pin: platform/flux -> flux2 2.14.1 -> Flux
+# v2.4.0) already shallow-clones unconditionally —
+# `internal/controller/gitrepository_controller.go` builds
+# `repository.CloneConfig{... ShallowClone: true}` with no conditional — and the
+# `source.toolkit.fluxcd.io/v1` CRD exposes no depth / shallowClone /
+# sparseCheckout field to tune. There is no lever here beyond the deadline.
+# `spec.ignore` does not help either: it filters at ARTIFACT-BUILD time, after
+# checkout, so the bytes still cross the wire.
+#
+# WHAT IS ASSERTED
+# ----------------
+#   1. The `GitRepository` named `openova` exists in the template.
+#   2. It declares an OPERATIVE (non-comment) `spec.timeout`. Absence is a
+#      failure in itself — absence means the 60s CRD default, which is the
+#      exact defect.
+#   3. That timeout is >= MIN (default 15m). The floor sits above the 651s
+#      measured clone with headroom for tree growth / a slower link.
+#   4. That timeout is <= MAX (default 60m) — the `DefaultWatchTimeout` of the
+#      Phase-1 HelmRelease watch. A budget larger than the watch window turns an
+#      unreachable origin into one silent endless attempt instead of a visible
+#      failure inside the watch.
+#
+# Exit codes:
+#   0 — the GitRepository's clone budget is present and within [MIN, MAX].
+#   1 — missing, unparseable, too small, or too large.
+#   2 — usage / setup error.
+#
+# Dependencies: bash, awk. No cluster, no network, no cloud call.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+TFTPL="${REPO_ROOT}/infra/providers/_shared/cloudinit-control-plane.tftpl"
+GITREPO_NAME="openova"
+MIN_SECONDS="${MIN_SECONDS:-900}"    # 15m — above the 651s measured clone
+MAX_SECONDS="${MAX_SECONDS:-3600}"   # 60m — helmwatch DefaultWatchTimeout
+SELF_TEST=0
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [--tftpl FILE] [--name NAME] [--self-test]
+
+  --tftpl FILE   control-plane cloud-init template to scan
+                 (default: ${TFTPL})
+  --name NAME    GitRepository metadata.name to check (default: ${GITREPO_NAME})
+  --self-test    run the cluster-free fixture suite and exit
+  -h, --help     show this message
+
+Env: MIN_SECONDS (default 900), MAX_SECONDS (default 3600).
+See issue #6336.
+EOF
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --tftpl)     TFTPL="$2"; shift 2 ;;
+    --name)      GITREPO_NAME="$2"; shift 2 ;;
+    --self-test) SELF_TEST=1; shift ;;
+    -h|--help)   usage; exit 0 ;;
+    *) echo "ERROR: unknown argument: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+_err() { printf 'ERROR: %s\n' "$*" >&2; }
+_ok()  { printf 'OK: %s\n' "$*"; }
+
+# ---------------------------------------------------------------------------
+# extract_timeout <file> <gitrepository-name>
+#
+# Prints the operative `timeout:` value declared inside the GitRepository
+# document whose metadata.name matches, or nothing if there is none. Prints
+# `__NO_SUCH_DOC__` when no GitRepository with that name exists at all, so the
+# caller can tell "guard looked and found nothing to check" (a setup error, and
+# the vacuity control for this guard) apart from "found the doc, no timeout"
+# (the #6336 defect).
+#
+# The documents are embedded in a cloud-init `write_files` `content: |` block
+# interleaved with HCL directives, so this is an indentation-agnostic scan
+# rather than a YAML parse — the same technique
+# scripts/check-cloudinit-kustomization-deps.sh uses. Comment lines are skipped
+# so prose that quotes `timeout:` can never satisfy the check.
+# ---------------------------------------------------------------------------
+extract_timeout() {
+  awk -v want="$2" '
+    function trim(s){ sub(/^[ \t]+/,"",s); sub(/[ \t]+$/,"",s); return s }
+    BEGIN{ in_doc=0; meta_seen=0; name=""; timeout=""; found=0 }
+    {
+      t=trim($0)
+      if (t ~ /^#/) next          # comments are never operative
+
+      if (t=="kind: GitRepository") {
+        if (in_doc && name==want) { found=1; print timeout; exit }
+        in_doc=1; meta_seen=0; name=""; timeout=""
+        next
+      }
+      if (!in_doc) next
+
+      if (t=="---" || t ~ /^apiVersion:/) {
+        if (name==want) { found=1; print timeout; exit }
+        in_doc=0; meta_seen=0; name=""; timeout=""
+        next
+      }
+
+      # metadata.name is the FIRST `name:` in the document; later `name:` keys
+      # (sourceRef.name, secretRef.name) must not shadow it.
+      if (!meta_seen && t ~ /^name:[ ]*/) {
+        v=t; sub(/^name:[ ]*/,"",v); gsub(/["'\'']/,"",v)
+        name=trim(v); meta_seen=1
+        next
+      }
+
+      if (t ~ /^timeout:[ ]*/) {
+        v=t; sub(/^timeout:[ ]*/,"",v); gsub(/["'\'']/,"",v)
+        timeout=trim(v)
+        next
+      }
+    }
+    END{ if (!found) { if (in_doc && name==want) print timeout; else print "__NO_SUCH_DOC__" } }
+  ' "$1"
+}
+
+# ---------------------------------------------------------------------------
+# duration_seconds <go-duration>
+#   Converts a Go/Flux duration ("60s", "20m", "1h", "10m30s") to seconds on
+#   stdout. Returns 1 and prints nothing when the string is not a duration.
+# ---------------------------------------------------------------------------
+duration_seconds() {
+  local d="$1" total=0 num unit rest
+  [ -n "${d}" ] || return 1
+  rest="${d}"
+  while [ -n "${rest}" ]; do
+    num="${rest%%[smh]*}"
+    case "${num}" in
+      ''|*[!0-9]*) return 1 ;;
+    esac
+    rest="${rest#"${num}"}"
+    unit="${rest:0:1}"
+    rest="${rest:1}"
+    case "${unit}" in
+      s) total=$(( total + num )) ;;
+      m) total=$(( total + num * 60 )) ;;
+      h) total=$(( total + num * 3600 )) ;;
+      *) return 1 ;;
+    esac
+  done
+  printf '%s' "${total}"
+}
+
+# ---------------------------------------------------------------------------
+# check_file <file> <name> -> 0 pass / 1 fail   (prints its own diagnostics)
+# ---------------------------------------------------------------------------
+check_file() {
+  local file="$1" name="$2" raw secs
+  if [ ! -f "${file}" ]; then
+    _err "template not found: ${file}"
+    return 1
+  fi
+
+  raw="$(extract_timeout "${file}" "${name}")"
+
+  if [ "${raw}" = "__NO_SUCH_DOC__" ]; then
+    _err "no GitRepository named '${name}' found in ${file}."
+    _err "  The bootstrap source moved or was renamed. This guard has nothing to"
+    _err "  assert and must not pass silently — point it at the new site (--name/--tftpl)."
+    return 1
+  fi
+
+  if [ -z "${raw}" ]; then
+    _err "GitRepository/${name} declares NO operative 'spec.timeout' in ${file}."
+    _err "  Absence means the source-controller CRD default of 60s applies. On this"
+    _err "  repo a depth-1 clone measured 651s (hw297, 2026-08-14), so every"
+    _err "  reconcile fails 'context deadline exceeded', no artifact is ever built,"
+    _err "  and a fresh Sovereign converges to ZERO HelmReleases. Issue #6336."
+    return 1
+  fi
+
+  if ! secs="$(duration_seconds "${raw}")"; then
+    _err "GitRepository/${name} timeout '${raw}' is not a parseable Go duration (want e.g. 20m)."
+    return 1
+  fi
+
+  if [ "${secs}" -lt "${MIN_SECONDS}" ]; then
+    _err "GitRepository/${name} timeout '${raw}' (${secs}s) is below the ${MIN_SECONDS}s floor."
+    _err "  A full depth-1 clone of this repo measured 651s on hw297 (2026-08-14);"
+    _err "  the floor keeps headroom for tree growth and slower links. Issue #6336."
+    _err "  NOTE: the 5m of issue #492 is the kustomize-controller revision-lock"
+    _err "  budget — it does not apply to a GitRepository, which holds no lock."
+    return 1
+  fi
+
+  if [ "${secs}" -gt "${MAX_SECONDS}" ]; then
+    _err "GitRepository/${name} timeout '${raw}' (${secs}s) exceeds the ${MAX_SECONDS}s ceiling."
+    _err "  That is longer than helmwatch DefaultWatchTimeout (60m), so an"
+    _err "  unreachable origin would never surface as a failure inside the Phase-1"
+    _err "  watch window — it would look like one silent endless attempt."
+    return 1
+  fi
+
+  _ok "GitRepository/${name} clone budget = ${raw} (${secs}s), within [${MIN_SECONDS}s, ${MAX_SECONDS}s] — issue #6336."
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+# --self-test — fixtures only, no repo file, no cluster.
+#
+# Every fixture that MUST fail is asserted to fail, so a future edit that makes
+# this guard structurally unable to fail (the classic dead-guard shape) is
+# caught here. The `__NO_SUCH_DOC__` fixture is the vacuity control: a file with
+# no matching GitRepository must NOT be reported as a pass.
+# ---------------------------------------------------------------------------
+run_self_test() {
+  local tmp rc fails=0
+  tmp="$(mktemp -d "${TMPDIR:-/tmp}/gitrepo-timeout-selftest.XXXXXX")"
+  # shellcheck disable=SC2064
+  trap "rm -rf '${tmp}'" EXIT
+
+  _fixture() { printf '%s\n' "$2" > "${tmp}/$1"; }
+
+  _fixture absent.yaml '      apiVersion: source.toolkit.fluxcd.io/v1
+      kind: GitRepository
+      metadata:
+        name: openova
+        namespace: flux-system
+      spec:
+        interval: 1m
+        url: https://github.com/openova-io/openova
+        ref:
+          branch: main'
+
+  _fixture sixty.yaml '      kind: GitRepository
+      metadata:
+        name: openova
+      spec:
+        interval: 1m
+        timeout: 60s'
+
+  _fixture five-min.yaml '      kind: GitRepository
+      metadata:
+        name: openova
+      spec:
+        timeout: 5m'
+
+  _fixture good.yaml '      kind: GitRepository
+      metadata:
+        name: openova
+      spec:
+        interval: 1m
+        timeout: 20m
+        url: https://github.com/openova-io/openova'
+
+  _fixture too-long.yaml '      kind: GitRepository
+      metadata:
+        name: openova
+      spec:
+        timeout: 2h'
+
+  _fixture wrong-name.yaml '      kind: GitRepository
+      metadata:
+        name: some-other-source
+      spec:
+        timeout: 20m'
+
+  # Prose that merely quotes an operative-looking key must not satisfy the check.
+  _fixture comment-only.yaml '      kind: GitRepository
+      metadata:
+        name: openova
+      spec:
+        # timeout: 20m   <- commentary, not a declaration
+        interval: 1m'
+
+  # A later sourceRef-style `name:` must not shadow metadata.name.
+  _fixture shadowed-name.yaml '      kind: GitRepository
+      metadata:
+        name: openova
+      spec:
+        timeout: 20m
+        secretRef:
+          name: not-the-doc-name'
+
+  # Two GitRepository docs in one file — the wanted one is second.
+  _fixture two-docs.yaml '      kind: GitRepository
+      metadata:
+        name: other-source
+      spec:
+        timeout: 1h
+      ---
+      apiVersion: source.toolkit.fluxcd.io/v1
+      kind: GitRepository
+      metadata:
+        name: openova
+      spec:
+        timeout: 20m'
+
+  _expect() { # <fixture> <want-rc> <why>
+    local out
+    out="$(check_file "${tmp}/$1" "${GITREPO_NAME}" 2>&1)"; rc=$?
+    if [ "${rc}" -ne "$2" ]; then
+      printf 'SELF-TEST FAIL: %-20s expected rc=%s got rc=%s (%s)\n' "$1" "$2" "${rc}" "$3" >&2
+      printf '%s\n' "${out}" | sed 's/^/    /' >&2
+      fails=$((fails+1))
+    else
+      printf 'SELF-TEST ok:   %-20s rc=%s (%s)\n' "$1" "${rc}" "$3"
+    fi
+  }
+
+  _expect absent.yaml        1 'no timeout at all => 60s CRD default => the #6336 defect'
+  _expect sixty.yaml         1 'explicit 60s is the measured-failing value'
+  _expect five-min.yaml      1 '5m is the #492 Kustomization budget, still under the 651s clone'
+  _expect good.yaml          0 '20m clears the 651s measurement and stays under the watch window'
+  _expect too-long.yaml      1 '2h outruns the 60m Phase-1 watch'
+  _expect wrong-name.yaml    1 'vacuity control: nothing named openova => must not pass'
+  _expect comment-only.yaml  1 'commented-out timeout is not a declaration'
+  _expect shadowed-name.yaml 0 'metadata.name survives a later secretRef.name'
+  _expect two-docs.yaml      0 'the wanted doc is found even as the second document'
+
+  # Duration parser unit checks (the arithmetic the verdicts rest on).
+  _dur() {
+    local got; got="$(duration_seconds "$1")" || got="ERR"
+    if [ "${got}" != "$2" ]; then
+      printf 'SELF-TEST FAIL: duration_seconds(%s) = %s, want %s\n' "$1" "${got}" "$2" >&2
+      fails=$((fails+1))
+    else
+      printf 'SELF-TEST ok:   duration_seconds(%-7s) = %s\n' "$1" "${got}"
+    fi
+  }
+  _dur 60s 60
+  _dur 5m 300
+  _dur 20m 1200
+  _dur 1h 3600
+  _dur 10m51s 651
+  _dur banana ERR
+  _dur 20 ERR
+
+  if [ "${fails}" -gt 0 ]; then
+    printf '\nSELF-TEST: %d failure(s) — this guard cannot be trusted until they are fixed.\n' "${fails}" >&2
+    return 1
+  fi
+  printf '\nSELF-TEST: all fixtures behaved as specified (failing cases DID fail).\n'
+  return 0
+}
+
+if [ "${SELF_TEST}" -eq 1 ]; then
+  run_self_test
+  exit $?
+fi
+
+check_file "${TFTPL}" "${GITREPO_NAME}"
+exit $?


### PR DESCRIPTION
Refs #6336

## The defect

A fresh prov converges to **zero HelmReleases**. Measured live on hw297, each link:

1. `GitRepository flux-system/openova` → `READY=False`, `failed to checkout and determine revision: unable to clone 'https://github.com/openova-io/openova': context deadline exceeded`
2. `bootstrap-kit`, `bootstrap-kit-crs`, `sovereign-tls` → all `READY=False`, `Source artifact not found, retrying in 30s`
3. `kubectl get helmrelease -A` → `No resources found`
4. Provisioner logs `Phase 1 watch saw 0 HelmReleases in 15m0s`; the deployment sits at `phase1-watching`.

Not a network fault, ruled out by measurement rather than assumed: from a pod in `flux-system` on the affected cluster `nslookup github.com` resolved and `nc -w 6 -z github.com 443` returned TCP-OK; all six Flux controllers `Running` with zero restarts; cloud-init finished cleanly and its `allow-egress` NetworkPolicies were already gone.

## Root cause — arithmetic, then confirmed by experiment

The bootstrap `GitRepository` is authored in cloud-init at **`infra/providers/_shared/cloudinit-control-plane.tftpl:506-523`** (the `write_files` entry for `/var/lib/catalyst/flux-bootstrap.yaml`). It declared `interval: 1m`, `ref.branch: main`, and **no `spec.timeout` at all** — so the source-controller CRD default applies:

```
$ python3 -c "...print spec props..." < source.toolkit.fluxcd.io_gitrepositories.yaml   # v1.4.1
VERSION v1
   ...
   timeout | default= 60s
```

Patching **only** `spec.timeout` → `10m` on the live hw297 region-b object, nothing else: `13:41:33Z building artifact` … `13:52:24Z ready=True rev=main@sha1:e050028da1634e`. **651s (10m51s) of clone, given 60 seconds.** Immediately after, `bootstrap-kit-crs` went `True — Applied revision` and `bootstrap-kit` moved to `Reconciliation in progress`. The starvation lifted.

## Shallow clone was evaluated first, and is not available

It is the stronger lever in principle, so it was checked against the pinned version rather than assumed. `platform/flux/chart/values.yaml` pins flux2 `2.14.1` = Flux appVersion `v2.4.0` = source-controller `v1.4.1`. Two findings, both from that exact tag:

- **No knob exists.** The `source.toolkit.fluxcd.io/v1` spec properties are exactly: `ignore, include, interval, provider, proxySecretRef, recurseSubmodules, ref, secretRef, suspend, timeout, url, verify`. No `depth`, no `shallowClone`, no `sparseCheckout` (that one lands in a later source-controller). The only shallow-related text in the whole CRD is on `ref.commit` — "can be combined with Branch to shallow clone" — which means pinning a SHA, not tracking `main`.
- **It is already on, unconditionally.** `internal/controller/gitrepository_controller.go` at `v1.4.1`, line 850:

```go
cloneOpts := repository.CloneConfig{
    RecurseSubmodules: obj.Spec.RecurseSubmodules,
    ShallowClone:      true,
}
```

So the history is already excluded and cannot be excluded further from here. What actually crosses the wire is the **depth-1 tree at HEAD**, measured in this repo:

| | |
|---|---|
| `.git` | 939 MB |
| tracked bytes at HEAD (what a depth-1 clone transfers) | **449.3 MB** |
| of which `docs/` | 373.2 MB (`docs/sessions/` alone 338.1 MB) |
| effective throughput implied by the measurement | 449.3 MB / 651 s ≈ **0.69 MB/s** |

And `spec.ignore` does not help: it is an **artifact-build** filter applied *after* checkout, so the bytes still cross the wire.

## What ships: the timeout, at 20m

`timeout: 20m` on that one object. **1.84× the measured 651s**, chosen with a floor and a ceiling rather than rounded:

- **Floor** — it must clear a real observed clone with room for the tree to keep growing (`docs/sessions/` grows every walk) or the link to roughly halve.
- **Ceiling** — it must stay well inside the 60m `DefaultWatchTimeout` of the Phase-1 HelmRelease watch, so a genuinely unreachable origin still fails *visibly inside* the watch window instead of looking like one silent endless attempt.
- Retry count deliberately did not enter the choice: a retry cannot rescue a slow clone, since each attempt re-clones from scratch at the same speed. Single-attempt headroom is the only thing that matters here.

Stated plainly, since shallow clone was unavailable: **this moves the cliff, it does not remove it.** At any fixed timeout, repo growth eventually crosses the value. The durable removal is to stop carrying hundreds of MB of walk evidence inside the reconciled tree — 83% of what every Sovereign clones on first boot is `docs/`, which `ignore:` already discards immediately afterwards.

A note is carried in the template itself that this is *not* the issue #492 knob: a `GitRepository` holds no revision lock, so a longer deadline costs nothing on the happy path, while a short one produces zero HelmReleases forever. That distinction is what the guard below enforces mechanically.

## Before / after — the emitted YAML

Rendered through `templatefile()` with the `cloudinit-size-check.sh` fixture and passed through the byte-identical comment strip the provider applies before handing `user_data` to the cloud API, i.e. the actual bytes that land at `/var/lib/catalyst/flux-bootstrap.yaml`:

```diff
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: GitRepository
 metadata:
   name: openova
   namespace: flux-system
 spec:
   interval: 1m
+  timeout: 20m
   url: https://github.com/openova-io/openova
   ref:
     branch: main
   ignore: |
     /*
     !/clusters/_template
     !/platform
     !/products
```

## Guards, watched RED first

**`scripts/check-gitrepository-clone-timeout.sh`** — parses the template for the `GitRepository` named `openova` (by kind + `metadata.name`, skipping comments, so prose quoting `timeout:` can never satisfy it) and asserts an operative `spec.timeout` exists and sits in `[15m, 60m]`. Absence is a failure in its own right, because absence *is* the 60s default that caused this.

RED against the pre-fix tree, obtained with `git archive origin/main` rather than by reverting the edit in place:

```
$ git archive origin/main infra/providers/_shared/cloudinit-control-plane.tftpl -o pre.tar && tar -xf pre.tar -C premain
$ bash scripts/check-gitrepository-clone-timeout.sh --tftpl premain/infra/providers/_shared/cloudinit-control-plane.tftpl
ERROR: GitRepository/openova declares NO operative 'spec.timeout' in .../cloudinit-control-plane.tftpl.
ERROR:   Absence means the source-controller CRD default of 60s applies. On this
ERROR:   repo a depth-1 clone measured 651s (hw297, 2026-08-14), so every
ERROR:   reconcile fails 'context deadline exceeded', no artifact is ever built,
ERROR:   and a fresh Sovereign converges to ZERO HelmReleases. Issue #6336.
TRUE-RC=1
```

GREEN on this branch:

```
$ bash scripts/check-gitrepository-clone-timeout.sh
OK: GitRepository/openova clone budget = 20m (1200s), within [900s, 3600s] — issue #6336.
TRUE-RC=0
```

`--self-test` runs cluster-free fixtures and asserts that **each must-fail case does fail** — no timeout, `60s`, `5m`, `2h`, a file with no `openova` GitRepository (the vacuity control), a commented-out `timeout:` — plus duration-parser unit checks. All 16 behave as specified, `TRUE-RC=0`.

**Wiring.** Added to `.github/workflows/test-bootstrap-kit.yaml`, whose `paths:` filters already carry `infra/providers/_shared/cloudinit-control-plane.tftpl` on both `push` and `pull_request`; the guard's own path is added to both lists too, so a future edit to either the subject or the guard re-triggers it. The self-test runs as its own step ahead of the enforcing step. `scripts/check-guards-are-wired.sh` → `OK — all 24 self-test-capable guard(s) are invoked by at least one workflow`, `TRUE-RC=0`.

**`kustomization_timeout_test.go`** — the issue #492 pins now bucket operative `timeout:` lines **by owning document kind** instead of counting them globally, because the two controllers mean opposite things by the field. `Kustomization`-owned timeouts stay pinned at exactly one × `timeout: 5m`; the `GitRepository`-owned one is asserted separately by `TestGitRepositoryCloneTimeout_HasHeadroom`; a timeout owned by neither now fails loudly rather than being absorbed. That is a tightening, not a relaxation — the previous form would have silently accepted any second timeout that happened to read `5m`. The `timeout: 30m` negative guard and the `wait: true` guard are untouched, and 20m does not collide with either.

Red proof for the new Go test uses the same archive technique — the new test file dropped onto the `origin/main` tree:

```
$ git archive origin/main products/catalyst/bootstrap/api infra/providers/_shared clusters/_template/infrastructure | tar -x -C prefull
$ cp <this branch's kustomization_timeout_test.go> prefull/.../provisioner/
$ go test ./internal/provisioner/ -run 'TestKustomizationTimeout|TestGitRepositoryCloneTimeout' -count=1
--- FAIL: TestGitRepositoryCloneTimeout_HasHeadroom (0.00s)
    #6336: expected exactly 1 operative GitRepository `timeout:` in the cloud-init template, got 0: []
TRUE-RC=1
```

Note the four pre-existing #492 tests **passed** in that same run against the old template — the change does not break them.

## Full check run on this branch

| check | TRUE-RC |
|---|---|
| `go test ./internal/provisioner/ -count=1` (whole package) | 0 |
| `go vet ./internal/provisioner/` | 0 |
| `check-gitrepository-clone-timeout.sh --self-test` | 0 |
| `check-gitrepository-clone-timeout.sh` | 0 |
| `check-guards-are-wired.sh` | 0 |
| `cloudinit-size-check.sh both` | 0 — huawei CP 27414/32256 B, hetzner CP 23775/32256 B (comments are stripped from `user_data`, so the annotation costs nothing) |
| `lint-cloudinit.sh both` | 0 |
| `check-cloudinit-kustomization-deps.sh` | 0 |
| `check-tofu-flux-envsubst.sh` | 0 |
| `check-no-banned-words.sh` | 0 |
| `shellcheck -S warning` on the new guard | 0 |

## Not a chart

The authoring site is plain cloud-init, so no chart version bump, no five-site lockstep, no umbrella slot-13 pin, no catalog regeneration applies here.

## Why this is worth landing first

Every remaining non-green UAT row (G11, 60, 166, 219, 220, 221, 222, 227) needs a converged Sovereign to walk, and no fresh prov converges while its only source never produces an artifact.
