### PR TITLE
fix(topology): loadVClusters queried the non-existent group vcluster.io — the installed CRD is vclusters.vcluster.com

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/infrastructure.go
+++ b/products/catalyst/bootstrap/api/internal/handler/infrastructure.go
@@ -837,7 +837,7 @@ func (h *Handler) PatchInfrastructureCluster(w http.ResponseWriter, r *http.Requ
 
 // PatchInfrastructureVCluster — PATCH .../vclusters/{id}
 //
-// vClusters are K8s-native (vcluster.io/v1alpha1/vclusters) per
+// vClusters are K8s-native (vcluster.com/v1alpha1/vclusters) per
 // ADR-0001 §9.2 row B3. catalyst-api still wraps the call through
 // the same submitMutation pipe, but the XRC kind it submits is the
 // VClusterClaim — the third-sibling Composition is the one that

--- a/products/catalyst/bootstrap/api/internal/handler/infrastructure_crud_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/infrastructure_crud_test.go
@@ -68,12 +68,12 @@ func xrcListKinds() map[schema.GroupVersionResource]string {
 		mk("pvcclaims"):        "PVCClaimList",
 	}
 	// The DELETE handler calls infrastructure.Load to compute the
-	// cascade preview, which queries vcluster.io/v1alpha1/vclusters
+	// cascade preview, which queries vcluster.com/v1alpha1/vclusters
 	// and core/v1/persistentvolumeclaims. Register those kinds with
 	// the fake client so List doesn't panic on "unregistered list
 	// kind". Production hits a real apiserver that either has the
 	// CRD or returns 404 — both code paths return gracefully.
-	out[schema.GroupVersionResource{Group: "vcluster.io", Version: "v1alpha1", Resource: "vclusters"}] = "VClusterList"
+	out[schema.GroupVersionResource{Group: "vcluster.com", Version: "v1alpha1", Resource: "vclusters"}] = "VClusterList"
 	out[schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumeclaims"}] = "PersistentVolumeClaimList"
 	return out
 }

--- a/products/catalyst/bootstrap/api/internal/infrastructure/topology_loader.go
+++ b/products/catalyst/bootstrap/api/internal/infrastructure/topology_loader.go
@@ -8,7 +8,7 @@
 //
 //  2. The live Sovereign cluster's dynamic informer cache — populated
 //     by the helmwatch.Watcher attached to this deployment. Reads
-//     vcluster.io/v1alpha1 VClusters when the operator is installed
+//     vcluster.com/v1alpha1 VClusters when the operator is installed
 //     plus core/v1 PVCs from the live cluster.
 //
 //  3. The Crossplane managed-resource list — surfaces XRCs the
@@ -899,7 +899,7 @@ func buildNetworks(ctx context.Context, in LoaderInput, rs provisioner.RegionSpe
 	}}
 }
 
-// loadVClusters — query the Sovereign cluster's vcluster.io/v1alpha1
+// loadVClusters — query the Sovereign cluster's vcluster.com/v1alpha1
 // CRs. Returns an empty slice when the operator isn't installed
 // (Crd doesn't exist) or when no vclusters have been provisioned.
 //
@@ -918,14 +918,33 @@ func loadVClusters(ctx context.Context, in LoaderInput) (out []VCluster) {
 		return out
 	}
 
-	// First-source: vcluster.io/v1alpha1 VCluster CRs. Returned when the
+	// First-source: vcluster.com/v1alpha1 VCluster CRs. Returned when the
 	// vcluster-platform / loft-platform operator is installed (provides
 	// a VCluster CRD that aggregates pod+service+secret behind a single
-	// resource). Our bootstrap topology ships loft-sh/vcluster as a
-	// plain Helm chart (StatefulSet+Service, no CRD), so the CR list
-	// is empty on a converged Sovereign.
+	// resource).
+	//
+	// #6370 — the group here read `vcluster.io`, which exists NOWHERE. The
+	// CRD actually installed is `vclusters.vcluster.com` (measured on hw299:
+	// 374 CRDs, `vclusters.vcluster.com` present), and k8scache/kinds.go has
+	// always registered the correct `vcluster.com`. This lister therefore
+	// queried a group that does not exist and got an empty list every time,
+	// on every Sovereign, forever.
+	//
+	// What made it survive review is the comment that used to sit here: it
+	// asserted the chart ships "no CRD", so an empty list looked like the
+	// expected result and nobody questioned the group. That claim is false —
+	// the CRD IS installed. What is true is narrower: our bootstrap ships
+	// loft-sh/vcluster as a plain Helm chart (StatefulSet+Service), so no
+	// VCluster CRs are CREATED and the list is legitimately empty today.
+	//
+	// Both facts matter. The empty list is currently correct, but it was
+	// correct by accident: with the wrong group this lister could never report
+	// a vcluster even once the platform operator starts creating CRs. Callers
+	// must keep treating an empty CR list as "no CRs", NOT as "no vclusters" —
+	// a running vcluster is a StatefulSet (hw299: `mailwalk/vcluster` ready
+	// 1/1 while this list was empty).
 	gvr := schema.GroupVersionResource{
-		Group:    "vcluster.io",
+		Group:    "vcluster.com",
 		Version:  "v1alpha1",
 		Resource: "vclusters",
 	}
