### PR TITLE
fix(infra,catalyst-api): primary region captures its kubeconfig, fails loudly, and every CP keeps its own cloud-init log

### DIFF
--- a/.github/workflows/check-cloudinit-primary-kubeconfig-capture.yaml
+++ b/.github/workflows/check-cloudinit-primary-kubeconfig-capture.yaml
@@ -1,0 +1,91 @@
+name: check — primary-region kubeconfig capture (#6339)
+
+# WHAT THIS BLOCKS. Measured on hw297 and hw298, two consecutive 2-region
+# Huawei provs: `GET /deployments/{id}/kubeconfig` answered 409 while
+# `GET .../kubeconfig?region=<secondary>` answered 200 with a working
+# kubeconfig. The secondary's capture works; the primary's never landed, so
+# there is no route into the primary cluster at all — which is why the failed
+# `cutover-egress-block-test` Job on hw298 could not be read and UAT rows G11 /
+# 166 / 227 have no root-cause path.
+#
+# The guard renders the REAL `kubeconfig_put_block` heredoc out of
+# infra/providers/huawei/main.tf with real `tofu` and asserts that the PRIMARY
+# region's render carries the primary PUT-back, fails LOUDLY when it exhausts,
+# and that every control plane keeps its OWN cloud-init log (the shared
+# `<id>-cloudinit.log` key was last-writer-wins across regions, which is what
+# made the primary's failure unreadable in the first place).
+#
+# PATHS MATTER HERE. A guard scoped to a tree that does not contain its subject
+# never runs — that exact defect was found on main. Every path below is a file
+# the guard actually reads:
+#   infra/providers/huawei/main.tf            the PUT-back block + prelude uploader
+#   infra/providers/_shared/…tftpl            the fail-loud `mark` log pusher
+#   products/…/handler/cloudinit_log.go       the per-node capture writer
+#   scripts/lint-cloudinit.sh                 its PUT-back fixture (drift check)
+#   scripts/cloudinit-size-check.sh           its PUT-back fixture (drift check)
+#
+# Per CLAUDE.md "every workflow MUST be event-driven, NEVER scheduled": this is
+# pull-request-on-touch + push-on-merge; ad-hoc reruns via workflow_dispatch.
+# It contacts no cluster, no cloud API, and provisions nothing.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'infra/providers/**'
+      - 'products/catalyst/bootstrap/api/internal/handler/cloudinit_log.go'
+      - 'scripts/check-cloudinit-primary-kubeconfig-capture.sh'
+      - 'scripts/lint-cloudinit.sh'
+      - 'scripts/cloudinit-size-check.sh'
+      - '.github/workflows/check-cloudinit-primary-kubeconfig-capture.yaml'
+  pull_request:
+    paths:
+      - 'infra/providers/**'
+      - 'products/catalyst/bootstrap/api/internal/handler/cloudinit_log.go'
+      - 'scripts/check-cloudinit-primary-kubeconfig-capture.sh'
+      - 'scripts/lint-cloudinit.sh'
+      - 'scripts/cloudinit-size-check.sh'
+      - '.github/workflows/check-cloudinit-primary-kubeconfig-capture.yaml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  primary-kubeconfig-capture:
+    name: primary region captures its kubeconfig
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install OpenTofu
+        uses: opentofu/setup-opentofu@v1
+        with:
+          # Lockstep with infra-huawei-tofu.yaml / preflight-cloudinit-posix.yml
+          # / cloud-init-size.yaml.
+          tofu_version: 1.8.5
+
+      - name: bash syntax
+        run: bash -n scripts/check-cloudinit-primary-kubeconfig-capture.sh
+
+      - name: Self-test (fixtures only, no cluster) — every regression watched RED
+        run: bash scripts/check-cloudinit-primary-kubeconfig-capture.sh --self-test
+
+      - name: Assert the primary region's kubeconfig capture
+        run: bash scripts/check-cloudinit-primary-kubeconfig-capture.sh
+
+      - name: Rendered evidence (the real block, per region)
+        if: always()
+        run: |
+          set -eu
+          {
+            echo '## rendered kubeconfig PUT-back, per region'
+            echo ''
+            echo 'The REAL heredoc from `infra/providers/huawei/main.tf`, rendered by'
+            echo 'tofu. Only the CP EIP is a fixture (it has no value before apply).'
+            echo ''
+            echo '```sh'
+            bash scripts/check-cloudinit-primary-kubeconfig-capture.sh --render || true
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY" 2>&1 || true

--- a/infra/providers/_shared/cloudinit-control-plane.tftpl
+++ b/infra/providers/_shared/cloudinit-control-plane.tftpl
@@ -400,7 +400,11 @@ write_files:
   # kom4dc VPC would otherwise dial the AAAA and the push dies silently
   # (#5068). 0700 root-only — the body embeds the bearer token. Callers append
   # `||true` so a helper failure can never mask the leg's own fail-loud exit
-  # code (no `|| true` inside — the caller guards). WHOLLY HUAWEI-GATED — a
+  # code (no `|| true` inside — the caller guards). #6339: the push carries
+  # `?node=$(hostname)` so a multi-region Sovereign keeps EVERY CP's log
+  # instead of one node's — the shared `<id>-cloudinit.log` key was
+  # last-writer-wins across regions and destroyed the primary's forensics.
+  # WHOLLY HUAWEI-GATED — a
   # hard cloud dependency, same class as the prelude uploader: Hetzner keeps
   # sshd + a console API for forensics AND its three_region CP render sits
   # ~200 B under the 32512 guardrail — these bytes would tip it (the 32768
@@ -415,7 +419,7 @@ write_files:
       echo "CLOUDINIT-SENTINEL: $1"
 %{ if deployment_id != "" && kubeconfig_bearer_token != "" && catalyst_api_url != "" ~}
       sleep 1
-      curl -4 -sk -X PUT -H "Authorization: Bearer ${kubeconfig_bearer_token}" -H "Content-Type: text/plain" --data-binary @/var/log/cloud-init-output.log --max-time 20 "${catalyst_api_url}/api/v1/deployments/${deployment_id}/cloudinit-log" >/dev/null 2>&1
+      curl -4 -sk -X PUT -H "Authorization: Bearer ${kubeconfig_bearer_token}" -H "Content-Type: text/plain" --data-binary @/var/log/cloud-init-output.log --max-time 20 "${catalyst_api_url}/api/v1/deployments/${deployment_id}/cloudinit-log?node=$(hostname)" >/dev/null 2>&1
 %{ endif ~}
 %{ endif ~}
 

--- a/infra/providers/huawei/main.tf
+++ b/infra/providers/huawei/main.tf
@@ -965,6 +965,15 @@ locals {
   #      output API + no reachable sshd, so /var/log/cloud-init-output.log can
   #      only be PUSHED. Backgrounded EARLY so it keeps uploading even if a
   #      later step aborts cloud-init — the founder's capture-before-wipe guard.
+  #      #6339: the push now carries `?node=$(hostname)`. Without it EVERY CP in
+  #      EVERY region wrote the SAME `<id>-cloudinit.log` key every 30s for ~50
+  #      min, so a 2-region Sovereign kept exactly ONE node's log — last writer
+  #      wins — and the other region's was gone for good. Measured across the 13
+  #      archived logs in docs/sessions/**/prov-diagnostics/ that carry a
+  #      PUT-back line: every one holds exactly ONE hostname, 7 region-a and 6
+  #      region-b, never both. That is why "the primary never PUT its
+  #      kubeconfig" could not be root-caused on hw297/hw298 — the surviving log
+  #      was region-b's and the primary's outcome is echoed only into region-a's.
   #
   # NOTE (#4682 / #4690): the former iptables DNAT (443→30443 / 80→30080) is
   # GONE. The Cilium Gateway is served as a Service type=LoadBalancer on the
@@ -993,7 +1002,7 @@ locals {
               -H "Content-Type: text/plain" \
               --data-binary @/var/log/cloud-init-output.log \
               --max-time 20 \
-              "${var.catalyst_api_url}/api/v1/deployments/${var.deployment_id}/cloudinit-log" >/dev/null 2>&1 || true
+              "${var.catalyst_api_url}/api/v1/deployments/${var.deployment_id}/cloudinit-log?node=$(hostname)" >/dev/null 2>&1 || true
             n=$$((n+1))
             sleep 30
           done
@@ -1241,63 +1250,124 @@ locals {
       # runtime. Used for k3s --node-ip + cilium k8sServiceHost substitution.
       node_ip_cmd = "ip -4 -o addr show dev eth0 | awk '{print $4}' | cut -d/ -f1"
 
-      # kubeconfig PUT-back — Huawei. Each CP decides at RUNTIME by hostname:
-      #   primary CP (hostname == primary_cp_hostname) → PUT to /kubeconfig.
-      #   secondary CP                                 → POST to /sovereign/secondary-kubeconfig.
+      # kubeconfig PUT-back — Huawei. #6339: the primary-vs-secondary choice is
+      # made at RENDER time from `idx` (this map is ALREADY built per region),
+      # not by a runtime `[ "$HOSTNAME" = "$PRIMARY_HOST" ]` compare.
+      #
+      # What the old shape cost. BOTH branches shipped in EVERY region's
+      # user_data and the hostname compare picked one at boot:
+      #   - Any drift between the ECS `name` formula and the booted hostname
+      #     flipped region 0 into the SECONDARY branch — the primary region
+      #     would register under a bare region key instead of being captured at
+      #     <id>.yaml, so `GET /deployments/{id}/kubeconfig` keeps answering
+      #     409. That drift is reachable, not theoretical: the CP resource below
+      #     carries `lifecycle.ignore_changes=[name]` precisely so an ACTIVE CP
+      #     KEEPS its old name when a retry_attempt bump changes the formula,
+      #     while PRIMARY_HOST here is recomputed from the CURRENT
+      #     retry_attempt.
+      #   - A region-0 REPLICA CP (huawei_control_plane_count > 1) matched
+      #     `!= PRIMARY_HOST` and POSTed ITS kubeconfig under the PRIMARY
+      #     region's own key — the primary region registered as a secondary.
+      #   - CI could not assert "the primary region's cloud-init carries the
+      #     primary PUT-back", because which branch fired was a runtime fact.
+      #     It is a render-time fact now, and
+      #     scripts/check-cloudinit-primary-kubeconfig-capture.sh asserts it.
+      # The cp1-only restriction inside region 0 is KEPT as a hostname test, but
+      # a region-0 replica now does NOTHING instead of mis-registering.
+      #
+      # The SECONDARY branch is byte-identical to the pre-#6339 one, including
+      # its `!= PRIMARY_HOST` gate: in a secondary region's render PRIMARY_HOST
+      # names region-0's cp1, which no node here can ever equal, so the gate
+      # stays trivially true and the measured-working path is untouched.
+      #
+      # Fail-loud (#6339 (c)): the primary loop no longer falls through in
+      # silence. On exhaustion it prints PRIMARY-KUBECONFIG-CAPTURE-FAILED with
+      # the last HTTP code, retries ONCE through the per-region channel the
+      # secondaries prove works (POST /sovereign/secondary-kubeconfig under this
+      # region's own key) so `GET .../kubeconfig?region=<primary>` yields a
+      # working kubeconfig instead of a second 409, and drops the
+      # kubeconfig-put-FAILED sentinel — which also force-pushes THIS node's
+      # cloud-init log. Deliberately NOT fatal: trading a forensics gap for a
+      # dead provision is the wrong trade.
+      #
       # Server URL rewritten to this region's EIP (cross-cloud reachability).
-      # Both gated so only the right CP fires; runcmd 0-indent items.
+      # runcmd 0-indent items (the shared template re-indents via indent(2,…)).
+      # Content sits at column 0 on purpose: `<<-` dedent does NOT apply to a
+      # heredoc carrying %{ … } directives (measured with tofu 1.12), so an
+      # indented body would emit indented runcmd items and break the YAML.
       kubeconfig_put_block = <<-PUT
-        - |
-          HOSTNAME=$(hostname)
-          PRIMARY_HOST='${local.name_prefix}-${local.region_keys[0]}-cp1-${substr(sha256("${var.deployment_id}-${local.region_keys[0]}-cp0-${var.retry_attempt}"), 0, 6)}'
-          if [ -n "${var.deployment_id}" ] && [ -n "${var.kubeconfig_bearer_token}" ] && [ "$${HOSTNAME}" = "$${PRIMARY_HOST}" ]; then
-            sed "s|server: https://127.0.0.1:6443|server: https://${huaweicloud_vpc_eip.cp[local.region_keys[0]].publicip.0.ip_address}:6443|" /etc/rancher/k3s/k3s.yaml > /tmp/kubeconfig-rewritten.yaml
-            for attempt in 1 2 3 4 5 6 7 8 9 10 11 12; do
-              HTTP_CODE=$(curl -sk -o /dev/null -w '%%{http_code}' -X PUT \
-                -H "Authorization: Bearer ${var.kubeconfig_bearer_token}" \
-                -H "Content-Type: application/x-yaml" \
-                --data-binary @/tmp/kubeconfig-rewritten.yaml \
-                --max-time 15 \
-                "${var.catalyst_api_url}/api/v1/deployments/${var.deployment_id}/kubeconfig" || echo "000")
-              echo "primary kubeconfig PUT-back attempt $${attempt} -> HTTP $${HTTP_CODE}"
-              case "$${HTTP_CODE}" in 2*) break;; esac
-              sleep 30
-            done
-          fi
-        - |
-          HOSTNAME=$(hostname)
-          PRIMARY_HOST='${local.name_prefix}-${local.region_keys[0]}-cp1-${substr(sha256("${var.deployment_id}-${local.region_keys[0]}-cp0-${var.retry_attempt}"), 0, 6)}'
-          MY_REGION='${idx == 0 ? r.code : "${r.code}-${idx}"}'
-          MY_EIP='${huaweicloud_vpc_eip.cp[r.code].publicip.0.ip_address}'
-          # #3991 — this CP's PRIVATE eth0 IP (same detection as --node-ip).
-          # The kubeconfig keeps MY_EIP as `server:` so the EXTERNAL mothership
-          # can reach this region. We ALSO ship the private IP so the IN-CLUSTER
-          # catalyst-api (chroot), which sits inside region-a's VPC and cannot
-          # route to this region's DNAT'd EIP, can rewrite the server host to
-          # this VPC-peered private IP it CAN reach (over the cross-VPC peering
-          # routes provisioned above). The k3s apiserver lists NODE_IP as a TLS
-          # SAN, so the pinned-CA handshake still validates after the swap.
-          export MY_NODE_IP=$(ip -4 -o addr show dev eth0 | awk '{print $4}' | cut -d/ -f1)
-          if [ -n "${var.deployment_id}" ] && [ -n "${var.kubeconfig_bearer_token}" ] && [ "$${HOSTNAME}" != "$${PRIMARY_HOST}" ] && [ -n "$${MY_REGION}" ] && [ -n "$${MY_EIP}" ]; then
-            sed "s|server: https://127.0.0.1:6443|server: https://$${MY_EIP}:6443|" /etc/rancher/k3s/k3s.yaml > /tmp/kubeconfig-secondary.yaml
-            python3 -c "import json,os; print(json.dumps({'deploymentId':'${var.deployment_id}','regionKey':'$${MY_REGION}','kubeconfigYaml':open('/tmp/kubeconfig-secondary.yaml').read(),'nodeInternalIp':os.environ.get('MY_NODE_IP','')}))" > /tmp/secondary-kubeconfig-body.json
-            for attempt in 1 2 3 4 5 6 7 8 9 10 11 12; do
-              HTTP_CODE=$(curl -sk -o /dev/null -w '%%{http_code}' -X POST \
-                -H "Authorization: Bearer ${var.kubeconfig_bearer_token}" \
-                -H "Content-Type: application/json" \
-                --data-binary @/tmp/secondary-kubeconfig-body.json \
-                --max-time 15 \
-                "${var.catalyst_api_url}/api/v1/sovereign/secondary-kubeconfig" || echo "000")
-              echo "secondary kubeconfig PUT-back attempt $${attempt} -> HTTP $${HTTP_CODE}"
-              # #5012 hw255: the secondary endpoint answers 201 Created — the old
-              # 204|200-only check never broke, so every healthy secondary burned
-              # 12 attempts x sleep 30 (~6 min) HERE, pushing flux-install past the
-              # mothership's flux-CRD probe budget. Accept ANY 2xx.
-              case "$${HTTP_CODE}" in 2*) break;; esac
-              sleep 30
-            done
-            rm -f /tmp/secondary-kubeconfig-body.json
-          fi
+%{~if idx == 0~}
+- |
+  HOSTNAME=$(hostname)
+  PRIMARY_HOST='${local.name_prefix}-${local.region_keys[0]}-cp1-${substr(sha256("${var.deployment_id}-${local.region_keys[0]}-cp0-${var.retry_attempt}"), 0, 6)}'
+  if [ -n "${var.deployment_id}" ] && [ -n "${var.kubeconfig_bearer_token}" ] && [ "$${HOSTNAME}" = "$${PRIMARY_HOST}" ]; then
+    sed "s|server: https://127.0.0.1:6443|server: https://${huaweicloud_vpc_eip.cp[local.region_keys[0]].publicip.0.ip_address}:6443|" /etc/rancher/k3s/k3s.yaml > /tmp/kubeconfig-rewritten.yaml
+    LAST_CODE=000
+    for attempt in 1 2 3 4 5 6 7 8 9 10 11 12; do
+      LAST_CODE=$(curl -sk -o /dev/null -w '%%{http_code}' -X PUT \
+        -H "Authorization: Bearer ${var.kubeconfig_bearer_token}" \
+        -H "Content-Type: application/x-yaml" \
+        --data-binary @/tmp/kubeconfig-rewritten.yaml \
+        --max-time 15 \
+        "${var.catalyst_api_url}/api/v1/deployments/${var.deployment_id}/kubeconfig" || echo "000")
+      echo "primary kubeconfig PUT-back attempt $${attempt} -> HTTP $${LAST_CODE}"
+      case "$${LAST_CODE}" in 2*) break;; esac
+      sleep 30
+    done
+    case "$${LAST_CODE}" in
+      2*) ;;
+      *)
+        echo "PRIMARY-KUBECONFIG-CAPTURE-FAILED region=${local.region_keys[0]} lastHTTP=$${LAST_CODE} after 12 attempts; GET /api/v1/deployments/${var.deployment_id}/kubeconfig stays 409 until this is repaired"
+        export MY_NODE_IP=$(ip -4 -o addr show dev eth0 | awk '{print $4}' | cut -d/ -f1)
+        python3 -c "import json,os; print(json.dumps({'deploymentId':'${var.deployment_id}','regionKey':'${local.region_keys[0]}','kubeconfigYaml':open('/tmp/kubeconfig-rewritten.yaml').read(),'nodeInternalIp':os.environ.get('MY_NODE_IP','')}))" > /tmp/primary-kubeconfig-body.json
+        FALLBACK_CODE=$(curl -sk -o /dev/null -w '%%{http_code}' -X POST \
+          -H "Authorization: Bearer ${var.kubeconfig_bearer_token}" \
+          -H "Content-Type: application/json" \
+          --data-binary @/tmp/primary-kubeconfig-body.json \
+          --max-time 15 \
+          "${var.catalyst_api_url}/api/v1/sovereign/secondary-kubeconfig" || echo "000")
+        echo "PRIMARY-KUBECONFIG-FALLBACK per-region-channel regionKey=${local.region_keys[0]} -> HTTP $${FALLBACK_CODE}"
+        rm -f /tmp/primary-kubeconfig-body.json
+        sh /var/lib/catalyst/mark kubeconfig-put-FAILED || true
+        ;;
+    esac
+  fi
+%{~else~}
+- |
+  HOSTNAME=$(hostname)
+  PRIMARY_HOST='${local.name_prefix}-${local.region_keys[0]}-cp1-${substr(sha256("${var.deployment_id}-${local.region_keys[0]}-cp0-${var.retry_attempt}"), 0, 6)}'
+  MY_REGION='${idx == 0 ? r.code : "${r.code}-${idx}"}'
+  MY_EIP='${huaweicloud_vpc_eip.cp[r.code].publicip.0.ip_address}'
+  # #3991 — this CP's PRIVATE eth0 IP (same detection as --node-ip).
+  # The kubeconfig keeps MY_EIP as `server:` so the EXTERNAL mothership
+  # can reach this region. We ALSO ship the private IP so the IN-CLUSTER
+  # catalyst-api (chroot), which sits inside region-a's VPC and cannot
+  # route to this region's DNAT'd EIP, can rewrite the server host to
+  # this VPC-peered private IP it CAN reach (over the cross-VPC peering
+  # routes provisioned above). The k3s apiserver lists NODE_IP as a TLS
+  # SAN, so the pinned-CA handshake still validates after the swap.
+  export MY_NODE_IP=$(ip -4 -o addr show dev eth0 | awk '{print $4}' | cut -d/ -f1)
+  if [ -n "${var.deployment_id}" ] && [ -n "${var.kubeconfig_bearer_token}" ] && [ "$${HOSTNAME}" != "$${PRIMARY_HOST}" ] && [ -n "$${MY_REGION}" ] && [ -n "$${MY_EIP}" ]; then
+    sed "s|server: https://127.0.0.1:6443|server: https://$${MY_EIP}:6443|" /etc/rancher/k3s/k3s.yaml > /tmp/kubeconfig-secondary.yaml
+    python3 -c "import json,os; print(json.dumps({'deploymentId':'${var.deployment_id}','regionKey':'$${MY_REGION}','kubeconfigYaml':open('/tmp/kubeconfig-secondary.yaml').read(),'nodeInternalIp':os.environ.get('MY_NODE_IP','')}))" > /tmp/secondary-kubeconfig-body.json
+    for attempt in 1 2 3 4 5 6 7 8 9 10 11 12; do
+      HTTP_CODE=$(curl -sk -o /dev/null -w '%%{http_code}' -X POST \
+        -H "Authorization: Bearer ${var.kubeconfig_bearer_token}" \
+        -H "Content-Type: application/json" \
+        --data-binary @/tmp/secondary-kubeconfig-body.json \
+        --max-time 15 \
+        "${var.catalyst_api_url}/api/v1/sovereign/secondary-kubeconfig" || echo "000")
+      echo "secondary kubeconfig PUT-back attempt $${attempt} -> HTTP $${HTTP_CODE}"
+      # #5012 hw255: the secondary endpoint answers 201 Created — the old
+      # 204|200-only check never broke, so every healthy secondary burned
+      # 12 attempts x sleep 30 (~6 min) HERE, pushing flux-install past the
+      # mothership's flux-CRD probe budget. Accept ANY 2xx.
+      case "$${HTTP_CODE}" in 2*) break;; esac
+      sleep 30
+    done
+    rm -f /tmp/secondary-kubeconfig-body.json
+  fi
+%{~endif~}
       PUT
     }), "/(?m)^[ ]*#( |$).*\n/", "")
   }

