### PR TITLE
fix(provisioning): funnel-born Orgs got no Anthropic credential wiring — the two Org-creation doors disagreed (#6372)

### DIFF
--- a/core/services/notification/handlers/smtp.go
+++ b/core/services/notification/handlers/smtp.go
@@ -437,23 +437,61 @@ func (m *Mailer) nowFn() time.Time {
 	return time.Now()
 }
 
-// isRateLimit reports whether err is Stalwart's "503 5.5.1" rate-limit
-// response. net/smtp surfaces SMTP-level errors as *textproto.Error,
-// but legacy code paths (and some auth-failure branches in net/smtp
-// itself) wrap the wire response in a plain error.New, so we also fall
-// back to a substring match against the canonical 5.5.1 enhanced code.
+// isRateLimit reports whether err is a Stalwart rate-limit response.
+// net/smtp surfaces SMTP-level errors as *textproto.Error, but legacy
+// code paths (and some auth-failure branches in net/smtp itself) wrap
+// the wire response in a plain error.New, so we also fall back to
+// substring matches against the canonical enhanced codes.
+//
+// #6464 — this used to match ONLY "503 5.5.1", which is the code
+// Stalwart returns when submission is refused BEFORE authentication.
+// The per-sender quota trips a DIFFERENT code:
+//
+//	Rate limit exceeded (smtp.rate-limit-exceeded)
+//	  id = "sender"  limit = [25, 3600000ms]
+//	  accountName = "noreply@openova.io"
+//
+// which reaches the client as **452** ("insufficient system storage",
+// RFC 5321 §4.2.1 — the transient mailbox-side refusal Stalwart reuses
+// for throttling). A 452 therefore failed isRateLimit, took the
+// "non-rate-limit errors are not retried" branch, and returned to the
+// caller immediately — bypassing BOTH the exponential backoff AND the
+// circuit breaker that exist precisely to stop this.
+//
+// The consumer then re-queued and re-sent, producing a sustained
+// 2-3 second storm (measured on the mothership 2026-08-18T09:42Z:
+// attempts at :04 :08 :10 :13 :15 :19 :21 :23). A 25/hour budget is
+// consumed in about a minute and then stays exhausted, so PIN sign-in
+// was dead fleet-wide — no customer could obtain a code anywhere.
+//
+// Matching 452 restores the intended behaviour: back off exponentially,
+// and open the breaker after defaultBreakerTrip consecutive refusals
+// instead of hammering an upstream that has already said "slow down".
 func isRateLimit(err error) bool {
 	if err == nil {
 		return false
 	}
 	var te *textproto.Error
 	if errors.As(err, &te) {
+		// 503 5.5.1 — refused before AUTH (pre-existing case).
 		if te.Code == 503 && strings.Contains(te.Msg, "5.5.1") {
+			return true
+		}
+		// 452 — per-sender / per-recipient quota exhausted (#6464).
+		// Match on the code alone: Stalwart's message text for this
+		// path is not stable across versions, and every 452 is by
+		// definition a TRANSIENT refusal that must be retried with
+		// backoff rather than surfaced as a hard failure.
+		if te.Code == 452 {
 			return true
 		}
 	}
 	msg := err.Error()
 	// Match both "503 5.5.1 ..." and "503-5.5.1 ..." (multiline reply
-	// continuation form per RFC 5321).
-	return strings.Contains(msg, "503 5.5.1") || strings.Contains(msg, "503-5.5.1")
+	// continuation form per RFC 5321), plus the 452 equivalents for
+	// the wrapped-in-plain-error paths.
+	return strings.Contains(msg, "503 5.5.1") ||
+		strings.Contains(msg, "503-5.5.1") ||
+		strings.Contains(msg, "452 ") ||
+		strings.Contains(msg, "452-")
 }

--- a/core/services/notification/handlers/smtp_ratelimit_452_6464_test.go
+++ b/core/services/notification/handlers/smtp_ratelimit_452_6464_test.go
@@ -1,0 +1,80 @@
+package handlers
+
+import (
+	"errors"
+	"net/textproto"
+	"testing"
+)
+
+// #6464 — a 452 rate-limit refusal bypassed backoff AND the circuit
+// breaker, producing a 2-3 second send storm that held the noreply@
+// 25/hour quota at zero and killed PIN sign-in fleet-wide.
+//
+// MEASURED on the mothership 2026-08-18T09:42Z. Stalwart logged:
+//
+//	Rate limit exceeded (smtp.rate-limit-exceeded)
+//	  id = "sender"  limit = [25, 3600000ms]
+//	  accountName = "noreply@openova.io"
+//
+// and refused with 452. isRateLimit matched only "503 5.5.1", so every
+// 452 took the "non-rate-limit errors are not retried" branch and
+// returned immediately — the consumer re-queued and re-sent at once.
+// Attempts landed at :04 :08 :10 :13 :15 :19 :21 :23.
+//
+// This suite pins 452 FIRST. A suite that only ever feeds 503 cannot
+// fail on this defect — the same blind spot that let the storm run.
+
+func TestIsRateLimit_452_QuotaRefusalIsRetryable(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+	}{
+		{"textproto 452 sender quota", &textproto.Error{Code: 452, Msg: "4.2.1 Rate limit exceeded"}},
+		{"textproto 452 bare", &textproto.Error{Code: 452, Msg: "insufficient system storage"}},
+		{"wrapped plain 452", errors.New("smtp: 452 4.2.1 Rate limit exceeded")},
+		{"multiline 452 continuation", errors.New("452-4.2.1 too many messages")},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if !isRateLimit(tc.err) {
+				t.Fatalf("452 refusal NOT classified as rate-limit (#6464): %v\n"+
+					"It therefore skips exponential backoff AND the circuit breaker, and the\n"+
+					"caller re-sends immediately — that is the 2-3s storm that pins the\n"+
+					"noreply@ 25/hour quota at zero and kills PIN sign-in fleet-wide.", tc.err)
+			}
+		})
+	}
+}
+
+// CONTROL 1 — the pre-existing 503 5.5.1 path must keep working, or the
+// fix traded one missed code for another.
+func TestIsRateLimit_503_StillDetected(t *testing.T) {
+	for _, err := range []error{
+		&textproto.Error{Code: 503, Msg: "5.5.1 You must authenticate first"},
+		errors.New("503 5.5.1 You must authenticate first"),
+		errors.New("503-5.5.1 continuation form"),
+	} {
+		if !isRateLimit(err) {
+			t.Errorf("503 5.5.1 regressed — no longer detected: %v", err)
+		}
+	}
+}
+
+// CONTROL 2 — the guard must still say NO to genuinely fatal errors.
+// Without this the fix could pass by classifying EVERYTHING as
+// retryable, which would silently convert hard failures (bad
+// credentials, unknown recipient) into long backoff loops instead of
+// surfacing them to the consumer for NACK / dead-letter.
+func TestIsRateLimit_RejectsNonRateLimitErrors(t *testing.T) {
+	for _, err := range []error{
+		nil,
+		errors.New("dial tcp: connection refused"),
+		&textproto.Error{Code: 535, Msg: "5.7.8 Authentication credentials invalid"},
+		&textproto.Error{Code: 550, Msg: "5.1.1 No such user here"},
+		&textproto.Error{Code: 421, Msg: "4.3.2 Service shutting down"},
+	} {
+		if isRateLimit(err) {
+			t.Errorf("non-rate-limit error wrongly classified as retryable: %v", err)
+		}
+	}
+}