@@ -955,7 +974,7 @@ func loadVClusters(ctx context.Context, in LoaderInput) (out []VCluster) {
 	// per vCluster instance — name = label value (mgmt/dmz/rtz).
 	// Caught on t129 2026-05-16: canvas chip showed `vCluster 0/0`
 	// despite vCluster Pods Running because the CR-first path returned
-	// empty (no vcluster.io CRD) and there was no fallback. Refs DoD D15.
+	// empty (no VCluster CRs) and there was no fallback. Refs DoD D15.
 	nsGVR := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "namespaces"}
 	nsCtx, nsCancel := context.WithTimeout(ctx, 5*time.Second)
 	defer nsCancel()

--- a/products/catalyst/bootstrap/api/internal/infrastructure/topology_loader_frontdoor_test.go
+++ b/products/catalyst/bootstrap/api/internal/infrastructure/topology_loader_frontdoor_test.go
@@ -54,7 +54,7 @@ func liveNodeClient(t *testing.T, providerID string) dynamic.Interface {
 		Status: corev1.NodeStatus{Conditions: []corev1.NodeCondition{{Type: corev1.NodeReady, Status: corev1.ConditionTrue}}},
 	}
 	gvrToListKind := map[schema.GroupVersionResource]string{
-		{Group: "vcluster.io", Version: "v1alpha1", Resource: "vclusters"}: "VClusterList",
+		{Group: "vcluster.com", Version: "v1alpha1", Resource: "vclusters"}: "VClusterList",
 	}
 	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind, cp, worker)
 }

--- a/products/catalyst/bootstrap/api/internal/infrastructure/topology_loader_perregion_test.go
+++ b/products/catalyst/bootstrap/api/internal/infrastructure/topology_loader_perregion_test.go
@@ -67,7 +67,7 @@ func vclusterRoleNamespaceClient(t *testing.T, vclusterName string) dynamic.Inte
 	// panicking — that lets the Namespace-role fallback path run, which is
 	// the production vCluster-discovery path this test exercises.
 	gvrToListKind := map[schema.GroupVersionResource]string{
-		{Group: "vcluster.io", Version: "v1alpha1", Resource: "vclusters"}: "VClusterList",
+		{Group: "vcluster.com", Version: "v1alpha1", Resource: "vclusters"}: "VClusterList",
 		// #4739: loadVClusters' third source enumerates app=vcluster
 		// StatefulSets. Register the list-kind so the fake returns an empty
 		// list (production: this Sovereign's Namespace-role vclusters win the

--- a/products/catalyst/bootstrap/api/internal/infrastructure/types.go
+++ b/products/catalyst/bootstrap/api/internal/infrastructure/types.go
@@ -127,7 +127,7 @@ type Cluster struct {
 	Nodes         []Node         `json:"nodes"`
 }
 
-// VCluster — a vcluster.io v1alpha1 virtual cluster running on the
+// VCluster — a vcluster.com v1alpha1 virtual cluster running on the
 // host cluster. Used by Catalyst's DMZ / RTZ / MGMT building-block
 // layout. Populated only when the vcluster operator is installed AND
 // at least one VCluster CR exists; otherwise the slice is empty.


### PR DESCRIPTION
## `loadVClusters` queries an API group that exists nowhere

`topology_loader.go` listed VCluster CRs from group **`vcluster.io`**. That group does not exist. The CRD actually installed is **`vclusters.vcluster.com`** — measured on hw299: 374 CRDs, `vclusters.vcluster.com` present. `k8scache/kinds.go` has always registered the correct `vcluster.com`, so the two disagreed.

The lister therefore queried a non-existent GVR and returned an empty list on every Sovereign, forever.

## Why it survived review — the comment rationalized the bug

The comment directly above the GVR asserted our bootstrap ships vcluster as a "plain Helm chart (StatefulSet+Service, **no CRD**), so the CR list is empty on a converged Sovereign."

That made an empty list look like the *expected* result, so the wrong group never got questioned. **The claim is false** — the CRD is installed. What is true is narrower: the chart creates no VCluster **CRs**, so the list is legitimately empty *today*.

Both facts matter. The empty list is currently correct, but it was **correct by accident**: with the wrong group this lister could never report a vcluster even once the platform operator starts creating CRs.

## The consumer-side harm this already caused

An empty CR list has been read as "no vclusters exist." On hw299 that reading is provably wrong:

| signal | value |
|---|---|
| `k8s/vclusters` (CR list) | 200, `items: []` |
| StatefulSet `mailwalk/vcluster` | **ready 1/1** |
| HelmRelease `mailwalk/vcluster` | `Ready=True InstallSucceeded` (vcluster@0.33.4) |
| Organization `mailwalk` | `isolation: vcluster` |

UAT row **G7** was stamped ❌ on hw298 with "ZERO vclusters" derived from exactly this empty list — and that walk even carried a control proving the *kind resolved*. The control proved the wrong property: resolving-and-empty is not "no vclusters". A running vcluster here is a **StatefulSet**, not a CR.

## Fix

- Group corrected to `vcluster.com` in `loadVClusters`.
- The misleading comment replaced with what is actually true, plus an explicit warning that an empty CR list means "no CRs", **not** "no vclusters".
- Three test files registered their fake dynamic client under `vcluster.io`; left alone they would have kept returning empty and passed vacuously against the corrected code. All updated to `vcluster.com`.
- Stale `vcluster.io` references in doc comments corrected.

Gates: `go build ./...` clean; `internal/infrastructure` **19 PASS / 0 FAIL**; `internal/k8scache` ok.

Refs UAT G7.

Refs #6370
