### PR TITLE
fix(placement): one Primary for an active-hot-standby app, and no phantom third leg (hw298 row 60)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/applications_placement_declared_roles_6347.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications_placement_declared_roles_6347.go
@@ -1,0 +1,242 @@
+// Package handler — applications_placement_declared_roles_6347.go (#6347 /
+// UAT row 60).
+//
+// THE DEFECT, measured on hw298 (dep 2540d866403f1f7c) AFTER #6345 landed and
+// the mothership was rolled to `catalyst-api:8c41df2`:
+//
+//	shared-pg      active-hot-standby → 2 targets  Primary(cluster set) + Standby(cluster set)
+//	spine-gitea    active-hot-standby → 3 targets  Primary(set) + Primary(set) + Standby(cluster "")
+//	spine-keycloak active-hot-standby → 3 targets  Primary(set) + Primary(set) + Standby(cluster "")
+//
+// #6345 made the Primary resolve — and nothing downstream turns two occupied
+// regions into ONE Primary and ONE Standby. `bpv1.DerivePattern` reads a
+// 2-Primary list as `active-active`, and `bpv1.ValidatePlacement` rejects it
+// outright as `MultiPrimaryNotSupported` under the default `primary+standby`
+// capability: the projection was emitting a placement its own validator
+// refuses.
+//
+// WHY THE CONTROL ESCAPES, AND WHY THAT IS NOT A PROPERTY OF THE APP.
+// `derivePlacementTargets` assigns roles from the `openova.io/cnpg-role` label
+// when it sees one — positive, per-leg evidence of which half serves writes.
+// `shared-pg` has it; a Deployment-backed app does not. Its last arm therefore
+// reads "every occupied region serves traffic → Primary", which is a fair
+// reading for a bootstrap component that declares nothing, and the wrong one
+// for an app that declares `active-hot-standby`. gitea and keycloak really do
+// run in both region clusters — `10-gitea.yaml` / `09-keycloak.yaml` carry no
+// `catalyst.openova.io/region-role` gate, and "no gate ⇒ every region".
+//
+// WHAT THIS FILE ADDS. The declaration the app already carries, used ONLY where
+// no runtime evidence exists. `placement.Resolve`
+// (core/controllers/internal/placement/placement.go) puts `regions[0]` Primary
+// and `regions[1..]` Standby for both asymmetric modes; `placementRegionCountError`
+// states the same rule back to any caller that tries to write a one-region
+// multi-region placement ("regions[0] is the primary and regions[1..] are the
+// standbys"). So regions[0] is not a heuristic invented here — it is the rule
+// the write doors already enforce, read back on the projection side.
+//
+// THE THREE LINES IT WILL NOT CROSS:
+//
+//   - It never OVERRULES an observation. A CNPG pair that has failed over
+//     reports its live primary in region B while `spec.regions[0]` still names
+//     region A; the labels win, always. A declaration is not evidence, and a
+//     projection that tracked config here would point an operator at the region
+//     that no longer holds the write path — worse than the defect being fixed.
+//   - It never INVENTS a leg. Everything here re-labels targets that occupancy
+//     already produced. An app with no Pods in a region still has no target
+//     there, the #6268 half-pair refusal still fires, and an app occupied only
+//     in its declared STANDBY region now says so honestly (a lone Standby,
+//     `unresolvedPrimary: true`) instead of promoting that leg to writer.
+//   - It never SPEAKS where the declaration is silent or degenerate. No
+//     Application CR, no `spec.placement`, a `singleton` / `active-active`
+//     posture, or fewer than two distinct regions ⇒ byte-identical behaviour.
+//     `active-active` is multi-primary BY DEFINITION and must keep both
+//     Primaries.
+//
+// AND THE REGION VOCABULARY IS LOAD-BEARING. A target's region comes from the
+// `openova.io/region` node label — the full cluster name
+// `hw-me-east-215-a-rtz-prod` — while a spine Application's `spec.regions[]`
+// carries the bare cloud region `me-east-215-a` (post_handover_spine_apps.go
+// takes them from `RegionSpec.CloudRegion`), and #5482 recorded all three
+// divergent spellings on one Application. Comparing the two raw resolves
+// NOTHING: the fix would read as shipped and change no wire byte. The
+// controller already folds the two vocabularies together for exactly this
+// reason (`normalizeRegion`, core/controllers/application/internal/controller/
+// placement_projection.go) — `internal/` puts that package out of reach from
+// this module, so the fold is mirrored here, token set for token set, and
+// pinned by its own table.
+//
+// Refs #6347, #6344, #6345, #3375 (UAT row 60).
+package handler
+
+import (
+	"strings"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	bpv1 "github.com/openova-io/openova/core/controllers/pkg/apis/blueprint/v1alpha1"
+)
+
+// declaredPlacement is an Application's OWN statement of its posture: the
+// canonical mode plus the ordered region list `placement.Resolve` reads. The
+// zero value means the component declared nothing — a bootstrap-kit HelmRelease
+// with no Application CR, or a CR with no placement — and every method below
+// answers "no opinion" for it, which is what keeps the un-declared components
+// on their pre-#6347 projection.
+type declaredPlacement struct {
+	mode    string   // canonical (canonicalizeTopology)
+	regions []string // spec.regions[], order load-bearing: [0] is the primary
+}
+
+// asymmetric reports whether this declaration names ONE writer and one or more
+// followers — the `primary+standby` capability class. Both members of that
+// class are included because both resolve the same way in placement.Resolve
+// (regions[0] primary, regions[1..] standby); they differ only in the standby
+// TYPE. `active-active` is deliberately absent: it is multi-primary by
+// definition, so its two Primaries are correct and must not be touched.
+//
+// Two DISTINCT regions are required, mirroring placementRegionCountError:
+// `["a","a"]` is one place, and a declaration that names one place cannot say
+// which of two observed legs is the follower.
+func (d declaredPlacement) asymmetric() bool {
+	switch d.mode {
+	case "active-hot-standby", "active-passive":
+		return len(d.normalizedRegions()) >= 2
+	}
+	return false
+}
+
+// standbyType is the follower type the DECLARED mode implies. It is the only
+// evidence available for it: `StandbyHot` asserts a live streaming replica that
+// promotes in seconds, which nothing on this path observes, so the type is
+// mirrored from the declaration rather than assumed — and for `active-passive`
+// that means the weaker claim (Cold), never the stronger one.
+func (d declaredPlacement) standbyType() bpv1.StandbyType {
+	if d.mode == "active-passive" {
+		return bpv1.StandbyCold
+	}
+	return bpv1.StandbyHot
+}
+
+// normalizedRegions is the declared list folded onto one region vocabulary,
+// de-duplicated, ORDER PRESERVED — so entry 0 stays the primary.
+func (d declaredPlacement) normalizedRegions() []string {
+	out := make([]string, 0, len(d.regions))
+	seen := make(map[string]struct{}, len(d.regions))
+	for _, r := range d.regions {
+		r = normalizePlacementRegion(r)
+		if r == "" {
+			continue
+		}
+		if _, dup := seen[r]; dup {
+			continue
+		}
+		seen[r] = struct{}{}
+		out = append(out, r)
+	}
+	return out
+}
+
+// roleForRegion returns the role the DECLARATION assigns to a region, and
+// ok=false when it assigns none — no asymmetric declaration, an unresolvable
+// region, or a region the declaration simply does not name (a component running
+// somewhere its own spec never mentioned; the caller then keeps whatever the
+// runtime derived, because guessing is what this file exists to stop).
+func (d declaredPlacement) roleForRegion(region string) (bpv1.DataRole, bpv1.StandbyType, bool) {
+	if !d.asymmetric() {
+		return "", "", false
+	}
+	key := normalizePlacementRegion(region)
+	if key == "" {
+		return "", "", false
+	}
+	regions := d.normalizedRegions()
+	if key == regions[0] {
+		return bpv1.DataRolePrimary, "", true
+	}
+	for _, r := range regions[1:] {
+		if key == r {
+			return bpv1.DataRoleStandby, d.standbyType(), true
+		}
+	}
+	return "", "", false
+}
+
+// declaredPlacementForComponent reads the posture off the Application CR the
+// route id names, through the SAME selector the identity resolution uses
+// (applicationCRForComponent) — one CR, one Organization-isolation rule. A
+// component with no CR, or a cache that cannot list Applications, yields the
+// zero value.
+func (h *Handler) declaredPlacementForComponent(primaryID, name, ns string) declaredPlacement {
+	return declaredPlacementFromCR(h.applicationCRForComponent(primaryID, componentNameCandidates(name), ns))
+}
+
+// declaredPlacementFromCR projects the CR's declaration. `spec.placement` is
+// read through placementFromSpec so BOTH stored shapes resolve (the legacy bare
+// string and the #3373 object whose posture rides in `mode`), and the region
+// list is `spec.regions[]` — the exact slice placement.Resolve is called with
+// (application_controller.go: `placement.Resolve(spec.Placement, spec.Regions)`)
+// — falling back to the object form's own `regions` only when `spec.regions` is
+// absent entirely.
+func declaredPlacementFromCR(cr *unstructured.Unstructured) declaredPlacement {
+	if cr == nil {
+		return declaredPlacement{}
+	}
+	d := declaredPlacement{mode: canonicalizeTopology(placementFromSpec(cr))}
+	if regs, ok, err := unstructured.NestedStringSlice(cr.Object, "spec", "regions"); err == nil && ok && len(regs) > 0 {
+		d.regions = regs
+	} else if regs, ok, err := unstructured.NestedStringSlice(cr.Object, "spec", "placement", "regions"); err == nil && ok {
+		d.regions = regs
+	}
+	return d
+}
+
+// placementClusterName{Providers,BuildingBlocks,EnvTypes} are the CLOSED token
+// sets that identify a `{prov}-{reg}-{bb}-{env_type}` host-cluster name. They
+// mirror the controller's sets (placement_projection.go); a token added there
+// belongs here too.
+var (
+	placementClusterNameProviders      = map[string]bool{"hw": true, "hz": true, "aws": true, "gcp": true, "azure": true}
+	placementClusterNameBuildingBlocks = map[string]bool{"rtz": true, "dmz": true, "mgt": true, "mgmt": true}
+	placementClusterNameEnvTypes       = map[string]bool{"prod": true, "stg": true, "staging": true, "dev": true, "uat": true}
+)
+
+// normalizePlacementRegion folds a host-cluster name (hw-me-east-215-a-rtz-prod)
+// down to its bare region label (me-east-215-a) so both spellings of one place
+// compare equal. IDEMPOTENT: a value that is already a bare region comes back
+// unchanged.
+//
+// Detection anchors on the CLOSED token sets, not the segment count — that is
+// what tells the two 4-segment shapes apart: `me-east-215-a` (region: first
+// segment is not a provider, last is not an env_type) versus `hz-fsn-rtz-prod`
+// (cluster: provider first, building-block second-to-last, env_type last). Any
+// value that does not match every anchor is returned VERBATIM — the
+// `platform-bootstrap-owned-host` placeholder, the seed door's literal
+// "primary", or anything unexpected — so an unrecognised region stays visible
+// instead of being silently mangled into a false match.
+func normalizePlacementRegion(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	parts := strings.Split(s, "-")
+	if len(parts) < 4 {
+		return s
+	}
+	if !placementClusterNameProviders[parts[0]] ||
+		!placementClusterNameBuildingBlocks[parts[len(parts)-2]] ||
+		!placementClusterNameEnvTypes[parts[len(parts)-1]] {
+		return s
+	}
+	region := strings.Join(parts[1:len(parts)-2], "-")
+	if region == "" {
+		return s
+	}
+	return region
+}
+
+// samePlacementRegion is the single spelling-tolerant region comparison, so no
+// caller re-hand-rolls it with a raw `==` and silently stops matching.
+func samePlacementRegion(a, b string) bool {
+	na, nb := normalizePlacementRegion(a), normalizePlacementRegion(b)
+	return na != "" && na == nb
+}

