### PR TITLE
fix(cutover): a catalog chart that declares ZERO images must say so (#6360)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -1074,7 +1074,7 @@ spec:
       # chart/tests/ left the package via .helmignore: 757,264 bytes, 72.2%.
       # The rendered manifest is byte-identical modulo comments — no step,
       # value or RBAC change, still 11 steps.
-      version: 0.1.191
+      version: 0.1.194
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1451,7 +1451,7 @@ spec:
       #   staged commit and push, and makes the Phase-3 pre-strip read-back the
       #   single fail-closed gate (#5436 relocated, not weakened). Lockstep w/
       #   products/catalyst/chart/Chart.yaml.
-      version: 1.4.1520
+      version: 1.4.1524
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.191
+  version: 0.1.194
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -4153,7 +4153,7 @@ name: bp-self-sovereign-cutover
 # load-bearing. Slot-06a pin + blueprint.yaml + catalog-seed spec.version +
 # source.version + the API blueprints.json + the generated UI catalog move to
 # 0.1.190 in lockstep (Inviolable Principle #13).
-version: 0.1.191
+version: 0.1.194
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/03c-catalog-chart-set.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/03c-catalog-chart-set.yaml
@@ -288,7 +288,31 @@ data:
                 continue ;;
             esac
             printf '%s\n' "${_ci_ref}"
-          done | sort -u
+          done | sort -u > "${_ci_dir}/.catalog-images.$$"
+      {{- /*
+       #6360 — a chart that renders CLEANLY and declares ZERO images is the
+       silent case. Every rejection above `continue`s with a WARN, so a skipped
+       ref is visible; a chart that simply contributes nothing is not. It
+       returns success and adds no rows, which is indistinguishable downstream
+       from a chart whose images were all already cached.
+
+       That is how a post-cutover Sovereign came to SELL uptime-kuma and then
+       fail to install it: prewarm reported no missing images because it had
+       enumerated none. A marketplace Blueprint chart that renders an
+       Application/HelmRelease CR rather than a pod spec legitimately has no
+       `image:` scalar — the workload ref only materialises when the app's own
+       chart renders later, which is after the upstream has been severed.
+
+       This does not guess at the missing ref. It makes the zero VISIBLE, so
+       the A3 guard and the operator can tell "nothing to mirror" apart from
+       "nothing was measured" — the distinction the deny-set and catalog-seed
+       defects both turned on.
+      */}}
+      if [ ! -s "${_ci_dir}/.catalog-images.$$" ]; then
+        echo "[catalog-set] WARN: ${_ci_tgz##*/} rendered OK but declared ZERO addressable images — nothing will be prewarmed for it. If this chart is a customer-visible (visibility: listed) Blueprint, its workload image is composed downstream and prewarm cannot see it; the app will ImagePullBackOff once upstream is severed (#6360)." >&2
+      fi
+      cat "${_ci_dir}/.catalog-images.$$"
+      rm -f "${_ci_dir}/.catalog-images.$$"
       rm -f "${_ci_out}" "${_ci_err}"
       return 0
     }

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -4640,7 +4640,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "0.1.191",
+      "version": "0.1.194",
       "section": "pts-2-3-per-sovereign-supporting-services",
       "depends": [
         "bp-gitea",

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -4775,7 +4775,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "0.1.191",
+    "version": "0.1.194",
     "section": "pts-2-3-per-sovereign-supporting-services",
     "depends": [
       "bp-gitea",

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3968,7 +3968,7 @@ name: bp-catalyst-platform
 #   file's 1.4.1325 entry records as permanently burned. The republish
 #   therefore lands on 1.4.1468 — ahead of main's 1.4.1467, absent from GHCR,
 #   and claimed by no open PR.)
-version: 1.4.1520
+version: 1.4.1524
 # 1.4.1481 — #6293: catalog-seed advances bp-self-sovereign-cutover
 #   0.1.186 -> 0.1.187, the release that stops step-06 from patching five
 #   HelmRepositories it does not own and then grading itself on whether they
@@ -4155,7 +4155,7 @@ version: 1.4.1520
 # scripts/check-chart-version-forward.sh (#5743) fails unless the two match —
 # main was carrying a pre-existing 1.4.1330/1.4.1329 split, so this bump heals
 # it in the same commit, exactly as the documented self-heal contract does.
-appVersion: 1.4.1520
+appVersion: 1.4.1524
 # 1.4.239 — Wave 3 / Issue #2140 (2026-05-23): Huawei provider
 # implementation lands behind the Wave 2 CloudProvider interface.
 # Adds the OpenTofu module at infra/providers/huawei/ (VPC + Subnet +


### PR DESCRIPTION
A post-cutover Sovereign **sold** `uptime-kuma` and then could not install it — ImagePullBackOff on `proxy-dockerhub` with upstream severed, customer's purchased app serving 404/503.

## The prewarm machinery was not missing

`catalog_chart_set()` already reads `blueprints.catalyst.openova.io` and treats `visibility: listed` as **CONTRACTUAL**, so listed marketplace Blueprints are in scope by design. Building a "prewarm the catalog" feature would have duplicated it.

What was missing was a **signal**.

## The silent case

`chart_declared_images` WARNs on every ref it rejects — empty tag, placeholder tag, untagged, unrenderable. The one case it says nothing about is a chart that renders **cleanly and yields zero images**: it returns success, contributes no rows, and is indistinguishable downstream from a chart whose images were all already cached.

That is exactly the uptime-kuma shape. A marketplace Blueprint chart renders an Application/HelmRelease CR, **not a pod spec**, so it legitimately has no `image:` scalar — the workload ref only materialises when the app's own chart renders, which is *after* step-08 severs upstream. Prewarm reported nothing missing because it had enumerated nothing.

## What this changes

It does not guess the missing ref. It makes the zero **visible**, so "nothing to mirror" can be told apart from "nothing was measured" — the same distinction the deny-set (#5921) and catalog-seed (#5920) defects both turned on.

## Controls

Run against the real extracted `catalog-set.sh`, not a mock:

| case | result |
|---|---|
| zero-image chart (HelmRelease CR, the uptime-kuma shape) | WARN `ZERO addressable images` **fires** |
| normal chart with a pod spec | image extracted (`louislam/uptime-kuma:1.23.17`), **0** spurious warns |

`check-chart-version-bumped.sh` → `PASS: all 1 touched chart(s) bumped their version`.

Lockstep sites taken from this chart's precedent commit. Umbrella takes 1.4.1524 (1521 → #6470, 1523 → #6473).

Refs #6360