### PR TITLE
fix(provisioning): funnel path can now render bp-agenity — DoD Pillar 4 had no emitter (Refs #6352)

### DIFF
--- a/core/services/provisioning/gitops/agenity_hr_6352_test.go
+++ b/core/services/provisioning/gitops/agenity_hr_6352_test.go
@@ -1,0 +1,73 @@
+package gitops
+
+import (
+	"strings"
+	"testing"
+)
+
+// #6352 — the Pillar-4 emitter must render, must claim the slug, and must put
+// the SOVEREIGN host in issuerHost (never the Org zone — that is #6314).
+func TestAgenityHR_6352(t *testing.T) {
+	if !isHelmReleaseApp("agenity") {
+		t.Fatal("agenity is not registered in helmReleaseAppSlugs")
+	}
+	opt := helmReleaseAppOpts{
+		slug:              "chepherd",
+		parentDomain:      "omani.rest",
+		sharedRealmIssuer: "https://auth.hw298.omantel.biz/realms/sovereign",
+		chartVersion:      "0.5.28",
+	}
+	out := generateHelmReleaseApp("agenity", opt)
+	if out == "" {
+		t.Fatal("generateHelmReleaseApp returned EMPTY for agenity")
+	}
+	for _, want := range []string{
+		"chart: bp-agenity",
+		`version: "0.5.28"`,
+		"issuerHost: hw298.omantel.biz",
+		"sovereignFqdn: chepherd.omani.rest",
+		"- agenity.chepherd.omani.rest",
+		"clientId: agenity-chepherd",
+		"name: cilium-gateway-console",
+		"allowGatewayEntity: true",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("rendered HR missing %q\n---\n%s", want, out)
+		}
+	}
+	// CONTROL 1 — the Org zone must NEVER be the issuer host (#6314 regression).
+	if strings.Contains(out, "issuerHost: chepherd.omani.rest") {
+		t.Error("issuerHost is the ORG zone — this is the #6314 envoy-404 bug")
+	}
+	// CONTROL 2 — no dependsOn (would wedge on a never-rendered bp-keycloak).
+	// Assert on the YAML KEY, not the substring: the template's own header
+	// comment explains why there is no dependsOn, and a naive Contains matched
+	// that prose on the first run. Strip comment lines, then look for the key.
+	if yamlHasKey(out, "dependsOn") {
+		t.Error("agenity HR carries a dependsOn — wedges in DependencyNotReady")
+	}
+	// CONTROL 3 — with no shared realm issuer the key is OMITTED, not malformed.
+	bare := generateHelmReleaseApp("agenity", helmReleaseAppOpts{slug: "a", parentDomain: "b.c"})
+	if strings.Contains(bare, "issuerHost:") {
+		t.Errorf("issuerHost stamped without a derivable Sovereign host:\n%s", bare)
+	}
+	// VACUITY — the positive assertion above must be able to fail.
+	if !strings.Contains(bare, "chart: bp-agenity") {
+		t.Error("control render is not an agenity HR at all — assertions vacuous")
+	}
+}
+
+
+// yamlHasKey reports whether a real (non-comment) line declares the key.
+func yamlHasKey(doc, key string) bool {
+	for _, ln := range strings.Split(doc, "\n") {
+		t := strings.TrimSpace(ln)
+		if t == "" || strings.HasPrefix(t, "#") {
+			continue
+		}
+		if strings.HasPrefix(t, key+":") || strings.HasPrefix(t, "- "+key+":") {
+			return true
+		}
+	}
+	return false
+}

--- a/core/services/provisioning/gitops/helmrelease_apps.go
+++ b/core/services/provisioning/gitops/helmrelease_apps.go
@@ -59,6 +59,7 @@ var helmReleaseAppSlugs = map[string]bool{
 	"openclaw":      true, // #4272 — bp-openclaw HelmRelease overlay
 	"stalwart-mail": true, // #4307 — bp-stalwart-tenant HelmRelease overlay
 	"newapi":        true, // #4739 — bp-newapi HelmRelease (openclaw's LLM gateway + row225 funnel parity with the BSS-door orgTenantBPNewAPI)
+	"agenity":       true, // #6352 — bp-agenity HelmRelease (DoD Pillar 4 per-Org Agenity workspace; funnel parity with the BSS-door orgTenantBPAgenity)
 }
 
 // isHelmReleaseApp reports whether the catalog slug is rendered as a
@@ -192,6 +193,8 @@ func generateHelmReleaseApp(appSlug string, opt helmReleaseAppOpts) string {
 		out = generateStalwartHR(opt)
 	case "newapi":
 		out = generateNewAPIHR(opt)
+	case "agenity":
+		out = generateAgenityHR(opt)
 	default:
 		return ""
 	}
@@ -716,7 +719,7 @@ spec:
 // core/services/provisioning/** while the value it asserts on lives in
 // products/catalyst/chart/templates/catalog-seed/ — the guard never ran on the
 // commit that broke it. Those paths are now in the trigger (#6324).
