### PR TITLE
fix(notification): 452 quota refusal bypassed backoff and the circuit breaker — the storm that killed PIN sign-in fleet-wide (#6464)

### DIFF
--- a/core/services/notification/handlers/smtp.go
+++ b/core/services/notification/handlers/smtp.go
@@ -437,23 +437,61 @@ func (m *Mailer) nowFn() time.Time {
 	return time.Now()
 }
 
-// isRateLimit reports whether err is Stalwart's "503 5.5.1" rate-limit
-// response. net/smtp surfaces SMTP-level errors as *textproto.Error,
-// but legacy code paths (and some auth-failure branches in net/smtp
-// itself) wrap the wire response in a plain error.New, so we also fall
-// back to a substring match against the canonical 5.5.1 enhanced code.
+// isRateLimit reports whether err is a Stalwart rate-limit response.
+// net/smtp surfaces SMTP-level errors as *textproto.Error, but legacy
+// code paths (and some auth-failure branches in net/smtp itself) wrap
+// the wire response in a plain error.New, so we also fall back to
+// substring matches against the canonical enhanced codes.
+//
+// #6464 — this used to match ONLY "503 5.5.1", which is the code
+// Stalwart returns when submission is refused BEFORE authentication.
+// The per-sender quota trips a DIFFERENT code:
+//
+//	Rate limit exceeded (smtp.rate-limit-exceeded)
+//	  id = "sender"  limit = [25, 3600000ms]
+//	  accountName = "noreply@openova.io"
+//
+// which reaches the client as **452** ("insufficient system storage",
+// RFC 5321 §4.2.1 — the transient mailbox-side refusal Stalwart reuses
+// for throttling). A 452 therefore failed isRateLimit, took the
+// "non-rate-limit errors are not retried" branch, and returned to the
+// caller immediately — bypassing BOTH the exponential backoff AND the
+// circuit breaker that exist precisely to stop this.
+//
+// The consumer then re-queued and re-sent, producing a sustained
+// 2-3 second storm (measured on the mothership 2026-08-18T09:42Z:
+// attempts at :04 :08 :10 :13 :15 :19 :21 :23). A 25/hour budget is
+// consumed in about a minute and then stays exhausted, so PIN sign-in
+// was dead fleet-wide — no customer could obtain a code anywhere.
+//
+// Matching 452 restores the intended behaviour: back off exponentially,
+// and open the breaker after defaultBreakerTrip consecutive refusals
+// instead of hammering an upstream that has already said "slow down".
 func isRateLimit(err error) bool {
 	if err == nil {
 		return false
 	}
 	var te *textproto.Error
 	if errors.As(err, &te) {
+		// 503 5.5.1 — refused before AUTH (pre-existing case).
 		if te.Code == 503 && strings.Contains(te.Msg, "5.5.1") {
+			return true
+		}
+		// 452 — per-sender / per-recipient quota exhausted (#6464).
+		// Match on the code alone: Stalwart's message text for this
+		// path is not stable across versions, and every 452 is by
+		// definition a TRANSIENT refusal that must be retried with
+		// backoff rather than surfaced as a hard failure.
+		if te.Code == 452 {
 			return true
 		}
 	}
 	msg := err.Error()
 	// Match both "503 5.5.1 ..." and "503-5.5.1 ..." (multiline reply
-	// continuation form per RFC 5321).
-	return strings.Contains(msg, "503 5.5.1") || strings.Contains(msg, "503-5.5.1")
+	// continuation form per RFC 5321), plus the 452 equivalents for
+	// the wrapped-in-plain-error paths.
+	return strings.Contains(msg, "503 5.5.1") ||
+		strings.Contains(msg, "503-5.5.1") ||
+		strings.Contains(msg, "452 ") ||
+		strings.Contains(msg, "452-")
 }

--- a/core/services/notification/handlers/smtp_ratelimit_452_6464_test.go
+++ b/core/services/notification/handlers/smtp_ratelimit_452_6464_test.go
@@ -1,0 +1,80 @@
+package handlers
+
+import (
+	"errors"
+	"net/textproto"
+	"testing"
+)
+
+// #6464 — a 452 rate-limit refusal bypassed backoff AND the circuit
+// breaker, producing a 2-3 second send storm that held the noreply@
+// 25/hour quota at zero and killed PIN sign-in fleet-wide.
+//
+// MEASURED on the mothership 2026-08-18T09:42Z. Stalwart logged:
+//
+//	Rate limit exceeded (smtp.rate-limit-exceeded)
+//	  id = "sender"  limit = [25, 3600000ms]
+//	  accountName = "noreply@openova.io"
+//
+// and refused with 452. isRateLimit matched only "503 5.5.1", so every
+// 452 took the "non-rate-limit errors are not retried" branch and
+// returned immediately — the consumer re-queued and re-sent at once.
+// Attempts landed at :04 :08 :10 :13 :15 :19 :21 :23.
+//
+// This suite pins 452 FIRST. A suite that only ever feeds 503 cannot
+// fail on this defect — the same blind spot that let the storm run.
+
+func TestIsRateLimit_452_QuotaRefusalIsRetryable(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+	}{
+		{"textproto 452 sender quota", &textproto.Error{Code: 452, Msg: "4.2.1 Rate limit exceeded"}},
+		{"textproto 452 bare", &textproto.Error{Code: 452, Msg: "insufficient system storage"}},
+		{"wrapped plain 452", errors.New("smtp: 452 4.2.1 Rate limit exceeded")},
+		{"multiline 452 continuation", errors.New("452-4.2.1 too many messages")},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if !isRateLimit(tc.err) {
+				t.Fatalf("452 refusal NOT classified as rate-limit (#6464): %v\n"+
+					"It therefore skips exponential backoff AND the circuit breaker, and the\n"+
+					"caller re-sends immediately — that is the 2-3s storm that pins the\n"+
+					"noreply@ 25/hour quota at zero and kills PIN sign-in fleet-wide.", tc.err)
+			}
+		})
+	}
+}
+
+// CONTROL 1 — the pre-existing 503 5.5.1 path must keep working, or the
+// fix traded one missed code for another.
+func TestIsRateLimit_503_StillDetected(t *testing.T) {
+	for _, err := range []error{
+		&textproto.Error{Code: 503, Msg: "5.5.1 You must authenticate first"},
+		errors.New("503 5.5.1 You must authenticate first"),
+		errors.New("503-5.5.1 continuation form"),
+	} {
+		if !isRateLimit(err) {
+			t.Errorf("503 5.5.1 regressed — no longer detected: %v", err)
+		}
+	}
+}
+
+// CONTROL 2 — the guard must still say NO to genuinely fatal errors.
+// Without this the fix could pass by classifying EVERYTHING as
+// retryable, which would silently convert hard failures (bad
+// credentials, unknown recipient) into long backoff loops instead of
+// surfacing them to the consumer for NACK / dead-letter.
+func TestIsRateLimit_RejectsNonRateLimitErrors(t *testing.T) {
+	for _, err := range []error{
+		nil,
+		errors.New("dial tcp: connection refused"),
+		&textproto.Error{Code: 535, Msg: "5.7.8 Authentication credentials invalid"},
+		&textproto.Error{Code: 550, Msg: "5.1.1 No such user here"},
+		&textproto.Error{Code: 421, Msg: "4.3.2 Service shutting down"},
+	} {
+		if isRateLimit(err) {
+			t.Errorf("non-rate-limit error wrongly classified as retryable: %v", err)
+		}
+	}
+}


