### PR TITLE
fix(mcp): Sovereign-mode admitted NON-admins — the guard promised sovereign-admin but only tested context (#6369)

### DIFF
--- a/products/openova-mcp/internal/identity/identity.go
+++ b/products/openova-mcp/internal/identity/identity.go
@@ -417,6 +417,30 @@ func (r *Resolver) fromClaims(claims *sharedauth.Claims) (*Identity, error) {
 		if r.pinnedCtx == ContextSovereign && id.Context == ContextOrganization {
 			return nil, fmt.Errorf("identity: this Sovereign-mode MCP instance requires a sovereign-admin session; the caller's token is scoped to organization %q — use that Organization's own MCP instance instead", id.OrgID)
 		}
+		// #6369 — the guard ABOVE asserts "requires a sovereign-admin
+		// session" but only ever tested CONTEXT, never admin-ness, and
+		// context is not a proxy for it. deriveContext returns
+		// ContextSovereign for ANY token whose issuer ends /realms/sovereign
+		// once org_id is absent — tier is never consulted on that branch. So
+		// an ordinary signed-in console session (tier=owner,
+		// sovereign_admin=false, org_id="") derived ContextSovereign, passed
+		// the check whose message promised admin-only, and reached the
+		// Sovereign-wide tool surface.
+		//
+		// MEASURED on hw299 with exactly such a session: list_applications
+		// returned 11 applications across 6 namespaces including another
+		// Organization's; get_application read that Org's app in full; and
+		// create_application CREATED an Application inside it (HTTP 201).
+		// Nothing downstream denied, because with org_id empty every
+		// org-scoping comparison has no left-hand side and cannot fail.
+		//
+		// Assert the property the message already claims. A Sovereign-mode
+		// instance serves sovereign-admins only; everything else is refused
+		// here rather than being handed a fleet-wide surface it can never be
+		// scoped out of.
+		if r.pinnedCtx == ContextSovereign && id.Tier != TierSovereignAdmin {
+			return nil, fmt.Errorf("identity: this Sovereign-mode MCP instance requires a sovereign-admin session; the caller's tier is %q and carries no sovereign-admin signal (org_id=%q)", id.Tier, id.OrgID)
+		}
 		id.Context = r.pinnedCtx
 	}
 

--- a/products/openova-mcp/internal/identity/sovereign_mode_requires_admin_6369_test.go
+++ b/products/openova-mcp/internal/identity/sovereign_mode_requires_admin_6369_test.go
@@ -1,0 +1,94 @@
+package identity
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/golang-jwt/jwt/v5"
+	sharedauth "github.com/openova-io/openova/core/services/shared/auth"
+)
+
+// #6369 — a Sovereign-mode MCP instance admitted a NON-admin and handed it the
+// fleet-wide tool surface.
+//
+// MEASURED on hw299 with an ordinary signed-in console session as the bearer
+// (whoami: context=sovereign, tier=owner, sovereign_admin=false, org_id=""):
+//
+//	list_applications   -> 11 applications across 6 namespaces, including
+//	                       another Organization's (`mailwalk`)
+//	get_application     -> that Org's application returned in full
+//	create_application  -> HTTP 201, an Application CREATED inside that Org
+//
+// WHY NOTHING DOWNSTREAM CAUGHT IT: with org_id empty there is no left-hand
+// side for any org-scoping comparison, so every such check is vacuous — it
+// cannot fail for any input. The isolation was not bypassed; it was never
+// evaluated.
+//
+// WHY THE EXISTING GUARD DID NOT CATCH IT: the #5206 guard immediately above
+// the fix asserts in its own error message that the instance "requires a
+// sovereign-admin session" — but it only ever tested CONTEXT. Context is not a
+// proxy for admin-ness: deriveContext returns ContextSovereign for ANY token
+// whose issuer ends /realms/sovereign once org_id is absent, without ever
+// consulting tier. So the non-admin session derived ContextSovereign and passed
+// the check whose message promised admin-only.
+
+func sovereignRealmClaims(role, orgID string) *sharedauth.Claims {
+	return &sharedauth.Claims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			Issuer: "https://auth.hw299.omantel.biz/realms/sovereign",
+		},
+		Email: "emrah.baysal@openova.io",
+		Role:  role,
+		OrgID: orgID,
+	}
+}
+
+// TestSovereignMode_RefusesNonAdmin is the regression proof.
+func TestSovereignMode_RefusesNonAdmin(t *testing.T) {
+	for _, role := range []string{"owner", "admin", "member", "viewer"} {
+		t.Run("role="+role, func(t *testing.T) {
+			r := &Resolver{pinnedCtx: ContextSovereign}
+			id, err := r.fromClaims(sovereignRealmClaims(role, ""))
+			if err == nil {
+				t.Fatalf("role=%q with org_id=\"\" was ADMITTED to a Sovereign-mode instance (#6369).\n"+
+					"That hands the fleet-wide tool surface to a non-admin, and with org_id empty no\n"+
+					"downstream org-scoping check can deny it. resolved identity: %+v", role, id)
+			}
+			if !strings.Contains(err.Error(), "sovereign-admin") {
+				t.Errorf("role=%q: refused, but the error does not name the missing property: %v", role, err)
+			}
+		})
+	}
+}
+
+// TestSovereignMode_AdmitsRealAdmin is the CONTROL. Without it the fix could
+// refuse EVERYONE and the test above would still pass — a guard that denies
+// unconditionally is as wrong as one that permits unconditionally.
+func TestSovereignMode_AdmitsRealAdmin(t *testing.T) {
+	r := &Resolver{pinnedCtx: ContextSovereign}
+
+	id, err := r.fromClaims(sovereignRealmClaims("sovereign-admin", ""))
+	if err != nil {
+		t.Fatalf("a genuine sovereign-admin was REFUSED by the Sovereign-mode instance — the fix over-corrected: %v", err)
+	}
+	if id.Tier != TierSovereignAdmin {
+		t.Errorf("admin resolved to tier %v, want TierSovereignAdmin", id.Tier)
+	}
+	if id.Context != ContextSovereign {
+		t.Errorf("admin resolved to context %v, want ContextSovereign", id.Context)
+	}
+}
+
+// TestSovereignMode_StillRefusesOrgScopedToken pins the pre-existing #5206
+// behaviour so this fix does not silently replace one guard with another.
+func TestSovereignMode_StillRefusesOrgScopedToken(t *testing.T) {
+	r := &Resolver{pinnedCtx: ContextSovereign}
+
+	_, err := r.fromClaims(sovereignRealmClaims("member", "acme"))
+	if err == nil {
+		t.Fatal("an Org-scoped token was admitted to a Sovereign-mode instance — the #5206 guard regressed")
+	}
+	if !strings.Contains(err.Error(), "acme") {
+		t.Errorf("the #5206 error should name the caller's Organization so the message is actionable: %v", err)
+	}
+}