--- a/products/catalyst/bootstrap/api/internal/handler/cloudinit_log.go
+++ b/products/catalyst/bootstrap/api/internal/handler/cloudinit_log.go
@@ -29,6 +29,26 @@
 // repeatedly and each PUT OVERWRITES the prior snapshot (latest wins).
 // It never triggers Phase-1 watch / SMTP seed — it is pure diagnostics.
 //
+// PER-NODE CAPTURE (#6339). Latest-wins was written for a single-CP
+// Sovereign. On a multi-region one EVERY control plane uploads to this
+// same `{id}` every 30s for ~50 minutes, so the surviving
+// `<id>-cloudinit.log` is whichever node wrote last and the other
+// region's log is destroyed. Measured on the 13 archived captures in
+// docs/sessions/**/prov-diagnostics/ that carry a kubeconfig PUT-back
+// line: each holds exactly ONE hostname — 7 from region a, 6 from
+// region b, never both. That is the whole reason "the primary never
+// PUT its kubeconfig" was undiagnosable on hw297/hw298: the primary
+// echoes its PUT-back outcome only into ITS log, and the surviving
+// capture was the secondary's.
+//
+// So the cloud-init now sends `?node=<hostname>` and this handler
+// ALSO writes `<id>-cloudinit-<node>.log`. The shared
+// `<id>-cloudinit.log` keeps its exact old latest-wins semantics so
+// every existing reader (GET with no query, the wipe-forensics flow,
+// docs/sessions archives) is untouched. GET gains `?node=` to fetch a
+// specific node's capture and advertises what it holds in the
+// `X-Catalyst-Cloudinit-Nodes` response header.
+//
 // Credential hygiene (INVIOLABLE-PRINCIPLES #10): logs only id + byte
 // length + outcome, never the body or the bearer.
 package handler
