### PR TITLE
fix(bp-guacamole): connection producer was deleted at render time by a CNPG capability gate (UAT row 115)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1451,7 +1451,7 @@ spec:
       #   staged commit and push, and makes the Phase-3 pre-strip read-back the
       #   single fail-closed gate (#5436 relocated, not weakened). Lockstep w/
       #   products/catalyst/chart/Chart.yaml.
-      version: 1.4.1512
+      version: 1.4.1513
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/clusters/_template/bootstrap-kit/52-bp-guacamole.yaml
+++ b/clusters/_template/bootstrap-kit/52-bp-guacamole.yaml
@@ -206,7 +206,7 @@ spec:
       # Sovereign's own node, address from the downward API) and the
       # per-minute enroll CronJob re-converges it. Credentials come from an
       # optional Secret, never from values.
-      version: 0.2.41
+      version: 0.2.42
       sourceRef:
         kind: HelmRepository
         name: bp-guacamole

--- a/platform/guacamole/blueprint.yaml
+++ b/platform/guacamole/blueprint.yaml
@@ -7,7 +7,7 @@ metadata:
     catalyst.openova.io/category: platform
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.2.41
+  version: 0.2.42
   card:
     title: Apache Guacamole
     summary: Clientless HTML5 remote-desktop gateway. Browser-based RDP / VNC / SSH and kubectl-exec into Pods, with Keycloak SSO and full session recording to SeaweedFS. One Guacamole per Sovereign per ADR-0001 §11.

--- a/platform/guacamole/chart/Chart.yaml
+++ b/platform/guacamole/chart/Chart.yaml
@@ -399,7 +399,7 @@ name: bp-guacamole
 # Lockstep: 52-bp-guacamole.yaml pin + blueprint.yaml + catalog-seed
 # source.version → 0.2.38.
 # Refs #5991.
-version: 0.2.41
+version: 0.2.42
 appVersion: "1.5.5"
 description: |
   Catalyst-authored Blueprint chart for Apache Guacamole — a clientless

--- a/platform/guacamole/chart/templates/jdbc-schema-seed-job.yaml
+++ b/platform/guacamole/chart/templates/jdbc-schema-seed-job.yaml
@@ -42,14 +42,44 @@ DB-direct via the CNPG <cluster>-app Secret (host/port/dbname/user/password).
 enableSuperuserAccess on the Cluster is for the schema DDL; the app owner here
 owns the objects it creates, so the app credential suffices for the seed.
 
-Skip-render: guacamole.enabled=false, database.enabled=false, or the
-postgresql.cnpg.io CRD absent.
+Skip-render: guacamole.enabled=false, or database.enabled=false.
+
+NOT skip-render, deliberately: the presence of the postgresql.cnpg.io CRD.
+That probe used to be a third condition here and it silently deleted this
+whole file — schema seed, admin group, AND the connection producer — whenever
+the chart happened to render before the CNPG CRD was visible. Measured on
+hw298 (UAT row 115, #5991): guacamole came up Ready on chart 0.2.41, which is
+NEWER than the 0.2.38 that shipped the producer, and `guacamole_connection`
+was still empty. `.Capabilities` is evaluated at RENDER time, so a bootstrap
+ordering race does not produce a Job that waits — it produces no Job at all.
+Because these objects are `post-install,post-upgrade` HOOKS, a later reconcile
+that changes nothing never re-runs them, so the gap is permanent rather than
+self-healing.
+
+Reproduced deterministically before removing it:
+  helm template … --api-versions "postgresql.cnpg.io/v1"  -> seed Job renders
+  helm template …                                          -> ZERO seed lines
+
+The probe also bought nothing: the CNPG CRD is a bootstrap-kit invariant, and
+when it is genuinely late the seeder already waits — wait_for_db() retries
+until the CNPG `<cluster>-app` Secret and the database answer. Losing the
+manifest is strictly worse than waiting for the database.
 */ -}}
 {{- $db := .Values.guacamole.database | default dict -}}
 {{- $cl := $db.cluster | default dict -}}
+{{- /* The database master switch, resolved the SAFE way. `default true
+   $db.enabled` is wrong for an explicit false: sprig's `default` substitutes
+   whenever the value is FALSY, and `false` is falsy, so `default true false`
+   yields TRUE and `database.enabled: false` never disabled anything. That
+   latent bug sat masked behind the CNPG capability probe removed above — with
+   the probe gone it became load-bearing, so it is resolved by key PRESENCE
+   here, matching how this same file already resolves the connection switches
+   below (`hasKey $conn "enabled"`). */ -}}
+{{- $dbEnabled := true -}}
+{{- if hasKey $db "enabled" }}{{- $dbEnabled = $db.enabled -}}{{- end -}}
 {{- /* #5358: seeds + enrols against the local CNPG store, which only the
    crossRegion `primary` region renders. */ -}}