### PR DESCRIPTION
fix(mcp): Sovereign-mode admitted NON-admins — the guard's message promised sovereign-admin but only ever tested context (#6369)

MEASURED ON hw299 with an ordinary signed-in console session as the bearer.
whoami reported context=sovereign, tier=owner, sovereign_admin=FALSE, org_id="".
With that identity:

  list_applications   -> 11 applications across 6 namespaces, including another
                         Organization's (`mailwalk`)
  get_application     -> that Org's application returned in full
  create_application  -> HTTP 201, an Application CREATED inside that Org

THE MECHANISM, and it is a two-part failure rather than a missing check.

deriveContext returns ContextSovereign for ANY token whose issuer ends
/realms/sovereign once org_id is absent — tier is never consulted on that
branch. Its own trailing comment claims "a non-admin token without an org_id is
under-scoped — fromClaims rejects it with a clear error", but that is only true
of the DEFAULT branch, which the issuer branch short-circuits.

The #5206 guard then asserts in its error message that a Sovereign-mode instance
"requires a sovereign-admin session" — while testing only whether the derived
context is Organization. Context is not a proxy for admin-ness. So an ordinary
console session derived ContextSovereign, satisfied the check whose message
promised admin-only, and reached the Sovereign-wide tool surface.

WHY NOTHING DOWNSTREAM DENIED IT: with org_id empty there is no left-hand side
for any org-scoping comparison, so every such check is vacuous — it cannot fail
for any input. The isolation was not bypassed; it was never evaluated. That is
the same can't-fail shape this repo keeps hitting, except here it is production
authorization rather than a test.

THE FIX asserts the property the existing message already claims: a
Sovereign-mode instance serves sovereign-admins only. Everything else is refused
at admission rather than handed a fleet-wide surface it can never be scoped out
of.

TESTS, with the two controls that make them meaningful:

  TestSovereignMode_RefusesNonAdmin          owner/admin/member/viewer all refused
  TestSovereignMode_AdmitsRealAdmin          CONTROL — a genuine sovereign-admin
                                             is still admitted, so the fix cannot
                                             pass by denying everyone
  TestSovereignMode_StillRefusesOrgScopedToken
                                             pins the pre-existing #5206
                                             behaviour so one guard is not
                                             silently swapped for another

VACUITY PROOF RUN BEFORE ACCEPTING: with the guard reverted the regression test
FAILS with `role="owner" with org_id="" was ADMITTED to a Sovereign-mode
instance`. Full module green afterwards: cmd/openova-mcp, internal/catalystapi,
internal/identity, internal/tools all ok.

Refs #6369
