### PR TITLE
fix(placement): join Pods to an Application by its RESOLVED workload identity, not by name coincidence

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/applications_placement_identity_6344.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications_placement_identity_6344.go
@@ -1,0 +1,329 @@
+// applications_placement_identity_6344.go — how the placement projection
+// decides that a live Pod belongs to the Application it was asked about.
+//
+// THE DEFECT (#6344, measured on hw298 dep 2540d866403f1f7c, owner session,
+// one binary, one pass). Four Applications, all `phase: Ready`, all asked the
+// same question on the same endpoint:
+//
+//	shared-pg      ns shared-data  active-hot-standby → 2 targets, Primary + Standby, both with a cluster
+//	spine-gitea    ns catalyst     active-hot-standby → 1 target,  Standby, cluster ""
+//	spine-keycloak ns catalyst     active-hot-standby → 1 target,  Standby, cluster ""
+//	spine-openbao  ns catalyst     active-passive     → 1 target,  Standby, cluster ""
+//
+// `shared-pg` is the CONTROL and it proves the projection itself works: #6268 /
+// #6291 / #6301 are present and functioning. The three that collapse differ
+// from it in exactly ONE property, and it is not a property of the app.
+//
+// `derivePlacementTargets` keeps a Pod when `podBelongsToComponent` says so,
+// and that predicate compares the ROUTE ID the console asked with — through
+// `componentNameCandidates`, i.e. `{name, TrimPrefix(name, "bp-")}` — against
+// labels the CHART happens to stamp: `app.kubernetes.io/instance`,
+// `app.kubernetes.io/name`, the loft display name. A Pod is therefore joined to
+// its Application by STRING COINCIDENCE.
+//
+//   - `shared-pg` matches because the CNPG Cluster it owns is itself named
+//     `shared-pg`, so the pods' identity happens to resolve back to the app's
+//     own name.
+//   - `spine-gitea` is an Application CR (post_handover_spine_apps.go) named
+//     `spine-gitea` in ns `catalyst` that ADOPTS HelmRelease
+//     `flux-system/bp-gitea`. That HR declares `releaseName: gitea` and
+//     `targetNamespace: gitea`; its Pods are labelled
+//     `app.kubernetes.io/instance=gitea` and live in ns `gitea`. Neither the
+//     name nor the namespace coincides, occupancy matches nothing, NO Primary
+//     is produced, and control falls through to `augmentWithContinuumStandby` —
+//     the only term in the whole path that can emit `cluster: ""` — leaving the
+//     lone Standby and `unresolvedPrimary: true` the walk recorded.
+//
+// So the blast radius is not "Catalog-provisioned apps" (the hw296 reading) and
+// not "spine apps" (the hw298 reading). It is every Application whose name does
+// not coincide with a label on its own Pods.
+//
+// THE FIX. Stop asking the route id what the workload is called and ask the
+// authoritative link instead: Application CR → adopted HelmRelease →
+// `spec.releaseName` + `spec.targetNamespace`. That is not a new mechanism —
+// it is the SAME chain the rest of this package already trusts:
+// `installLabelSelectorForHR` (#1928) derives the Resources/Logs tab selector
+// as `app.kubernetes.io/instance=<releaseName>` off exactly these fields, and
+// `hrLookupName` (#4889) already resolves `spine-gitea → flux-system/bp-gitea`
+// through `spec.helmRelease.name` for the HR-Ready overlay. The placement path
+// was the one consumer still deriving identity a second way, which is why it is
+// the one that disagreed.
+//
+// STRICTLY WIDENING, NEVER NARROWING. Resolution can only ADD identity strings
+// and namespaces that a live authoritative object NAMES. It never removes a
+// route candidate (so every app that resolves today keeps resolving), and it
+// never narrows the namespace set: when the caller passed no `?namespace=`, the
+// set stays empty — i.e. every namespace — because turning "anywhere" into "the
+// declared targetNamespace" would be a new way to MISS pods, which is the
+// defect, not the fix.
+//
+// AND IT CANNOT FABRICATE A PRIMARY. Everything here decides which Pods are
+// LOOKED AT. An app with no Pods in a region still yields no occupancy there,
+// still yields no Primary, and the #6268 half-pair refusal still fires — the
+// declaration is never allowed to stand in for an observation. Refs #6344,
+// #3375 (UAT row 60).
+package handler
+
+import (
+	"strings"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+// spineAdoptsHelmReleaseLabel names the EXISTING bootstrap HelmRelease a spine
+// Application CR enrolls rather than re-renders (Invariant #3, #4416). It is
+// the back-pointer of last resort here: a CR that carries the label but not
+// `spec.helmRelease` still resolves to its workload.
+const spineAdoptsHelmReleaseLabel = "catalyst.openova.io/adopts-helmrelease"
+
+// componentWorkloadIdentity is the set of identities a Pod may carry to count
+// as part of one Application, plus the namespaces it may occupy.
+//
+// The two name sets are deliberately NOT merged, because they are matched
+// differently and merging them would import a heuristic into a place that has a
+// contract:
+//
+//   - `route` holds what the CALLER said (`componentNameCandidates`). Nothing
+//     guarantees a chart stamped it anywhere, so it keeps the historical
+//     three-way match — applicationKey, app.kubernetes.io/name, and the loft
+//     display-name PREFIX.
+//   - `release` holds Helm release names read off a live Application CR /
+//     HelmRelease. Here the Helm chart-helpers contract (#1928) DOES guarantee
+//     `app.kubernetes.io/instance=<releaseName>` on every rendered object, so
+//     the label match is exact and sufficient. Extending the display-name
+//     prefix to these would absorb a SIBLING release whose name merely starts
+//     the same way — `gitea-pg`, rendered BY bp-gitea but a different workload
+//     with its own CNPG role labels, would be counted as gitea itself and its
+//     role labels would then drive the collapse in derivePlacementTargets.
+type componentWorkloadIdentity struct {
+	route      []string
+	release    []string
+	namespaces []string // empty = every namespace (the bootstrap-safe default)
+}
+
+// routeWorkloadIdentity is the identity the caller stated and nothing more —
+// byte-for-byte the pre-#6344 matching input. Used directly by callers that
+// have no authoritative link to resolve against.
+func routeWorkloadIdentity(name, ns string) componentWorkloadIdentity {
+	id := componentWorkloadIdentity{route: componentNameCandidates(name)}
+	if ns = strings.TrimSpace(ns); ns != "" {
+		id.namespaces = []string{ns}
+	}
+	return id
+}
+
+// addRelease records a resolved Helm release name. A release that merely
+// repeats a route candidate adds nothing and is dropped, so the route set stays
+// the only place a given string is matched loosely.
+func (id *componentWorkloadIdentity) addRelease(rel string) {
+	rel = strings.TrimSpace(rel)
+	if rel == "" {
+		return
+	}
+	for _, r := range id.route {
+		if r == rel {
+			return
+		}
+	}
+	for _, r := range id.release {
+		if r == rel {
+			return
+		}
+	}
+	id.release = append(id.release, rel)
+}
+
+// addNamespace widens the namespace set. Only ever called when the set is
+// ALREADY restrictive (the caller passed `?namespace=`); widening an empty set
+// would narrow "every namespace" down to one, which is the miss this file
+// exists to remove.
+func (id *componentWorkloadIdentity) addNamespace(ns string) {
+	ns = strings.TrimSpace(ns)
+	if ns == "" || len(id.namespaces) == 0 {
+		return
+	}
+	for _, n := range id.namespaces {
+		if n == ns {
+			return
+		}
+	}
+	id.namespaces = append(id.namespaces, ns)
+}
+
+// matchesNamespace reports whether the Pod sits in one of the identity's
+// namespaces, reusing objectInAppNamespace so the loft-synced case (host ns
+// `mgmt`, in-vCluster ns `gitea`) resolves exactly as it does for the
+// Resources tab. An empty set matches every namespace.
+func (id componentWorkloadIdentity) matchesNamespace(p *unstructured.Unstructured) bool {
+	if len(id.namespaces) == 0 {
+		return true
+	}
+	for _, ns := range id.namespaces {
+		if objectInAppNamespace(p, ns) {
+			return true
+		}
+	}
+	return false
+}
+
+// podCarriesReleaseIdentity is the exact-label half of the join: the #1928
+// contract that every Helm-rendered object of release R carries
+// `app.kubernetes.io/instance=R` (the loft syncer preserves both labels
+// verbatim, so a host-synced Pod is covered without touching its mangled name).
+func podCarriesReleaseIdentity(p *unstructured.Unstructured, release string) bool {
+	if p == nil || release == "" {
+		return false
+	}
+	lbls := p.GetLabels()
+	return lbls["app.kubernetes.io/instance"] == release ||
+		lbls["app.kubernetes.io/name"] == release
+}
+
+// podBelongsToIdentity is THE identity predicate — one function, so the
+// placement endpoint, the #5827 runtime-synth existence check, and anything
+// added later cannot answer "is this Pod part of that app" two different ways.
+func podBelongsToIdentity(p *unstructured.Unstructured, id componentWorkloadIdentity) bool {
+	if p == nil {
+		return false
+	}
+	if !id.matchesNamespace(p) {
+		return false
+	}
+
+	// Route candidates — the historical match, unchanged.
+	//
+	// nil ReplicaSet index: this join has no cache handle, so a Pod owned by a
+	// ReplicaSet keeps the ReplicaSet name (pre-#5485 behavior). The
+	// instance/name labels below carry the match in the cases this is called for.
+	appKey := applicationKey(p, nil)
+	chartName := p.GetLabels()["app.kubernetes.io/name"]
+	// The de-mangled in-vCluster object name (loft annotation), e.g. a host Pod
+	// `grafana-…-x-grafana-x-mgmt-vcluster` carries object-name `grafana-…`.
+	displayName := vClusterSyncedDisplayName(p)
+	for _, cand := range id.route {
+		if cand == "" {
+			continue
+		}
+		if appKey == cand || chartName == cand {
+			return true
+		}
+		if displayName != "" && strings.HasPrefix(displayName, cand) {
+			return true
+		}
+	}
+
+	// Resolved release names — exact label identity only (see the struct doc).
+	for _, rel := range id.release {
+		if podCarriesReleaseIdentity(p, rel) {
+			return true
+		}
+	}
+	return false
+}
+
+// resolveComponentWorkloadIdentity walks the authoritative link from the route
+// id to the workload it actually installs.
+//
+//	Application CR ──spec.helmRelease{name,namespace}──▶ HelmRelease
+//	      │                (or the adopts-helmrelease label)     │
+//	      └─ spec.releaseName / spec.targetNamespace             └─ spec.releaseName / spec.targetNamespace
+//
+// Both hops are best-effort and independently useful: a wizard-installed app
+// resolves off its own CR fields, a bare bootstrap-kit HelmRelease resolves off
+// the HR alone (the #3370 shape, where the console addresses the RELEASE
+// `shared-pg` while the HR is named `bp-postgres-shared`), and a spine CR
+// resolves through the adoption pointer. Every miss leaves the identity exactly
+// as the caller stated it, so a cluster with no CRDs, an unregistered informer,
+// or a component that is neither CR- nor HR-backed behaves as it did before.
+func (h *Handler) resolveComponentWorkloadIdentity(primaryID, name, ns string) componentWorkloadIdentity {
+	id := routeWorkloadIdentity(name, ns)
+	if h.k8sCache == nil || strings.TrimSpace(primaryID) == "" || len(id.route) == 0 {
+		return id
+	}
+
+	route := make(map[string]struct{}, len(id.route))
+	for _, c := range id.route {
+		route[c] = struct{}{}
+	}
+
+	// (1) The Application CR, when the route id names one.
+	//
+	// 🔒 Organization isolation: the CR is selected the way getApplicationCR
+	// already selects it — an EXACT (name, namespace) match when the caller
+	// scoped the request (the console passes the CR's own namespace), and a
+	// cluster-wide name match only when it did not. Accepting any namespace on
+	// a scoped request would let one Organization's `wordpress` answer for
+	// another's.
+	crNS := strings.TrimSpace(ns)
+	var hrName, hrNS string
+	if apps, _, err := h.k8sCache.List(primaryID, "application", labels.Everything()); err == nil {
+		for _, a := range apps {
+			if a == nil {
+				continue
+			}
+			if _, ok := route[a.GetName()]; !ok {
+				continue
+			}
+			if crNS != "" && a.GetNamespace() != crNS {
+				continue
+			}
+			if rn, _, _ := unstructured.NestedString(a.Object, "spec", "releaseName"); rn != "" {
+				id.addRelease(rn)
+			}
+			if tn, _, _ := unstructured.NestedString(a.Object, "spec", "targetNamespace"); tn != "" {
+				id.addNamespace(tn)
+			}
+			if n, _, _ := unstructured.NestedString(a.Object, "spec", "helmRelease", "name"); n != "" {
+				hrName = n
+				hrNS, _, _ = unstructured.NestedString(a.Object, "spec", "helmRelease", "namespace")
+			} else if adopted := strings.TrimSpace(a.GetLabels()[spineAdoptsHelmReleaseLabel]); adopted != "" {
+				hrName = adopted
+			}
+			break
+		}
+	}
+
+	// (2) The HelmRelease — the one the CR adopts, or one the route id names
+	// directly (by object name or by spec.releaseName, the #3370 pair).
+	if hrs, _, err := h.k8sCache.List(primaryID, "helmrelease", labels.Everything()); err == nil {
+		for _, hr := range hrs {
+			if hr == nil {
+				continue
+			}
+			releaseName, _, _ := unstructured.NestedString(hr.Object, "spec", "releaseName")
+			if !helmReleaseNamesComponent(hr, releaseName, route, hrName, hrNS) {
+				continue
+			}
+			if releaseName == "" {
+				// Flux v2 default: the release takes the HR's own name.
+				releaseName = hr.GetName()
+			}
+			id.addRelease(releaseName)
+			if tn, _, _ := unstructured.NestedString(hr.Object, "spec", "targetNamespace"); tn != "" {
+				id.addNamespace(tn)
+			}
+		}
+	}
+
+	return id
+}
+
+// helmReleaseNamesComponent reports whether this HelmRelease is the one backing
+// the component — either because the Application CR pointed at it
+// (`spec.helmRelease`, matched on namespace too when the CR stated one), or
+// because the route id is the HR's own name or its release name.
+func helmReleaseNamesComponent(hr *unstructured.Unstructured, releaseName string, route map[string]struct{}, hrName, hrNS string) bool {
+	if hrName != "" && hr.GetName() == hrName && (hrNS == "" || hr.GetNamespace() == hrNS) {
+		return true
+	}
+	if _, ok := route[hr.GetName()]; ok {
+		return true
+	}
+	if releaseName != "" {
+		if _, ok := route[releaseName]; ok {
+			return true
+		}
+	}
+	return false
+}

--- a/products/catalyst/bootstrap/api/internal/handler/applications_placement_runtime.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications_placement_runtime.go
@@ -148,7 +148,18 @@ func (h *Handler) HandleApplicationPlacement(w http.ResponseWriter, r *http.Requ
 	// "the cache can only see one region" that looks identical downstream.
 	depID, fqdn, declaredRegions := h.placementDeploymentIdentity(urlID)
 
-	targets, cov := h.derivePlacementTargets(name, ns, primaryID, clusterRegion, depID, fqdn)
+	// #6344 — resolve WHAT this component's workload is called before asking
+	// where it runs. The route id is what the console addresses, not what the
+	// chart labelled: `spine-gitea` is an Application CR adopting HelmRelease
+	// `flux-system/bp-gitea`, whose Pods are `instance=gitea` in ns `gitea`.
+	// Matching the route id against pod labels made occupancy miss every one of
+	// them, so no Primary was ever produced and the Continuum augmentation's
+	// lone `cluster: ""` Standby became the whole answer (hw298). Resolution
+	// only ADDS identities a live Application CR / HelmRelease names — it can
+	// widen which Pods are looked at, never invent one that is not there.
+	ident := h.resolveComponentWorkloadIdentity(primaryID, name, ns)
+
+	targets, cov := h.derivePlacementTargets(ident, primaryID, clusterRegion, depID, fqdn)
 
 	// #4551 — Standby discovery for cross-region CNPG-backed components.
 	//
@@ -669,7 +680,10 @@ type placementOccupancy struct {
 // DATA while the caller keeps asserting `derivedFromRuntime: true` is what
 // turned a blind cache into a fabricated singleton. The coverage report is how
 // the caller can tell the two apart.
-func (h *Handler) derivePlacementTargets(name, ns, primaryID string, clusterRegion map[string]string, depID, fqdn string) ([]bpv1.PlacementTarget, placementRuntimeCoverage) {
+// #6344: it takes a RESOLVED componentWorkloadIdentity rather than a raw
+// (name, ns) pair, so the Pods it keeps are the ones the Application actually
+// installs — not the ones whose labels happen to spell the route id.
+func (h *Handler) derivePlacementTargets(ident componentWorkloadIdentity, primaryID string, clusterRegion map[string]string, depID, fqdn string) ([]bpv1.PlacementTarget, placementRuntimeCoverage) {
 	// Fan out across primary + every secondary region cluster.
 	clusterIDs := []string{primaryID}
 	seen := map[string]struct{}{primaryID: {}}
@@ -707,7 +721,7 @@ func (h *Handler) derivePlacementTargets(name, ns, primaryID string, clusterRegi
 		nodeByName := indexByName(nodes)
 
 		for _, p := range pods {
-			if !podBelongsToComponent(p, name, ns) {
+			if !podBelongsToIdentity(p, ident) {
 				continue
 			}
 			region := podRegion(p, nsByName, nodeByName, clusterRegion[cid])
@@ -840,37 +854,14 @@ func componentNameCandidates(name string) []string {
 // as `grafana-…-x-grafana-x-mgmt-vcluster` in host ns `mgmt` but still
 // labelled `app.kubernetes.io/{instance,name}=grafana` — resolve instead of
 // yielding a false singleton.
+//
+// #6344 — this is now a thin projection onto podBelongsToIdentity with the
+// UNRESOLVED (route-only) identity, i.e. byte-for-byte the behaviour above.
+// The placement path passes a RESOLVED identity instead; keeping both on one
+// predicate is what stops the two surfaces answering "does this component
+// exist" and "where does it run" from different joins again (#5827).
 func podBelongsToComponent(p *unstructured.Unstructured, name, ns string) bool {
-	if p == nil || name == "" {
-		return false
-	}
-	if ns != "" && !objectInAppNamespace(p, ns) {
-		return false
-	}
-	// nil ReplicaSet index: this join has no cache handle, so a Pod owned
-	// by a ReplicaSet keeps the ReplicaSet name (pre-#5485 behavior). The
-	// instance/name labels below carry the match in the cases this
-	// function is called for.
-	appKey := applicationKey(p, nil)
-	chartName := p.GetLabels()["app.kubernetes.io/name"]
-	// The de-mangled in-vCluster object name (loft annotation), e.g. a host
-	// Pod `grafana-…-x-grafana-x-mgmt-vcluster` carries object-name
-	// `grafana-…`. The instance/name labels match in the common case; this
-	// resolves charts that omit the instance label via the synced
-	// Deployment/StatefulSet owner name prefix.
-	displayName := vClusterSyncedDisplayName(p)
-	for _, cand := range componentNameCandidates(name) {
-		if appKey == cand {
-			return true
-		}
-		if chartName == cand {
-			return true
-		}
-		if displayName != "" && strings.HasPrefix(displayName, cand) {
-			return true
-		}
-	}
-	return false
+	return podBelongsToIdentity(p, routeWorkloadIdentity(name, ns))
 }
 
 // podRegion derives the region a Pod runs in: pod label → namespace label →

--- a/products/catalyst/bootstrap/api/internal/handler/applications_placement_workload_identity_6344_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications_placement_workload_identity_6344_test.go
@@ -1,0 +1,413 @@
+package handler
+
+// applications_placement_workload_identity_6344_test.go — UAT row 60 (#3375),
+// the hw298 reproduction.
+//
+// WHAT WAS MEASURED. On hw298 (dep 2540d866403f1f7c), owner session, one
+// binary, one pass, four Ready Applications answered the SAME endpoint:
+//
+//	shared-pg      ns shared-data  active-hot-standby → 2 targets, Primary + Standby, clusters set, derivedFromRuntime true
+//	spine-gitea    ns catalyst     active-hot-standby → 1 target,  Standby, cluster "", unresolvedPrimary true
+//	spine-keycloak ns catalyst     active-hot-standby → 1 target,  Standby, cluster "", unresolvedPrimary true
+//	spine-openbao  ns catalyst     active-passive     → 1 target,  Standby, cluster "", unresolvedPrimary true
+//
+// `shared-pg` is the CONTROL: the projection works, so the fix cannot be "make
+// the projection work". The three that collapse differ in one property only —
+// their Pods do not carry their name. `shared-pg` owns a CNPG Cluster called
+// `shared-pg`; `spine-gitea` is an Application CR in ns `catalyst` adopting
+// HelmRelease `flux-system/bp-gitea`, whose Pods are `instance=gitea` in ns
+// `gitea`. Occupancy matched none of them, no Primary was produced, and the
+// Continuum augmentation's lone `cluster: ""` Standby became the whole answer.
+//
+// The three cases below are exactly that discriminator, plus the invariant the
+// fix must NOT trade away.
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	kfake "k8s.io/client-go/kubernetes/fake"
+
+	bpv1 "github.com/openova-io/openova/core/controllers/pkg/apis/blueprint/v1alpha1"
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/k8scache"
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/provisioner"
+)
+
+// identityFixturePod — a Pod carrying the identity a HELM CHART stamps, in the
+// namespace the chart installs into. `instance` is the Helm release name, which
+// for the failing shapes is NOT the Application's name.
+func identityFixturePod(ns, name, instance, region, cnpgRole string) *unstructured.Unstructured {
+	lbls := map[string]any{
+		"app.kubernetes.io/instance": instance,
+		"app.kubernetes.io/name":     instance,
+	}
+	if region != "" {
+		lbls["openova.io/region"] = region
+	}
+	if cnpgRole != "" {
+		lbls["openova.io/cnpg-role"] = cnpgRole
+		lbls["cnpg.io/cluster"] = instance
+	}
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata": map[string]any{
+			"namespace":         ns,
+			"name":              name,
+			"creationTimestamp": time.Now().Add(-time.Hour).UTC().Format(time.RFC3339),
+			"resourceVersion":   "1",
+			"labels":            lbls,
+		},
+		"spec": map[string]any{
+			"containers": []any{map[string]any{"name": "main", "image": "ghcr.io/x:1"}},
+		},
+		"status": map[string]any{
+			"phase":      "Running",
+			"conditions": []any{map[string]any{"type": "Ready", "status": "True"}},
+		},
+	}}
+}
+
+// spineApplicationFixtureCR — the shape post_handover_spine_apps.go actually
+// applies: named `spine-<chart>` in ns `catalyst`, spec.bootstrap true, and the
+// ADOPTION pointer at the bootstrap HelmRelease. It carries NO releaseName and
+// NO targetNamespace of its own — the workload identity lives one hop away.
+func spineApplicationFixtureCR(name, hrName, hrNS string) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{}
+	u.SetAPIVersion("apps.openova.io/v1")
+	u.SetKind("Application")
+	u.SetName(name)
+	u.SetNamespace("catalyst")
+	// The label is spelled out rather than taken from the const it mirrors:
+	// this fixture stands in for what a LIVE cluster carries, and a fixture
+	// that reads the same const the code reads cannot notice the const moving.
+	u.SetLabels(map[string]string{"catalyst.openova.io/adopts-helmrelease": hrName})
+	_ = unstructured.SetNestedMap(u.Object, map[string]any{
+		"bootstrap": true,
+		"helmRelease": map[string]any{
+			"name":      hrName,
+			"namespace": hrNS,
+		},
+	}, "spec")
+	return u
+}
+
+// helmReleaseFixture — the bootstrap-kit HR shape
+// (clusters/_template/bootstrap-kit/10-gitea.yaml): `bp-<chart>` in flux-system
+// declaring the release name and the namespace the workload installs into.
+func helmReleaseFixture(name, ns, releaseName, targetNS string) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{}
+	u.SetAPIVersion("helm.toolkit.fluxcd.io/v2")
+	u.SetKind("HelmRelease")
+	u.SetName(name)
+	u.SetNamespace(ns)
+	_ = unstructured.SetNestedMap(u.Object, map[string]any{
+		"releaseName":     releaseName,
+		"targetNamespace": targetNS,
+	}, "spec")
+	return u
+}
+
+// identityFixtureClients builds a fake dynamic client that knows the FOUR kinds
+// this join reads: Pods (occupancy), Namespaces + Nodes (the region join), and
+// the Application / HelmRelease CRs that carry the authoritative identity link.
+func identityFixtureClients(objs ...runtime.Object) (*dynamicfake.FakeDynamicClient, *kfake.Clientset) {
+	scheme := runtime.NewScheme()
+	kinds := []schema.GroupVersionKind{
+		{Version: "v1", Kind: "Pod"}, {Version: "v1", Kind: "PodList"},
+		{Version: "v1", Kind: "Namespace"}, {Version: "v1", Kind: "NamespaceList"},
+		{Version: "v1", Kind: "Node"}, {Version: "v1", Kind: "NodeList"},
+		{Group: "apps.openova.io", Version: "v1", Kind: "Application"},
+		{Group: "apps.openova.io", Version: "v1", Kind: "ApplicationList"},
+		{Group: "helm.toolkit.fluxcd.io", Version: "v2", Kind: "HelmRelease"},
+		{Group: "helm.toolkit.fluxcd.io", Version: "v2", Kind: "HelmReleaseList"},
+	}
+	for _, gvk := range kinds {
+		if len(gvk.Kind) > 4 && gvk.Kind[len(gvk.Kind)-4:] == "List" {
+			scheme.AddKnownTypeWithName(gvk, &unstructured.UnstructuredList{})
+			continue
+		}
+		scheme.AddKnownTypeWithName(gvk, &unstructured.Unstructured{})
+	}
+	listKinds := map[schema.GroupVersionResource]string{
+		{Version: "v1", Resource: "pods"}:                                          "PodList",
+		{Version: "v1", Resource: "namespaces"}:                                    "NamespaceList",
+		{Version: "v1", Resource: "nodes"}:                                         "NodeList",
+		{Group: "apps.openova.io", Version: "v1", Resource: "applications"}:        "ApplicationList",
+		{Group: "helm.toolkit.fluxcd.io", Version: "v2", Resource: "helmreleases"}: "HelmReleaseList",
+	}
+	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds, objs...), kfake.NewSimpleClientset()
+}
+
+// newIdentityPlacementHandler wires a two-region k8scache (pods + the CR kinds
+// the identity link is read from) AND a sovereign dynamic client seeded with
+// the Continuum CRs, so augmentWithContinuumStandby — the ONLY term that can
+// emit a `cluster: ""` Standby — is genuinely reachable. Without it the pre-fix
+// symptom would degrade to an empty target list and the test would be pinning
+// something the walk never saw.
+func newIdentityPlacementHandler(
+	t *testing.T,
+	depID, regionA, regionB string,
+	objsA, objsB []runtime.Object,
+	continuumCRs []runtime.Object,
+) *Handler {
+	t.Helper()
+
+	clusterA := depID
+	clusterB := depID + "-" + regionB
+
+	reg := k8scache.NewRegistry()
+	for _, k := range []k8scache.Kind{
+		{Name: "pod", GVR: schema.GroupVersionResource{Version: "v1", Resource: "pods"}, Namespaced: true},
+		{Name: "namespace", GVR: schema.GroupVersionResource{Version: "v1", Resource: "namespaces"}},
+		{Name: "node", GVR: schema.GroupVersionResource{Version: "v1", Resource: "nodes"}},
+		{Name: "application", GVR: schema.GroupVersionResource{Group: "apps.openova.io", Version: "v1", Resource: "applications"}, Namespaced: true},
+		{Name: "helmrelease", GVR: schema.GroupVersionResource{Group: "helm.toolkit.fluxcd.io", Version: "v2", Resource: "helmreleases"}, Namespaced: true},
+	} {
+		if err := reg.Add(k); err != nil {
+			t.Fatalf("registry add %s: %v", k.Name, err)
+		}
+	}
+
+	dynA, coreA := identityFixtureClients(objsA...)
+	dynB, coreB := identityFixtureClients(objsB...)
+
+	f, err := k8scache.NewFactory(k8scache.Config{
+		Logger:   quietHandlerLogger(),
+		Registry: reg,
+		Clusters: []k8scache.ClusterRef{
+			{ID: clusterA, DynamicClient: dynA, CoreClient: coreA},
+			{ID: clusterB, DynamicClient: dynB, CoreClient: coreB},
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewFactory: %v", err)
+	}
+	if err := f.Start(t.Context()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(f.Stop)
+
+	// Wait for BOTH clusters' pod informers AND cluster A's CR informers.
+	// Asserting on counts rather than sleeping keeps a slow machine from
+	// turning "not synced yet" into "the fix does not work".
+	deadline := time.Now().Add(3 * time.Second)
+	wantA, wantB := countKind(objsA, "Pod"), countKind(objsB, "Pod")
+	wantApps, wantHRs := countKind(objsA, "Application"), countKind(objsA, "HelmRelease")
+	for time.Now().Before(deadline) {
+		a, _, _ := f.List(clusterA, "pod", labels.Everything())
+		b, _, _ := f.List(clusterB, "pod", labels.Everything())
+		apps, _, _ := f.List(clusterA, "application", labels.Everything())
+		hrs, _, _ := f.List(clusterA, "helmrelease", labels.Everything())
+		if len(a) >= wantA && len(b) >= wantB && len(apps) >= wantApps && len(hrs) >= wantHRs {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	h := NewWithPDM(quietHandlerLogger(), &fakePDM{})
+	h.SetK8sCache(f, k8scache.NewSARCache(), "")
+	factory, _ := fakeContinuumDynamicFactory(continuumCRs...)
+	h.dynamicFactory = factory
+
+	kubeconfig := filepath.Join(t.TempDir(), depID+".yaml")
+	if err := os.WriteFile(kubeconfig, []byte("apiVersion: v1\nkind: Config"), 0o600); err != nil {
+		t.Fatalf("write kubeconfig: %v", err)
+	}
+	h.deployments.Store(depID, &Deployment{
+		ID:     depID,
+		Status: "ready",
+		Request: provisioner.Request{
+			SovereignFQDN: "t99.omani.works",
+			Regions: []provisioner.RegionSpec{
+				{CloudRegion: regionA},
+				{CloudRegion: regionB},
+			},
+		},
+		Result: &provisioner.Result{
+			SovereignFQDN:  "t99.omani.works",
+			KubeconfigPath: kubeconfig,
+		},
+	})
+	return h
+}
+
+func countKind(objs []runtime.Object, kind string) int {
+	n := 0
+	for _, o := range objs {
+		if u, ok := o.(*unstructured.Unstructured); ok && u.GetKind() == kind {
+			n++
+		}
+	}
+	return n
+}
+
+// TestPlacementWorkloadIdentity_Row60_6344 — the hw298 discriminator, run as
+// one table so the CONTROL and the DEFECT are answered by the same code path
+// in the same run. A fix that only moves the failing rows by breaking the
+// control fails here too.
+func TestPlacementWorkloadIdentity_Row60_6344(t *testing.T) {
+	const (
+		regionA = "me-east-215-a"
+		regionB = "me-east-215-b"
+	)
+
+	cases := []struct {
+		name    string
+		depID   string
+		appName string
+		queryNS string
+		objsA   []runtime.Object
+		objsB   []runtime.Object
+		crs     []runtime.Object
+
+		wantTargets      int
+		wantPrimary      bool
+		wantStandby      bool
+		wantDerived      bool
+		wantUnresolvedPr bool
+		wantPrimaryRegn  string
+		wantStandbyRegn  string
+		wantPattern      bpv1.Pattern
+		why              string
+	}{
+		{
+			// THE CONTROL — hw298 row 1. The app name coincides with the
+			// identity its own Pods carry, which is the ONLY reason this row
+			// was green. It must stay green: resolution widens, never narrows.
+			name:    "shared-pg shape: pod labels equal the app name — still resolves both legs",
+			depID:   "dep-6344-sharedpg",
+			appName: "shared-pg",
+			queryNS: "shared-data",
+			objsA: []runtime.Object{
+				identityFixturePod("shared-data", "shared-pg-1", "shared-pg", regionA, cnpgRolePrimary),
+				helmReleaseFixture("bp-postgres-shared", "flux-system", "shared-pg", "shared-data"),
+			},
+			objsB: []runtime.Object{
+				identityFixturePod("shared-data", "shared-pg-r-1", "shared-pg", regionB, cnpgRoleReplica),
+			},
+			wantTargets:     2,
+			wantPrimary:     true,
+			wantStandby:     true,
+			wantDerived:     true,
+			wantPrimaryRegn: regionA,
+			wantStandbyRegn: regionB,
+			wantPattern:     bpv1.PatternActiveHotStandby,
+			why:             "the control proves the projection works; if this row moves, the fix broke what already worked",
+		},
+		{
+			// THE DEFECT — hw298 rows 2-4. Identical backing state, identical
+			// binary; the app name simply does not appear on its own Pods.
+			//
+			// PRE-FIX this returns exactly what the walk recorded: ONE target,
+			// role Standby, cluster "", unresolvedPrimary true,
+			// derivedFromRuntime false — which the Topology tab draws as
+			// `Pattern: not reported`, one card, Switchover disabled.
+			name:    "spine-gitea shape: pods carry the RELEASE identity, not the app name",
+			depID:   "dep-6344-spinegitea",
+			appName: "spine-gitea",
+			queryNS: "catalyst",
+			objsA: []runtime.Object{
+				identityFixturePod("gitea", "gitea-75d9f486fb-g8hsr", "gitea", regionA, ""),
+				spineApplicationFixtureCR("spine-gitea", "bp-gitea", "flux-system"),
+				helmReleaseFixture("bp-gitea", "flux-system", "gitea", "gitea"),
+			},
+			objsB: []runtime.Object{},
+			crs: []runtime.Object{
+				newContinuumUnstructured("dr-spine-gitea", "catalyst", "spine-gitea", regionA, []string{regionB}),
+			},
+			wantTargets:     2,
+			wantPrimary:     true,
+			wantStandby:     true,
+			wantDerived:     true,
+			wantPrimaryRegn: regionA,
+			wantStandbyRegn: regionB,
+			wantPattern:     bpv1.PatternActiveHotStandby,
+			why:             "row 60's clause: region-a primary + region-b replica, not one card",
+		},
+		{
+			// THE INVARIANT the fix must not trade away (#6268 / #6271).
+			// Same authoritative link, same Continuum declaration — and NO
+			// Pods anywhere. The declaration must NOT be promoted into an
+			// observation: no Primary may be invented, and the half-pair must
+			// still refuse to claim derivedFromRuntime.
+			name:    "genuinely absent workload: declaration must not become an observed Primary",
+			depID:   "dep-6344-absent",
+			appName: "spine-keycloak",
+			queryNS: "catalyst",
+			objsA: []runtime.Object{
+				spineApplicationFixtureCR("spine-keycloak", "bp-keycloak", "flux-system"),
+				helmReleaseFixture("bp-keycloak", "flux-system", "keycloak", "keycloak"),
+			},
+			objsB: []runtime.Object{},
+			crs: []runtime.Object{
+				newContinuumUnstructured("dr-spine-keycloak", "catalyst", "spine-keycloak", regionA, []string{regionB}),
+			},
+			wantTargets:      1,
+			wantPrimary:      false,
+			wantStandby:      true,
+			wantDerived:      false,
+			wantUnresolvedPr: true,
+			wantStandbyRegn:  regionB,
+			why:              "no pods observed anywhere — the honest answer is an unresolved half-pair, never a fabricated Primary",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newIdentityPlacementHandler(t, tc.depID, regionA, regionB, tc.objsA, tc.objsB, tc.crs)
+			resp := callPlacementNS(t, h, tc.depID, tc.appName, tc.queryNS)
+
+			if len(resp.Targets) != tc.wantTargets {
+				t.Fatalf("#6344 %s: got %d target(s) want %d — %s (targets=%+v, derivedFromRuntime=%v, unresolvedPrimary=%v)",
+					tc.appName, len(resp.Targets), tc.wantTargets, tc.why, resp.Targets, resp.DerivedFromRuntime, resp.UnresolvedPrimary)
+			}
+			if got := hasPrimaryTarget(resp.Targets); got != tc.wantPrimary {
+				t.Fatalf("#6344 %s: hasPrimary=%v want %v — %s (targets=%+v)",
+					tc.appName, got, tc.wantPrimary, tc.why, resp.Targets)
+			}
+			if got := hasStandbyTarget(resp.Targets); got != tc.wantStandby {
+				t.Fatalf("#6344 %s: hasStandby=%v want %v (targets=%+v)", tc.appName, got, tc.wantStandby, resp.Targets)
+			}
+			if resp.DerivedFromRuntime != tc.wantDerived {
+				t.Fatalf("#6344 %s: derivedFromRuntime=%v want %v (targets=%+v)",
+					tc.appName, resp.DerivedFromRuntime, tc.wantDerived, resp.Targets)
+			}
+			if resp.UnresolvedPrimary != tc.wantUnresolvedPr {
+				t.Fatalf("#6344 %s: unresolvedPrimary=%v want %v — a Standby with no Primary renders identically to an honest single-region app (targets=%+v)",
+					tc.appName, resp.UnresolvedPrimary, tc.wantUnresolvedPr, resp.Targets)
+			}
+
+			primary := targetByRole(resp.Targets, bpv1.DataRolePrimary)
+			standby := targetByRole(resp.Targets, bpv1.DataRoleStandby)
+			if tc.wantPrimaryRegn != "" {
+				if primary == nil || primary.Region != tc.wantPrimaryRegn {
+					t.Fatalf("#6344 %s: Primary region %+v want %q", tc.appName, primary, tc.wantPrimaryRegn)
+				}
+				// An empty `cluster` on the Primary was one of the two live
+				// symptoms; an observed leg always names the cluster it ran on.
+				if primary.Cluster == "" {
+					t.Fatalf("#6344 %s: Primary carries an EMPTY cluster (%+v) — that is the augmentation's synthetic leg, not an observation", tc.appName, *primary)
+				}
+			}
+			if tc.wantStandbyRegn != "" {
+				if standby == nil || standby.Region != tc.wantStandbyRegn {
+					t.Fatalf("#6344 %s: Standby region %+v want %q", tc.appName, standby, tc.wantStandbyRegn)
+				}
+			}
+			if tc.wantPattern != "" {
+				if got := bpv1.DerivePattern(resp.Targets, bpv1.CapabilityPrimaryStandby); got != tc.wantPattern {
+					t.Fatalf("#6344 %s: pattern %q want %q — the tab showed `Pattern: not reported` (targets=%+v)",
+						tc.appName, got, tc.wantPattern, resp.Targets)
+				}
+			}
+		})
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/applications_placement_workload_identity_resolver_6344_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications_placement_workload_identity_resolver_6344_test.go
@@ -1,0 +1,72 @@
+package handler
+
+// applications_placement_workload_identity_resolver_6344_test.go — the half of
+// the #6344 contract the endpoint-level table cannot see: resolution is
+// ADDITIVE. It lives in its own file because it names the resolver directly,
+// which is API that does not exist on the pre-fix tree the table test is
+// watched RED against.
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// Two ways this fix could regress into a NEW miss rather than removing one —
+// both pinned here. (a) A route candidate dropped in favour of the resolved
+// release name would break every app that resolves today by coincidence
+// (shared-pg, grafana, every bp-* route id). (b) Adopting the HelmRelease's
+// targetNamespace when the caller passed NO namespace would turn "match
+// anywhere" — the documented bootstrap-safe default the console relies on for
+// exactly these components (#4000) — into "match one namespace", which is the
+// same defect pointed the other way.
+func TestResolveComponentWorkloadIdentity_NeverNarrows_6344(t *testing.T) {
+	const (
+		depID   = "dep-6344-widen"
+		regionA = "me-east-215-a"
+		regionB = "me-east-215-b"
+	)
+	h := newIdentityPlacementHandler(t, depID, regionA, regionB,
+		[]runtime.Object{
+			spineApplicationFixtureCR("spine-gitea", "bp-gitea", "flux-system"),
+			helmReleaseFixture("bp-gitea", "flux-system", "gitea", "gitea"),
+		}, nil, nil)
+
+	scoped := h.resolveComponentWorkloadIdentity(depID, "spine-gitea", "catalyst")
+	if !containsString(scoped.route, "spine-gitea") {
+		t.Fatalf("route candidate dropped: %+v — resolution must ADD, never replace", scoped)
+	}
+	if !containsString(scoped.release, "gitea") {
+		t.Fatalf("release identity not resolved through spec.helmRelease -> HR releaseName: %+v", scoped)
+	}
+	if !containsString(scoped.namespaces, "catalyst") || !containsString(scoped.namespaces, "gitea") {
+		t.Fatalf("namespaces %v want BOTH the requested `catalyst` and the HR targetNamespace `gitea`", scoped.namespaces)
+	}
+
+	unscoped := h.resolveComponentWorkloadIdentity(depID, "spine-gitea", "")
+	if len(unscoped.namespaces) != 0 {
+		t.Fatalf("namespaces %v want EMPTY — a caller that scoped nothing must keep matching every namespace; adopting the targetNamespace here is a new way to MISS pods", unscoped.namespaces)
+	}
+	if !containsString(unscoped.release, "gitea") {
+		t.Fatalf("release identity must still resolve without a namespace scope: %+v", unscoped)
+	}
+
+	// 🔒 Organization isolation. The CR is selected exactly as
+	// getApplicationCR selects it: a SCOPED request must not pick up a
+	// same-named Application from another namespace, because the identity it
+	// yields then decides which Pods a different Organization's Topology tab
+	// reports on.
+	elsewhere := h.resolveComponentWorkloadIdentity(depID, "spine-gitea", "some-other-org")
+	if containsString(elsewhere.release, "gitea") {
+		t.Fatalf("a scoped request resolved a CR from ANOTHER namespace: %+v", elsewhere)
+	}
+}
+
+func containsString(ss []string, want string) bool {
+	for _, s := range ss {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}

--- a/products/catalyst/bootstrap/api/internal/handler/post_handover_spine_apps.go
+++ b/products/catalyst/bootstrap/api/internal/handler/post_handover_spine_apps.go
@@ -503,7 +503,7 @@ func renderSpineApplicationCR(sc spineComponent, envRef, orgRef string, regions 
 	// CR apart from an Org install, and the adopt label names the existing
 	// HelmRelease this CR ENROLLS (never re-renders).
 	lbls["catalyst.openova.io/spine"] = "true"
-	lbls["catalyst.openova.io/adopts-helmrelease"] = sc.HRName
+	lbls[spineAdoptsHelmReleaseLabel] = sc.HRName
 	obj.SetLabels(lbls)
 
 	rgs := make([]interface{}, 0, len(regions))


### PR DESCRIPTION
## What was measured

hw298, dep `2540d866403f1f7c`, owner session, all four Applications `phase: Ready`,
same binary, same pass, same endpoint
(`GET /sovereign/api/v1/sovereigns/{id}/applications/{name}/placement?namespace={ns}`):

| app | ns | declared | targets returned | derivedFromRuntime | unresolvedPrimary |
|---|---|---|---|---|---|
| **shared-pg** | shared-data | active-hot-standby | **2 — Primary(cluster set) + Standby(cluster set)** | **true** | — |
| spine-gitea | catalyst | active-hot-standby | 1 — Standby, `cluster: ""` | false | **true** |
| spine-keycloak | catalyst | active-hot-standby | 1 — Standby, `cluster: ""` | false | **true** |
| spine-openbao | catalyst | active-passive | 1 — Standby, `cluster: ""` | false | **true** |

`shared-pg` is the **control**, and it is the reason this PR does not re-implement
anything: the projection works, so #6268 / #6291 / #6301 are present and functioning.
The three that collapse differ from it in exactly one property — and it is not a
property of the app.

## The seam, quoted

`derivePlacementTargets` (`applications_placement_runtime.go:710`, pre-fix) keeps a Pod
only when `podBelongsToComponent(p, name, ns)` says so. That predicate
(`applications_placement_runtime.go:843`, pre-fix) compares
`componentNameCandidates(name)` — which is only `{name, strings.TrimPrefix(name, "bp-")}`
(`:816`) — against `applicationKey(p, nil)` (the `app.kubernetes.io/instance` label,
falling back to `app.kubernetes.io/name`, then ownerRefs — `dashboard.go:711`),
`app.kubernetes.io/name`, and the loft display-name **prefix**.

So a Pod is joined to its Application by **string coincidence between the route id and a
label the chart happens to stamp**.

- `shared-pg` matches because the CNPG Cluster it owns is itself named `shared-pg`, so
  the Pods' identity resolves back to the app's own name.
- `spine-gitea` is an Application CR (`post_handover_spine_apps.go:472`) named
  `spine-gitea` in ns `catalyst` that **adopts** HelmRelease `flux-system/bp-gitea` via
  `spec.helmRelease`. That HR declares `releaseName: gitea` and `targetNamespace: gitea`
  (`clusters/_template/bootstrap-kit/10-gitea.yaml:63-64`); its Pods are labelled
  `app.kubernetes.io/instance=gitea` and live in ns `gitea`. Neither the name nor the
  namespace coincides, occupancy matches nothing, **no Primary is produced**, and control
  falls through to `augmentWithContinuumStandby` (`:491`) — the only term in the whole
  path that can emit `cluster: ""` — leaving the lone Standby.

The blast radius is therefore neither "Catalog-provisioned apps" (the hw296 reading) nor
"spine apps" (the hw298 reading): it is **every Application whose name does not appear on
its own Pods**.

## The mechanism this replaces it with, and why that one

Application CR → adopted HelmRelease → `spec.releaseName` + `spec.targetNamespace`.

Chosen because the package **already trusts exactly this chain everywhere else**, so this
removes a second derivation rather than adding one:

- `installLabelSelectorForHR` (`applications.go:1959`, #1928) builds the Resources/Logs
  tab selector as `app.kubernetes.io/instance=<releaseName>` off these same fields — and
  #1928 is the issue that pinned the contract that every Helm-rendered object of release
  R carries that label.
- `hrLookupName` (`applications.go:1863`, #4889) already makes the identical hop —
  `spine-gitea → flux-system/bp-gitea` through `spec.helmRelease.name` — for the HR-Ready
  overlay. That fix was applied to the status surface and not to the placement surface.
- The CR itself is selected the way `getApplicationCR` (`applications.go:1279`) selects
  it: exact `(name, namespace)` when the caller scoped, cluster-wide name match when it
  did not.

## Honesty invariants — what is deliberately NOT traded

- **Strictly widening.** Resolution only ADDS identity strings and namespaces that a live
  authoritative object NAMES. Route candidates are never dropped, so every app resolving
  today by coincidence keeps resolving. The namespace set is never narrowed: when the
  caller passed no `?namespace=` it stays empty (match anywhere, the documented
  bootstrap-safe default, #4000), because turning "anywhere" into "the declared
  targetNamespace" would be a **new** way to miss Pods.
- **No fabricated Primary.** Everything added here decides which Pods are *looked at*. An
  app with no Pods in a region still yields no occupancy there, still yields no Primary,
  and the #6268 half-pair refusal still fires — a declaration is never promoted into an
  observation. Third table row pins this.
- **`derivedFromRuntime` untouched.** The #6015/#6271 coverage gate and the #6301
  positively-observed-follower rule are not modified; a lone Primary still yields an
  honest unknown.
- **Organization isolation.** A scoped request cannot resolve a same-named Application
  from another namespace.
- **One predicate, still.** `podBelongsToComponent` becomes a thin projection onto
  `podBelongsToIdentity` with the route-only identity — byte-for-byte the old behaviour —
  so the #5827 existence check and the placement join cannot answer "does this component
  exist" differently. The AST guard in
  `applications_runtime_synth_5827_test.go` stays meaningful and still passes.

## Proof — RED then green

The pre-fix tree was materialised with `git archive origin/main` (`a14b991e1`), **not** by
reverting the change in place. The harness aborts if the fix is present in the archived
tree; it printed the pre-fix call site before running:

```
PRE-FIX TREE CONFIRMED: no applications_placement_identity_6344.go, derivePlacementTargets still calls podBelongsToComponent
710:			if !podBelongsToComponent(p, name, ns) {
```

**RED (origin/main + the new table test):**

```
--- FAIL: TestPlacementWorkloadIdentity_Row60_6344 (0.06s)
    --- PASS: .../shared-pg_shape:_pod_labels_equal_the_app_name_—_still_resolves_both_legs (0.02s)
    --- FAIL: .../spine-gitea_shape:_pods_carry_the_RELEASE_identity,_not_the_app_name (0.02s)
    --- PASS: .../genuinely_absent_workload:_declaration_must_not_become_an_observed_Primary (0.02s)

applications_placement_workload_identity_6344_test.go:369: #6344 spine-gitea: got 1 target(s) want 2 —
  row 60's clause: region-a primary + region-b replica, not one card
  (targets=[{Region:me-east-215-b Cluster: VCluster: Role:Standby StandbyType:Hot}],
   derivedFromRuntime=false, unresolvedPrimary=true)
TRUE-RC=1
```

That is the hw298 wire shape reproduced field for field: one target, role Standby, **empty
`Cluster`**, `derivedFromRuntime: false`, `unresolvedPrimary: true`. The control passes on
the same run and the honesty invariant passes on the same run, so the table discriminates
rather than simply failing.

**GREEN (this branch):**

```
--- PASS: TestPlacementWorkloadIdentity_Row60_6344 (0.06s)
    --- PASS: .../shared-pg_shape:_pod_labels_equal_the_app_name_—_still_resolves_both_legs
    --- PASS: .../spine-gitea_shape:_pods_carry_the_RELEASE_identity,_not_the_app_name
    --- PASS: .../genuinely_absent_workload:_declaration_must_not_become_an_observed_Primary
--- PASS: TestResolveComponentWorkloadIdentity_NeverNarrows_6344 (0.02s)
TRUE-RC=0
```

**Whole package, this branch:**

```
ok  github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/handler  327.399s
TRUE-RC=0
```

(`go build ./...` and `go vet ./internal/handler/` both TRUE-RC=0. Every run used
`-count=1`.)

The test wires a real sovereign dynamic client seeded with the Continuum CR, so
`augmentWithContinuumStandby` — the only term that can emit `cluster: ""` — is genuinely
reachable. Without it the pre-fix answer would degrade to an empty target list and the
test would pin something the walk never saw.

## Not closed by this change, stated plainly

The hw296 `r60fresh` sub-case is a **different** mechanism and is not addressed here: its
Pods carry `app.kubernetes.io/instance=postgres` / `name=postgresql` (documented at
`continuum_standby_crossregion_6268.go:242`), i.e. a *different chart's* workload rather
than the app's own release, so no CR→HR hop reaches them. That one is already handled by
the cross-cluster CNPG pair term (#6268/#6291) — the same term that keeps `shared-pg`
green.

## Other callers of the seam

Two, both checked. `synthesiseAppFromRuntime` (`applications_runtime_synth_5827.go:58`)
keeps the route-only identity, which is unchanged behaviour and is also the only correct
input there: it is reached ONLY when neither an Application CR nor a same-named/released
HelmRelease exists, i.e. precisely when resolution would find nothing to add — so the two
surfaces stay in lockstep by construction. `HandleApplicationGet`
(`applications.go:1652`) reaches it through that same guard.

Refs #6344
Refs #3375