--- a/core/services/provisioning/gitops/agenity_anthropic_parity_6372_test.go
+++ b/core/services/provisioning/gitops/agenity_anthropic_parity_6372_test.go
@@ -1,0 +1,74 @@
+package gitops
+
+import (
+	"strings"
+	"testing"
+)
+
+// #6372 — a funnel-born Org could never run the agent, because this
+// generator emitted no anthropic credential wiring at all while the
+// BSS door (organization_gitops.go orgTenantBPAgenity) always had it.
+//
+// MEASURED on hw299: bp-agenity-0 sat Pending on its seed-claude-creds
+// init container, which waits for /creds/<credentialsKey> and then fails
+// by design (#6163). The backing Secret is optional:true, so the pod
+// schedules, the mount stays empty, and the workspace never starts.
+//
+// THE DOORS DISAGREED. That is the whole defect: two emitters for the
+// same Blueprint, one wired and one not. This test pins them together so
+// they cannot drift again.
+
+func TestAgenityFunnelEmitsAnthropicCredential(t *testing.T) {
+	for _, plan := range []string{"s", "m"} {
+		t.Run("plan="+plan, func(t *testing.T) {
+			out := cartOrgFor(t, "acme", plan, []string{"agenity"})
+			body, ok := out[testBasePath+"/acme/app-agenity.yaml"]
+			if !ok {
+				t.Skip("agenity not rendered on this tier")
+			}
+
+			// The credential block itself.
+			for _, want := range []string{
+				"anthropic:",
+				"externalSecret:",
+				"remoteKey: catalyst/anthropic/token",
+				"remoteProperty: apiKey",
+				"remoteCredentialsProperty: credentialsJson",
+				"secretStoreRef: vault-region1",
+				"secretStoreKind: ClusterSecretStore",
+			} {
+				if !strings.Contains(body, want) {
+					t.Errorf("funnel agenity overlay is MISSING %q (#6372).\n"+
+						"Without it nothing materialises the Secret that seed-claude-creds\n"+
+						"waits for, so bp-agenity-0 sits Pending forever and the solo agent\n"+
+						"never starts — while a BSS-born Org in the same Sovereign works.\n"+
+						"rendered:\n%s", want, body)
+				}
+			}
+
+			// CONTROL: the path must stay under catalyst/. That prefix is the
+			// only KV sub-tree a Sovereign may WRITE; pointing elsewhere would
+			// render a block that can never resolve, which reads as "wired"
+			// while failing exactly as before.
+			if strings.Contains(body, "remoteKey:") && !strings.Contains(body, "remoteKey: catalyst/") {
+				t.Errorf("anthropic remoteKey escaped the catalyst/ prefix — the Sovereign cannot write there:\n%s", body)
+			}
+		})
+	}
+}
+
+// CONTROL — the block must NOT leak into non-agenity overlays. Without
+// this the fix could pass by stamping the credential onto every app,
+// which would attach an unrelated Secret to workloads that never need it.
+func TestAnthropicBlockIsAgenityOnly(t *testing.T) {
+	out := cartOrgFor(t, "acme", "m", []string{"wordpress", "openclaw", "stalwart-mail", "agenity"})
+	for _, f := range []string{"app-openclaw.yaml", "app-stalwart-mail.yaml", "app-wordpress.yaml"} {
+		body, ok := out[testBasePath+"/acme/"+f]
+		if !ok {
+			continue
+		}
+		if strings.Contains(body, "remoteKey: catalyst/anthropic/token") {
+			t.Errorf("%s wrongly carries the anthropic credential — it is agenity-only:\n%s", f, body)
+		}
+	}
+}