@@ -39,6 +59,9 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
 
 	"github.com/go-chi/chi/v5"
 )
@@ -47,6 +70,55 @@ import (
 // /var/log/cloud-init-output.log is ~100-500 KB; 4 MiB leaves generous
 // headroom while keeping a runaway upload from filling the PVC.
 const maxCloudInitLogBytes = 4 << 20
+
+// unsafeNodeKeyChars — anything outside [a-z0-9-] in a `?node=` value.
+// The node key is a hostname (`catalyst-<slug>-<dep8>-<region>-cp1-<6hex>`,
+// 60 chars on kom4dc) that is composed into a filename on a shared PVC,
+// so it is folded to lowercase and every other byte — `/`, `.`, `..`,
+// NUL, unicode — is replaced rather than rejected: a node whose hostname
+// carries an odd byte must still get its log captured, it just gets a
+// sanitised key. An all-unsafe value collapses to "" and the per-node
+// write is skipped (the shared latest-wins file still lands).
+var unsafeNodeKeyChars = regexp.MustCompile(`[^a-z0-9-]+`)
+
+// maxNodeKeyLen bounds the composed filename. HOST_NAME_MAX is 64 on
+// Linux; 96 leaves room without letting a hostile caller push the path
+// toward NAME_MAX.
+const maxNodeKeyLen = 96
+
+// sanitiseNodeKey folds a `?node=` value to a filename-safe key.
+// Returns "" when nothing usable survives, which callers treat as
+// "no per-node capture for this upload".
+func sanitiseNodeKey(in string) string {
+	s := strings.ToLower(strings.TrimSpace(in))
+	s = unsafeNodeKeyChars.ReplaceAllString(s, "-")
+	s = strings.Trim(s, "-")
+	if len(s) > maxNodeKeyLen {
+		s = strings.Trim(s[:maxNodeKeyLen], "-")
+	}
+	return s
+}
+
+// cloudInitNodeKeys lists the per-node captures on disk for a
+// deployment, newest-agnostic and sorted for a deterministic answer.
+// A read error yields an empty list — this is a diagnostics aid, never
+// a gate.
+func cloudInitNodeKeys(dir, id string) []string {
+	if dir == "" || id == "" {
+		return nil
+	}
+	prefix := filepath.Join(dir, id+"-cloudinit-")
+	matches, err := filepath.Glob(prefix + "*.log")
+	if err != nil {
+		return nil
+	}
+	keys := make([]string, 0, len(matches))
+	for _, m := range matches {
+		keys = append(keys, strings.TrimSuffix(strings.TrimPrefix(m, prefix), ".log"))
+	}
+	sort.Strings(keys)
+	return keys
+}
 
 // PutCloudInitLog — PUT /api/v1/deployments/{id}/cloudinit-log.
 //
@@ -118,9 +190,25 @@ func (h *Handler) PutCloudInitLog(w http.ResponseWriter, r *http.Request) {
 		})
 		return
 	}
+
+	// #6339 — additionally keep THIS node's own capture so a second
+	// region's uploader cannot destroy it. Best-effort by design: the
+	// shared file above is already durable, so a per-node write failure
+	// must never turn a diagnostics upload into a 5xx the cloud-init
+	// would retry for six minutes.
+	node := sanitiseNodeKey(r.URL.Query().Get("node"))
+	if node != "" {
+		perNode := filepath.Join(h.kubeconfigsDir, id+"-cloudinit-"+node+".log")
+		if err := writeFileAtomic0600(perNode, body); err != nil {
+			h.log.Warn("per-node cloud-init log write failed; shared capture still landed",
+				"id", id, "node", node, "err", err)
+		}
+	}
+
 	h.log.Info("cloud-init log received from control-plane",
 		"id", id,
 		"sovereignFQDN", dep.Request.SovereignFQDN,
+		"node", node,
 		"bytes", len(body),
 	)
 	w.WriteHeader(http.StatusNoContent)
@@ -193,7 +281,26 @@ func (h *Handler) GetCloudInitLog(w http.ResponseWriter, r *http.Request) {
 		})
 		return
 	}
+	// #6339 — per-node selection. `?node=<hostname>` serves THAT control
+	// plane's capture; without it the shared latest-wins file is served
+	// exactly as before. Either way the response advertises which
+	// per-node captures exist, so an operator who fetched the secondary's
+	// log by accident can see the primary's key without a second contract
+	// to learn.
+	nodes := cloudInitNodeKeys(h.kubeconfigsDir, id)
 	target := filepath.Join(h.kubeconfigsDir, id+"-cloudinit.log")
