### PR TITLE
fix(cutover): re-seed the status ConfigMap when empty — resource-policy:keep makes it unrepairable (Refs #6356)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -1074,7 +1074,7 @@ spec:
       # chart/tests/ left the package via .helmignore: 757,264 bytes, 72.2%.
       # The rendered manifest is byte-identical modulo comments — no step,
       # value or RBAC change, still 11 steps.
-      version: 0.1.190
+      version: 0.1.191
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1451,7 +1451,7 @@ spec:
       #   staged commit and push, and makes the Phase-3 pre-strip read-back the
       #   single fail-closed gate (#5436 relocated, not weakened). Lockstep w/
       #   products/catalyst/chart/Chart.yaml.
-      version: 1.4.1510
+      version: 1.4.1511
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.190
+  version: 0.1.191
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -4153,7 +4153,7 @@ name: bp-self-sovereign-cutover
 # load-bearing. Slot-06a pin + blueprint.yaml + catalog-seed spec.version +
 # source.version + the API blueprints.json + the generated UI catalog move to
 # 0.1.190 in lockstep (Inviolable Principle #13).
-version: 0.1.190
+version: 0.1.191
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml
@@ -70,6 +70,43 @@ data:
     : "${HARBOR_USERNAME:=admin}"
 
     {{- /*
+     #6356 — RE-SEED THE STATUS ConfigMap IF IT IS EMPTY.
+
+     09-cutover-status-configmap.yaml renders a POPULATED object (totalSteps
+     + the 11 step slugs) and carries `helm.sh/resource-policy: keep`. Keep is
+     correct — mid-cutover progress must survive a chart upgrade — but it also
+     means Helm will NEVER update an object that already exists. So if that
+     ConfigMap is ever empty there is NO reconcile path back: no chart upgrade
+     can re-seed it, totalSteps stays absent, the /jobs cutover group can never
+     render 11 steps, and cutoverComplete is unprovable on that Sovereign
+     forever.
+
+     Measured live on hw298 2026-08-15: the ConfigMap existed (created
+     15:20:00Z, managed-by Helm, keep annotation present) with ZERO data keys
+     and 0 Jobs cluster-wide — the annotation protecting an empty artifact,
+     the one state it was added to prevent. Root cause of UAT rows G11/166.
+
+     The Job is the right repair point precisely BECAUSE Helm is forbidden:
+     this step always runs, already holds STATUS_CONFIGMAP_NAME/NAMESPACE, and
+     already merge-patches this object. A merge patch only ADDS absent keys, so
+     a ConfigMap already carrying mid-cutover progress is left untouched — this
+     can fill a gap, never overwrite a verdict.
+    */}}
+    if [ -n "${STATUS_CONFIGMAP_NAME:-}" ] && [ -n "${STATUS_CONFIGMAP_NAMESPACE:-}" ]; then
+      _seed_total="$(kubectl get configmap "${STATUS_CONFIGMAP_NAME}" -n "${STATUS_CONFIGMAP_NAMESPACE}" -o jsonpath='{.data.totalSteps}' 2>/dev/null || true)"
+      if [ -z "${_seed_total}" ]; then
+        echo "[harbor-prewarm] #6356: status ConfigMap ${STATUS_CONFIGMAP_NAMESPACE}/${STATUS_CONFIGMAP_NAME} has no totalSteps — re-seeding (resource-policy:keep means Helm cannot)"
+        if kubectl patch configmap "${STATUS_CONFIGMAP_NAME}" -n "${STATUS_CONFIGMAP_NAMESPACE}" --type merge -p '{"data":{"totalSteps":"11","reseededBy":"harbor-prewarm-6356"}}' >/dev/null 2>&1; then
+          echo "[harbor-prewarm] #6356: re-seeded totalSteps=11"
+        else
+          echo "[harbor-prewarm] #6356: WARN could not re-seed the status ConfigMap — cutover continues, but /jobs may not render all 11 steps"
+        fi
+      else
+        echo "[harbor-prewarm] #6356: status ConfigMap already seeded (totalSteps=${_seed_total}) — no write"
+      fi
+    fi
+
+    {{- /*
      #4975 — the offline-mirror image→local-path resolver (shared with
      step-08). Defines offlinemirror_normalize_ref + offlinemirror_local_paths
      over the HOST_PROJECT_MAP / EXCLUDED_* / LOCAL_REGISTRY_HOST env.

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-14T12:17:23.691Z",
+  "generatedAt": "2026-08-16T04:57:28.492Z",
   "blueprints": [
     {
       "id": "bp-agenity",
@@ -4640,7 +4640,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "0.1.190",
+      "version": "0.1.191",
       "section": "pts-2-3-per-sovereign-supporting-services",
       "depends": [
         "bp-gitea",

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -4775,7 +4775,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "0.1.190",
+    "version": "0.1.191",
     "section": "pts-2-3-per-sovereign-supporting-services",
     "depends": [
       "bp-gitea",

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3968,7 +3968,7 @@ name: bp-catalyst-platform
 #   file's 1.4.1325 entry records as permanently burned. The republish
 #   therefore lands on 1.4.1468 — ahead of main's 1.4.1467, absent from GHCR,
 #   and claimed by no open PR.)
-version: 1.4.1510
+version: 1.4.1511
 # 1.4.1481 — #6293: catalog-seed advances bp-self-sovereign-cutover
 #   0.1.186 -> 0.1.187, the release that stops step-06 from patching five
 #   HelmRepositories it does not own and then grading itself on whether they

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5115,7 +5115,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.1.190"
+  version: "0.1.191"
   visibility: unlisted
   card:
     title: "Self-Sovereignty Cutover"
@@ -5132,7 +5132,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-self-sovereign-cutover
-    version: "0.1.190"
+    version: "0.1.191"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
fix(cutover): re-seed the status ConfigMap when it is empty — keep makes it otherwise unrepairable (Refs #6356)

ROOT CAUSE, measured live on hw298 (dep 2540d866403f1f7c) 2026-08-15.

09-cutover-status-configmap.yaml renders a POPULATED object — line 68 `data:`,
line 74 `totalSteps: "11"`, plus the step slugs contract Case 93 asserts — and
carries `helm.sh/resource-policy: keep` (line 67). Keep is CORRECT: mid-cutover
progress must survive a chart upgrade. Its unintended consequence is the exact
inverse of its purpose: Helm never updates an object that already exists, so if
that ConfigMap is ever empty there is NO reconcile path back. No chart upgrade
can re-seed it, `totalSteps` stays absent, the /jobs cutover group can never
render 11 steps, and `cutoverComplete` is unprovable on that Sovereign forever.

Live evidence:

  ConfigMap catalyst/self-sovereign-cutover-status
    created 2026-08-14T15:20:00Z, managed-by Helm, keep annotation PRESENT
    data: {}                <- ZERO keys
  Jobs cluster-wide: 0      <- every step Job reaped

The annotation is protecting an empty artifact — the one state it exists to
prevent. That is the root cause of UAT rows G11 and 166.

Verified with a single-resource GET, not a list: the console k8s LIST route
strips `data` from ALL 307 ConfigMaps, so a list-only read reports {} for
everything and proves nothing.

THE FIX — repair from the Job, precisely BECAUSE Helm is forbidden.

step-03 (harbor-prewarm) is the earliest step that already holds
STATUS_CONFIGMAP_NAME/NAMESPACE and already merge-patches this object. At its
`set -eu` preamble it now reads `.data.totalSteps`; if absent it merge-patches
`totalSteps: "11"` plus a `reseededBy` marker, and logs which branch it took.

Three properties that make this safe:
  - a MERGE patch only ADDS absent keys, so a ConfigMap already carrying
    mid-cutover progress is untouched — this can fill a gap, never overwrite
    a verdict;
  - it is a no-op on the healthy path and says so ("already seeded ... no write");
  - a failed patch WARNs and the cutover continues rather than dying on a
    bookkeeping write.

Chart 0.1.190 -> 0.1.191 with the bootstrap-kit slot pin moved in the SAME
commit (clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml:1077)
so the pin is not hollow.

GATES, unpiped, TRUE-RC captured:
  helm template                       rc=0  (5 marker occurrences rendered)
  cutover-contract.sh                 rc=0  87 cases
  check-bootstrap-kit-pin-sync.sh     rc=0
  check-chart-version-forward.sh      rc=0
  check-helm-release-payload-size.py  rc=0  — NOTE: this chart is at 81.2% of the
                                      1048576-byte Secret ceiling and is the next
                                      one in line for #6004. Worth reducing before
                                      it reaches 90%.

SCOPE: this makes an empty status ConfigMap repairable going forward. It does NOT
retroactively fix hw298 — that Sovereign is post-registry-pivot and cannot receive
a new chart without a re-mirror. Rows G11/166 stay ❌ until this ships on an env
that runs a cutover.

Refs #6356 #3379
