### PR TITLE
fix(cutover): step-07a pivots customer sign-in mail off the mothership (#5921)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -1074,7 +1074,7 @@ spec:
       # chart/tests/ left the package via .helmignore: 757,264 bytes, 72.2%.
       # The rendered manifest is byte-identical modulo comments — no step,
       # value or RBAC change, still 11 steps.
-      version: 0.1.191
+      version: 0.1.193
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1451,7 +1451,7 @@ spec:
       #   staged commit and push, and makes the Phase-3 pre-strip read-back the
       #   single fail-closed gate (#5436 relocated, not weakened). Lockstep w/
       #   products/catalyst/chart/Chart.yaml.
-      version: 1.4.1520
+      version: 1.4.1523
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.191
+  version: 0.1.193
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -4153,7 +4153,7 @@ name: bp-self-sovereign-cutover
 # load-bearing. Slot-06a pin + blueprint.yaml + catalog-seed spec.version +
 # source.version + the API blueprints.json + the generated UI catalog move to
 # 0.1.190 in lockstep (Inviolable Principle #13).
-version: 0.1.191
+version: 0.1.193
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/07a-smtp-relay-pivot-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/07a-smtp-relay-pivot-job.yaml
@@ -1,0 +1,139 @@
+{{- /*
+Step 07a — smtp-relay-pivot: repoint customer sign-in mail at the Sovereign's
+own Stalwart (#5921, the 9th tether).
+
+catalyst-system/sovereign-smtp-credentials carries smtp-host = mail.openova.io.
+marketplace-api reads it to send the customer sign-in code, so a Sovereign with
+cutoverComplete=true still depends on the OpenOva mothership for every customer
+login — on the PURCHASE path.
+
+Why this is a PIVOT and not a seed-default fix. The seed writes that host
+deliberately: products/catalyst/bootstrap/api/internal/handler/sovereign_smtp_seed.go
+defaults relayHost to mail.openova.io because at Phase 1 the Sovereign has NO
+mail server of its own yet, and the in-cluster Stalwart host resolved to
+`no such host` and broke operator PIN-login on every fresh prov (#4748). The
+tether is CORRECT at bootstrap and only becomes a sovereignty violation here,
+once the Sovereign's own Stalwart is serving. Changing the seed default would
+reintroduce the #4748 outage.
+
+That is also why no ADR-0002 step pivots it: the eight enumerated tethers are all
+wrong from the start, and this one is not.
+
+Ordering: this MUST run before step-08. Step-08 now denies mail.openova.io
+(#6471), so a Sovereign that has not pivoted fails the hold — which is the
+intended behaviour, not a regression.
+
+Fail-loud: the step verifies Stalwart actually ANSWERS on 587 before rewriting
+the Secret, and re-reads the Secret afterwards to confirm the new value landed.
+A step that rewrites the Secret and reports success without either check is the
+"reads clean because nothing was measured" shape this defect was found by.
+
+Image phase: post.
+*/ -}}
+{{- if .Values.smtpRelayPivot.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: cutover-step-07a-smtp-relay-pivot
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "bp-self-sovereign-cutover.labels" . | nindent 4 }}
+    cutover.openova.io/step: "07a"
+spec:
+  backoffLimit: {{ .Values.smtpRelayPivot.backoffLimit }}
+  template:
+    metadata:
+      labels:
+        {{- include "bp-self-sovereign-cutover.labels" . | nindent 8 }}
+        cutover.openova.io/step: "07a"
+    spec:
+      restartPolicy: Never
+      serviceAccountName: {{ include "bp-self-sovereign-cutover.serviceAccountName" . }}
+      containers:
+      - name: smtp-relay-pivot
+        image: {{ include "bp-self-sovereign-cutover.image" (dict "repository" .Values.images.kubectl.repository "tag" .Values.images.kubectl.tag "cutoverPhase" "post" "Values" .Values) }}
+        env:
+        - name: TARGET_HOST
+          value: {{ .Values.smtpRelayPivot.targetHost | quote }}
+        - name: TARGET_PORT
+          value: {{ .Values.smtpRelayPivot.targetPort | quote }}
+        - name: SECRET_NS
+          value: {{ .Values.smtpRelayPivot.secretNamespace | quote }}
+        - name: SECRET_NAME
+          value: {{ .Values.smtpRelayPivot.secretName | quote }}
+        - name: PROBE_TIMEOUT
+          value: {{ .Values.smtpRelayPivot.probeTimeoutSeconds | quote }}
+        command: ["/bin/sh", "-c"]
+        args:
+        - |
+          set -eu
+
+          echo "step-07a: pivoting ${SECRET_NS}/${SECRET_NAME} smtp-host -> ${TARGET_HOST}:${TARGET_PORT}"
+
+          current=$(kubectl -n "${SECRET_NS}" get secret "${SECRET_NAME}" \
+            -o jsonpath='{.data.smtp-host}' 2>/dev/null | base64 -d || true)
+          if [ -z "${current}" ]; then
+            echo "FATAL: ${SECRET_NS}/${SECRET_NAME} has no smtp-host key."
+            echo "       Nothing to pivot means the tether is somewhere this step"
+            echo "       does not know about — failing loud rather than reporting"
+            echo "       a green no-op."
+            exit 1
+          fi
+          echo "step-07a: current smtp-host = ${current}"
+
+          if [ "${current}" = "${TARGET_HOST}" ]; then
+            echo "step-07a: already pivoted; verifying it still answers before exiting 0."
+          fi
+
+          # Gate 1 — the Sovereign-local relay must ANSWER before we cut to it.
+          # Pivoting to a dead host would trade a sovereignty defect for a total
+          # sign-in outage, which is strictly worse for the customer.
+          echo "step-07a: probing ${TARGET_HOST}:${TARGET_PORT} ..."
+          probed=""
+          i=0
+          while [ "${i}" -lt "${PROBE_TIMEOUT}" ]; do
+            if nc -z -w 2 "${TARGET_HOST}" "${TARGET_PORT}" 2>/dev/null; then
+              probed="yes"; break
+            fi
+            i=$((i+3)); sleep 3
+          done
+          if [ -z "${probed}" ]; then
+            echo "FATAL: ${TARGET_HOST}:${TARGET_PORT} did not answer within ${PROBE_TIMEOUT}s."
+            echo "       Refusing to pivot customer sign-in mail onto a relay that"
+            echo "       is not serving. The mothership tether stays live and"
+            echo "       step-08 will fail on it — that is the correct outcome:"
+            echo "       an unpivoted Sovereign is not sovereign."
+            exit 1
+          fi
+          echo "step-07a: ${TARGET_HOST}:${TARGET_PORT} answered."
+
+          patch=$(printf '{"stringData":{"smtp-host":"%s","smtp-port":"%s"}}' \
+            "${TARGET_HOST}" "${TARGET_PORT}")
+          kubectl -n "${SECRET_NS}" patch secret "${SECRET_NAME}" \
+            --type=merge -p "${patch}"
+
+          # Gate 2 — re-read. A patch that reports success and does not land is
+          # the exact failure this step exists to prevent.
+          after=$(kubectl -n "${SECRET_NS}" get secret "${SECRET_NAME}" \
+            -o jsonpath='{.data.smtp-host}' | base64 -d)
+          if [ "${after}" != "${TARGET_HOST}" ]; then
+            echo "FATAL: readback mismatch — wanted ${TARGET_HOST}, Secret holds ${after}."
+            exit 1
+          fi
+          echo "step-07a: readback OK, smtp-host = ${after}"
+
+          # Consumers cache the value at start; roll them so the pivot takes
+          # effect rather than sitting in a Secret nothing has re-read.
+          for d in {{ .Values.smtpRelayPivot.consumerDeployments | join " " }}; do
+            ns="${d%%/*}"; name="${d##*/}"
+            if kubectl -n "${ns}" get deploy "${name}" >/dev/null 2>&1; then
+              echo "step-07a: rolling ${ns}/${name}"
+              kubectl -n "${ns}" rollout restart "deploy/${name}"
+              kubectl -n "${ns}" rollout status "deploy/${name}" --timeout={{ .Values.smtpRelayPivot.rolloutTimeout }}
+            else
+              echo "step-07a: ${ns}/${name} absent, skipping"
+            fi
+          done
+
+          echo "step-07a: DONE — customer sign-in mail no longer leaves the Sovereign."
+{{- end }}

--- a/platform/self-sovereign-cutover/chart/tests/smtp-relay-pivot-5921.sh
+++ b/platform/self-sovereign-cutover/chart/tests/smtp-relay-pivot-5921.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Render guard for step-07a smtp-relay-pivot (#5921).
+#
+# Vacuity first: this suite asserts on rendered CONTENT, so it opens by proving
+# the template renders anything at all. A grep-based guard that silently matches
+# an empty render is the failure mode this repo keeps re-learning.
+set -euo pipefail
+
+CHART="$(cd "$(dirname "$0")/.." && pwd)"
+TPL="templates/07a-smtp-relay-pivot-job.yaml"
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+render() { helm template t "$CHART" -s "$TPL" "$@" 2>/dev/null; }
+
+# ── 0. vacuity ────────────────────────────────────────────────────────────
+out="$(render)"
+[ -n "$out" ] || fail "template rendered EMPTY — every assertion below would pass vacuously"
+echo "$out" | grep -q 'kind: Job' || fail "no Job in render"
+
+# ── 1. the pivot targets the Sovereign-local relay, not the mothership ────
+echo "$out" | grep -q 'stalwart-web.stalwart.svc.cluster.local' \
+  || fail "TARGET_HOST is not the Sovereign-local Stalwart"
+echo "$out" | grep -q 'mail\.openova\.io' \
+  && fail "render still names mail.openova.io as a target — that is the tether"
+
+# ── 2. it must patch the Secret the seed actually writes ─────────────────
+echo "$out" | grep -q 'sovereign-smtp-credentials' || fail "does not name the SMTP Secret"
+echo "$out" | grep -q 'catalyst-system'             || fail "does not name the Secret namespace"
+
+# ── 3. fail-loud gates: probe before pivot, readback after ───────────────
+# Without these the step reports success while having changed nothing real.
+echo "$out" | grep -q 'did not answer within' \
+  || fail "no pre-pivot reachability gate — would cut sign-in onto a dead relay"
+echo "$out" | grep -q 'readback mismatch' \
+  || fail "no post-patch readback — a patch that does not land would report green"
+echo "$out" | grep -q 'has no smtp-host key' \
+  || fail "no missing-key gate — a no-op would be indistinguishable from a pivot"
+
+# ── 4. consumers get rolled, else the pivot sits unread ──────────────────
+echo "$out" | grep -q 'rollout restart' || fail "consumers are never rolled"
+echo "$out" | grep -q 'marketplace-api' || fail "marketplace-api not in the consumer set"
+
+# ── 5. CONTROL: the step is disableable, and disabling it renders NOTHING ─
+# Proves the enabled flag is actually wired rather than decorative.
+off="$(render --set smtpRelayPivot.enabled=false || true)"
+[ -z "$(echo "${off}" | grep -c 'kind: Job' | grep -v '^0$' || true)" ] \
+  || fail "smtpRelayPivot.enabled=false still rendered a Job"
+
+echo "PASS: step-07a pivots SMTP to the Sovereign-local relay, with probe + readback gates."

--- a/platform/self-sovereign-cutover/chart/values.yaml
+++ b/platform/self-sovereign-cutover/chart/values.yaml
@@ -2217,6 +2217,30 @@ egressTest:
   # The FULL host registry.<fqdn> classifies correctly in every case. An
   # operator on a non-registry.<fqdn> local registry name overrides here.
   localRegistryHostSubstr: ""
+# ── step-07a smtp-relay-pivot (#5921) ────────────────────────────────────
+# Repoints catalyst-system/sovereign-smtp-credentials at the Sovereign's own
+# Stalwart so customer sign-in mail stops traversing mail.openova.io. Must run
+# BEFORE step-08, which now denies that host.
+#
+# targetHost matches the chart default in products/catalyst/chart/values.yaml —
+# the seed overrode it with the mothership relay because at Phase 1 no local
+# mail server existed yet (#4748). By this step it does.
+smtpRelayPivot:
+  enabled: true
+  targetHost: "stalwart-web.stalwart.svc.cluster.local"
+  targetPort: "587"
+  secretNamespace: "catalyst-system"
+  secretName: "sovereign-smtp-credentials"
+  # Refuse to pivot onto a relay that is not answering — a dead target would
+  # trade a sovereignty defect for a total sign-in outage.
+  probeTimeoutSeconds: 120
+  rolloutTimeout: "300s"
+  backoffLimit: 2
+  # Consumers cache smtp-host at start; without a roll the pivot sits in a
+  # Secret nothing has re-read.
+  consumerDeployments:
+    - "catalyst-system/marketplace-api"
+
   blockedDomains:
     - "github.com"
     - "ghcr.io"

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -4640,7 +4640,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "0.1.191",
+      "version": "0.1.193",
       "section": "pts-2-3-per-sovereign-supporting-services",
       "depends": [
         "bp-gitea",

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -4775,7 +4775,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "0.1.191",
+    "version": "0.1.193",
     "section": "pts-2-3-per-sovereign-supporting-services",
     "depends": [
       "bp-gitea",

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3968,7 +3968,7 @@ name: bp-catalyst-platform
 #   file's 1.4.1325 entry records as permanently burned. The republish
 #   therefore lands on 1.4.1468 — ahead of main's 1.4.1467, absent from GHCR,
 #   and claimed by no open PR.)
-version: 1.4.1520
+version: 1.4.1523
 # 1.4.1481 — #6293: catalog-seed advances bp-self-sovereign-cutover
 #   0.1.186 -> 0.1.187, the release that stops step-06 from patching five
 #   HelmRepositories it does not own and then grading itself on whether they
@@ -4155,7 +4155,7 @@ version: 1.4.1520
 # scripts/check-chart-version-forward.sh (#5743) fails unless the two match —
 # main was carrying a pre-existing 1.4.1330/1.4.1329 split, so this bump heals
 # it in the same commit, exactly as the documented self-heal contract does.
-appVersion: 1.4.1520
+appVersion: 1.4.1523
 # 1.4.239 — Wave 3 / Issue #2140 (2026-05-23): Huawei provider
 # implementation lands behind the Wave 2 CloudProvider interface.
 # Adds the OpenTofu module at infra/providers/huawei/ (VPC + Subnet +

--- a/scripts/check-cutover-denies-mothership-hosts.py
+++ b/scripts/check-cutover-denies-mothership-hosts.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Fail if a known mothership host is missing from the cutover deny-egress set.
+
+Why this guard exists (#5921, sibling of #5919). The step-08 hold denies a LIST of
+hosts for 600s and calls the Sovereign independent if the cluster stays green.
+That makes the proof only as complete as the list. Two tethers have already
+survived it for exactly this reason:
+
+  • #5919 — 62 HelmRepositories still pointing at ghcr.io
+  • #5921 — customer sign-in mail via mail.openova.io, on the PURCHASE path,
+            on a Sovereign with cutoverComplete=true
+
+Neither was a broken check. Both were hosts nobody had put on the list, and
+absence of a denial reads exactly like absence of a dependency.
+
+So the deny set cannot be maintained by memory. This guard pins it: every host in
+MOTHERSHIP_HOSTS must appear in egressTest.blockedDomains, and adding a new
+mothership surface without denying it fails CI rather than silently widening the
+sovereignty claim.
+
+Exit 0 = every known mothership host is denied. Exit 1 = the proof has a hole.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+VALUES = REPO / "platform/self-sovereign-cutover/chart/values.yaml"
+
+# Every OpenOva-operated surface a Sovereign could still depend on after cutover.
+# Adding a mothership host anywhere in the platform means adding it here too.
+MOTHERSHIP_HOSTS = {
+    "github.com":          "catalog source — pivoted by step-01 to local Gitea",
+    "ghcr.io":             "chart/image source — pivoted by steps 03/06 to local Harbor (#5919)",
+    "harbor.openova.io":   "mothership registry — pivoted by step-03 prewarm",
+    "console.openova.io":  "mothership front door / token issuer (#3678)",
+    "mail.openova.io":     "customer sign-in SMTP relay — pivoted by step-07a (#5921)",
+}
+
+
+def blocked_domains(text: str) -> list[str]:
+    """Read the blockedDomains list items out of values.yaml without a YAML dep."""
+    m = re.search(r"^\s*blockedDomains:\s*$", text, re.MULTILINE)
+    if not m:
+        return []
+    out: list[str] = []
+    for line in text[m.end():].split("\n"):
+        s = line.strip()
+        if not s or s.startswith("#"):
+            continue
+        item = re.match(r'-\s*"?([^"#\s]+)"?', s)
+        if item:
+            out.append(item.group(1))
+            continue
+        # first non-comment, non-item line ends the block
+        break
+    return out
+
+
+def main() -> int:
+    if not VALUES.exists():
+        print(f"FAIL: {VALUES} missing — cannot assert on a deny set that is not there",
+              file=sys.stderr)
+        return 1
+
+    denied = blocked_domains(VALUES.read_text())
+
+    # Vacuity: an empty parse would make every membership test below pass.
+    if not denied:
+        print("FAIL: parsed ZERO blockedDomains entries. Either the key moved or the "
+              "reader broke — refusing to report the sovereignty proof complete when "
+              "nothing was measured.", file=sys.stderr)
+        return 1
+
+    missing = [h for h in MOTHERSHIP_HOSTS if h not in denied]
+    if missing:
+        print(f"FAIL: {len(missing)} mothership host(s) absent from the step-08 deny set:",
+              file=sys.stderr)
+        for h in missing:
+            print(f"  - {h}  ({MOTHERSHIP_HOSTS[h]})", file=sys.stderr)
+        print("\nThe hold would pass with these tethers fully live — sovereignty asserted "
+              "from the absence of a host nobody listed. Add them to "
+              "egressTest.blockedDomains, and make sure a step actually pivots them.",
+              file=sys.stderr)
+        return 1
+
+    print(f"PASS: all {len(MOTHERSHIP_HOSTS)} known mothership host(s) are denied during "
+          f"the step-08 hold ({len(denied)} entries in the deny set).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
The **pivot half** of the 9th tether (detection half shipped in #6471).

`catalyst-system/sovereign-smtp-credentials` carries `smtp-host = mail.openova.io`, and `marketplace-api` reads it to send the customer sign-in code — so a Sovereign with `cutoverComplete=true` still depends on **our** mail server for every customer login, on the purchase path.

## Why this is not a seed-default fix

`sovereign_smtp_seed.go:208-211` writes that host **deliberately**. At Phase 1 the Sovereign has no mail server of its own, the in-cluster Stalwart host resolved to `no such host`, and operator PIN-login 502'd on *every* fresh prov (#4748). The tether is correct at bootstrap and only becomes a sovereignty violation after cutover. Changing the default would reintroduce that outage.

That is also why no ADR-0002 step pivots it: the eight enumerated tethers are all wrong from the start, and this one is not.

The chart default (`products/catalyst/chart/values.yaml:128`) is **already** the Sovereign-local Stalwart — the seed Secret is source-wins and overrides it. So the pivot rewrites the Secret, touching neither default.

## Fail-loud gates

A step that rewrites a Secret and reports success without checks is the *reads-clean-because-nothing-was-measured* shape this defect was found by. So:

- **probe the target relay before cutting to it** — pivoting onto a dead host trades a sovereignty defect for a total sign-in outage, strictly worse
- **re-read the Secret after patching**, fail on mismatch
- **missing-key gate**, so a no-op cannot pass as a pivot
- roll + wait on `marketplace-api`, which caches `smtp-host` at start

## Ordering

Runs **before** step-08, which now denies `mail.openova.io` (#6471). An unpivoted Sovereign fails the hold — intended.

## Gates

- render suite `PASS`, opening with a **vacuity check** and closing with an `enabled=false` **control** so the flag is proven wired
- `check-chart-version-bumped.sh` — see run below

Umbrella takes 1.4.1523 (1521 → #6470, 1522 → #6471).

Refs #5921