+	if node := sanitiseNodeKey(r.URL.Query().Get("node")); node != "" {
+		target = filepath.Join(h.kubeconfigsDir, id+"-cloudinit-"+node+".log")
+		if _, statErr := os.Stat(target); statErr != nil {
+			writeJSON(w, http.StatusNotFound, map[string]any{
+				"error":     "no-cloudinit-log-for-node",
+				"detail":    "no cloud-init log has been uploaded by that node",
+				"node":      node,
+				"available": nodes,
+			})
+			return
+		}
+	}
 	raw, err := os.ReadFile(target)
 	if err != nil {
 		writeJSON(w, http.StatusNotFound, map[string]string{
@@ -203,6 +310,9 @@ func (h *Handler) GetCloudInitLog(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	if len(nodes) > 0 {
+		w.Header().Set("X-Catalyst-Cloudinit-Nodes", strings.Join(nodes, ","))
+	}
 	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write(raw)
 }

--- a/products/catalyst/bootstrap/api/internal/handler/cloudinit_log_per_node_6339_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/cloudinit_log_per_node_6339_test.go
@@ -1,0 +1,217 @@
+// Tests for the #6339 per-node cloud-init capture.
+//
+// THE DEFECT THESE PIN. PutCloudInitLog wrote every upload to ONE key,
+// `<id>-cloudinit.log`. That is correct for a single-CP Sovereign and
+// destructive for a multi-region one: every control plane in every
+// region pushes to the same `{id}` on a 30s loop for ~50 minutes, so the
+// surviving capture is whichever node wrote last and the other region's
+// log is gone. Measured across the 13 archived captures in
+// docs/sessions/**/prov-diagnostics/ that carry a kubeconfig PUT-back
+// line: each holds exactly ONE hostname — 7 region a, 6 region b, never
+// both. That is why "the primary never PUT its kubeconfig" could not be
+// root-caused on hw297/hw298 — the primary echoes its PUT-back outcome
+// only into ITS OWN log, and the capture that survived was the
+// secondary's.
+//
+// The fix keeps the shared latest-wins file byte-for-byte as it was
+// (every existing reader is untouched) and ADDS `<id>-cloudinit-<node>.log`
+// keyed on the `?node=` the cloud-init now sends. TestTwoRegionUploads…
+// is the one that would have failed before the fix.
+package handler
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/provisioner"
+)
+
+// cloudInitLogFixture builds a Handler with a live deployment record and
+// a real bearer, plus the kubeconfigs dir the captures land in.
+func cloudInitLogFixture(t *testing.T) (h *Handler, dir, id, bearer string) {
+	t.Helper()
+	dir = t.TempDir()
+	bearer, hash, err := newBearerToken()
+	if err != nil {
+		t.Fatalf("newBearerToken: %v", err)
+	}
+	id = "6339cafe6339cafe"
+	h = &Handler{log: slog.Default(), kubeconfigsDir: dir}
+	h.deployments.Store(id, &Deployment{
+		ID:                   id,
+		StartedAt:            time.Now(),
+		Request:              provisioner.Request{SovereignFQDN: "hw299.omani.works"},
+		kubeconfigBearerHash: hash,
+	})
+	return h, dir, id, bearer
+}
+
+// putCloudInitLog fires one upload, optionally carrying ?node=.
+func putCloudInitLog(t *testing.T, h *Handler, id, bearer, node, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	url := "/api/v1/deployments/" + id + "/cloudinit-log"
+	if node != "" {
+		url += "?node=" + node
+	}
+	req := httptest.NewRequest(http.MethodPut, url, bytes.NewReader([]byte(body)))
+	req.Header.Set("Authorization", "Bearer "+bearer)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", id)
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+	rec := httptest.NewRecorder()
+	h.PutCloudInitLog(rec, req)
+	return rec
+}
+
+// TestTwoRegionUploads_BothNodeCapturesSurvive — THE regression test.
+// Region a uploads (its log carries the primary PUT-back outcome), then
+// region b uploads and, pre-fix, obliterated it. Post-fix both are on
+// disk under their own keys and the primary's outcome is readable.
+func TestTwoRegionUploads_BothNodeCapturesSurvive(t *testing.T) {
+	h, dir, id, bearer := cloudInitLogFixture(t)
+
+	const (
+		nodeA = "catalyst-hw299-omani-works-6339cafe-me-east-215-a-cp1-aa1111"
+		nodeB = "catalyst-hw299-omani-works-6339cafe-me-east-215-b-cp1-bb2222"
+		logA  = "PRIMARY-KUBECONFIG-CAPTURE-FAILED region=me-east-215-a lastHTTP=000\n"
+		logB  = "secondary kubeconfig PUT-back attempt 1 -> HTTP 201\n"
+	)
+
+	if rec := putCloudInitLog(t, h, id, bearer, nodeA, logA); rec.Code != http.StatusNoContent {
+		t.Fatalf("region-a upload: want 204, got %d (%s)", rec.Code, rec.Body.String())
+	}
+	// Region b's uploader runs LAST — the pre-fix clobber.
+	if rec := putCloudInitLog(t, h, id, bearer, nodeB, logB); rec.Code != http.StatusNoContent {
+		t.Fatalf("region-b upload: want 204, got %d (%s)", rec.Code, rec.Body.String())
+	}
+
+	gotA, err := os.ReadFile(filepath.Join(dir, id+"-cloudinit-"+nodeA+".log"))
+	if err != nil {
+		t.Fatalf("region-a per-node capture must survive region-b's upload: %v", err)
+	}
+	if string(gotA) != logA {
+		t.Fatalf("region-a capture body:\n want %q\n got  %q", logA, string(gotA))
+	}
+	gotB, err := os.ReadFile(filepath.Join(dir, id+"-cloudinit-"+nodeB+".log"))
+	if err != nil {
+		t.Fatalf("region-b per-node capture missing: %v", err)
+	}
+	if string(gotB) != logB {
+		t.Fatalf("region-b capture body:\n want %q\n got  %q", logB, string(gotB))
+	}
+
+	// Back-compat: the shared key keeps its exact latest-wins semantics.
+	shared, err := os.ReadFile(filepath.Join(dir, id+"-cloudinit.log"))
+	if err != nil {
+		t.Fatalf("shared latest-wins capture missing: %v", err)
+	}
+	if string(shared) != logB {
+		t.Fatalf("shared key must stay latest-wins:\n want %q\n got  %q", logB, string(shared))
+	}
+}
+
+// TestGetCloudInitLog_ByNode — the operator can address either region's
+// capture, and the default GET is unchanged while advertising what else
+// is held.
+func TestGetCloudInitLog_ByNode(t *testing.T) {
+	h, _, id, bearer := cloudInitLogFixture(t)
+	const (
+		nodeA = "catalyst-hw299-omani-works-6339cafe-me-east-215-a-cp1-aa1111"
+		nodeB = "catalyst-hw299-omani-works-6339cafe-me-east-215-b-cp1-bb2222"
+		logA  = "primary kubeconfig PUT-back attempt 1 -> HTTP 204\n"
+		logB  = "secondary kubeconfig PUT-back attempt 1 -> HTTP 201\n"
+	)
+	putCloudInitLog(t, h, id, bearer, nodeA, logA)
+	putCloudInitLog(t, h, id, bearer, nodeB, logB)
+
+	get := func(q string) *httptest.ResponseRecorder {
+		r := chi.NewRouter()
+		r.Get("/api/v1/deployments/{id}/cloudinit-log", h.GetCloudInitLog)
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/deployments/"+id+"/cloudinit-log"+q, nil)
+		rec := httptest.NewRecorder()
+		r.ServeHTTP(rec, req)
+		return rec
+	}
+
+	recA := get("?node=" + nodeA)
+	if recA.Code != http.StatusOK || recA.Body.String() != logA {
+		t.Fatalf("?node=<region-a>: want 200 %q, got %d %q", logA, recA.Code, recA.Body.String())
+	}
+	recB := get("?node=" + nodeB)
+	if recB.Code != http.StatusOK || recB.Body.String() != logB {
+		t.Fatalf("?node=<region-b>: want 200 %q, got %d %q", logB, recB.Code, recB.Body.String())
+	}
+
+	// Default GET: unchanged (latest-wins body) + discovery header.
+	recDefault := get("")
+	if recDefault.Code != http.StatusOK || recDefault.Body.String() != logB {
+		t.Fatalf("default GET: want 200 %q, got %d %q", logB, recDefault.Code, recDefault.Body.String())
+	}
+	hdr := recDefault.Header().Get("X-Catalyst-Cloudinit-Nodes")
+	if !strings.Contains(hdr, nodeA) || !strings.Contains(hdr, nodeB) {
+		t.Fatalf("X-Catalyst-Cloudinit-Nodes must advertise both captures, got %q", hdr)
+	}
+
+	// Unknown node → 404 naming what IS held, so the operator who asked
+	// for the wrong region is told the right key instead of nothing.
+	recMiss := get("?node=catalyst-hw299-omani-works-6339cafe-me-east-215-z-cp1-zz9999")
+	if recMiss.Code != http.StatusNotFound {
+		t.Fatalf("unknown node: want 404, got %d", recMiss.Code)
+	}
+	if !strings.Contains(recMiss.Body.String(), nodeA) {
+		t.Fatalf("404 body must list available captures, got %q", recMiss.Body.String())
+	}
+}
+
+// TestSanitiseNodeKey_NoTraversal — the node key is composed into a path
+// on a shared PVC, so traversal and separator bytes must not survive.
+func TestSanitiseNodeKey_NoTraversal(t *testing.T) {
+	cases := map[string]string{
+		"catalyst-hw299-a-cp1-aa1111": "catalyst-hw299-a-cp1-aa1111",
+		"CATALYST-HW299-A":            "catalyst-hw299-a",
+		"../../etc/shadow":            "etc-shadow",
+		"/absolute/path":              "absolute-path",
+		"..":                          "",
+		"":                            "",
+		"   ":                         "",
+		"node..name":                  "node-name",
+		"node\x00name":                "node-name",
+		strings.Repeat("a", 200):      strings.Repeat("a", maxNodeKeyLen),
+	}
+	for in, want := range cases {
+		if got := sanitiseNodeKey(in); got != want {
+			t.Errorf("sanitiseNodeKey(%q) = %q, want %q", in, got, want)
+		}
+		if got := sanitiseNodeKey(in); strings.ContainsAny(got, `/\.`) {
+			t.Errorf("sanitiseNodeKey(%q) = %q — leaks a path separator", in, got)
+		}
+	}
+}
+
+// TestPutCloudInitLog_NoNodeParam_UnchangedBehaviour — an older cloud-init
+// (or the Hetzner render, which does not push per-node) must keep working
+// and must not create a stray per-node file.
+func TestPutCloudInitLog_NoNodeParam_UnchangedBehaviour(t *testing.T) {
+	h, dir, id, bearer := cloudInitLogFixture(t)
+	const body = "cloud-init v24 running modules:final\n"
+	if rec := putCloudInitLog(t, h, id, bearer, "", body); rec.Code != http.StatusNoContent {
+		t.Fatalf("want 204, got %d", rec.Code)
+	}
+	got, err := os.ReadFile(filepath.Join(dir, id+"-cloudinit.log"))
+	if err != nil || string(got) != body {
+		t.Fatalf("shared capture: err=%v body=%q", err, string(got))
+	}
+	if keys := cloudInitNodeKeys(dir, id); len(keys) != 0 {
+		t.Fatalf("no ?node= must create no per-node capture, got %v", keys)
+	}
+}

--- a/scripts/check-cloudinit-primary-kubeconfig-capture.sh
+++ b/scripts/check-cloudinit-primary-kubeconfig-capture.sh
@@ -1,0 +1,411 @@
+#!/usr/bin/env bash
+# check-cloudinit-primary-kubeconfig-capture.sh — the PRIMARY region's
+# kubeconfig PUT-back is emitted, is fail-loud, and every control plane keeps
+# its own cloud-init log. Refs #6339.
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# WHY THIS GUARD EXISTS
+#
+# Measured on hw297 and hw298, two consecutive 2-region Huawei provs:
+#
+#   GET /sovereign/api/v1/deployments/{id}/kubeconfig                    -> 409
+#   GET .../kubeconfig?region=me-east-215-a   (the PRIMARY region)       -> 409
+#   GET .../kubeconfig?region=me-east-215-b-1 (the SECONDARY region)     -> 200
+#
+# The secondary's capture works. The primary's never landed, so there is no
+# route to the primary cluster at all — which is why the failed
+# `cutover-egress-block-test` Job on hw298 could not be read and UAT rows G11 /
+# 166 / 227 cannot be root-caused.
+#
+# TWO surfaces had to hold for that failure to be INVISIBLE, and this guard
+# pins both:
+#
+#  1. WHICH BRANCH THE PRIMARY REGION RUNS. Pre-#6339 both the primary PUT and
+#     the secondary POST shipped in EVERY region's user_data and a runtime
+#     `[ "$HOSTNAME" = "$PRIMARY_HOST" ]` compare picked one at boot. Any drift
+#     between the ECS `name` formula and the booted hostname flipped region 0
+#     into the SECONDARY branch — and `lifecycle.ignore_changes=[name]` on the
+#     CP resource deliberately pins an ACTIVE CP's name across a retry_attempt
+#     bump while PRIMARY_HOST is recomputed from the CURRENT one, so the drift
+#     is reachable. A region-0 REPLICA CP hit it unconditionally. Worse, no CI
+#     check could ever assert "the primary region carries the primary PUT-back"
+#     because which branch fired was a RUNTIME fact. It is a RENDER-time fact
+#     now (`%{ if idx == 0 }`) and this guard asserts it on the RENDERED text.
+#
+#  2. WHETHER THE FAILURE LEAVES A TRACE. The PUT loop echoed one line per
+#     attempt and fell through in silence, and the only sink was
+#     `<id>-cloudinit.log` — ONE key that every CP in every region overwrites
+#     every 30s for ~50 minutes. Measured across the 13 archived captures in
+#     docs/sessions/**/prov-diagnostics/ that carry a PUT-back line: each holds
+#     exactly ONE hostname, 7 region-a and 6 region-b, never both. So on a
+#     2-region prov the primary's log — the only place its PUT-back outcome is
+#     written — is destroyed by the secondary's uploader.
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# HOW IT MEASURES (and why it is not the stale-fixture trap)
+#
+# scripts/lint-cloudinit.sh and scripts/cloudinit-size-check.sh both render the
+# SHARED template with a HAND-WRITTEN `kubeconfig_put_block` fixture that has
+# drifted years away from the real provider block — no primary/secondary split,
+# 6 attempts instead of 12, no hostname gate. Neither guard has ever read the
+# real subject. This one extracts the REAL heredoc out of
+# infra/providers/huawei/main.tf and renders it with REAL `tofu`, substituting
+# ONLY the one expression tofu cannot know without an apply (the CP EIP
+# address). The `%{ if idx == 0 }` directive and every `${…}` ternary are
+# evaluated by tofu itself, not re-implemented here.
+#
+# USAGE
+#   scripts/check-cloudinit-primary-kubeconfig-capture.sh
+#   scripts/check-cloudinit-primary-kubeconfig-capture.sh --self-test
+#   scripts/check-cloudinit-primary-kubeconfig-capture.sh --render   # evidence
+#
+# EXIT: 0 = every assertion holds. 1 = an assertion failed. 2 = the harness
+#       could not measure (missing tofu, missing file, render error) — never
+#       reported as a pass.
+#
+# REQUIREMENTS: tofu (render), python3 (JSON decode). No cluster, no network,
+#               no cloud credentials. Nothing is provisioned or modified.
+set -uo pipefail
+
+ROOT="${ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+TOFU_BIN="${TOFU_BIN:-tofu}"
+PY_BIN="${PY_BIN:-python3}"
+
+HUAWEI_TF="infra/providers/huawei/main.tf"
+SHARED_TPL="infra/providers/_shared/cloudinit-control-plane.tftpl"
+LOG_HANDLER="products/catalyst/bootstrap/api/internal/handler/cloudinit_log.go"
+
+C_RED=$'\033[31m'; C_GRN=$'\033[32m'; C_RST=$'\033[0m'
+[ -t 1 ] || { C_RED=; C_GRN=; C_RST=; }
+
+FAILURES=0
+pass() { printf '%s  PASS%s %s\n' "${C_GRN}" "${C_RST}" "$1"; }
+fail() { printf '%s  FAIL%s %s\n' "${C_RED}" "${C_RST}" "$1"; FAILURES=$((FAILURES + 1)); }
+die()  { printf '%sFATAL%s %s\n' "${C_RED}" "${C_RST}" "$1" >&2; exit 2; }
+
+# ─────────────────────────────────────────────────────────────────────────────
+# render_put_blocks <root> — extract the real kubeconfig_put_block heredoc from
+# the Huawei provider and render it, per region, through tofu. Prints the
+# rendered blocks as `=== <region-key>` sections on stdout.
+# ─────────────────────────────────────────────────────────────────────────────
+render_put_blocks() {
+  local root="$1" tf="$1/${HUAWEI_TF}" work body
+  [ -f "${tf}" ] || die "not found: ${tf}"
+
+  work="$(mktemp -d)"
+  # shellcheck disable=SC2064
+  trap "rm -rf '${work}'" RETURN
+
+  # Extract the heredoc BODY: everything strictly between the
+  # `kubeconfig_put_block = <<-PUT` line and the closing `PUT` marker.
+  body="$(awk '
+    /kubeconfig_put_block = <<-PUT$/ { grab = 1; next }
+    grab && /^[[:space:]]*PUT[[:space:]]*$/ { grab = 0; next }
+    grab { print }
+  ' "${tf}")"
+  [ -n "${body}" ] || die "could not extract the kubeconfig_put_block heredoc from ${tf} (anchor 'kubeconfig_put_block = <<-PUT' moved?)"
+
+  # The ONLY substitution: the CP EIP is a resource attribute that has no value
+  # until apply. Everything else — local.name_prefix, local.region_keys, idx,
+  # r.code, substr(), sha256(), var.* — is evaluated by tofu below.
+  # Greedy `.+` on purpose: the index expression itself contains a `]`
+  # (`local.region_keys[0]`), so a non-greedy/negated-class match stops early
+  # and leaves the resource reference behind — which then fails to evaluate.
+  body="$(printf '%s\n' "${body}" |
+    sed -E 's/huaweicloud_vpc_eip\.cp\[(.+)\]\.publicip\.0\.ip_address/local.cp_eip[\1]/g')"
+  case "${body}" in
+    *huaweicloud_vpc_eip*)
+      die "the CP-EIP substitution did not fully apply — a resource reference survived into the render harness" ;;
+  esac
+
+  {
+    cat <<'HCL'
+variable "regions" {
+  type    = list(object({ code = string }))
+  default = [{ code = "me-east-215-a" }, { code = "me-east-215-b" }]
+}
+variable "deployment_id" { default = "6339cafe6339cafe" }
+variable "kubeconfig_bearer_token" { default = "bearerFIXTURE0001" }
+variable "catalyst_api_url" { default = "https://console.openova.io/sovereign" }
+variable "retry_attempt" { default = 0 }
+
+locals {
+  name_prefix = "catalyst-t99-omani-works-6339cafe"
+  region_keys = [for r in var.regions : r.code]
+  cp_eip      = { "me-east-215-a" = "203.0.113.10", "me-east-215-b" = "203.0.113.20" }
+
+  blocks = {
+    for idx, r in var.regions :
+    r.code => <<-PUT
+HCL
+    printf '%s\n' "${body}"
+    cat <<'HCL'
+    PUT
+  }
+}
+
+output "blocks_json" { value = jsonencode(local.blocks) }
+HCL
+  } > "${work}/main.tf"
+
+  ( cd "${work}" && "${TOFU_BIN}" init -backend=false -input=false -no-color >/dev/null 2>&1 ) ||
+    die "tofu init failed in the render harness"
+  local out
+  out="$( cd "${work}" && "${TOFU_BIN}" apply -auto-approve -input=false -no-color 2>&1 )" || {
+    printf '%s\n' "${out}" >&2
+    die "tofu apply (render) failed — the extracted heredoc did not evaluate"
+  }
+
+  printf '%s\n' "${out}" | "${PY_BIN}" -c '
+import json, sys
+raw = None
+for line in sys.stdin:
+    if line.startswith("blocks_json = "):
+        raw = line.split(" = ", 1)[1].strip()
+        break
+if raw is None:
+    sys.stderr.write("no blocks_json output in tofu apply result\n")
+    sys.exit(2)
+blocks = json.loads(json.loads(raw))
+for key in sorted(blocks):
+    print("=== " + key)
+    print(blocks[key])
+' || die "could not decode the rendered blocks"
+}
+
+# section <rendered> <region-key> — the rendered text for one region.
+section() {
+  printf '%s\n' "$1" | awk -v want="=== $2" '
+    $0 == want { grab = 1; next }
+    /^=== / { grab = 0 }
+    grab { print }
+  '
+}
+
+want_in()    { case "$2" in *"$3"*) pass "$1";; *) fail "$1";; esac; }
+want_notin() { case "$2" in *"$3"*) fail "$1";; *) pass "$1";; esac; }
+
+file_has() {
+  local label="$1" path="$2" needle="$3"
+  [ -f "${path}" ] || { fail "${label} — file missing: ${path}"; return; }
+  if grep -qF -- "${needle}" "${path}"; then pass "${label}"; else fail "${label}"; fi
+}
+
+run_checks() {
+  local root="$1" rendered primary secondary
+  rendered="$(render_put_blocks "${root}")" || return 2
+
+  primary="$(section "${rendered}" "me-east-215-a")"
+  secondary="$(section "${rendered}" "me-east-215-b")"
+  [ -n "${primary}" ]   || { fail "primary region rendered an EMPTY kubeconfig PUT-back block"; return 1; }
+  [ -n "${secondary}" ] || { fail "secondary region rendered an EMPTY kubeconfig PUT-back block"; return 1; }
+
+  # ── (1) the primary region actually captures the primary kubeconfig ──
+  want_in "primary render: PUTs to /deployments/<id>/kubeconfig" \
+    "${primary}" "/api/v1/deployments/6339cafe6339cafe/kubeconfig"
+  want_in "primary render: uses -X PUT (the capture verb)" \
+    "${primary}" "-X PUT"
+  want_in "primary render: labels its attempts 'primary kubeconfig PUT-back'" \
+    "${primary}" "primary kubeconfig PUT-back"
+
+  # The mis-registration path #6339 closed: region 0 must NOT also carry the
+  # SECONDARY BRANCH, or a hostname mismatch silently registers the PRIMARY
+  # region under a bare region key and GET /kubeconfig stays 409 forever.
+  # Discriminate on the branch's own artefacts, NOT on the endpoint URL: the
+  # primary's fail-loud path deliberately reuses that endpoint as a fallback,
+  # so a URL match is true either way and the assertion could not fail. (It
+  # read as PASS on the pre-fix tree during the red run that proved this guard
+  # — the exact "guard tested a surface that cannot fail" shape.)
+  want_notin "primary render: does NOT carry the 'secondary kubeconfig PUT-back' label" \
+    "${primary}" "secondary kubeconfig PUT-back"
+  want_notin "primary render: does NOT carry the secondary branch body (kubeconfig-secondary.yaml)" \
+    "${primary}" "/tmp/kubeconfig-secondary.yaml"
+
+  # ── (2) failure is LOUD, not a silent fall-through ──
+  want_in "primary render: prints PRIMARY-KUBECONFIG-CAPTURE-FAILED on exhaustion" \
+    "${primary}" "PRIMARY-KUBECONFIG-CAPTURE-FAILED"
+  want_in "primary render: carries the last HTTP code into the fail-loud line" \
+    "${primary}" 'lastHTTP=${LAST_CODE}'
+  want_in "primary render: drops the kubeconfig-put-FAILED sentinel (pushes this node's log)" \
+    "${primary}" "kubeconfig-put-FAILED"
+  want_in "primary render: falls back to the per-region channel the secondaries prove works" \
+    "${primary}" "PRIMARY-KUBECONFIG-FALLBACK"
+
+  # ── (3) the secondary path is untouched ──
+  want_in "secondary render: POSTs to /sovereign/secondary-kubeconfig" \
+    "${secondary}" "/api/v1/sovereign/secondary-kubeconfig"
+  want_in "secondary render: labels its attempts 'secondary kubeconfig PUT-back'" \
+    "${secondary}" "secondary kubeconfig PUT-back"
+  want_notin "secondary render: does NOT carry the primary PUT branch" \
+    "${secondary}" "primary kubeconfig PUT-back"
+
+  # ── (4) every CP keeps its OWN cloud-init log ──
+  # Without this the fail-loud line above lands in a file the other region
+  # overwrites 30 seconds later, and the guard would be pinning a message
+  # nobody can ever read.
+  file_has "huawei prelude uploader is per-node (?node=)" \
+    "${root}/${HUAWEI_TF}" 'cloudinit-log?node=$(hostname)'
+  file_has "shared-template fail-loud 'mark' pusher is per-node (?node=)" \
+    "${root}/${SHARED_TPL}" 'cloudinit-log?node=$(hostname)'
+  file_has "catalyst-api keeps a per-node capture alongside the shared one" \
+    "${root}/${LOG_HANDLER}" 'id+"-cloudinit-"+node+".log"'
+
+  # ── (5) the OTHER cloud-init gates are not lying about their subject ──
+  # scripts/lint-cloudinit.sh (dash -n) and scripts/cloudinit-size-check.sh
+  # (byte cap) both render the SHARED template with a HAND-WRITTEN
+  # `kubeconfig_put_block` fixture. Those copies had drifted so far from the
+  # real provider block that neither gate had ever parsed or weighed the shell
+  # the control plane actually runs — Huawei's byte measurement was ~1.2 KB
+  # optimistic and the dash lint was checking a block that does not exist.
+  # Pin the load-bearing tokens so the next drift fails here instead of on a
+  # lost provision.
+  local fixture
+  for fixture in scripts/lint-cloudinit.sh scripts/cloudinit-size-check.sh; do
+    file_has "${fixture} fixture carries the real primary PUT-back label" \
+      "${root}/${fixture}" "primary kubeconfig PUT-back"
+    file_has "${fixture} fixture carries the real fail-loud banner" \
+      "${root}/${fixture}" "PRIMARY-KUBECONFIG-CAPTURE-FAILED"
+  done
+
+  [ "${FAILURES}" -eq 0 ]
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# --self-test — regress a COPY of the tree to each pre-#6339 shape and prove
+# the guard goes RED on it. A guard nobody has watched fail is not evidence.
+# ─────────────────────────────────────────────────────────────────────────────
+self_test() {
+  local tmp rc st_fail=0
+  printf '[self-test] positive control — the real tree must PASS\n'
+  FAILURES=0
+  run_checks "${ROOT}" >/dev/null 2>&1
+  rc=$?
+  if [ "${rc}" -eq 0 ]; then
+    pass "self-test: real tree passes"
+  else
+    fail "self-test: real tree FAILS its own guard (rc=${rc})"
+    st_fail=1
+  fi
+
+  # Regression 1 — the pre-#6339 runtime-gated shape: region 0's render also
+  # carries the secondary POST branch.
+  tmp="$(mktemp -d)"
+  cp -r "${ROOT}/infra" "${ROOT}/products" "${ROOT}/scripts" "${tmp}/" 2>/dev/null
+  "${PY_BIN}" - "${tmp}/${HUAWEI_TF}" <<'PY'
+import re, sys
+p = sys.argv[1]
+s = open(p).read()
+# Drop the render-time split so BOTH branches ship in every region again.
+# Whitespace-tolerant: `tofu fmt` rewrites `%{~ if x ~}` to `%{~if x~}`, so a
+# literal-string mutation would silently no-op and the regression would go
+# unmeasured — the mutation MUST be asserted to have changed the file.
+s2 = re.sub(r"(?m)^%\{~\s*(if [^}]*|else|endif)\s*~\}\n", "", s)
+if s2 == s:
+    sys.exit("self-test mutation 1 changed NOTHING — the directive anchor moved")
+open(p, "w").write(s2)
+PY
+  [ $? -eq 0 ] || { fail "self-test: could not apply the both-branches mutation"; st_fail=1; }
+  FAILURES=0
+  run_checks "${tmp}" >/dev/null 2>&1
+  rc=$?
+  if [ "${rc}" -ne 0 ]; then
+    pass "self-test: RED on the pre-#6339 both-branches-in-every-region shape"
+  else
+    fail "self-test: guard PASSED the both-branches shape it exists to catch"
+    st_fail=1
+  fi
+  rm -rf "${tmp}"
+
+  # Regression 2 — fail-loud stripped: the PUT loop falls through in silence.
+  tmp="$(mktemp -d)"
+  cp -r "${ROOT}/infra" "${ROOT}/products" "${ROOT}/scripts" "${tmp}/" 2>/dev/null
+  "${PY_BIN}" - "${tmp}/${HUAWEI_TF}" <<'PY'
+import sys
+p = sys.argv[1]
+s = open(p).read()
+s2 = s.replace("PRIMARY-KUBECONFIG-CAPTURE-FAILED", "primary put exhausted")
+if s2 == s:
+    sys.exit("self-test mutation 2 changed NOTHING — the fail-loud banner moved")
+open(p, "w").write(s2)
+PY
+  [ $? -eq 0 ] || { fail "self-test: could not apply the fail-loud-stripped mutation"; st_fail=1; }
+  FAILURES=0
+  run_checks "${tmp}" >/dev/null 2>&1
+  rc=$?
+  if [ "${rc}" -ne 0 ]; then
+    pass "self-test: RED when the fail-loud banner is removed"
+  else
+    fail "self-test: guard PASSED a silent-fall-through PUT loop"
+    st_fail=1
+  fi
+  rm -rf "${tmp}"
+
+  # Regression 3 — per-node capture stripped: the loud line lands in a file
+  # the other region overwrites, i.e. the hw297/hw298 blindness returns.
+  tmp="$(mktemp -d)"
+  cp -r "${ROOT}/infra" "${ROOT}/products" "${ROOT}/scripts" "${tmp}/" 2>/dev/null
+  "${PY_BIN}" - "${tmp}/${HUAWEI_TF}" "${tmp}/${SHARED_TPL}" <<'PY'
+import sys
+changed = 0
+for p in sys.argv[1:]:
+    s = open(p).read()
+    s2 = s.replace("cloudinit-log?node=$(hostname)", "cloudinit-log")
+    if s2 != s:
+        changed += 1
+    open(p, "w").write(s2)
+if changed != 2:
+    sys.exit("self-test mutation 3 changed %d of 2 files — a per-node uploader moved" % changed)
+PY
+  [ $? -eq 0 ] || { fail "self-test: could not apply the single-key-log mutation"; st_fail=1; }
+  FAILURES=0
+  run_checks "${tmp}" >/dev/null 2>&1
+  rc=$?
+  if [ "${rc}" -ne 0 ]; then
+    pass "self-test: RED when the cloud-init log stops being per-node"
+  else
+    fail "self-test: guard PASSED a single-key cloud-init log on a multi-region prov"
+    st_fail=1
+  fi
+  rm -rf "${tmp}"
+
+  if [ "${st_fail}" -eq 0 ]; then
+    printf '\n[self-test] PASS — cluster-free; every regression above was watched RED.\n'
+    return 0
+  fi
+  printf '\n[self-test] FAIL\n'
+  return 1
+}
+
+command -v "${TOFU_BIN}" >/dev/null 2>&1 || die "required tool not found on PATH: ${TOFU_BIN}"
+command -v "${PY_BIN}"  >/dev/null 2>&1 || die "required tool not found on PATH: ${PY_BIN}"
+
+case "${1:-}" in
+  --self-test)
+    self_test
+    exit $?
+    ;;
+  --render)
+    # Print the RENDERED per-region PUT-back blocks and exit. This is the
+    # evidence surface: it is the same render the assertions run against, so a
+    # reviewer reads the real emitted shell, not the template source.
+    render_put_blocks "${ROOT}"
+    exit $?
+    ;;
+  "")
+    printf '[check-cloudinit-primary-kubeconfig-capture] rendering the REAL Huawei kubeconfig_put_block with tofu\n\n'
+    run_checks "${ROOT}"
+    rc=$?
+    printf '\n'
+    if [ "${rc}" -eq 0 ]; then
+      printf 'RESULT: the primary region captures its kubeconfig, fails loudly, and every CP keeps its own log.\n'
+    elif [ "${rc}" -eq 2 ]; then
+      printf '%sRESULT: COULD NOT MEASURE (rc=2) — this is NOT a pass. See the FATAL line above.%s\n' "${C_RED}" "${C_RST}"
+    else
+      printf '%sRESULT: %d assertion(s) failed — a primary-region kubeconfig capture gap is back (Refs #6339).%s\n' "${C_RED}" "${FAILURES}" "${C_RST}"
+    fi
+    exit "${rc}"
+    ;;
+  *)
+    die "unknown argument: $1 (expected no args, or --self-test)"
+    ;;
+esac