-const DefaultHRAppChartVersions = "openclaw=0.2.19,stalwart-mail=0.1.15,newapi=1.4.153"
+const DefaultHRAppChartVersions = "openclaw=0.2.19,stalwart-mail=0.1.15,newapi=1.4.153,agenity=0.5.28"
 
 // ParseHRAppVersions parses the CATALYST_HR_APP_CHART_VERSIONS wire format
 // ("slug=version,slug=version") into the HelmReleaseAppVersions map (#4706).
@@ -733,4 +736,116 @@ func ParseHRAppVersions(raw string) map[string]string {
 		}
 	}
 	return out
+}
+
+// sovereignHostFromRealmIssuer extracts `<sovereign-fqdn>` from a shared-realm
+// issuer of the form `https://auth.<sovereign-fqdn>/realms/<realm>`. Returns ""
+// when the issuer is empty or not in that shape, so callers fall back rather
+// than stamp a malformed host.
+//
+// This exists because the Sovereign FQDN is NOT a field on helmReleaseAppOpts:
+// the funnel generator is per-Org and carries the Org zone (slug+parentDomain).
+// sharedRealmIssuer is the one opt that already names the Sovereign, and the
+// browser-facing OIDC issuer must be the SOVEREIGN host, never the Org zone.
+func sovereignHostFromRealmIssuer(issuer string) string {
+	iss := strings.TrimSpace(issuer)
+	if iss == "" {
+		return ""
+	}
+	iss = strings.TrimPrefix(strings.TrimPrefix(iss, "https://"), "http://")
+	host, _, found := strings.Cut(iss, "/")
+	if !found || !strings.HasPrefix(host, "auth.") {
+		return ""
+	}
+	return strings.TrimPrefix(host, "auth.")
+}
+
+// generateAgenityHR mirrors the BSS-door orgTenantBPAgenity
+// (products/catalyst/bootstrap/api/internal/handler/organization_gitops.go)
+// for the generic funnel path — DoD Pillar 4, the per-Organization Agenity
+// workspace served at https://agenity.<slug>.<parent>/app/.
+//
+// WHY THIS EXISTS (#6352): agenity had NO render path in this generator, so
+// helmReleaseAppSlugs never claimed it, DeployableAppSlugs() flagged it
+// Deployable=false, the marketplace drew "COMING SOON" and funnel
+// cart-placement skipped it. Measured live on hw298: a real funnel Organization
+// (`chepherd`, tenantPublic omani.rest) converged Ready=True with its per-Org
+// Kustomizations green — and agenity inventory entries across ALL SEVEN org
+// Kustomizations were ZERO. The legacy BSS overlay is the only emitter of
+// bp-agenity in the repo (organization_gitops.go's own #5425 header says so),
+// and it is gated off for per-Org-GitOps Sovereigns. Exactly the #4272/#4307
+// gap shape, for the Pillar-4 app.
+//
+// NO dependsOn — deliberate, and the same reasoning the BSS-door template
+// records: the dashboard SPA renders independent of keycloak and cnpg, and a
+// dependsOn on a never-rendered bp-keycloak wedges the release in
+// DependencyNotReady forever (the divergence this file's header describes).
+//
+// oidcGate.issuerHost is the SOVEREIGN host, not the Org zone (#6314). The
+// browser-facing issuer is auth.<sovereign-fqdn>; the Org zone would render
+// auth.<slug>.<parent>, a host with no HTTPRoute — envoy 404 at sign-in. That
+// bug was fixed in the chart (bp-agenity 0.5.28, oidcGate.issuerHost) and this
+// generator carries the fix forward rather than reintroducing it. Falls back to
+// omitting the key when the Sovereign host is not derivable, which restores the
+// chart default (issuerHost | default .Values.sovereignFqdn).
+func generateAgenityHR(opt helmReleaseAppOpts) string {
+	host := fmt.Sprintf("agenity.%s.%s", opt.slug, opt.parentDomain)
+	orgZone := fmt.Sprintf("%s.%s", opt.slug, opt.parentDomain)
+	issuerHostLine := ""
+	if sov := sovereignHostFromRealmIssuer(opt.sharedRealmIssuer); sov != "" {
+		issuerHostLine = fmt.Sprintf("\n      issuerHost: %s", sov)
+	}
+	return fmt.Sprintf(`# bp-agenity (#4180, #6352) — the per-Organization agentic dashboard, rendered
+# by the generic funnel generator. Mirrors the BSS-door orgTenantBPAgenity; see
+# generateAgenityHR for why there is no dependsOn and why issuerHost is the
+# Sovereign host.
+%s
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bp-agenity
+  namespace: %s
+  labels:
+    catalyst.openova.io/app: agenity
+    openova.io/category: customer-facing-capability
+spec:
+  interval: 10m
+  releaseName: agenity
+  targetNamespace: %s%s
+  chart:
+    spec:
+      chart: bp-agenity
+      version: "*"
+      sourceRef:
+        kind: HelmRepository
+        name: bp-agenity
+        namespace: flux-system
+  install:
+    timeout: 15m
+    remediation:
+      retries: 3
+  upgrade:
+    timeout: 15m
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    # Per-Org identity zone — openova-MCP derives https://console.<fqdn> from it.
+    sovereignFqdn: %s
+    oidcGate:
+      enabled: true
+      clientId: agenity-%s%s
+    httpRoute:
+      enabled: true
+      hostnames:
+        - %s
+      parentRefs:
+        - name: cilium-gateway-console
+          namespace: kube-system
+    networkPolicy:
+      ingress:
+        allowGatewayEntity: true
+`, helmRepoBlock("bp-agenity"), opt.slug, opt.slug, opt.kubeConfigBlock(),
+		orgZone, opt.slug, issuerHostLine, host)
 }


