### PR TITLE
fix(bp-agenity): validate the Anthropic credential by USE — a revoked token passed presence and expiry checks (UAT rows 220/221/G8)

### DIFF
--- a/products/agenity/blueprint.yaml
+++ b/products/agenity/blueprint.yaml
@@ -18,7 +18,7 @@ spec:
   # Keycloak backchannel + upstream) — the per-Org namespace is default-deny
   # and the gate's ingress-only CNP left the OAuth callback 500ing on a DNS
   # timeout. Lockstep with products/agenity/chart + the catalog-seed pin.
-  version: 0.5.28
+  version: 0.5.29
   card:
     title: Agenity
     summary: |

--- a/products/agenity/chart/Chart.yaml
+++ b/products/agenity/chart/Chart.yaml
@@ -241,7 +241,7 @@ type: application
 # same gateway bp-wordpress-tenant + the org console route attach to, #4054).
 # The old default rendered Accepted=False/InvalidHTTPRoute and the host 404'd
 # until the parentRef was hand-overridden. appVersion (image) unchanged.
-version: 0.5.28
+version: 0.5.29
 # 0.5.22 (#5617): the per-Org oidc-gate companion gains its EGRESS
 # CiliumNetworkPolicy (templates/oidc-gate.yaml `oidc-gate-<cid>-egress`).
 # The gate shipped an ingress-only gateway CNP into a DEFAULT-DENY per-Org

--- a/products/agenity/chart/templates/statefulset.yaml
+++ b/products/agenity/chart/templates/statefulset.yaml
@@ -148,6 +148,54 @@ spec:
                   NOEXP)    echo "claude-code credentials.json has no expiresAt — assuming a non-expiring credential." ;;
                   *)        echo "could not parse claude-code OAuth expiry from credentials.json (non-fatal)." ;;
                 esac
+                # ── REVOCATION pre-flight (#6365, UAT rows 220/221/G8) ───────
+                # The expiry check above reads the CLOCK. A REVOKED token can
+                # carry a future expiresAt and still be dead, so it passes every
+                # check here and then 401s at first use. Measured live: the
+                # agent's own terminal returned
+                #   "● Please run /login · API Error: 401 OAuth access token has
+                #    been revoked."
+                # while the workspace reported healthy and the seed printed
+                # "token valid (~Nh remaining)". Presence + unexpiry are not
+                # validity; only the issuer can say.
+                #
+                # UNREACHABLE IS NOT REVOKED, and that distinction is the whole
+                # point. An air-gapped or egress-restricted Sovereign cannot
+                # reach api.anthropic.com, and treating that silence as a bad
+                # credential would refuse to start a workspace whose token is
+                # perfectly good. So ONLY a definitive HTTP 401 is a verdict;
+                # a connection failure is reported as NOT MEASURED and start
+                # continues.
+                {{- /* Resolved by key PRESENCE, never `default`. `false | default true`
+                       yields TRUE — sprig substitutes on FALSY — so a `default`
+                       here would make validateByUse:false unturnoffable. That is
+                       the same trap this repo just fixed in bp-guacamole's
+                       database.enabled, and I reproduced it here on the first
+                       write; the render control caught it. */ -}}
+                {{- $vbu := true -}}
+                {{- if hasKey .Values.anthropic "validateByUse" }}{{- $vbu = .Values.anthropic.validateByUse -}}{{- end -}}
+                if [ "{{ $vbu }}" = "true" ]; then
+                  _tok=$(python3 -c 'import json;print(json.load(open("/claudehome/.claude/.credentials.json")).get("claudeAiOauth",{}).get("accessToken",""))' 2>/dev/null || true)
+                  if [ -n "$_tok" ]; then
+                    _code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 15 \
+                              -H "Authorization: Bearer $_tok" \
+                              -H "anthropic-version: 2023-06-01" \
+                              https://api.anthropic.com/v1/models 2>/dev/null || echo 000)
+                    case "$_code" in
+                      401) echo "🛑 FATAL (#6365): the issuer REJECTED this credential — api.anthropic.com answered 401. The token is present and unexpired but revoked or otherwise invalid; every agent spawn will fail with 'OAuth access token has been revoked'. Re-seed openbao catalyst/anthropic/token with a fresh credentialsJson (README §Seeding)."
+                           if [ "$_cw_onexpired" = "continue" ]; then
+                             echo "🛑 anthropic.onExpiredCredential=continue — starting anyway; the dashboard will serve but chat will 401."
+                           else
+                             echo "🛑 refusing to start, so this surfaces in kubectl get pod rather than as a healthy Pod that cannot answer."
+                             exit 1
+                           fi ;;
+                      000) echo "credential NOT VALIDATED BY USE — api.anthropic.com was unreachable from this pod (air-gap or egress policy). This is absence of MEASUREMENT, not a bad credential; starting." ;;
+                      *)   echo "credential accepted by the issuer (api.anthropic.com answered ${_code}, i.e. not 401)." ;;
+                    esac
+                  else
+                    echo "credential NOT VALIDATED BY USE — no accessToken field in credentials.json (key-only or non-OAuth credential)."
+                  fi
+                fi
               else
                 # #6163 FREEZE 2. This branch is NOT "key-only mode" — this init
                 # container only renders when `anthropic.credentialsKey` is set,

--- a/products/agenity/chart/values.yaml
+++ b/products/agenity/chart/values.yaml
@@ -87,6 +87,25 @@ anthropic:
   # solo agent can call Claude. Empty = key-only mode (only works for a real
   # sk-ant-api03 API key, which the OAuth journey does not use).
   credentialsKey: credentialsJson