--- a/scripts/cloudinit-size-check.sh
+++ b/scripts/cloudinit-size-check.sh
@@ -287,21 +287,49 @@ fixture_cp_huawei() {
           ' >/dev/null 2>&1 &
         fi
     PRE
+    # #6339 — MIRRORS the real primary-region block in
+    # infra/providers/huawei/main.tf (the `%{ if idx == 0 }` arm). The previous
+    # stub was ~1.2 KB SMALLER than the block the CP really carries, so every
+    # byte measurement this gate has ever reported for Huawei was optimistic.
+    # The primary arm is the larger of the two per-region arms, so using it for
+    # both surfaces below keeps the measurement conservative.
+    # scripts/check-cloudinit-primary-kubeconfig-capture.sh fails if this copy
+    # loses the real block's load-bearing tokens.
     kubeconfig_put_block = <<-PUT
       - |
         HOSTNAME=$(hostname)
-        if [ -n "test-dep-0001" ] && [ -n "kubeconfigTESTbearer0001" ]; then
+        PRIMARY_HOST='catalyst-t99-omani-works-testdep0-test-region-a-cp1-abc123'
+        if [ -n "test-dep-0001" ] && [ -n "kubeconfigTESTbearer0001" ] && [ "$${HOSTNAME}" = "$${PRIMARY_HOST}" ]; then
           sed "s|server: https://127.0.0.1:6443|server: https://203.0.113.10:6443|" /etc/rancher/k3s/k3s.yaml > /tmp/kubeconfig-rewritten.yaml
-          for attempt in 1 2 3 4 5 6; do
-            HTTP_CODE=$(curl -sk -o /dev/null -w '%%{http_code}' -X PUT \
+          LAST_CODE=000
+          for attempt in 1 2 3 4 5 6 7 8 9 10 11 12; do
+            LAST_CODE=$(curl -sk -o /dev/null -w '%%{http_code}' -X PUT \
               -H "Authorization: Bearer kubeconfigTESTbearer0001" \
+              -H "Content-Type: application/x-yaml" \
               --data-binary @/tmp/kubeconfig-rewritten.yaml \
               --max-time 15 \
               "https://console.openova.io/sovereign/api/v1/deployments/test-dep-0001/kubeconfig" || echo "000")
-            echo "kubeconfig PUT-back attempt $attempt -> HTTP $HTTP_CODE"
-            if [ "$HTTP_CODE" = "204" ] || [ "$HTTP_CODE" = "200" ]; then break; fi
+            echo "primary kubeconfig PUT-back attempt $${attempt} -> HTTP $${LAST_CODE}"
+            case "$${LAST_CODE}" in 2*) break;; esac
             sleep 30
           done
+          case "$${LAST_CODE}" in
+            2*) ;;
+            *)
+              echo "PRIMARY-KUBECONFIG-CAPTURE-FAILED region=test-region-a lastHTTP=$${LAST_CODE} after 12 attempts; GET /api/v1/deployments/test-dep-0001/kubeconfig stays 409 until this is repaired"
+              export MY_NODE_IP=$(ip -4 -o addr show dev eth0 | awk '{print $4}' | cut -d/ -f1)
+              python3 -c "import json,os; print(json.dumps({'deploymentId':'test-dep-0001','regionKey':'test-region-a','kubeconfigYaml':open('/tmp/kubeconfig-rewritten.yaml').read(),'nodeInternalIp':os.environ.get('MY_NODE_IP','')}))" > /tmp/primary-kubeconfig-body.json
+              FALLBACK_CODE=$(curl -sk -o /dev/null -w '%%{http_code}' -X POST \
+                -H "Authorization: Bearer kubeconfigTESTbearer0001" \
+                -H "Content-Type: application/json" \
+                --data-binary @/tmp/primary-kubeconfig-body.json \
+                --max-time 15 \
+                "https://console.openova.io/sovereign/api/v1/sovereign/secondary-kubeconfig" || echo "000")
+              echo "PRIMARY-KUBECONFIG-FALLBACK per-region-channel regionKey=test-region-a -> HTTP $${FALLBACK_CODE}"
+              rm -f /tmp/primary-kubeconfig-body.json
+              sh /var/lib/catalyst/mark kubeconfig-put-FAILED || true
+              ;;
+          esac
         fi
     PUT
 HCL