### PR DESCRIPTION
fix(provisioning): the funnel path can now render bp-agenity — DoD Pillar 4 had no emitter (Refs #6352)

MEASURED, not inferred. Drove the marketplace funnel end-to-end on hw298 (plan ->
app -> PIN -> voucher, OMR 0.000 due) and it minted a real customer Organization
`chepherd` (tenantPublic parentDomain omani.rest). It converged Ready=True with all
three per-Org Kustomizations green and a working uptime-kuma Deployment — and
agenity inventory entries across ALL SEVEN org Kustomizations were ZERO.

Root cause: `agenity` was absent from `helmReleaseAppSlugs`, so this generator had
no render path for it. Per this file's own header that means DeployableAppSlugs()
flags it Deployable=false, the marketplace draws "COMING SOON", and funnel
cart-placement skips it — the exact #4272/#4307 gap shape, this time for the
Pillar-4 app. The legacy BSS overlay (organization_gitops.go orgTenantBPAgenity) is
the ONLY emitter of bp-agenity in the repo, and its own #5425 header records that it
is gated off for per-Org-GitOps Sovereigns and that the per-Org tree has no
equivalent for four resources — bp-agenity being the Pillar-4 one.

WHAT THIS CHANGE DOES
  - registers "agenity" in helmReleaseAppSlugs
  - routes it in generateHelmReleaseApp
  - adds generateAgenityHR, mirroring the BSS-door template's values contract
  - pins agenity=0.5.28 in DefaultHRAppChartVersions

WHY THE PIN IS NOT OPTIONAL HERE
pinHRChartVersion's own comment records that the bp-agenity CHART repo was squatted
by the dashboard IMAGE pushed as :0.9.7. A floating version "*" resolves to the
highest semver tag, i.e. that image — which is how "ONE mis-tagged artifact broke
every Org install at once". 0.5.28 is verified against the catalog seed
(products/catalyst/chart/templates/catalog-seed/blueprints.yaml:6038,6068) and
against the published GHCR tags, satisfying the row-234 invariant the
TestDefaultHRAppPins_MatchCatalogSeed guard enforces — which is exactly the guard
that caught this and made me add the pin.

issuerHost CARRIES #6314 FORWARD
The browser-facing OIDC issuer is stamped as the SOVEREIGN host, derived from
sharedRealmIssuer, never the Org zone. Stamping the Org zone renders
auth.<slug>.<parent> — a host with no HTTPRoute, envoy 404 at sign-in, which is the
bug fixed in bp-agenity 0.5.28 (oidcGate.issuerHost) and verified live this session.
When the Sovereign host is not derivable the key is OMITTED, restoring the chart
default rather than stamping something malformed.

NO dependsOn, deliberately — same reasoning both the BSS template and this file's
header record: the dashboard renders independent of keycloak/cnpg, and a dependsOn on
a never-rendered bp-keycloak wedges the release in DependencyNotReady forever.

TESTS — agenity_hr_6352_test.go, four controls:
  1. issuerHost must NOT be the Org zone (the #6314 regression)
  2. no dependsOn — asserted on the YAML KEY, not a substring. The first version
     matched the template's own header comment prose and failed; recorded in the
     test so it is not re-introduced.
  3. with no shared-realm issuer the key is omitted, not malformed
  4. vacuity: the control render must still be an agenity HR, or 1-3 assert nothing

  go test ./gitops/ -count=1   ok (full package)
  go vet ./...                 rc=0

SCOPE — this makes agenity RENDERABLE. It does not yet emit it unconditionally for
every Org the way the BSS door does (a fixed entry in orgTenantTemplates); that
BSS/funnel divergence is the same one #4739 hit for bp-newapi and impliedHelmReleaseApps
partially closed. Deliberately left as a separate decision rather than bundled here.

UAT rows 219/220/221/222 stay ❌ until this is deployed and walked live.

Refs #6352 #4180 #6314 #4272 #4307
