### PR TITLE
fix(catalog): stop selling Sandbox — retired 2026-06-30, still listed (#5920)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -4464,7 +4464,7 @@
       "category": "devtools",
       "tagline": null,
       "tags": [],
-      "visibility": "listed",
+      "visibility": "unlisted",
       "version": "0.3.12",
       "section": "pts-4-sandbox",
       "depends": [

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -4599,7 +4599,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "category": "devtools",
     "tagline": null,
     "tags": [],
-    "visibility": "listed",
+    "visibility": "unlisted",
     "version": "0.3.12",
     "section": "pts-4-sandbox",
     "depends": [

--- a/scripts/check-retired-products-not-listed.py
+++ b/scripts/check-retired-products-not-listed.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Fail if a RETIRED product is still `visibility: listed` in a generated catalog.
+
+Why this guard exists (#5920). The marketplace sold `Sandbox` for six weeks after
+the concept was retired on 2026-06-30. It survived because the obvious check —
+grepping the catalog-seed — returns NOTHING: the seed carries no sandbox
+Blueprint at all. The live entry sat in the two GENERATED catalogs the storefront
+actually serves, with `"visibility": "listed"`.
+
+So "absent from the seed" reads identically to "not for sale", and it is not the
+same thing. This guard asserts on the surface the customer actually gets.
+
+It is deliberately NOT a grep for the word "sandbox". A hardcoded denylist rots
+the moment the next product is retired. Instead RETIRED is declared once, below,
+and every generated catalog is checked against it.
+
+Exit 0 = no retired product is listed. Exit 1 = a retired product is on sale.
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+# Products retired by founder decision. Adding a row here is the ONE edit needed
+# when something is withdrawn — the guard then enforces it across every catalog.
+RETIRED = {
+    "sandbox": "Sandbox concept removed 2026-06-30; superseded by agenity + openova-mcp",
+}
+
+# The catalogs the storefront and console actually read. The catalog-seed is
+# intentionally absent: it is not where the defect lives, and including it would
+# recreate the false-clean signal this guard exists to kill.
+CATALOGS = [
+    "products/catalyst/bootstrap/api/internal/catalog/blueprints.json",
+    "products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts",
+]
+
+
+def entries_from_json(text: str):
+    data = json.loads(text)
+    items = data.get("blueprints", data) if isinstance(data, dict) else data
+    for b in items:
+        if isinstance(b, dict) and b.get("slug"):
+            yield b["slug"], b.get("visibility")
+
+
+def entries_from_ts(text: str):
+    """The .ts catalog is a TS module wrapping a JSON array; pull slug/visibility
+    pairs positionally rather than trying to parse TypeScript."""
+    for m in re.finditer(r'"slug":\s*"([^"]+)"', text):
+        slug = m.group(1)
+        window = text[m.end(): m.end() + 4000]
+        vis = re.search(r'"visibility":\s*"([^"]+)"', window)
+        yield slug, (vis.group(1) if vis else None)
+
+
+def main() -> int:
+    failures: list[str] = []
+    checked = 0
+    seen_any_slug = False
+
+    for rel in CATALOGS:
+        path = REPO / rel
+        if not path.exists():
+            failures.append(f"{rel}: MISSING — cannot assert on a catalog that is not there")
+            continue
+        text = path.read_text()
+        reader = entries_from_json if path.suffix == ".json" else entries_from_ts
+
+        try:
+            pairs = list(reader(text))
+        except Exception as exc:  # noqa: BLE001 - surface the parse failure, never swallow it
+            failures.append(f"{rel}: could not parse ({exc}) — refusing to report clean")
+            continue
+
+        if not pairs:
+            # Vacuity: a reader that yields nothing would make every assertion
+            # below pass. That is the exact false-green this guard is about.
+            failures.append(f"{rel}: parsed ZERO entries — guard would pass vacuously")
+            continue
+
+        seen_any_slug = True
+        for slug, vis in pairs:
+            checked += 1
+            if slug in RETIRED and vis == "listed":
+                failures.append(
+                    f"{rel}: '{slug}' is RETIRED ({RETIRED[slug]}) but visibility=listed "
+                    f"— a customer can still add it to a stack and buy it"
+                )
+
+    if not seen_any_slug:
+        print("FAIL: no catalog yielded any entry; the guard measured nothing.", file=sys.stderr)
+        return 1
+
+    if failures:
+        print(f"FAIL: {len(failures)} retired-product listing problem(s):", file=sys.stderr)
+        for f in failures:
+            print(f"  - {f}", file=sys.stderr)
+        print(
+            "\nFix: set visibility to 'unlisted' in the generated catalog(s). Do not "
+            "delete the record — other Blueprints may reference it, and unlisted is "
+            "the field the storefront already honours.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        f"PASS: {checked} catalog entrie(s) checked across {len(CATALOGS)} catalog(s); "
+        f"no retired product ({', '.join(sorted(RETIRED))}) is listed."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
The marketplace grid still renders a **Sandbox** card — category `devtools`, badged FREE, live "Add to stack" button, counted in "16 available". The concept was retired by founder decision on 2026-06-30 and superseded by Agenity + `bp-openova-mcp` (Pillar 4).

## Why a source grep could not see it

The catalog-seed carries **no** sandbox Blueprint. The entry lives in the two *generated* catalogs the storefront actually serves — `blueprints.json` and `catalog.generated.ts` — both with `"visibility": "listed"`. Grepping the seed returns nothing and reads as absence, which is how this survived six weeks.

## Change

Flipped `visibility` to `unlisted` in both generated catalogs. Unlisted (not deleted) because it is the field the storefront already honours to drop a card from the customer grid while keeping the record addressable; deletion risks dangling references.

## Verification

- No Blueprint declares a `depends` on sandbox — checked, **NONE**
- Post-edit assertion: `sandbox` absent from the listed set, while `openclaw`, `stalwart-mail`, `wordpress` remain listed — this removes one card, not a category

Refs #5920