--- a/scripts/lint-cloudinit.sh
+++ b/scripts/lint-cloudinit.sh
@@ -277,21 +277,48 @@ fixture_huawei() {
           ' >/dev/null 2>&1 &
         fi
     PRE
+    # #6339 — this MIRRORS the real primary-region block in
+    # infra/providers/huawei/main.tf (the `%{ if idx == 0 }` arm). It had drifted
+    # badly: no primary/secondary split, 6 attempts instead of 12, no hostname
+    # gate — so this lint has never once parsed the shell the CP actually runs.
+    # scripts/check-cloudinit-primary-kubeconfig-capture.sh renders the REAL
+    # heredoc and FAILS if this copy loses the block's load-bearing tokens, so
+    # the drift is now caught by CI instead of by a lost provision.
     kubeconfig_put_block = <<-PUT
       - |
         HOSTNAME=$(hostname)
-        if [ -n "test-dep-0001" ] && [ -n "kubeconfigTESTbearer0001" ]; then
+        PRIMARY_HOST='catalyst-t99-omani-works-testdep0-test-region-a-cp1-abc123'
+        if [ -n "test-dep-0001" ] && [ -n "kubeconfigTESTbearer0001" ] && [ "$${HOSTNAME}" = "$${PRIMARY_HOST}" ]; then
           sed "s|server: https://127.0.0.1:6443|server: https://203.0.113.10:6443|" /etc/rancher/k3s/k3s.yaml > /tmp/kubeconfig-rewritten.yaml
-          for attempt in 1 2 3 4 5 6; do
-            HTTP_CODE=$(curl -sk -o /dev/null -w '%%{http_code}' -X PUT \
+          LAST_CODE=000
+          for attempt in 1 2 3 4 5 6 7 8 9 10 11 12; do
+            LAST_CODE=$(curl -sk -o /dev/null -w '%%{http_code}' -X PUT \
               -H "Authorization: Bearer kubeconfigTESTbearer0001" \
+              -H "Content-Type: application/x-yaml" \
               --data-binary @/tmp/kubeconfig-rewritten.yaml \
               --max-time 15 \
               "https://console.openova.io/sovereign/api/v1/deployments/test-dep-0001/kubeconfig" || echo "000")
-            echo "kubeconfig PUT-back attempt $attempt -> HTTP $HTTP_CODE"
-            if [ "$HTTP_CODE" = "204" ] || [ "$HTTP_CODE" = "200" ]; then break; fi
+            echo "primary kubeconfig PUT-back attempt $${attempt} -> HTTP $${LAST_CODE}"
+            case "$${LAST_CODE}" in 2*) break;; esac
             sleep 30
           done
+          case "$${LAST_CODE}" in
+            2*) ;;
+            *)
+              echo "PRIMARY-KUBECONFIG-CAPTURE-FAILED region=test-region-a lastHTTP=$${LAST_CODE} after 12 attempts; GET /api/v1/deployments/test-dep-0001/kubeconfig stays 409 until this is repaired"
+              export MY_NODE_IP=$(ip -4 -o addr show dev eth0 | awk '{print $4}' | cut -d/ -f1)
+              python3 -c "import json,os; print(json.dumps({'deploymentId':'test-dep-0001','regionKey':'test-region-a','kubeconfigYaml':open('/tmp/kubeconfig-rewritten.yaml').read(),'nodeInternalIp':os.environ.get('MY_NODE_IP','')}))" > /tmp/primary-kubeconfig-body.json
+              FALLBACK_CODE=$(curl -sk -o /dev/null -w '%%{http_code}' -X POST \
+                -H "Authorization: Bearer kubeconfigTESTbearer0001" \
+                -H "Content-Type: application/json" \
+                --data-binary @/tmp/primary-kubeconfig-body.json \
+                --max-time 15 \
+                "https://console.openova.io/sovereign/api/v1/sovereign/secondary-kubeconfig" || echo "000")
+              echo "PRIMARY-KUBECONFIG-FALLBACK per-region-channel regionKey=test-region-a -> HTTP $${FALLBACK_CODE}"
+              rm -f /tmp/primary-kubeconfig-body.json
+              sh /var/lib/catalyst/mark kubeconfig-put-FAILED || true
+              ;;
+          esac
         fi
     PUT
 HCL