-{{- if and (include "bp-guacamole.renderWorkloads" .) (default true $db.enabled) (.Capabilities.APIVersions.Has "postgresql.cnpg.io/v1") }}
+{{- if and (include "bp-guacamole.renderWorkloads" .) $dbEnabled }}
 {{- $name := $cl.name | default "guacamole-pg" -}}
 {{- $appSecret := $db.appSecretName | default (printf "%s-app" $name) -}}
 {{- $adminGroup := $db.adminGroup | default "sovereign-admins" -}}

--- a/platform/guacamole/chart/tests/connection-seed-render.sh
+++ b/platform/guacamole/chart/tests/connection-seed-render.sh
@@ -45,10 +45,17 @@ if [[ ! -d charts ]] || [[ -z "$(ls -A charts 2>/dev/null)" ]]; then
   }
 fi
 
-# --api-versions is REQUIRED: the seed Job + enroll CronJob are gated on
-# `.Capabilities.APIVersions.Has "postgresql.cnpg.io/v1"`, and without it the
-# render is silently empty and every assertion below "fails" for a reason that
-# has nothing to do with the chart. The vacuity check at the end catches that.
+# --api-versions is still passed here so this file exercises the same shape a
+# converged cluster reports.
+#
+# IT IS NO LONGER REQUIRED, and that is the whole point of case 7 below. The
+# seed Job used to be gated on `.Capabilities.APIVersions.Has
+# "postgresql.cnpg.io/v1"` and THIS FILE ALWAYS SUPPLIED THAT CAPABILITY — so
+# the suite could not observe the one condition under which the producer
+# disappeared. That is a guard testing a surface that cannot fail: every
+# assertion below passed while live hw298 had zero connections, because the
+# render under test was never the render that shipped. The gate is gone
+# (#5991); case 7 pins its absence.
 render() { # render <outfile> [extra --set args…]
   local out="$1"; shift
   helm template bp-guacamole . \
@@ -396,6 +403,48 @@ if grep -q 'catalyst.openova.io/component: jdbc-seed' "${TMP}/default.yaml"; the
   pass "vacuity: the default render did contain the jdbc-seed Job"
 else
   fail "vacuity: no jdbc-seed Job in the default render — assertions above were empty-string comparisons"
+fi
+
+echo "[connection-seed] 7/7 — the producer survives WITHOUT the CNPG api-version"
+# THE CASE THIS SUITE COULD NOT HAVE HAD. `.Capabilities` is evaluated at
+# RENDER time, so when the chart rendered before the CNPG CRD was visible the
+# Job was not skipped-at-runtime — it was ABSENT FROM THE MANIFEST. Being a
+# post-install/post-upgrade hook, no later reconcile re-ran it, so the gap was
+# permanent. Measured on hw298: chart 0.2.41, NEWER than the 0.2.38 that
+# shipped the producer, with an empty ALL CONNECTIONS list.
+helm template bp-guacamole . \
+  --set guacamole.enabled=true \
+  --set guacamole.httproute.hostname=guacamole.test \
+  --set guacamole.oidc.issuer=https://kc.test/realms/c \
+  >"${TMP}/nocap.yaml" 2>"${TMP}/nocap.yaml.err" \
+  || { echo "helm template failed:"; cat "${TMP}/nocap.yaml.err"; exit 1; }
+
+if grep -q 'catalyst.openova.io/component: jdbc-seed' "${TMP}/nocap.yaml"; then
+  pass "seed Job renders without postgresql.cnpg.io/v1 declared"
+else
+  fail "seed Job VANISHES without the CNPG api-version — the #5991 render-time gate is back"
+fi
+for target in sovereign-node cluster-shell; do
+  if grep -q "${target}" "${TMP}/nocap.yaml"; then
+    pass "connection target '${target}' present without the api-version"
+  else
+    fail "connection target '${target}' missing without the api-version"
+  fi
+done
+# CONTROL: the master switch must still suppress it, so case 7 cannot be
+# satisfied by a chart that simply always renders. This also pins the sprig
+# trap — `default true $db.enabled` returns TRUE for an explicit false, so the
+# switch was inert until it was resolved by hasKey.
+helm template bp-guacamole . \
+  --set guacamole.enabled=true \
+  --set guacamole.database.enabled=false \
+  --set guacamole.httproute.hostname=guacamole.test \
+  --set guacamole.oidc.issuer=https://kc.test/realms/c \
+  >"${TMP}/dboff.yaml" 2>/dev/null || true
+if grep -q 'catalyst.openova.io/component: jdbc-seed' "${TMP}/dboff.yaml"; then
+  fail "CONTROL: database.enabled=false still rendered the seed Job — the master switch is inert"
+else
+  pass "CONTROL: database.enabled=false suppresses the seed Job"
 fi
 
 if [[ "${fails}" -gt 0 ]]; then

--- a/platform/guacamole/chart/tests/render.sh
+++ b/platform/guacamole/chart/tests/render.sh
@@ -136,7 +136,19 @@ helm template bp-guacamole . \
 # in ALL CONNECTIONS and then hang on click. tests/connection-seed-
 # render.sh asserts that policy's CONTENT and carries the control that
 # it does NOT render when no mTLS connection is declared.
-expect_total=14
+# 14 -> 17 (#5991). The three added objects are the jdbc-seed ConfigMap + Job
+# and the admin-enroll CronJob. They were ALWAYS meant to be in this bundle;
+# they were absent because the whole seed template was gated on a RENDER-TIME
+# `.Capabilities.APIVersions.Has "postgresql.cnpg.io/v1"`, and this script does
+# not pass --api-versions. So the old expectation of 14 was calibrated against
+# the buggy render — the count encoded the defect, which is why a guard that
+# counts can ratify a bug as the norm.
+#
+# The live consequence of that gate: a Sovereign whose chart rendered before
+# the CNPG CRD was visible got NO seed Job at all, and since it is a
+# post-install hook it never re-ran, so `guacamole_connection` stayed empty
+# forever while the admin looked healthy (UAT row 115).
+expect_total=17
 got_total="$(grep -cE '^kind:' "$render_on")"
 if [[ "$got_total" != "$expect_total" ]]; then
   echo "FAIL: full-ON (header mode) rendered $got_total resources, want $expect_total"
@@ -224,7 +236,8 @@ helm template bp-guacamole . \
 # 14 → 15 in 0.2.40 (#5991): the guacd egress NetworkPolicy. It is keyed
 # on the mTLS connection being declared, NOT on the SSO mode, so it
 # renders in both modes — guacd dials bp-k8s-ws-proxy either way.
-expect_legacy=15
+# 15 -> 18 (#5991): same three seed objects as the full-ON case above.
+expect_legacy=18
 got_legacy="$(grep -cE '^kind:' "$render_legacy")"
 if [[ "$got_legacy" != "$expect_legacy" ]]; then
   echo "FAIL: legacy openid mode rendered $got_legacy resources, want $expect_legacy"

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-16T04:57:28.492Z",
+  "generatedAt": "2026-08-16T08:15:56.802Z",
   "blueprints": [
     {
       "id": "bp-agenity",
@@ -1817,7 +1817,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "listed",
-      "version": "0.2.41",
+      "version": "0.2.42",
       "section": "pts-3-1-networking-and-service-mesh",
       "depends": [
         "bp-keycloak",

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -1952,7 +1952,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "listed",
-    "version": "0.2.41",
+    "version": "0.2.42",
     "section": "pts-3-1-networking-and-service-mesh",
     "depends": [
       "bp-keycloak",

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3968,7 +3968,7 @@ name: bp-catalyst-platform
 #   file's 1.4.1325 entry records as permanently burned. The republish
 #   therefore lands on 1.4.1468 — ahead of main's 1.4.1467, absent from GHCR,
 #   and claimed by no open PR.)
-version: 1.4.1512
+version: 1.4.1513
 # 1.4.1481 — #6293: catalog-seed advances bp-self-sovereign-cutover
 #   0.1.186 -> 0.1.187, the release that stops step-06 from patching five
 #   HelmRepositories it does not own and then grading itself on whether they
@@ -4155,7 +4155,7 @@ version: 1.4.1512
 # scripts/check-chart-version-forward.sh (#5743) fails unless the two match —
 # main was carrying a pre-existing 1.4.1330/1.4.1329 split, so this bump heals
 # it in the same commit, exactly as the documented self-heal contract does.
-appVersion: 1.4.1512
+appVersion: 1.4.1513
 # 1.4.239 — Wave 3 / Issue #2140 (2026-05-23): Huawei provider
 # implementation lands behind the Wave 2 CloudProvider interface.
 # Adds the OpenTofu module at infra/providers/huawei/ (VPC + Subnet +

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -1740,7 +1740,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.2.41"
+  version: "0.2.42"
   visibility: listed
   card:
     title: "Apache Guacamole"
@@ -1768,7 +1768,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-guacamole
-    version: "0.2.41"
+    version: "0.2.42"
   topology:
     supported:
     - active-hot-standby


### PR DESCRIPTION
## What was wrong

UAT row 115 asserts the Guacamole ALL CONNECTIONS list is non-empty for a
signed-in sovereign-admin, with an explicit vacuity guard that admin
**permissions do not count**. Walked live on hw298 and it failed: Guacamole's
own REST API answered **200** — a real read, not a 403 — with **zero**
connections on both data sources, `ROOT/tree` `childConnections=0`, and an
empty list in the DOM.

**Not a delivery gap.** The producer shipped in chart **0.2.38**; hw298 ran
**0.2.41**, which is newer, and both targets are enabled by default. The
deployed chart contained the producer and it still wrote nothing.

## Root cause

`templates/jdbc-schema-seed-job.yaml` gated the **entire file** — schema seed,
admin group, and the connection producer — on a **render-time**
`.Capabilities.APIVersions.Has "postgresql.cnpg.io/v1"`, and its objects are
`helm.sh/hook: post-install,post-upgrade`.

If the chart first rendered while the CNPG CRD was not yet visible, the Job was
not skipped-at-runtime — it was **absent from the manifest**. And because hooks
do not re-run on a reconcile that changes nothing, the gap was **permanent**
rather than self-healing. Guacamole came up Ready, admin-enroll (a separate
object, outside the gate) granted the `CREATE_*` permissions, and the
connection table stayed empty — precisely the state row 115 calls a FAIL.

Reproduced deterministically before touching anything:

```
helm template … --api-versions postgresql.cnpg.io/v1   -> seed Job renders
helm template …                                        -> ZERO seed lines
```

The probe bought nothing: the CNPG CRD is a bootstrap-kit invariant, and when
it is genuinely late the seeder already waits — `wait_for_db()` retries until
the CNPG app Secret and the database answer. Losing the manifest is strictly
worse than waiting for the database.

## A second, pre-existing defect surfaced when the gate came off

Caught by my own control, not by inspection. `(default true $db.enabled)` is
the sprig falsy-default trap: `default` substitutes whenever the value is
falsy, and `false` **is** falsy, so `default true false` yields `true` and
`database.enabled: false` **never disabled anything**. It had been masked —
with the capability probe in front of it the file was skipped for the other
reason. Now resolved by key presence (`hasKey`), matching how this same file
already resolves the connection switches.

## Verification — four-way matrix (objects rendered)

| condition | before | after |
|---|---|---|
| no api-version, db enabled *(the bug)* | **0** | **2** |
| WITH api-version, db enabled *(control)* | 2 | 2 |
| `database.enabled=false` *(master switch)* | 2 | **0** |
| `guacamole.enabled=false` | 0 | 0 |

`helm lint` rc=0. Both connection targets (`sovereign-node`, `cluster-shell`)
render in the bug condition.

## The guard that let this through

`tests/connection-seed-render.sh` **always** passed
`--api-versions postgresql.cnpg.io/v1` and documented it as REQUIRED. Every
assertion therefore ran against a render that was not the render being shipped,
so the suite stayed green while the live Sovereign had no connections — a guard
testing a surface that cannot fail.

**Case 7** renders *without* the api-version and demands the producer and both
targets survive, plus a CONTROL that `database.enabled=false` still suppresses
the Job, so the case cannot be satisfied by a chart that merely always renders.

It is **vacuity-proven, not assumed**: reintroducing the gate turns the suite
RED with `seed Job VANISHES without the CNPG api-version` (TRUE-RC=1);
reverting turns it green (TRUE-RC=0).

## Lockstep

Chart `0.2.41 -> 0.2.42` across blueprint.yaml, Chart.yaml, the bootstrap-kit
slot pin, and the catalog seed. Guards, true exit codes captured unpiped:

```
check-bootstrap-kit-pin-sync.sh   rc=0   (67 chart→pin pairs)
check-catalog-seed-lockstep.sh    rc=0   (68 seeds, 0 fail)
check-chart-version-bumped.sh     rc=0
```

Row 115 stays ❌ in the ledger until it is walked on a live env carrying
0.2.42 — merged is not delivered.

Refs #5991
Refs #6246
