### PR TITLE
fix(bp-agenity): credentialWait 0 silently rendered as 300/5 — sprig default on a numeric knob (#6374)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1451,7 +1451,7 @@ spec:
       #   staged commit and push, and makes the Phase-3 pre-strip read-back the
       #   single fail-closed gate (#5436 relocated, not weakened). Lockstep w/
       #   products/catalyst/chart/Chart.yaml.
-      version: 1.4.1518
+      version: 1.4.1519
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/agenity/chart/Chart.yaml
+++ b/products/agenity/chart/Chart.yaml
@@ -241,7 +241,7 @@ type: application
 # same gateway bp-wordpress-tenant + the org console route attach to, #4054).
 # The old default rendered Accepted=False/InvalidHTTPRoute and the host 404'd
 # until the parentRef was hand-overridden. appVersion (image) unchanged.
-version: 0.5.28
+version: 0.5.30
 # 0.5.22 (#5617): the per-Org oidc-gate companion gains its EGRESS
 # CiliumNetworkPolicy (templates/oidc-gate.yaml `oidc-gate-<cid>-egress`).
 # The gate shipped an ingress-only gateway CNP into a DEFAULT-DENY per-Org

--- a/products/agenity/chart/templates/statefulset.yaml
+++ b/products/agenity/chart/templates/statefulset.yaml
@@ -90,8 +90,25 @@ spec:
               # still running — that is what lets a late credential land with no
               # restart. Retrying here also survives an init-container restart,
               # because each attempt re-reads the mount rather than a snapshot.
-              _cw_timeout={{ (.Values.anthropic.credentialWait).timeoutSeconds | default 300 }}
-              _cw_interval={{ (.Values.anthropic.credentialWait).intervalSeconds | default 5 }}
+              {{- /* #6374 — these two are NUMBERS, so `default` is the wrong
+                     resolver: sprig substitutes on any FALSY value and 0 is
+                     falsy, so `timeoutSeconds: 0` rendered as 300 and
+                     `intervalSeconds: 0` rendered as 5. An operator asking for
+                     "do not wait, fail immediately if the credential is absent"
+                     silently got a 5-minute wait instead — the value was
+                     accepted, echoed back in the log line below as 300, and
+                     never applied. Same trap as the bp-guacamole render gate
+                     (#5991): `false | default true` yields true.
+                     Resolve by KEY PRESENCE. onTimeout stays on `default`
+                     because "" is not a meaningful setting for it — an empty
+                     verdict SHOULD fall back to fail. */ -}}
+              {{- $cw := .Values.anthropic.credentialWait | default dict -}}
+              {{- $cwTimeout := 300 -}}
+              {{- if hasKey $cw "timeoutSeconds" }}{{- $cwTimeout = $cw.timeoutSeconds -}}{{- end -}}
+              {{- $cwInterval := 5 -}}
+              {{- if hasKey $cw "intervalSeconds" }}{{- $cwInterval = $cw.intervalSeconds -}}{{- end }}
+              _cw_timeout={{ $cwTimeout }}
+              _cw_interval={{ $cwInterval }}
               _cw_ontimeout='{{ (.Values.anthropic.credentialWait).onTimeout | default "fail" }}'
               # #6163 FREEZE 3 — verdict for a credential that IS present but is
               # already expired. Same fail|continue vocabulary as onTimeout,

--- a/products/agenity/chart/tests/credential-wait-falsy-default-6374.sh
+++ b/products/agenity/chart/tests/credential-wait-falsy-default-6374.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# #6374 — credentialWait.timeoutSeconds/intervalSeconds are NUMBERS, so sprig's
+# `default` is the wrong resolver: it substitutes on any FALSY value and 0 is
+# falsy. `timeoutSeconds: 0` therefore rendered as 300 and `intervalSeconds: 0`
+# as 5. An operator asking for "do not wait — fail immediately if the credential
+# is absent" silently got a 5-minute wait, and the init container's own log line
+# echoed 300 back, so the setting looked applied.
+#
+# This suite deliberately renders the ZERO case FIRST. A suite that only ever
+# passes non-zero values cannot fail on this defect — the same shape as the
+# bp-guacamole render tests that always supplied the CNPG capability and so
+# could never see #5991.
+set -euo pipefail
+CHART="$(cd "$(dirname "$0")/.." && pwd)"
+fail=0
+
+expect() { # expect <desc> <needle> <render...>
+  local desc="$1" needle="$2"; shift 2
+  local out; out="$("$@" 2>&1)"
+  if printf '%s\n' "$out" | grep -qF -- "$needle"; then
+    echo "  ok   $desc  ($needle)"
+  else
+    echo "  FAIL $desc — expected '$needle'"
+    printf '%s\n' "$out" | grep -E '_cw_timeout=|_cw_interval=' || true
+    fail=1
+  fi
+}
+
+echo "== #6374 zero must survive (the defect) =="
+expect "timeoutSeconds=0 stays 0" "_cw_timeout=0" \
+  helm template ag "$CHART" --set anthropic.credentialWait.timeoutSeconds=0
+expect "intervalSeconds=0 stays 0" "_cw_interval=0" \
+  helm template ag "$CHART" --set anthropic.credentialWait.intervalSeconds=0
+
+echo "== CONTROLS — the defaults must still work, or the fix over-corrected =="
+expect "unset -> documented default 300" "_cw_timeout=300" helm template ag "$CHART"
+expect "unset -> documented default 5"   "_cw_interval=5"  helm template ag "$CHART"
+
+echo "== CONTROL — a normal explicit value passes through untouched =="
+expect "timeoutSeconds=42 -> 42" "_cw_timeout=42" \
+  helm template ag "$CHART" --set anthropic.credentialWait.timeoutSeconds=42
+
+echo "== onTimeout KEEPS sprig default: empty is not a meaningful verdict =="
+expect "onTimeout unset -> fail" "_cw_ontimeout='fail'" helm template ag "$CHART"
+expect "onTimeout=continue honoured" "_cw_ontimeout='continue'" \
+  helm template ag "$CHART" --set anthropic.credentialWait.onTimeout=continue
+
+[ "$fail" -eq 0 ] && echo "PASS: credentialWait resolves by key presence, not sprig default." || { echo "FAIL"; exit 1; }

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3968,7 +3968,7 @@ name: bp-catalyst-platform
 #   file's 1.4.1325 entry records as permanently burned. The republish
 #   therefore lands on 1.4.1468 — ahead of main's 1.4.1467, absent from GHCR,
 #   and claimed by no open PR.)
-version: 1.4.1518
+version: 1.4.1519
 # 1.4.1481 — #6293: catalog-seed advances bp-self-sovereign-cutover
 #   0.1.186 -> 0.1.187, the release that stops step-06 from patching five
 #   HelmRepositories it does not own and then grading itself on whether they
@@ -4155,7 +4155,7 @@ version: 1.4.1518
 # scripts/check-chart-version-forward.sh (#5743) fails unless the two match —
 # main was carrying a pre-existing 1.4.1330/1.4.1329 split, so this bump heals
 # it in the same commit, exactly as the documented self-heal contract does.
-appVersion: 1.4.1518
+appVersion: 1.4.1519
 # 1.4.239 — Wave 3 / Issue #2140 (2026-05-23): Huawei provider
 # implementation lands behind the Wave 2 CloudProvider interface.
 # Adds the OpenTofu module at infra/providers/huawei/ (VPC + Subnet +

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -6035,7 +6035,7 @@ spec:
   # 0.5.22 (#5617): the oidc-gate companion gains its egress CNP — the per-Org
   # namespace is default-deny and the gate's ingress-only CNP left DNS + the
   # Keycloak token exchange dropped, 500ing every OAuth callback after login.
-  version: "0.5.28"
+  version: "0.5.30"
   visibility: listed
   card:
     title: "Agenity"
@@ -6065,7 +6065,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-agenity
-    version: 0.5.28
+    version: 0.5.30
   topology:
     supported:
       - singleton


### PR DESCRIPTION
fix(bp-agenity): credentialWait 0 silently rendered as 300/5 — sprig default on a numeric knob (#6374)

`products/agenity/chart/templates/statefulset.yaml` resolved two NUMERIC knobs
with sprig `default`:

    _cw_timeout={{ (.Values.anthropic.credentialWait).timeoutSeconds | default 300 }}
    _cw_interval={{ (.Values.anthropic.credentialWait).intervalSeconds | default 5 }}

`default` substitutes on any FALSY value, and 0 is falsy. So
`timeoutSeconds: 0` rendered as 300 and `intervalSeconds: 0` as 5.

An operator setting `timeoutSeconds: 0` — "do not wait, fail immediately if the
credential is absent" — silently got a 5-minute wait. Worse, the init
container's own log line echoes ${_cw_timeout}, so it printed 300 back and the
setting looked applied.

Same trap as #5991 in bp-guacamole, where `false | default true` yielded true
and deleted the JDBC schema-seed Job at render time. Third instance of this
class in the codebase.

FIX: resolve by key PRESENCE (`hasKey`). `onTimeout` deliberately KEEPS
`default` — an empty verdict string is not a meaningful setting and should fall
back to `fail`.

RENDER PROOF

    timeoutSeconds=0   300 -> 0
    intervalSeconds=0    5 -> 0
    unset              300 / 5 unchanged
    timeoutSeconds=42   42 unchanged

The new suite `chart/tests/credential-wait-falsy-default-6374.sh` renders the
ZERO case FIRST — a suite that only passes non-zero values cannot fail on this
defect, the same blind spot that let #5991 live. Controls included so the fix
cannot pass by over-correcting the documented defaults away.

Reopened on a clean origin/main base: the previous branch was cut from a stale
fork and dragged unrelated ledger commits into conflict. Chart 0.5.30 avoids the
version collision with the concurrently-open agenity work.

Refs #6374