### PR DESCRIPTION
## The measurement

hw297 and hw298, two consecutive 2-region Huawei provs:

| request | result |
|---|---|
| `GET /sovereign/api/v1/deployments/{id}/kubeconfig` | **409** `not-implemented` |
| `GET .../kubeconfig?region=me-east-215-a` (PRIMARY) | **409** |
| `GET .../kubeconfig?region=me-east-215-b-1` (SECONDARY) | **200**, working (`Server Version: v1.31.4+k3s1`) |

The capture path exists and works — it is only ever exercised for the secondary. With no primary kubeconfig there is no route into the primary cluster, which is why the failed `catalyst/cutover-egress-block-test-1786728458` Job on hw298 could not be read and rows G11 / 166 / 227 have no root-cause path.

## What I found (a) — and what I could not find

**The primary block is NOT absent and is NOT gated off by a "this is a secondary region" conditional.** It lives at `infra/providers/huawei/main.tf` (pre-fix L1249-L1266), and the historical evidence proves it fires and succeeds: across the 13 archived captures in `docs/sessions/**/prov-diagnostics/` that carry a PUT-back line, the correlation between the node's hostname and the label is **13/13 exact** —

```
catalyst-hw256-…-me-east-215-a-cp1-b871ba  ->  primary kubeconfig PUT-back    (HTTP 204)
catalyst-hw265-…-me-east-215-a-cp1-2f6bb8  ->  primary kubeconfig PUT-back    (HTTP 204)
catalyst-hw268-…-me-east-215-a-cp1-c05208  ->  primary kubeconfig PUT-back    (HTTP 204)
catalyst-hw264-…-me-east-215-b-cp1-b57618  ->  secondary kubeconfig PUT-back  (HTTP 201)
catalyst-hw263-…-me-east-215-b-cp1-569794  ->  secondary kubeconfig PUT-back  (HTTP 201)
…  7 region-a logs, all "primary"; 6 region-b logs, all "secondary"
```