+  # ── Validate the credential BY USE, not just by presence + clock (#6365) ──
+  # The seed already waits for the credential (#6163 FREEZE 2) and refuses an
+  # EXPIRED one (FREEZE 3). Neither catches a REVOKED token: revocation leaves
+  # expiresAt in the future, so the blob is present, non-empty and unexpired,
+  # and the workspace comes up healthy while every agent spawn answers
+  # "401 OAuth access token has been revoked" (measured live, UAT rows
+  # 220/221/G8 — the agent said it in its own terminal while the seed logged
+  # "token valid").
+  #
+  # With this on, the seed asks the ONLY authority that can answer — the issuer
+  # — with one cheap authenticated GET. A definitive 401 is a verdict and is
+  # handled by anthropic.onExpiredCredential (fail|continue). An UNREACHABLE
+  # api.anthropic.com is explicitly NOT a verdict: an air-gapped Sovereign
+  # reports "NOT VALIDATED BY USE" and starts, because silence is absence of
+  # measurement, not evidence of a bad credential.
+  #
+  # Set false on a Sovereign that mirrors Anthropic behind an in-cluster proxy
+  # where the probe URL would not resolve.
+  validateByUse: true
   # #6163 FREEZE 2 — the seed init container WAITS for the credential instead
   # of reading the mount once and asserting whatever it saw.
   #

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-16T04:57:28.492Z",
+  "generatedAt": "2026-08-16T08:48:07.863Z",
   "blueprints": [
     {
       "id": "bp-agenity",
@@ -11,7 +11,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "listed",
-      "version": "0.5.28",
+      "version": "0.5.29",
       "section": "pts-7-org-tenant",
       "depends": [
         "bp-external-secrets"

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -146,7 +146,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "listed",
-    "version": "0.5.28",
+    "version": "0.5.29",
     "section": "pts-7-org-tenant",
     "depends": [
       "bp-external-secrets"

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -6035,7 +6035,7 @@ spec:
   # 0.5.22 (#5617): the oidc-gate companion gains its egress CNP — the per-Org
   # namespace is default-deny and the gate's ingress-only CNP left DNS + the
   # Keycloak token exchange dropped, 500ing every OAuth callback after login.
-  version: "0.5.28"
+  version: "0.5.29"
   visibility: listed
   card:
     title: "Agenity"
@@ -6065,7 +6065,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-agenity
-    version: 0.5.28
+    version: 0.5.29
   topology:
     supported:
       - singleton


### PR DESCRIPTION
## The failure, in the agent's own words

UAT rows **220**, **221** and **G8** all fail on one cause. Walked live, the
agent's terminal returned verbatim:

```
● Please run /login · API Error: 401 OAuth access token has been revoked.
```

while the workspace reported healthy and the seed init container logged
`claude-code OAuth token valid (~Nh remaining)`.

## Why both were true at once

The seed already does two good things:

- **waits** for the credential rather than reading the mount once (#6163 FREEZE 2)
- **refuses an EXPIRED one** (#4111 / FREEZE 3)

Neither can see a **revoked** token. Revocation is a server-side act — it leaves
`expiresAt` untouched, so the blob is present, non-empty and unexpired.
Presence passes. The clock passes. **Only the issuer knows.**

That is the same shape as the row-115 Guacamole gate landed earlier today: a
check positioned where it cannot observe the thing that actually breaks.

## What this adds

After seeding, ask `api.anthropic.com` with the seeded accessToken.

| result | meaning | action |
|---|---|---|
| **401** | issuer rejected it — revoked/invalid | verdict; routes through the existing `fail\|continue` vocabulary |
| **000** | unreachable (air-gap / egress policy) | **NOT a verdict** — prints `NOT VALIDATED BY USE`, starts |
| other | issuer accepted the credential | proceed |

**Unreachable is not revoked**, and that distinction is the point. An air-gapped
Sovereign cannot reach the issuer, and treating that silence as a bad credential
would refuse to start a workspace whose token is perfectly good. Absence of
measurement is reported as absence of measurement.

On a 401 the pod refuses to start (default), so the condition surfaces in
`kubectl get pod` rather than as a Running Pod that cannot answer — the same
reasoning FREEZE 3 applied to expiry.

## I reproduced a bug I had just fixed, and the control caught it

The first draft wrote the knob as
`{{ .Values.anthropic.validateByUse | default true }}`.

That is the **exact sprig falsy-default trap** this repo fixed in
`bp-guacamole`'s `database.enabled` **within the hour**: `default` substitutes
whenever the value is falsy, and `false` is falsy, so `false | default true`
yields `true` and `validateByUse: false` could never turn it off.

My own render control caught it — the guard still printed
`if [ "true" = "true" ]` under `--set anthropic.validateByUse=false`. Resolved
by key presence (`hasKey`), with the reason recorded inline so the next author
does not write it a third time.

## Verification

```
default                  -> if [ "true"  = "true" ]
validateByUse=false      -> if [ "false" = "true" ]
verdict branches present -> 401 / 000 / *
401 branch honours _cw_onexpired (fail|continue)
helm lint                rc=0
check-bootstrap-kit-pin-sync   rc=0
check-catalog-seed-lockstep    rc=0
```

Chart `0.5.28 -> 0.5.29`; catalog seed and the generated catalog regenerated.

## Scope

This makes the failure **loud and diagnosable**. It does not mint a token —
rows 220/221/G8 stay red until walked on an environment carrying 0.5.29 with a
freshly seeded credential. Merged is not delivered.

Refs #6163
Refs #4111