### PR DESCRIPTION
fix(notification): a 452 quota refusal bypassed backoff AND the circuit breaker — the storm that killed PIN sign-in fleet-wide (#6464)

`isRateLimit` matched ONLY `503 5.5.1`, which is what Stalwart returns when
submission is refused BEFORE authentication. The per-sender quota trips a
different code entirely.

MEASURED on the mothership 2026-08-18T09:42Z:

  Rate limit exceeded (smtp.rate-limit-exceeded)
    listenerId = "submission"  localPort = 587
    accountName = "noreply@openova.io"
    id = "sender"  limit = [25, 3600000ms]

which reaches the client as 452 (RFC 5321 4.2.1 — the transient refusal
Stalwart reuses for throttling). A 452 therefore failed isRateLimit, fell into
the "non-rate-limit errors are not retried" branch, and returned to the caller
immediately — bypassing BOTH the exponential backoff AND the circuit breaker
that exist precisely to stop this.

The consumer re-queued and re-sent at once. Attempts landed at :04 :08 :10 :13
:15 :19 :21 :23 — roughly every 2-3 seconds, each completing AUTH + MAIL FROM
before refusal. A 25/hour budget is consumed in about a minute and then stays
exhausted permanently, so the limit is never actually "per hour" in practice.

CUSTOMER IMPACT: every POST /auth/pin/issue returned 502 / smtpCode 452. No
customer could obtain a sign-in code on any Sovereign, and no UAT walker could
authenticate either. This is the holding constraint behind #5921 and UAT rows 84/20/23.

THE FIX matches 452 on the code alone. Stalwart's message text for this path is
not stable across versions, and every 452 is by definition a TRANSIENT refusal
that must be retried with backoff rather than surfaced as a hard failure. The
existing 503 5.5.1 branch is untouched.

TESTS, with the controls that make them meaningful:

  TestIsRateLimit_452_QuotaRefusalIsRetryable   4 shapes: textproto 452 with and
                                                without quota text, wrapped
                                                plain-error, multiline 452-
                                                continuation
  TestIsRateLimit_503_StillDetected             CONTROL — the pre-existing path
                                                must keep working, or the fix
                                                traded one missed code for
                                                another
  TestIsRateLimit_RejectsNonRateLimitErrors     CONTROL — 535/550/421/dial-refused
                                                and nil must still be NON-retryable.
                                                Without this the fix could pass by
                                                calling everything retryable, which
                                                would convert hard failures into
                                                silent backoff loops instead of
                                                surfacing them for NACK/dead-letter

The suite pins 452 FIRST: a suite that only ever feeds 503 cannot fail on this
defect, which is the same blind spot that let the storm run.

VACUITY PROOF run before accepting: with the fix reverted the regression test
FAILS with `452 refusal NOT classified as rate-limit (#6464)`. Full module green
afterwards.

Refs #6464
Refs #5921