**Every one of those 13 files contains exactly ONE hostname. Never two.** That is the finding that changes the question. `PutCloudInitLog` writes every upload to one key, `<id>-cloudinit.log` (`cloudinit_log.go:113`), and every CP in every region PUTs there every 30s for ~50 minutes (`huawei/main.tf` prelude + the shared template's `mark` helper). On a 2-region Sovereign the surviving capture is whichever node wrote last; **the other region's log is destroyed**.

hw297's surviving capture is region-b's — its line 327 is the *secondary* label, which by the correlation above only ever appears in a region-b log. So the primary's PUT-back outcome, which is echoed **only** into region-a's log, was overwritten before anyone read it.

So, stated plainly: **CANNOT DETERMINE the terminal HTTP code the primary's PUT received on hw297/hw298**, because the only channel that records it is clobbered by design. What I *can* determine, and did:

- the primary cloud-init reached the PUT-back step (the structural invariant puts it before cilium/flux, and both provs went on to install Flux and run an 11-step cutover);
- the two branches were **complementary and exhaustive** (`= PRIMARY_HOST` / `!= PRIMARY_HOST`), so one of them ran;
- the secondary branch did **not** run on region-a, because it would have written `<id>-me-east-215-a.yaml` and `?region=me-east-215-a` would have answered 200 — it answered 409;
- therefore the primary branch ran and every one of its 12 attempts returned non-2xx, into a log that no longer exists.

Searches run: `grep -rn "PUT-back"` across the repo; the full `kubeconfig_put_block` in `huawei/main.tf` and both Hetzner variants; `GetKubeconfig`/`PutKubeconfig`/`HandleSovereignSecondaryKubeconfig`/`PutCloudInitLog`; hostname-vs-label correlation over all 22 archived cloud-init logs; `git log` on `infra/providers/huawei/main.tf` (untouched since #5246, so this is not a fresh regression in that file).

I have **not** shipped a speculative repair of an unknown HTTP code. What I shipped removes the two conditions that made the failure both *possible* and *invisible*, and one non-speculative redundancy.

## What changed (b), (c), (d)

**1 · The primary/secondary choice is a RENDER-time fact now, not a boot-time one.** `infra/providers/huawei/main.tf` — the block is emitted under `%{if idx == 0}` / `%{else}`. Previously both branches shipped in **every** region's `user_data` and `[ "$HOSTNAME" = "$PRIMARY_HOST" ]` picked one at boot. Three costs:

- Any drift between the ECS `name` formula and the booted hostname flips region 0 into the **secondary** branch — registering the primary region under a bare region key so `GET /kubeconfig` keeps answering 409. That drift is reachable, not theoretical: the CP resource carries `lifecycle.ignore_changes = [tags, metadata, name]` *precisely so an ACTIVE CP keeps its old name when a `retry_attempt` bump changes the formula*, while `PRIMARY_HOST` here is recomputed from the current `retry_attempt`.
- A region-0 **replica** CP (`huawei_control_plane_count > 1`) matched `!= PRIMARY_HOST` unconditionally and POSTed **its** kubeconfig under the primary region's own key.
- No CI check could assert "the primary region carries the primary PUT-back", because which branch fired was a runtime fact.

The cp1-only restriction inside region 0 is kept as a hostname test; a region-0 replica now does **nothing** instead of mis-registering. **The secondary branch is byte-identical, including its `!= PRIMARY_HOST` gate** — in a secondary region's render `PRIMARY_HOST` names region-0's cp1, which no node there can equal, so the gate stays trivially true and the measured-working path is untouched. Per-region `user_data` shrinks ~1.1 KB (each region now ships one branch, not two).

**2 · Fail loudly (c).** The loop no longer falls through in silence. On exhaustion it prints `PRIMARY-KUBECONFIG-CAPTURE-FAILED region=<r> lastHTTP=<code>`, then retries **once** through the per-region channel the secondaries prove works (`POST /sovereign/secondary-kubeconfig` with the primary's own region key) so `GET ...?region=<primary>` yields a working kubeconfig instead of a second 409, then drops the `kubeconfig-put-FAILED` sentinel — which force-pushes this node's log. **Not fatal**: trading a forensics gap for a dead provision is the wrong trade. The fallback is on the failure path only, so a healthy prov's behaviour is unchanged and no duplicate cluster is registered.

**3 · Every control plane keeps its own log.** Both uploaders send `?node=$(hostname)`; `PutCloudInitLog` additionally writes `<id>-cloudinit-<node>.log`. The shared `<id>-cloudinit.log` keeps its exact latest-wins semantics, so every existing reader is untouched. `GET` gains `?node=` (404 lists what *is* held) and an `X-Catalyst-Cloudinit-Nodes` discovery header. Without this, the loud line in (2) would land in a file the other region overwrites 30 seconds later.

**4 · The guard (d).** `scripts/check-cloudinit-primary-kubeconfig-capture.sh`, wired by `.github/workflows/check-cloudinit-primary-kubeconfig-capture.yaml` whose `paths:` list every file it reads (`infra/providers/**`, `cloudinit_log.go`, both fixture scripts, itself).

It extracts the **real** heredoc from `infra/providers/huawei/main.tf` and renders it with **real tofu**, substituting only the CP EIP (which has no value before apply). Everything else — the `%{if idx == 0}` directive, `local.region_keys`, `substr(sha256(...))`, the `idx == 0 ? … : …` ternary — is evaluated by tofu.

This mattered: **`scripts/lint-cloudinit.sh` and `scripts/cloudinit-size-check.sh` both render the shared template with a hand-written `kubeconfig_put_block` fixture that had drifted years from the real block** — no primary/secondary split, 6 attempts instead of 12, no hostname gate. Neither gate has ever parsed or weighed the shell the CP actually runs. Both fixtures are corrected, and the new guard fails on further drift. Huawei's honest CP render is **28864 B** against the 32256 cap (was reporting 27414 B while measuring a phantom); Hetzner unchanged at 23775 B.

## Proof

**Rendered primary block (the guard's `--render`, real tofu, post-fix).** The fail-loud + fallback path that previously did not exist:

```sh
=== me-east-215-a
- |
  HOSTNAME=$(hostname)
  PRIMARY_HOST='catalyst-t99-omani-works-6339cafe-me-east-215-a-cp1-8600b8'
  if [ -n "6339cafe6339cafe" ] && [ -n "bearerFIXTURE0001" ] && [ "${HOSTNAME}" = "${PRIMARY_HOST}" ]; then
    sed "s|server: https://127.0.0.1:6443|server: https://203.0.113.10:6443|" /etc/rancher/k3s/k3s.yaml > /tmp/kubeconfig-rewritten.yaml
    LAST_CODE=000
    for attempt in 1 2 3 4 5 6 7 8 9 10 11 12; do
      LAST_CODE=$(curl -sk -o /dev/null -w '%{http_code}' -X PUT \
        …
        "https://console.openova.io/sovereign/api/v1/deployments/6339cafe6339cafe/kubeconfig" || echo "000")
      echo "primary kubeconfig PUT-back attempt ${attempt} -> HTTP ${LAST_CODE}"
      case "${LAST_CODE}" in 2*) break;; esac
      sleep 30
    done
    case "${LAST_CODE}" in
      2*) ;;
      *)
        echo "PRIMARY-KUBECONFIG-CAPTURE-FAILED region=me-east-215-a lastHTTP=${LAST_CODE} after 12 attempts; GET /api/v1/deployments/6339cafe6339cafe/kubeconfig stays 409 until this is repaired"
        export MY_NODE_IP=$(ip -4 -o addr show dev eth0 | awk '{print $4}' | cut -d/ -f1)
        python3 -c "…'regionKey':'me-east-215-a'…" > /tmp/primary-kubeconfig-body.json
        FALLBACK_CODE=$(curl -sk -o /dev/null -w '%{http_code}' -X POST \
          … "https://console.openova.io/sovereign/api/v1/sovereign/secondary-kubeconfig" || echo "000")
        echo "PRIMARY-KUBECONFIG-FALLBACK per-region-channel regionKey=me-east-215-a -> HTTP ${FALLBACK_CODE}"
        rm -f /tmp/primary-kubeconfig-body.json
        sh /var/lib/catalyst/mark kubeconfig-put-FAILED || true
        ;;
    esac
  fi
```

The `me-east-215-b` render carries the secondary branch only — no `primary kubeconfig PUT-back`, no `-X PUT` to `/kubeconfig`.

**Guard RED against the pre-fix tree** — `git archive origin/main` (a83b911d8) extracted to a clean dir, with only the new guard script carried in (not by reverting an edit in place):

```
--- pre-fix tree extracted from origin/main (a83b911d8) ---
  PASS primary render: PUTs to /deployments/<id>/kubeconfig
  PASS primary render: uses -X PUT (the capture verb)
  PASS primary render: labels its attempts 'primary kubeconfig PUT-back'
  FAIL primary render: does NOT carry the 'secondary kubeconfig PUT-back' label
  FAIL primary render: does NOT carry the secondary branch body (kubeconfig-secondary.yaml)
  FAIL primary render: prints PRIMARY-KUBECONFIG-CAPTURE-FAILED on exhaustion
  FAIL primary render: carries the last HTTP code into the fail-loud line
  FAIL primary render: drops the kubeconfig-put-FAILED sentinel (pushes this node's log)
  FAIL primary render: falls back to the per-region channel the secondaries prove works
  PASS secondary render: POSTs to /sovereign/secondary-kubeconfig
  PASS secondary render: labels its attempts 'secondary kubeconfig PUT-back'
  FAIL secondary render: does NOT carry the primary PUT branch
  FAIL huawei prelude uploader is per-node (?node=)
  FAIL shared-template fail-loud 'mark' pusher is per-node (?node=)
  FAIL catalyst-api keeps a per-node capture alongside the shared one
  FAIL scripts/lint-cloudinit.sh fixture carries the real primary PUT-back label
  FAIL scripts/lint-cloudinit.sh fixture carries the real fail-loud banner
  FAIL scripts/cloudinit-size-check.sh fixture carries the real primary PUT-back label
  FAIL scripts/cloudinit-size-check.sh fixture carries the real fail-loud banner

RESULT: 14 assertion(s) failed — a primary-region kubeconfig capture gap is back (Refs #6339).
TRUE-RC=1
```

**Guard GREEN on this branch:**

```
  PASS primary render: PUTs to /deployments/<id>/kubeconfig
  PASS primary render: uses -X PUT (the capture verb)
  PASS primary render: labels its attempts 'primary kubeconfig PUT-back'
  PASS primary render: does NOT carry the 'secondary kubeconfig PUT-back' label
  PASS primary render: does NOT carry the secondary branch body (kubeconfig-secondary.yaml)
  PASS primary render: prints PRIMARY-KUBECONFIG-CAPTURE-FAILED on exhaustion
  PASS primary render: carries the last HTTP code into the fail-loud line
  PASS primary render: drops the kubeconfig-put-FAILED sentinel (pushes this node's log)
  PASS primary render: falls back to the per-region channel the secondaries prove works
  PASS secondary render: POSTs to /sovereign/secondary-kubeconfig
  PASS secondary render: labels its attempts 'secondary kubeconfig PUT-back'
  PASS secondary render: does NOT carry the primary PUT branch
  PASS huawei prelude uploader is per-node (?node=)
  PASS shared-template fail-loud 'mark' pusher is per-node (?node=)
  PASS catalyst-api keeps a per-node capture alongside the shared one
  PASS scripts/lint-cloudinit.sh fixture carries the real primary PUT-back label
  PASS scripts/lint-cloudinit.sh fixture carries the real fail-loud banner
  PASS scripts/cloudinit-size-check.sh fixture carries the real primary PUT-back label
  PASS scripts/cloudinit-size-check.sh fixture carries the real fail-loud banner

RESULT: the primary region captures its kubeconfig, fails loudly, and every CP keeps its own log.
TRUE-RC=0
```

The red run earned its keep immediately: it caught **one of my own assertions as vacuous** (a stray newline in the needle made "primary does not carry the secondary POST" pass on the pre-fix tree). It is now discriminated on the branch's own artefact, `/tmp/kubeconfig-secondary.yaml`, and fails correctly.

**`--self-test`** (cluster-free; each mutation asserts it actually changed the file, so a moved anchor cannot silently no-op):

```
  PASS self-test: real tree passes
  PASS self-test: RED on the pre-#6339 both-branches-in-every-region shape
  PASS self-test: RED when the fail-loud banner is removed
  PASS self-test: RED when the cloud-init log stops being per-node
TRUE-RC=0
```

**Other gates, all local:**

| check | result |
|---|---|
| `tofu validate` (real `infra/providers/huawei` module) | `Success! The configuration is valid.` |
| `tofu fmt -check -recursive infra/providers` | clean (only the pre-existing `_shared/tests/render.tf`) |
| `scripts/lint-cloudinit.sh both` | `dash -n` PASS, 26 hetzner + 29 huawei runcmd items |
| `dash -n` on the two rendered branches | rc=0 / rc=0 (2073 B, 2189 B) |
| `scripts/cloudinit-size-check.sh` | huawei 28864/32256, hetzner 23775/32256 |
| `go test ./internal/handler/` | ok (329s, full package) |
| `scripts/check-guards-are-wired.sh` | 25 self-test-capable guards, none orphaned |
| `scripts/check-no-conflict-markers.sh` | ok |

New Go coverage in `cloudinit_log_per_node_6339_test.go`: `TestTwoRegionUploads_BothNodeCapturesSurvive` is the one that reproduces the clobber (region a uploads, region b uploads, region a's capture must still be readable), plus `?node=` retrieval, the unchanged no-`?node=` path, and traversal-safety on the node key.

## What this does not claim

The mothership's catalyst-api does not auto-update, and a Sovereign already provisioned cannot receive a cloud-init change. This lands the fix in source; the primary-region capture is proven on the **next** fresh prov, and the first thing to read there is `GET .../cloudinit-log?node=<region-a-cp1>` — which, before this PR, did not exist.

Refs #6339
