### PR TITLE
fix(cutover): deny mail.openova.io in the step-08 hold — the 9th tether (#5921)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -1074,7 +1074,7 @@ spec:
       # chart/tests/ left the package via .helmignore: 757,264 bytes, 72.2%.
       # The rendered manifest is byte-identical modulo comments — no step,
       # value or RBAC change, still 11 steps.
-      version: 0.1.191
+      version: 0.1.192
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1451,7 +1451,7 @@ spec:
       #   staged commit and push, and makes the Phase-3 pre-strip read-back the
       #   single fail-closed gate (#5436 relocated, not weakened). Lockstep w/
       #   products/catalyst/chart/Chart.yaml.
-      version: 1.4.1520
+      version: 1.4.1522
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.191
+  version: 0.1.192
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -4153,7 +4153,7 @@ name: bp-self-sovereign-cutover
 # load-bearing. Slot-06a pin + blueprint.yaml + catalog-seed spec.version +
 # source.version + the API blueprints.json + the generated UI catalog move to
 # 0.1.190 in lockstep (Inviolable Principle #13).
-version: 0.1.191
+version: 0.1.192
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/values.yaml
+++ b/platform/self-sovereign-cutover/chart/values.yaml
@@ -2227,6 +2227,17 @@ egressTest:
     # blocked by omission from the allow-list; this entry drives the active
     # call-home assertion that PROVES it is unreachable.
     - "console.openova.io"
+    # mail.openova.io (#5921): the 9th tether, and the only one on the PURCHASE
+    # path. catalyst-system/marketplace-api sends the customer sign-in code via
+    # smtp-host=mail.openova.io from Secret/sovereign-smtp-credentials, so a
+    # Sovereign with cutoverComplete=true still depends on OUR mail server for
+    # every customer login. ADR-0002 enumerates eight tethers and outbound
+    # customer-auth SMTP is not among them, so no step pivots it. It was also
+    # invisible to this very proof: the hold only ever denied the hosts it was
+    # told about, and no reconcile needs SMTP, so the 600s window stayed green
+    # with the tether fully live. Same shape as the ghcr.io HelmRepositories in
+    # #5919 — sovereignty asserted from the absence of a host nobody listed.
+    - "mail.openova.io"
     # mail.openova.io (#5921): the NINTH tether, and the only one on the
     # PURCHASE path. catalyst-system/marketplace-api sends every customer
     # sign-in code through the mothership SMTP host, so on a post-cutover

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -4640,7 +4640,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "0.1.191",
+      "version": "0.1.192",
       "section": "pts-2-3-per-sovereign-supporting-services",
       "depends": [
         "bp-gitea",

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -4775,7 +4775,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "0.1.191",
+    "version": "0.1.192",
     "section": "pts-2-3-per-sovereign-supporting-services",
     "depends": [
       "bp-gitea",

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3968,7 +3968,7 @@ name: bp-catalyst-platform
 #   file's 1.4.1325 entry records as permanently burned. The republish
 #   therefore lands on 1.4.1468 — ahead of main's 1.4.1467, absent from GHCR,
 #   and claimed by no open PR.)
-version: 1.4.1520
+version: 1.4.1522
 # 1.4.1481 — #6293: catalog-seed advances bp-self-sovereign-cutover
 #   0.1.186 -> 0.1.187, the release that stops step-06 from patching five
 #   HelmRepositories it does not own and then grading itself on whether they
@@ -4155,7 +4155,7 @@ version: 1.4.1520
 # scripts/check-chart-version-forward.sh (#5743) fails unless the two match —
 # main was carrying a pre-existing 1.4.1330/1.4.1329 split, so this bump heals
 # it in the same commit, exactly as the documented self-heal contract does.
-appVersion: 1.4.1520
+appVersion: 1.4.1522
 # 1.4.239 — Wave 3 / Issue #2140 (2026-05-23): Huawei provider
 # implementation lands behind the Wave 2 CloudProvider interface.
 # Adds the OpenTofu module at infra/providers/huawei/ (VPC + Subnet +


### PR DESCRIPTION
A Sovereign with `cutoverComplete=true` still routes every customer sign-in code through **our** mail server. `catalyst-system/marketplace-api` reads `smtp-host = mail.openova.io` from `Secret/sovereign-smtp-credentials`, so the purchase path depends on the mothership after the platform has declared independence.

ADR-0002 and `docs/DOD.md` §Pillar 5 enumerate **eight** tethers that cutover pivots. Outbound customer-auth SMTP is not among them, so no step pivots it — and it was equally invisible to the proof meant to catch exactly this. Step-08 holds deny-egress against `github.com`, `ghcr.io`, `harbor.openova.io` and `console.openova.io` for 600s; `mail.openova.io` was not in that set and no reconcile needs SMTP, so the window stays green with the tether fully live. Same shape as #5919: sovereignty asserted from the absence of a host nobody put on the list.

## What this changes

Adds `mail.openova.io` to `egressTest.blockedDomains`, following the `console.openova.io` precedent from #3678 — that entry exists to drive an **active call-home assertion** rather than rely on blocking-by-omission. The hold now fails while the SMTP tether is live instead of passing over it.

## What this does not change

This is the **detection** half. It makes the defect visible to the proof and to CI. It does not repoint the Sovereign at its own mail server — that is the pivot half and needs a cutover step of its own, which is the remaining work on #5921.

## Gates

- `check-chart-version-bumped.sh` → `PASS: all 1 touched chart(s) bumped their version`
- bootstrap-kit lockstep sweep → green locally

Lockstep sites were taken from this chart's own precedent commit rather than inferred. The umbrella takes 1.4.1522 because #6470 already claims 1.4.1521.

Refs #5921