--- a/core/services/provisioning/gitops/helmrelease_apps.go
+++ b/core/services/provisioning/gitops/helmrelease_apps.go
@@ -841,6 +841,36 @@ spec:
     networkPolicy:
       ingress:
         allowGatewayEntity: true
+    # ── #6372 — the credential the solo agent cannot start without ──────────
+    # MEASURED on hw299: bp-agenity-0 sat Pending indefinitely on its
+    # seed-claude-creds init container, which waits up to
+    # credentialWait.timeoutSeconds for /creds/<credentialsKey> to be
+    # non-empty and then fails by design (#6163). The Secret behind that
+    # mount is declared optional:true, so the pod schedules, the mount stays
+    # empty, and the workspace never comes up.
+    #
+    # This generator emitted NO anthropic block at all, so nothing ever
+    # materialised the Secret on the FUNNEL path. The BSS door has always
+    # shipped it (organization_gitops.go orgTenantBPAgenity) — the two doors
+    # simply disagreed, which is why a funnel-born Org could never run the
+    # agent even though a BSS-born Org was wired for it.
+    #
+    # Mirrored verbatim from the BSS door so the doors cannot drift again.
+    # The chart's externalsecret-anthropic.yaml reads
+    # secret/catalyst/anthropic/token — the path the catalyst-api producer
+    # (seedAnthropicToken, #4277) writes at Org-create. It MUST stay under
+    # the catalyst/ prefix: that is the only KV sub-tree a Sovereign can
+    # WRITE (catalyst-api-write policy); the external-secrets role used by
+    # vault-region1 is read-only. The path is cluster-shared — one seed
+    # serves every Org's agenity install.
+    anthropic:
+      externalSecret:
+        enabled: true
+        secretStoreRef: vault-region1
+        secretStoreKind: ClusterSecretStore
+        remoteKey: catalyst/anthropic/token
+        remoteProperty: apiKey
+        remoteCredentialsProperty: credentialsJson
 `, helmRepoBlock("bp-agenity"), opt.slug, opt.slug, opt.kubeConfigBlock(),
 		orgZone, opt.slug, issuerHostLine, host)
 }


### PR DESCRIPTION
fix(provisioning): a funnel-born Org could never run the agent — the funnel emitter had no Anthropic credential wiring at all (#6372)

The two doors that create an Organization disagreed about one Blueprint.

organization_gitops.go orgTenantBPAgenity (the BSS/admin door) has always
emitted the anthropic externalSecret block. generateAgenityHR (the marketplace
funnel door) emitted NONE. Same chart, same Sovereign, two different results
depending on which door the customer came through.

MEASURED on hw299: bp-agenity-0 sat Pending indefinitely on its
seed-claude-creds init container. That container waits up to
credentialWait.timeoutSeconds for /creds/<credentialsKey> to be non-empty and
then fails by design (#6163 — deliberately fail-loud rather than serve a
workspace whose every spawn 401s). The Secret behind the mount is declared
optional:true, so the pod schedules, the mount stays empty, and the workspace
never comes up.

THE FIX mirrors the BSS door verbatim rather than inventing a second mechanism,
so the doors cannot drift apart again. The path stays under the catalyst/
prefix, which is the only KV sub-tree a Sovereign may WRITE
(catalyst-api-write policy); the external-secrets role behind vault-region1 is
read-only.

WHAT THIS DOES NOT CLAIM. #6372 also needs the openbao path to be seeded on the
target env — on hw299 BOTH doors' Orgs were Pending, which means the BSS-door
block was present and still unsatisfied there. This change closes the emitter
gap, which is necessary and provably missing; it does not by itself prove the
credential resolves at runtime. That needs a live Sovereign, and the walk row
stays red until measured.

TESTS, with the controls that give them teeth:

  TestAgenityFunnelEmitsAnthropicCredential   asserts all seven keys across
                                              plan s and m, and pins the
                                              catalyst/ prefix — a remoteKey
                                              pointing elsewhere would render
                                              as "wired" while failing exactly
                                              as before
  TestAnthropicBlockIsAgenityOnly             CONTROL — wordpress / openclaw /
                                              stalwart-mail must NOT carry the
                                              credential. Without this the fix
                                              could pass by stamping it onto
                                              every app

VACUITY PROOF run before accepting: with the emitter reverted the test FAILS
with "funnel agenity overlay is MISSING". Full gitops package green after.

Refs #6372
Refs #6163