--- a/products/catalyst/bootstrap/api/internal/handler/applications_placement_declared_roles_6347_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications_placement_declared_roles_6347_test.go
@@ -1,0 +1,347 @@
+package handler
+
+// applications_placement_declared_roles_6347_test.go — UAT row 60 (#3375), the
+// hw298 reproduction taken AFTER #6345 landed.
+//
+// WHAT WAS MEASURED. Mothership rolled to `catalyst-api:8c41df2`, same endpoint,
+// same deployment (2540d866403f1f7c), same pass:
+//
+//	shared-pg      active-hot-standby → 2 targets  Primary(cluster set) + Standby(cluster set)
+//	spine-gitea    active-hot-standby → 3 targets  Primary(set) + Primary(set) + Standby(cluster "")
+//	spine-keycloak active-hot-standby → 3 targets  Primary(set) + Primary(set) + Standby(cluster "")
+//
+// #6345 made the Primary resolve; what it exposed is that NOTHING downstream
+// turns two occupied regions into one Primary and one Standby. `shared-pg` is
+// again the CONTROL and again escapes for a reason that is not a property of
+// the app: CNPG stamps `openova.io/cnpg-role` on each half, so the roles come
+// from positive per-leg evidence. gitea and keycloak carry no such marker, and
+// their bootstrap-kit HelmReleases carry no `catalyst.openova.io/region-role`
+// gate — "no gate ⇒ every region" — so they genuinely run in BOTH region
+// clusters and the stateless arm calls each one a Primary.
+//
+// THE REGION VOCABULARY IS PART OF THE REPRODUCTION, not decoration. A target's
+// region comes from the `openova.io/region` node label — the full cluster name
+// `hw-me-east-215-a-rtz-prod` — while a spine Application's `spec.regions[]` and
+// its per-app `dr-<app>` Continuum carry the bare cloud region `me-east-215-a`
+// (post_handover_spine_apps.go:619). #5482 recorded all three divergent
+// spellings on one Application. The fixtures below use BOTH spellings on
+// purpose: a fix that compares the two raw resolves nothing and leaves the wire
+// exactly as the walk found it.
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	bpv1 "github.com/openova-io/openova/core/controllers/pkg/apis/blueprint/v1alpha1"
+)
+
+const (
+	// The deployment's declared regions (provisioner RegionSpec.CloudRegion) —
+	// what a spine Application CR's spec.regions[] holds.
+	declRegionA = "me-east-215-a"
+	declRegionB = "me-east-215-b"
+	// The canonical `openova.io/region` node/pod label — what a placement
+	// target's Region actually carries on the wire.
+	nodeRegionA = "hw-me-east-215-a-rtz-prod"
+	nodeRegionB = "hw-me-east-215-b-rtz-prod"
+)
+
+// spineApplicationFixtureCRWithPlacement is spineApplicationFixtureCR plus the
+// DECLARATION the live spine CRs carry: the canonical mode
+// (spinePlacementMode) and the ordered region list placement.Resolve reads,
+// where regions[0] is the primary and regions[1..] are the standbys.
+func spineApplicationFixtureCRWithPlacement(name, hrName, hrNS, mode string, regions []string) *unstructured.Unstructured {
+	u := spineApplicationFixtureCR(name, hrName, hrNS)
+	_ = unstructured.SetNestedField(u.Object, mode, "spec", "placement")
+	rgs := make([]any, 0, len(regions))
+	for _, r := range regions {
+		rgs = append(rgs, r)
+	}
+	_ = unstructured.SetNestedSlice(u.Object, rgs, "spec", "regions")
+	return u
+}
+
+// TestPlacementDeclaredRoles_Row60_6347 — one table so the CONTROL and the
+// DEFECT are answered by the same code path in the same run.
+func TestPlacementDeclaredRoles_Row60_6347(t *testing.T) {
+	cases := []struct {
+		name    string
+		depID   string
+		appName string
+		queryNS string
+		objsA   []runtime.Object
+		objsB   []runtime.Object
+		crs     []runtime.Object
+
+		wantTargets      int
+		wantPrimaries    int
+		wantStandbys     int
+		wantDerived      bool
+		wantUnresolvedPr bool
+		wantPrimaryRegn  string
+		wantStandbyRegn  string
+		wantStandbyType  bpv1.StandbyType
+		wantStandbyClstr bool // the Standby names the cluster it was observed in
+		wantPattern      bpv1.Pattern
+		why              string
+	}{
+		{
+			// THE DEFECT — hw298 post-#6345. Pods in BOTH region clusters, no
+			// role marker on either, an active-hot-standby declaration naming
+			// which region is which.
+			//
+			// PRE-FIX this returns exactly what the walk recorded: THREE
+			// targets — Primary(hw-…-a) + Primary(hw-…-b) + a third Standby
+			// carrying `cluster: ""` that augmentWithContinuumStandby appends
+			// because its region comparison never matches across the two
+			// spellings. DerivePattern reads that list as `active-active`.
+			name:    "spine-gitea shape: occupied in BOTH regions, declared active-hot-standby",
+			depID:   "dep-6347-gitea",
+			appName: "spine-gitea",
+			queryNS: "catalyst",
+			objsA: []runtime.Object{
+				identityFixturePod("gitea", "gitea-75d9f486fb-g8hsr", "gitea", nodeRegionA, ""),
+				spineApplicationFixtureCRWithPlacement("spine-gitea", "bp-gitea", "flux-system",
+					"active-hot-standby", []string{declRegionA, declRegionB}),
+				helmReleaseFixture("bp-gitea", "flux-system", "gitea", "gitea"),
+			},
+			objsB: []runtime.Object{
+				identityFixturePod("gitea", "gitea-75d9f486fb-qm4kt", "gitea", nodeRegionB, ""),
+			},
+			crs: []runtime.Object{
+				newContinuumUnstructured("dr-spine-gitea", "catalyst", "spine-gitea", declRegionA, []string{declRegionB}),
+			},
+			wantTargets:      2,
+			wantPrimaries:    1,
+			wantStandbys:     1,
+			wantDerived:      true,
+			wantPrimaryRegn:  nodeRegionA,
+			wantStandbyRegn:  nodeRegionB,
+			wantStandbyType:  bpv1.StandbyHot,
+			wantStandbyClstr: true,
+			wantPattern:      bpv1.PatternActiveHotStandby,
+			why:              "row 60's clause: ONE region-a primary + ONE region-b replica — not two primaries and a phantom third leg",
+		},
+		{
+			// THE CONTROL — the row that was already correct on the wire and
+			// must not move. Its roles come from positive per-leg CNPG
+			// evidence, and the declaration agrees with them.
+			name:    "shared-pg shape: CNPG role labels carry the split",
+			depID:   "dep-6347-sharedpg",
+			appName: "shared-pg",
+			queryNS: "shared-data",
+			objsA: []runtime.Object{
+				identityFixturePod("shared-data", "shared-pg-1", "shared-pg", nodeRegionA, cnpgRolePrimary),
+				spineApplicationFixtureCRWithPlacement("shared-pg", "bp-postgres-shared", "flux-system",
+					"active-hot-standby", []string{declRegionA, declRegionB}),
+				helmReleaseFixture("bp-postgres-shared", "flux-system", "shared-pg", "shared-data"),
+			},
+			objsB: []runtime.Object{
+				identityFixturePod("shared-data", "shared-pg-r-1", "shared-pg", nodeRegionB, cnpgRoleReplica),
+			},
+			wantTargets:      2,
+			wantPrimaries:    1,
+			wantStandbys:     1,
+			wantDerived:      true,
+			wantPrimaryRegn:  nodeRegionA,
+			wantStandbyRegn:  nodeRegionB,
+			wantStandbyType:  bpv1.StandbyHot,
+			wantStandbyClstr: true,
+			wantPattern:      bpv1.PatternActiveHotStandby,
+			why:              "the control proves the projection works; if this row moves, the fix broke what already worked",
+		},
+		{
+			// THE ANTI-REGRESSION that decides whether the declaration is
+			// allowed to overrule an OBSERVATION. After a switchover the live
+			// primary is in region B while spec.regions[0] still names region
+			// A. The cnpg-role labels are positive evidence of which half
+			// serves writes; a declaration is not evidence and must never
+			// overwrite one. A projection that tracked config here would tell
+			// an operator the write path is in the region that no longer holds
+			// it — worse than the defect being fixed.
+			name:    "failed-over CNPG pair: observed role beats the stale declaration",
+			depID:   "dep-6347-failedover",
+			appName: "shared-pg",
+			queryNS: "shared-data",
+			objsA: []runtime.Object{
+				identityFixturePod("shared-data", "shared-pg-1", "shared-pg", nodeRegionA, cnpgRoleReplica),
+				spineApplicationFixtureCRWithPlacement("shared-pg", "bp-postgres-shared", "flux-system",
+					"active-hot-standby", []string{declRegionA, declRegionB}),
+				helmReleaseFixture("bp-postgres-shared", "flux-system", "shared-pg", "shared-data"),
+			},
+			objsB: []runtime.Object{
+				identityFixturePod("shared-data", "shared-pg-r-1", "shared-pg", nodeRegionB, cnpgRolePrimary),
+			},
+			wantTargets:      2,
+			wantPrimaries:    1,
+			wantStandbys:     1,
+			wantDerived:      true,
+			wantPrimaryRegn:  nodeRegionB,
+			wantStandbyRegn:  nodeRegionA,
+			wantStandbyType:  bpv1.StandbyHot,
+			wantStandbyClstr: true,
+			wantPattern:      bpv1.PatternActiveHotStandby,
+			why:              "runtime role evidence is the authority; the declaration only speaks where no evidence exists",
+		},
+		{
+			// A GENUINELY SINGLE-REGION APP. One declared region, one occupied
+			// region, no Continuum. Nothing may invent a second leg: the honest
+			// answer is one Primary and the `singleton` pattern.
+			name:    "single-region app: no fabricated standby",
+			depID:   "dep-6347-singleton",
+			appName: "spine-powerdns",
+			queryNS: "catalyst",
+			objsA: []runtime.Object{
+				identityFixturePod("powerdns", "powerdns-0", "powerdns", nodeRegionA, ""),
+				spineApplicationFixtureCRWithPlacement("spine-powerdns", "bp-powerdns", "flux-system",
+					"singleton", []string{declRegionA}),
+				helmReleaseFixture("bp-powerdns", "flux-system", "powerdns", "powerdns"),
+			},
+			objsB:           []runtime.Object{},
+			wantTargets:     1,
+			wantPrimaries:   1,
+			wantStandbys:    0,
+			wantDerived:     true, // both of the DEPLOYMENT's clusters were listed, so the #6015 coverage gate is satisfied; the app simply occupies one of them
+			wantPrimaryRegn: nodeRegionA,
+			wantPattern:     bpv1.PatternSingleton,
+			why:             "a one-region app must stay one Primary — the declaration names no standby region to promote",
+		},
+		{
+			// #4551 MUST SURVIVE. Region B is genuinely empty here, so the
+			// declaration-derived Standby is the ONLY thing that can tell the
+			// Topology tab a standby region exists. Suppressing it whenever a
+			// runtime Primary is present would trade this defect for the one
+			// #4551 closed. Its `cluster` stays empty precisely because nothing
+			// was observed there.
+			name:    "standby region genuinely empty: the Continuum-derived leg is still emitted",
+			depID:   "dep-6347-declonly",
+			appName: "spine-keycloak",
+			queryNS: "catalyst",
+			objsA: []runtime.Object{
+				identityFixturePod("keycloak", "keycloak-0", "keycloak", nodeRegionA, ""),
+				spineApplicationFixtureCRWithPlacement("spine-keycloak", "bp-keycloak", "flux-system",
+					"active-hot-standby", []string{declRegionA, declRegionB}),
+				helmReleaseFixture("bp-keycloak", "flux-system", "keycloak", "keycloak"),
+			},
+			objsB: []runtime.Object{},
+			crs: []runtime.Object{
+				newContinuumUnstructured("dr-spine-keycloak", "catalyst", "spine-keycloak", declRegionA, []string{declRegionB}),
+			},
+			wantTargets:      2,
+			wantPrimaries:    1,
+			wantStandbys:     1,
+			wantDerived:      true,
+			wantPrimaryRegn:  nodeRegionA,
+			wantStandbyRegn:  declRegionB,
+			wantStandbyType:  bpv1.StandbyHot,
+			wantStandbyClstr: false,
+			wantPattern:      bpv1.PatternActiveHotStandby,
+			why:              "no leg was observed in region B, so the declaration is the only standby signal there — never suppress it",
+		},
+		{
+			// OCCUPIED ONLY IN THE DECLARED STANDBY REGION. Pre-fix this
+			// answers Primary(hw-…-b) plus an appended `cluster: ""` Standby
+			// naming me-east-215-b — the SAME region twice, spelled two ways,
+			// rendered as a cross-region pair. The honest answer is a half-pair:
+			// the region that serves writes was not observed, so #6268's
+			// refusal must fire rather than promote the standby leg to writer.
+			name:    "occupied only in the declared STANDBY region: honest half-pair, not a false primary",
+			depID:   "dep-6347-standbyonly",
+			appName: "spine-gitea",
+			queryNS: "catalyst",
+			objsA: []runtime.Object{
+				spineApplicationFixtureCRWithPlacement("spine-gitea", "bp-gitea", "flux-system",
+					"active-hot-standby", []string{declRegionA, declRegionB}),
+				helmReleaseFixture("bp-gitea", "flux-system", "gitea", "gitea"),
+			},
+			objsB: []runtime.Object{
+				identityFixturePod("gitea", "gitea-75d9f486fb-qm4kt", "gitea", nodeRegionB, ""),
+			},
+			crs: []runtime.Object{
+				newContinuumUnstructured("dr-spine-gitea", "catalyst", "spine-gitea", declRegionA, []string{declRegionB}),
+			},
+			wantTargets:      1,
+			wantPrimaries:    0,
+			wantStandbys:     1,
+			wantDerived:      false,
+			wantUnresolvedPr: true,
+			wantStandbyRegn:  nodeRegionB,
+			wantStandbyType:  bpv1.StandbyHot,
+			wantStandbyClstr: true,
+			wantPattern:      bpv1.PatternNotReported,
+			why:              "one leg in the declared standby region is not a placement — never two legs spelling one region",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newIdentityPlacementHandler(t, tc.depID, declRegionA, declRegionB, tc.objsA, tc.objsB, tc.crs)
+			resp := callPlacementNS(t, h, tc.depID, tc.appName, tc.queryNS)
+
+			primaries, standbys := 0, 0
+			for _, tgt := range resp.Targets {
+				switch tgt.Role {
+				case bpv1.DataRolePrimary:
+					primaries++
+				case bpv1.DataRoleStandby:
+					standbys++
+				}
+			}
+			if len(resp.Targets) != tc.wantTargets || primaries != tc.wantPrimaries || standbys != tc.wantStandbys {
+				t.Fatalf("#6347 %s: got %d target(s) (%d Primary, %d Standby) want %d (%d Primary, %d Standby) — %s\ntargets=%+v derivedFromRuntime=%v unresolvedPrimary=%v",
+					tc.appName, len(resp.Targets), primaries, standbys,
+					tc.wantTargets, tc.wantPrimaries, tc.wantStandbys, tc.why,
+					resp.Targets, resp.DerivedFromRuntime, resp.UnresolvedPrimary)
+			}
+			if resp.DerivedFromRuntime != tc.wantDerived {
+				t.Fatalf("#6347 %s: derivedFromRuntime=%v want %v (targets=%+v)",
+					tc.appName, resp.DerivedFromRuntime, tc.wantDerived, resp.Targets)
+			}
+			if resp.UnresolvedPrimary != tc.wantUnresolvedPr {
+				t.Fatalf("#6347 %s: unresolvedPrimary=%v want %v — a Standby with no Primary renders identically to an honest single-region app (targets=%+v)",
+					tc.appName, resp.UnresolvedPrimary, tc.wantUnresolvedPr, resp.Targets)
+			}
+
+			primary := targetByRole(resp.Targets, bpv1.DataRolePrimary)
+			standby := targetByRole(resp.Targets, bpv1.DataRoleStandby)
+			if tc.wantPrimaryRegn != "" {
+				if primary == nil || primary.Region != tc.wantPrimaryRegn {
+					t.Fatalf("#6347 %s: Primary region %+v want %q", tc.appName, primary, tc.wantPrimaryRegn)
+				}
+				if primary.Cluster == "" {
+					t.Fatalf("#6347 %s: Primary carries an EMPTY cluster (%+v) — an observed leg always names the cluster it ran on", tc.appName, *primary)
+				}
+				if primary.StandbyType != "" {
+					t.Fatalf("#6347 %s: Primary carries standbyType %q — ValidatePlacement rejects that outright (PrimaryHasStandbyType)", tc.appName, primary.StandbyType)
+				}
+			}
+			if tc.wantStandbyRegn != "" {
+				if standby == nil || standby.Region != tc.wantStandbyRegn {
+					t.Fatalf("#6347 %s: Standby region %+v want %q", tc.appName, standby, tc.wantStandbyRegn)
+				}
+				if standby.StandbyType != tc.wantStandbyType {
+					t.Fatalf("#6347 %s: Standby type %q want %q", tc.appName, standby.StandbyType, tc.wantStandbyType)
+				}
+				if gotCluster := standby.Cluster != ""; gotCluster != tc.wantStandbyClstr {
+					t.Fatalf("#6347 %s: Standby cluster=%q (set=%v) want set=%v — an OBSERVED leg names its cluster, a declaration-derived one cannot (%+v)",
+						tc.appName, standby.Cluster, gotCluster, tc.wantStandbyClstr, *standby)
+				}
+			}
+			if tc.wantPattern != "" {
+				if got := bpv1.DerivePattern(resp.Targets, bpv1.CapabilityPrimaryStandby); got != tc.wantPattern {
+					t.Fatalf("#6347 %s: pattern %q want %q (targets=%+v)", tc.appName, got, tc.wantPattern, resp.Targets)
+				}
+			}
+			// The whole point of the row: an app whose Blueprint capability is
+			// the default primary+standby must project a placement its OWN
+			// validator accepts. Two Primaries is MultiPrimaryNotSupported.
+			if len(resp.Targets) > 0 && tc.wantPattern != bpv1.PatternNotReported {
+				if err := bpv1.ValidatePlacement(bpv1.Placement{Targets: resp.Targets}, bpv1.CapabilityPrimaryStandby); err != nil {
+					t.Fatalf("#6347 %s: the projected placement fails its own validator: %v (targets=%+v)", tc.appName, err, resp.Targets)
+				}
+			}
+		})
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/applications_placement_declared_roles_unit_6347_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications_placement_declared_roles_unit_6347_test.go
@@ -1,0 +1,146 @@
+package handler
+
+// applications_placement_declared_roles_unit_6347_test.go — the half of the
+// #6347 contract the endpoint table cannot see. It lives in its own file
+// because it names API that does not exist on the pre-fix tree the table test
+// is watched RED against.
+//
+// Two things are pinned here that a passing endpoint test would NOT catch:
+//
+//  1. the region fold actually folds (a normalizer that returned its input
+//     verbatim would leave the endpoint table green ONLY because the fixtures
+//     happen to line up — so both directions and the pass-through cases are
+//     asserted directly);
+//  2. the declaration stays SILENT everywhere it has no standing — singleton,
+//     active-active, one distinct region, a region it never names, and a CR
+//     that declares nothing at all. Silence is what keeps every component
+//     without an Application CR on its pre-#6347 projection.
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	bpv1 "github.com/openova-io/openova/core/controllers/pkg/apis/blueprint/v1alpha1"
+)
+
+func TestNormalizePlacementRegion_6347(t *testing.T) {
+	cases := []struct {
+		in, want, why string
+	}{
+		{"hw-me-east-215-a-rtz-prod", "me-east-215-a", "the openova.io/region node label folds to the cloud region the CR declares"},
+		{"hw-me-east-215-b-rtz-prod", "me-east-215-b", "same, region B"},
+		{"hz-fsn-rtz-prod", "fsn", "the 4-segment CLUSTER shape: provider first, building-block + env_type last"},
+		{"hz-hel-mgmt-staging", "hel", "every token set member, not just the rtz/prod pair"},
+		{"me-east-215-a", "me-east-215-a", "IDEMPOTENT: an already-bare region is returned unchanged"},
+		{"fsn1", "fsn1", "short bare region, fewer than 4 segments"},
+		{"platform-bootstrap-owned-host", "platform-bootstrap-owned-host", "the host placeholder is not a cluster name — surfaced verbatim, never mangled"},
+		{"primary", "primary", "the seed door's literal — visibly unrecognised beats silently folded"},
+		{"aws-eu-west-1-dmz-uat", "eu-west-1", "provider/bb/env tokens outside the Huawei pair"},
+		{"me-east-215-a-rtz-prod", "me-east-215-a-rtz-prod", "first segment is not a provider ⇒ not a cluster name ⇒ verbatim"},
+		{"hw-me-east-215-a-rtz-qa", "hw-me-east-215-a-rtz-qa", "unknown env_type ⇒ verbatim, the closed set is the anchor"},
+		{"  hw-me-east-215-a-rtz-prod  ", "me-east-215-a", "trimmed before matching"},
+		{"", "", "empty stays empty and never compares equal to anything"},
+	}
+	for _, c := range cases {
+		if got := normalizePlacementRegion(c.in); got != c.want {
+			t.Errorf("normalizePlacementRegion(%q) = %q want %q — %s", c.in, got, c.want, c.why)
+		}
+	}
+
+	// The comparison built on it: two spellings of one place are equal, two
+	// places are not, and empty never matches (an empty region must never
+	// silently satisfy a "same region" test).
+	if !samePlacementRegion("hw-me-east-215-b-rtz-prod", "me-east-215-b") {
+		t.Error("samePlacementRegion: the node label and the declared region name ONE place and must compare equal — this is the comparison that failed on hw298")
+	}
+	if samePlacementRegion("hw-me-east-215-a-rtz-prod", "me-east-215-b") {
+		t.Error("samePlacementRegion: region A must not match region B")
+	}
+	if samePlacementRegion("", "") {
+		t.Error("samePlacementRegion(\"\",\"\") must be false — an unset region is not a place")
+	}
+}
+
+func TestDeclaredPlacementRoleForRegion_6347(t *testing.T) {
+	ahs := declaredPlacement{mode: "active-hot-standby", regions: []string{"me-east-215-a", "me-east-215-b"}}
+	ap := declaredPlacement{mode: "active-passive", regions: []string{"me-east-215-a", "me-east-215-b"}}
+
+	cases := []struct {
+		name        string
+		d           declaredPlacement
+		region      string
+		wantRole    bpv1.DataRole
+		wantStandby bpv1.StandbyType
+		wantOK      bool
+		why         string
+	}{
+		{"regions[0] is the primary", ahs, "hw-me-east-215-a-rtz-prod", bpv1.DataRolePrimary, "", true,
+			"the rule placement.Resolve and placementRegionCountError both state"},
+		{"regions[1..] are the standbys", ahs, "hw-me-east-215-b-rtz-prod", bpv1.DataRoleStandby, bpv1.StandbyHot, true,
+			"a leg in a declared standby region is a follower, not a second writer"},
+		{"declared spelling matches too", ahs, "me-east-215-b", bpv1.DataRoleStandby, bpv1.StandbyHot, true,
+			"either vocabulary resolves — the fold works in both directions"},
+		{"active-passive standbys are Cold", ap, "hw-me-east-215-b-rtz-prod", bpv1.DataRoleStandby, bpv1.StandbyCold, true,
+			"Hot asserts a streaming replica nothing here observed; mirror the declared type, never the stronger claim"},
+		{"a region the declaration never names", ahs, "hz-fsn-rtz-prod", "", "", false,
+			"no standing ⇒ the runtime reading stands"},
+		{"singleton declares no follower", declaredPlacement{mode: "singleton", regions: []string{"me-east-215-a"}}, "hw-me-east-215-a-rtz-prod", "", "", false,
+			"a one-region posture has no role split to impose"},
+		{"active-active is multi-primary BY DEFINITION", declaredPlacement{mode: "active-active", regions: []string{"me-east-215-a", "me-east-215-b"}}, "hw-me-east-215-b-rtz-prod", "", "", false,
+			"both regions serve traffic — demoting one would be the mirror-image defect"},
+		{"one distinct region under an asymmetric mode", declaredPlacement{mode: "active-hot-standby", regions: []string{"me-east-215-a", "me-east-215-a"}}, "hw-me-east-215-a-rtz-prod", "", "", false,
+			"`[a,a]` is ONE place (placementRegionCountError) and cannot say which leg follows"},
+		{"no declaration at all", declaredPlacement{}, "hw-me-east-215-a-rtz-prod", "", "", false,
+			"a bootstrap-kit HelmRelease with no Application CR keeps its pre-#6347 projection"},
+		{"empty region", ahs, "", "", "", false, "an unresolvable region gets no role"},
+	}
+	for _, c := range cases {
+		role, standby, ok := c.d.roleForRegion(c.region)
+		if ok != c.wantOK || role != c.wantRole || standby != c.wantStandby {
+			t.Errorf("%s: roleForRegion(%q) = (%q, %q, %v) want (%q, %q, %v) — %s",
+				c.name, c.region, role, standby, ok, c.wantRole, c.wantStandby, c.wantOK, c.why)
+		}
+	}
+}
+
+func TestDeclaredPlacementFromCR_6347(t *testing.T) {
+	// The dual form the CRD accepts, both read through placementFromSpec: the
+	// legacy bare string (what post_handover_spine_apps.go stamps) and the
+	// #3373 object whose posture rides in `mode`.
+	stringForm := spineApplicationFixtureCRWithPlacement("spine-gitea", "bp-gitea", "flux-system",
+		"active-hot-standby", []string{"me-east-215-a", "me-east-215-b"})
+	if d := declaredPlacementFromCR(stringForm); d.mode != "active-hot-standby" || len(d.regions) != 2 || d.regions[0] != "me-east-215-a" {
+		t.Fatalf("string form: %+v want mode active-hot-standby over [me-east-215-a me-east-215-b] IN ORDER", d)
+	}
+
+	objForm := spineApplicationFixtureCR("spine-openbao", "bp-openbao", "flux-system")
+	_ = unstructured.SetNestedMap(objForm.Object, map[string]any{
+		"mode":    "active_passive",
+		"regions": []any{"me-east-215-a", "me-east-215-b"},
+	}, "spec", "placement")
+	d := declaredPlacementFromCR(objForm)
+	if d.mode != "active-passive" {
+		t.Fatalf("object form: mode %q want the CANONICAL active-passive — one vocabulary regardless of stored spelling", d.mode)
+	}
+	if len(d.regions) != 2 || d.regions[1] != "me-east-215-b" {
+		t.Fatalf("object form: regions %v want the placement.regions fallback when spec.regions is absent", d.regions)
+	}
+
+	// spec.regions[] is the slice placement.Resolve is actually called with, so
+	// it wins when both are present.
+	both := spineApplicationFixtureCRWithPlacement("spine-gitea", "bp-gitea", "flux-system",
+		"active-hot-standby", []string{"me-east-215-a", "me-east-215-b"})
+	_ = unstructured.SetNestedSlice(both.Object, []any{"decoy-region"}, "spec", "placement", "regions")
+	if got := declaredPlacementFromCR(both); len(got.regions) != 2 || got.regions[0] != "me-east-215-a" {
+		t.Fatalf("both present: regions %v want spec.regions — the list placement.Resolve reads", got.regions)
+	}
+
+	if got := declaredPlacementFromCR(nil); got.mode != "" || len(got.regions) != 0 {
+		t.Fatalf("nil CR: %+v want the zero value — no CR, no opinion", got)
+	}
+	bare := spineApplicationFixtureCR("spine-harbor", "bp-harbor", "flux-system")
+	if got := declaredPlacementFromCR(bare); got.asymmetric() {
+		t.Fatalf("CR with no placement: %+v must not claim an asymmetric posture", got)
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/applications_placement_identity_6344.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications_placement_identity_6344.go
@@ -248,39 +248,19 @@ func (h *Handler) resolveComponentWorkloadIdentity(primaryID, name, ns string) c
 	}
 
 	// (1) The Application CR, when the route id names one.
-	//
-	// 🔒 Organization isolation: the CR is selected the way getApplicationCR
-	// already selects it — an EXACT (name, namespace) match when the caller
-	// scoped the request (the console passes the CR's own namespace), and a
-	// cluster-wide name match only when it did not. Accepting any namespace on
-	// a scoped request would let one Organization's `wordpress` answer for
-	// another's.
-	crNS := strings.TrimSpace(ns)
 	var hrName, hrNS string
-	if apps, _, err := h.k8sCache.List(primaryID, "application", labels.Everything()); err == nil {
-		for _, a := range apps {
-			if a == nil {
-				continue
-			}
-			if _, ok := route[a.GetName()]; !ok {
-				continue
-			}
-			if crNS != "" && a.GetNamespace() != crNS {
-				continue
-			}
-			if rn, _, _ := unstructured.NestedString(a.Object, "spec", "releaseName"); rn != "" {
-				id.addRelease(rn)
-			}
-			if tn, _, _ := unstructured.NestedString(a.Object, "spec", "targetNamespace"); tn != "" {
-				id.addNamespace(tn)
-			}
-			if n, _, _ := unstructured.NestedString(a.Object, "spec", "helmRelease", "name"); n != "" {
-				hrName = n
-				hrNS, _, _ = unstructured.NestedString(a.Object, "spec", "helmRelease", "namespace")
-			} else if adopted := strings.TrimSpace(a.GetLabels()[spineAdoptsHelmReleaseLabel]); adopted != "" {
-				hrName = adopted
-			}
-			break
+	if a := h.applicationCRForComponent(primaryID, id.route, ns); a != nil {
+		if rn, _, _ := unstructured.NestedString(a.Object, "spec", "releaseName"); rn != "" {
+			id.addRelease(rn)
+		}
+		if tn, _, _ := unstructured.NestedString(a.Object, "spec", "targetNamespace"); tn != "" {
+			id.addNamespace(tn)
+		}
+		if n, _, _ := unstructured.NestedString(a.Object, "spec", "helmRelease", "name"); n != "" {
+			hrName = n
+			hrNS, _, _ = unstructured.NestedString(a.Object, "spec", "helmRelease", "namespace")
+		} else if adopted := strings.TrimSpace(a.GetLabels()[spineAdoptsHelmReleaseLabel]); adopted != "" {
+			hrName = adopted
 		}
 	}
 
@@ -307,6 +287,51 @@ func (h *Handler) resolveComponentWorkloadIdentity(primaryID, name, ns string) c
 	}
 
 	return id
+}
+
+// applicationCRForComponent is THE selector for "which Application CR does this
+// route id name" — one function, so every consumer of that CR (the workload
+// identity above, the declared placement in #6347, anything added later) reads
+// the SAME object under the SAME isolation rule. Re-hand-rolling this loop is
+// how two surfaces start answering "which app is this" differently, which is
+// the #5827 / #6344 shape all over again.
+//
+// 🔒 Organization isolation: the CR is selected the way getApplicationCR already
+// selects it — an EXACT (name, namespace) match when the caller scoped the
+// request (the console passes the CR's own namespace), and a cluster-wide name
+// match only when it did not. Accepting any namespace on a scoped request would
+// let one Organization's `wordpress` answer for another's.
+//
+// Returns nil on every miss: no cache, no primary cluster, no candidates, an
+// unlistable Application kind, or simply no CR by that name.
+func (h *Handler) applicationCRForComponent(primaryID string, routeCandidates []string, ns string) *unstructured.Unstructured {
+	if h.k8sCache == nil || strings.TrimSpace(primaryID) == "" || len(routeCandidates) == 0 {
+		return nil
+	}
+	route := make(map[string]struct{}, len(routeCandidates))
+	for _, c := range routeCandidates {
+		if c = strings.TrimSpace(c); c != "" {
+			route[c] = struct{}{}
+		}
+	}
+	apps, _, err := h.k8sCache.List(primaryID, "application", labels.Everything())
+	if err != nil {
+		return nil
+	}
+	crNS := strings.TrimSpace(ns)
+	for _, a := range apps {
+		if a == nil {
+			continue
+		}
+		if _, ok := route[a.GetName()]; !ok {
+			continue
+		}
+		if crNS != "" && a.GetNamespace() != crNS {
+			continue
+		}
+		return a
+	}
+	return nil
 }
 
 // helmReleaseNamesComponent reports whether this HelmRelease is the one backing

--- a/products/catalyst/bootstrap/api/internal/handler/applications_placement_runtime.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications_placement_runtime.go
@@ -159,7 +159,14 @@ func (h *Handler) HandleApplicationPlacement(w http.ResponseWriter, r *http.Requ
 	// widen which Pods are looked at, never invent one that is not there.
 	ident := h.resolveComponentWorkloadIdentity(primaryID, name, ns)
 
-	targets, cov := h.derivePlacementTargets(ident, primaryID, clusterRegion, depID, fqdn)
+	// #6347 — what the Application DECLARES about its own posture, read off the
+	// same CR through the same selector. It is consulted for ONE thing: the role
+	// of a leg the runtime observed but could not classify, because occupancy
+	// alone cannot tell a writer from a follower for a workload that carries no
+	// role marker. It never invents a leg and never overrules one that does.
+	declared := h.declaredPlacementForComponent(primaryID, name, ns)
+
+	targets, cov := h.derivePlacementTargets(ident, declared, primaryID, clusterRegion, depID, fqdn)
 
 	// #4551 — Standby discovery for cross-region CNPG-backed components.
 	//
@@ -509,9 +516,12 @@ func (h *Handler) augmentWithContinuumStandby(
 	if region == "" {
 		return targets
 	}
-	// Don't double-list a region already represented as a Standby.
+	// Don't double-list a region already represented as a Standby. The compare
+	// is spelling-tolerant (#6347): the CR and the runtime leg name the same
+	// place in two different vocabularies, and a raw `==` reads "not listed
+	// yet" for a region that is already on the list.
 	for _, t := range targets {
-		if t.Role == bpv1.DataRoleStandby && t.Region == region {
+		if t.Role == bpv1.DataRoleStandby && samePlacementRegion(t.Region, region) {
 			return targets
 		}
 	}
@@ -548,10 +558,20 @@ func (h *Handler) continuumStandbyRegion(
 	// The set of Primary regions the runtime derivation already surfaced —
 	// a "standby" that equals a live Primary region is not an honest
 	// cross-region standby (single-region prov, or label mismatch).
-	primaryRegions := map[string]struct{}{}
+	//
+	// #6347 — the comparison is NORMALIZED, because the two sides speak
+	// different region vocabularies and a raw `==` could never match: the
+	// per-app `dr-<app>` Continuum carries the bare cloud region
+	// (`me-east-215-b`, taken from spec.regions[]) while a runtime leg carries
+	// the `openova.io/region` node label (`hw-me-east-215-b-rtz-prod`). On
+	// hw298 that mismatch is what appended a THIRD target, `cluster: ""`, over
+	// a region two live legs already covered — and in the one-region-occupied
+	// case it produced a "pair" whose two legs were the SAME region spelled two
+	// ways. The guard was there; it just could not see.
+	primaryRegions := make([]string, 0, len(targets))
 	for _, t := range targets {
 		if t.Role == bpv1.DataRolePrimary && t.Region != "" {
-			primaryRegions[t.Region] = struct{}{}
+			primaryRegions = append(primaryRegions, t.Region)
 		}
 	}
 	for _, s := range standbys {
@@ -559,7 +579,14 @@ func (h *Handler) continuumStandbyRegion(
 		if s == "" {
 			continue
 		}
-		if _, isPrimary := primaryRegions[s]; isPrimary {
+		isPrimary := false
+		for _, pr := range primaryRegions {
+			if samePlacementRegion(pr, s) {
+				isPrimary = true
+				break
+			}
+		}
+		if isPrimary {
 			continue
 		}
 		return s
@@ -683,7 +710,9 @@ type placementOccupancy struct {
 // #6344: it takes a RESOLVED componentWorkloadIdentity rather than a raw
 // (name, ns) pair, so the Pods it keeps are the ones the Application actually
 // installs — not the ones whose labels happen to spell the route id.
-func (h *Handler) derivePlacementTargets(ident componentWorkloadIdentity, primaryID string, clusterRegion map[string]string, depID, fqdn string) ([]bpv1.PlacementTarget, placementRuntimeCoverage) {
+// #6347: it also takes the app's DECLARED posture, which decides the role of a
+// leg no runtime signal can classify. See the role switch below.
+func (h *Handler) derivePlacementTargets(ident componentWorkloadIdentity, declared declaredPlacement, primaryID string, clusterRegion map[string]string, depID, fqdn string) ([]bpv1.PlacementTarget, placementRuntimeCoverage) {
 	// Fan out across primary + every secondary region cluster.
 	clusterIDs := []string{primaryID}
 	seen := map[string]struct{}{primaryID: {}}
@@ -753,8 +782,9 @@ func (h *Handler) derivePlacementTargets(ident componentWorkloadIdentity, primar
 	// CNPG path: if ANY occupancy carried a cnpg-role label, the component
 	// is a stateful pair — the occupancy(ies) that hold the primary
 	// instance are Primary; the rest are Standby·Hot (the pair streams).
-	// Stateless path: every region the component runs in is a Primary
-	// (multi-region stateless = active-active; single region = singleton).
+	// Stateless path: the occupancy carries NO role signal, so the role comes
+	// from the app's own declaration when it makes one (#6347), and otherwise
+	// from the pre-#6347 reading: every occupied region is a Primary.
 	anyCNPG := false
 	for _, o := range occ {
 		if o.anyCNPG {
@@ -783,8 +813,25 @@ func (h *Handler) derivePlacementTargets(ident componentWorkloadIdentity, primar
 			t.Role = bpv1.DataRoleStandby
 			t.StandbyType = bpv1.StandbyHot
 		default:
-			// Stateless: every occupied region serves traffic → Primary.
+			// Stateless: nothing on these Pods says which region serves
+			// writes. Pre-#6347 the answer was "all of them", which is a fair
+			// reading for a bootstrap component that declares nothing — and
+			// the wrong one for an app that declares `active-hot-standby`,
+			// where it produced the TWO Primaries hw298 measured and a
+			// `DerivePattern` of `active-active` over a primary+standby app.
+			//
+			// So the declaration decides the ROLE of a leg the runtime already
+			// established the PRESENCE of. It cannot reach the CNPG arms above
+			// (those carry positive per-leg evidence and keep it, so a
+			// failed-over pair still reports its live primary), it cannot add
+			// or remove an occupancy, and it stays silent unless the app names
+			// two distinct regions under an asymmetric mode — in which case a
+			// leg in a declared standby region is a follower, and a leg in a
+			// region the declaration never mentions keeps the reading below.
 			t.Role = bpv1.DataRolePrimary
+			if role, standbyType, ok := declared.roleForRegion(o.region); ok {
+				t.Role, t.StandbyType = role, standbyType
+			}
 		}
 		targets = append(targets, t)
 	}


### PR DESCRIPTION
## What was measured

hw298 (dep `2540d866403f1f7c`), mothership on `catalyst-api:8c41df2` — i.e. AFTER #6345 landed:

```
shared-pg      active-hot-standby → 2 targets  Primary(cluster set) + Standby(cluster set)   CONTROL, correct
spine-gitea    active-hot-standby → 3 targets  Primary(set) + Primary(set) + Standby(cluster "")
spine-keycloak active-hot-standby → 3 targets  Primary(set) + Primary(set) + Standby(cluster "")
```

`bpv1.DerivePattern` reads a 2-Primary list as `active-active`; `bpv1.ValidatePlacement` rejects it
outright as `MultiPrimaryNotSupported` under the default `primary+standby` capability. The
projection was emitting a placement its own validator refuses, and UAT row 60 wants a 2-region pair.

## The two terms, both confirmed in source before anything moved

**1. The stateless role arm has no discriminator.** `derivePlacementTargets` ends with *"every
occupied region serves traffic → Primary"*. `shared-pg` escapes only because CNPG stamps
`openova.io/cnpg-role` on each half, so its roles come from positive per-leg evidence. gitea and
keycloak have no equivalent marker, and `10-gitea.yaml` / `09-keycloak.yaml` carry **no**
`catalyst.openova.io/region-role` gate — "no gate ⇒ every region" — so they genuinely run in both
region clusters and both legs were labelled Primary.

**2. The empty-`cluster` leg is appended over a region the live legs already cover, because the two
sides never spell a region the same way.** `continuumStandbyRegion` skips a standby region that a
Primary already names — comparing raw. The per-app `dr-<app>` Continuum carries the bare cloud
region `me-east-215-b` (spine `spec.regions[]` is `RegionSpec.CloudRegion`,
`post_handover_spine_apps.go:619`) while a runtime leg carries the `openova.io/region` node label
`hw-me-east-215-b-rtz-prod`. #5482 recorded all three divergent spellings on one Application. The
guard was there; it could not see. The controller already folds the two vocabularies
(`normalizeRegion`, `core/controllers/application/internal/controller/placement_projection.go`) —
`internal/` puts that package out of reach from this module, so the fold is mirrored here token set
for token set, with its own table.

Both readings in the issue comment were right, and they are linked: term 2 is only *reachable*
because term 1 left the list with no Standby, and it only *fires* because of the vocabulary split.

## What changed

The role of a leg the runtime cannot classify now comes from the app's own declaration —
`placement.Resolve` and `placementRegionCountError` both state that `regions[0]` is the primary and
`regions[1..]` are the standbys, so this is the rule the write doors already enforce, read back on
the projection side. The declared list is read off the same Application CR through the same
selector the identity resolution uses (extracted to `applicationCRForComponent`, one CR and one
Organization-isolation rule for both consumers).

Three lines it does not cross, each pinned by its own case in the table:

- **It never overrules an observation.** A failed-over CNPG pair still reports its live primary in
  region B while `spec.regions[0]` names region A. The cnpg-role labels are evidence; a declaration
  is not, and a projection that tracked config here would point an operator at the region that no
  longer holds the write path.
- **It never invents a leg.** An app occupied only in its declared standby region now answers with a
  lone Standby and `unresolvedPrimary: true` (#6268) instead of promoting that leg to writer — and
  the #4551 declaration-derived Standby is *still* emitted when region B is genuinely empty, because
  there it is the only standby signal that exists.
- **It stays silent where it has no standing.** No Application CR, no `spec.placement`, a `singleton`
  or `active-active` posture, or fewer than two distinct regions ⇒ behaviour byte-for-byte as
  before. `active-active` is multi-primary by definition and keeps both Primaries.

## Red first, on a clean tree

The endpoint table was run against `git archive origin/main` before any source change:

```
--- FAIL: TestPlacementDeclaredRoles_Row60_6347/spine-gitea_shape:_occupied_in_BOTH_regions...
    got 3 target(s) (2 Primary, 1 Standby) want 2 (1 Primary, 1 Standby)
    targets=[{Region:hw-me-east-215-a-rtz-prod Cluster:dep-6347-gitea            Role:Primary}
             {Region:hw-me-east-215-b-rtz-prod Cluster:dep-6347-gitea-me-east-215-b Role:Primary}
             {Region:me-east-215-b             Cluster:                          Role:Standby StandbyType:Hot}]
    derivedFromRuntime=true unresolvedPrimary=false
--- FAIL: .../occupied_only_in_the_declared_STANDBY_region...
    got 2 target(s) (1 Primary, 1 Standby) want 1 (0 Primary, 1 Standby)
    targets=[{Region:hw-me-east-215-b-rtz-prod ... Role:Primary}
             {Region:me-east-215-b Cluster: Role:Standby StandbyType:Hot}]
TRUE-RC=1
```

The first block is the hw298 wire reproduced exactly, third leg and all. The second is the same
defect at its purest: a "cross-region pair" whose two legs are one region spelled two ways.

Post-fix, six cases green (`-count=1`), and the full `internal/handler` package green in 329s:

```
--- PASS: TestPlacementDeclaredRoles_Row60_6347
    --- PASS: .../spine-gitea shape: occupied in BOTH regions, declared active-hot-standby
    --- PASS: .../shared-pg shape: CNPG role labels carry the split
    --- PASS: .../failed-over CNPG pair: observed role beats the stale declaration
    --- PASS: .../single-region app: no fabricated standby
    --- PASS: .../standby region genuinely empty: the Continuum-derived leg is still emitted
    --- PASS: .../occupied only in the declared STANDBY region: honest half-pair, not a false primary
ok  github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/handler  329.361s
TRUE-RC=0
```

Every case also asserts the projected list passes `bpv1.ValidatePlacement` under
`primary+standby` — the invariant the live answer was violating.

UAT row 60 stays ❌ until an operator walk on a live Sovereign stamps it; this PR is the source fix,
not the stamp.

Refs #6344
Refs #3375
Refs #6347
Refs #6345

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HvMZTDx7W6EPZMmjyXmYh1
