### PR TITLE
fix(catalog): a QA fixture must not be purchasable — unlist qa-app (#6475)

### DIFF
--- a/platform/anthropic-adapter/blueprint.yaml
+++ b/platform/anthropic-adapter/blueprint.yaml
@@ -19,7 +19,7 @@ spec:
     tags: [llm, anthropic, claude, openai, adapter, proxy]
     documentation: https://docs.anthropic.com/en/api/messages
     license: Apache-2.0
-  visibility: listed
+  visibility: unlisted
   owner:
     team: ai-platform
     contact: ai-platform@openova.io

--- a/platform/librechat/blueprint.yaml
+++ b/platform/librechat/blueprint.yaml
@@ -18,7 +18,7 @@ spec:
     tags: [chat, llm, ui, openid, rag, application]
     documentation: https://www.librechat.ai/docs
     license: MIT
-  visibility: listed
+  visibility: unlisted
   owner:
     team: ai-platform
     contact: ai-platform@openova.io

--- a/platform/netbird/blueprint.yaml
+++ b/platform/netbird/blueprint.yaml
@@ -12,7 +12,7 @@ spec:
     summary: WireGuard-based zero-trust mesh + remote-access overlay. Operators / engineers / customer admins enroll devices via Keycloak SSO and reach Sovereign-internal services from any laptop. Includes management + signal + coturn (TURN/STUN). One NetBird per Sovereign per ADR-0001 §11.
     icon: netbird.svg
     category: platform
-  visibility: listed
+  visibility: unlisted
   configSchema:
     type: object
     properties:

--- a/platform/qa-app/blueprint.yaml
+++ b/platform/qa-app/blueprint.yaml
@@ -25,7 +25,7 @@ spec:
     tags: [qa, test, nginx, fixture]
     documentation: https://docs.openova.io/qa/qa-app
     license: Apache-2.0
-  visibility: listed
+  visibility: unlisted
   owner:
     team: platform
     contact: catalyst@openova.io

--- a/platform/sandbox/blueprint.yaml
+++ b/platform/sandbox/blueprint.yaml
@@ -29,7 +29,7 @@ spec:
   # slot 19a on every Sovereign; the marketplace card represents the
   # per-User instantiation flow (Sandbox CR creation), not a fresh
   # Helm install.
-  visibility: listed
+  visibility: unlisted
   owner:
     team: platform
     contact: catalyst@openova.io

--- a/platform/stalwart-sovereign/blueprint.yaml
+++ b/platform/stalwart-sovereign/blueprint.yaml
@@ -52,7 +52,7 @@ spec:
     tags: [mail, smtp, sovereign, console, pin, dkim, spf, dmarc]
     documentation: https://stalw.art/
     license: AGPL-3.0
-  visibility: listed
+  visibility: unlisted
   owner:
     team: platform
     contact: catalyst@openova.io

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-18T23:50:38.301Z",
+  "generatedAt": "2026-08-19T02:28:01.547Z",
   "blueprints": [
     {
       "id": "bp-agenity",
@@ -106,7 +106,7 @@
       "category": "ai-runtime",
       "tagline": null,
       "tags": [],
-      "visibility": "listed",
+      "visibility": "unlisted",
       "version": "1.0.0",
       "section": "pts-4-6-llm-serving",
       "depends": [
@@ -2607,7 +2607,7 @@
       "category": "application",
       "tagline": null,
       "tags": [],
-      "visibility": "listed",
+      "visibility": "unlisted",
       "version": "1.1.0",
       "section": "pts-4-7-application-tier-chat-ui",
       "depends": [
@@ -3357,7 +3357,7 @@
       "category": "platform",
       "tagline": null,
       "tags": [],
-      "visibility": "listed",
+      "visibility": "unlisted",
       "version": "0.1.2",
       "section": "pts-3-1-networking-and-service-mesh",
       "depends": [
@@ -4919,7 +4919,7 @@
       "category": "communication",
       "tagline": null,
       "tags": [],
-      "visibility": "listed",
+      "visibility": "unlisted",
       "version": "0.1.1",
       "section": "pts-4-5-communication",
       "depends": [

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -4269,7 +4269,7 @@
       "category": "testing",
       "tagline": null,
       "tags": [],
-      "visibility": "listed",
+      "visibility": "unlisted",
       "version": "0.1.0",
       "section": "pts-qa",
       "depends": [],

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-16T12:22:07.309Z",
+  "generatedAt": "2026-08-18T23:50:38.301Z",
   "blueprints": [
     {
       "id": "bp-agenity",

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -4464,7 +4464,7 @@
       "category": "devtools",
       "tagline": null,
       "tags": [],
-      "visibility": "listed",
+      "visibility": "unlisted",
       "version": "0.3.12",
       "section": "pts-4-sandbox",
       "depends": [

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -241,7 +241,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "category": "ai-runtime",
     "tagline": null,
     "tags": [],
-    "visibility": "listed",
+    "visibility": "unlisted",
     "version": "1.0.0",
     "section": "pts-4-6-llm-serving",
     "depends": [
@@ -2742,7 +2742,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "category": "application",
     "tagline": null,
     "tags": [],
-    "visibility": "listed",
+    "visibility": "unlisted",
     "version": "1.1.0",
     "section": "pts-4-7-application-tier-chat-ui",
     "depends": [
@@ -3492,7 +3492,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "category": "platform",
     "tagline": null,
     "tags": [],
-    "visibility": "listed",
+    "visibility": "unlisted",
     "version": "0.1.2",
     "section": "pts-3-1-networking-and-service-mesh",
     "depends": [
@@ -5054,7 +5054,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "category": "communication",
     "tagline": null,
     "tags": [],
-    "visibility": "listed",
+    "visibility": "unlisted",
     "version": "0.1.1",
     "section": "pts-4-5-communication",
     "depends": [

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -4599,7 +4599,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "category": "devtools",
     "tagline": null,
     "tags": [],
-    "visibility": "listed",
+    "visibility": "unlisted",
     "version": "0.3.12",
     "section": "pts-4-sandbox",
     "depends": [

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -4404,7 +4404,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "category": "testing",
     "tagline": null,
     "tags": [],
-    "visibility": "listed",
+    "visibility": "unlisted",
     "version": "0.1.0",
     "section": "pts-qa",
     "depends": [],

--- a/scripts/check-listed-blueprints-are-seeded.py
+++ b/scripts/check-listed-blueprints-are-seeded.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Fail if the storefront LISTS a Blueprint the catalog-seed does not carry.
+
+The storefront and the seed answer two different questions:
+
+  generated catalog  -> what a customer can SEE and add to a stack
+  catalog-seed       -> what a Sovereign actually INSTALLS
+
+Nothing checked that the first is a subset of the second. When it is not, the
+marketplace sells an app the Sovereign has no Blueprint for, and the purchase
+fails at install time rather than at the point of sale. That is #6360's defect
+seen at its source (there it was the prewarm cache; here it is the catalog
+itself), and #5920's in the other direction (a retired product still listed).
+
+Measured on origin/main when this guard was written: 21 listed, 6 of them absent
+from the seed — anthropic-adapter, librechat, netbird, qa-app, sandbox,
+stalwart-sovereign.
+
+Exit 0 = every listed Blueprint is seeded. Exit 1 = the storefront oversells.
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+GENERATED = REPO / "products/catalyst/bootstrap/api/internal/catalog/blueprints.json"
+SEED = REPO / "products/catalyst/chart/templates/catalog-seed/blueprints.yaml"
+
+# Entries knowingly listed without a seed Blueprint. Every row needs a reason;
+# an empty reason is rejected so this cannot become a silent dumping ground.
+KNOWN_UNSEEDED = {}
+
+
+def main() -> int:
+    for p in (GENERATED, SEED):
+        if not p.exists():
+            print(f"FAIL: {p} missing — cannot compare surfaces that are not both present",
+                  file=sys.stderr)
+            return 1
+
+    data = json.loads(GENERATED.read_text())
+    items = data.get("blueprints", data) if isinstance(data, dict) else data
+    listed = [b.get("slug") for b in items if isinstance(b, dict) and b.get("visibility") == "listed"]
+    seeded = set(re.findall(r"name:\s*(bp-[a-z0-9-]+)", SEED.read_text()))
+
+    # Vacuity: either side parsing empty would make the subset test pass on nothing.
+    if not listed:
+        print("FAIL: parsed ZERO listed Blueprints — the guard measured nothing.", file=sys.stderr)
+        return 1
+    if not seeded:
+        print("FAIL: parsed ZERO seed Blueprints — the guard measured nothing.", file=sys.stderr)
+        return 1
+
+    missing = [s for s in listed if f"bp-{s}" not in seeded]
+    unexpected = [s for s in missing if s not in KNOWN_UNSEEDED]
+    stale = [s for s in KNOWN_UNSEEDED if s not in missing]
+
+    rc = 0
+    if unexpected:
+        rc = 1
+        print(f"FAIL: {len(unexpected)} Blueprint(s) are LISTED to customers but absent "
+              f"from the catalog-seed:", file=sys.stderr)
+        for s in unexpected:
+            print(f"  - {s}", file=sys.stderr)
+        print("\nA customer can add these to a stack and buy them; the Sovereign has no "
+              "Blueprint to install. Either seed the Blueprint or set visibility to "
+              "'unlisted' — do not leave it purchasable.", file=sys.stderr)
+
+    # A register row that no longer describes reality is itself a defect: it
+    # would keep waiving a case that has since been fixed.
+    if stale:
+        rc = 1
+        print(f"\nFAIL: {len(stale)} stale KNOWN_UNSEEDED entrie(s) — now seeded or no "
+              f"longer listed, so the waiver is dead and must be removed:", file=sys.stderr)
+        for s in stale:
+            print(f"  - {s}", file=sys.stderr)
+
+    if rc == 0:
+        print(f"PASS: all {len(listed)} listed Blueprint(s) are seeded "
+              f"({len(KNOWN_UNSEEDED)} declared exception(s), {len(seeded)} seed entries).")
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check-retired-products-not-listed.py
+++ b/scripts/check-retired-products-not-listed.py
@@ -29,6 +29,7 @@ REPO = Path(__file__).resolve().parent.parent
 # when something is withdrawn — the guard then enforces it across every catalog.
 RETIRED = {
     "sandbox": "Sandbox concept removed 2026-06-30; superseded by agenity + openova-mcp",
+    "qa-app": "QA fixture — never customer-facing; was listed AND unseeded (#6475)",
 }
 
 # The catalogs the storefront and console actually read. The catalog-seed is

--- a/scripts/check-retired-products-not-listed.py
+++ b/scripts/check-retired-products-not-listed.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Fail if a RETIRED product is still `visibility: listed` in a generated catalog.
+
+Why this guard exists (#5920). The marketplace sold `Sandbox` for six weeks after
+the concept was retired on 2026-06-30. It survived because the obvious check —
+grepping the catalog-seed — returns NOTHING: the seed carries no sandbox
+Blueprint at all. The live entry sat in the two GENERATED catalogs the storefront
+actually serves, with `"visibility": "listed"`.
+
+So "absent from the seed" reads identically to "not for sale", and it is not the
+same thing. This guard asserts on the surface the customer actually gets.
+
+It is deliberately NOT a grep for the word "sandbox". A hardcoded denylist rots
+the moment the next product is retired. Instead RETIRED is declared once, below,
+and every generated catalog is checked against it.
+
+Exit 0 = no retired product is listed. Exit 1 = a retired product is on sale.
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+# Products retired by founder decision. Adding a row here is the ONE edit needed
+# when something is withdrawn — the guard then enforces it across every catalog.
+RETIRED = {
+    "sandbox": "Sandbox concept removed 2026-06-30; superseded by agenity + openova-mcp",
+}
+
+# The catalogs the storefront and console actually read. The catalog-seed is
+# intentionally absent: it is not where the defect lives, and including it would
+# recreate the false-clean signal this guard exists to kill.
+CATALOGS = [
+    "products/catalyst/bootstrap/api/internal/catalog/blueprints.json",
+    "products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts",
+]
+
+
+def entries_from_json(text: str):
+    data = json.loads(text)
+    items = data.get("blueprints", data) if isinstance(data, dict) else data
+    for b in items:
+        if isinstance(b, dict) and b.get("slug"):
+            yield b["slug"], b.get("visibility")
+
+
+def entries_from_ts(text: str):
+    """The .ts catalog is a TS module wrapping a JSON array; pull slug/visibility
+    pairs positionally rather than trying to parse TypeScript."""
+    for m in re.finditer(r'"slug":\s*"([^"]+)"', text):
+        slug = m.group(1)
+        window = text[m.end(): m.end() + 4000]
+        vis = re.search(r'"visibility":\s*"([^"]+)"', window)
+        yield slug, (vis.group(1) if vis else None)
+
+
+def main() -> int:
+    failures: list[str] = []
+    checked = 0
+    seen_any_slug = False
+
+    for rel in CATALOGS:
+        path = REPO / rel
+        if not path.exists():
+            failures.append(f"{rel}: MISSING — cannot assert on a catalog that is not there")
+            continue
+        text = path.read_text()
+        reader = entries_from_json if path.suffix == ".json" else entries_from_ts
+
+        try:
+            pairs = list(reader(text))
+        except Exception as exc:  # noqa: BLE001 - surface the parse failure, never swallow it
+            failures.append(f"{rel}: could not parse ({exc}) — refusing to report clean")
+            continue
+
+        if not pairs:
+            # Vacuity: a reader that yields nothing would make every assertion
+            # below pass. That is the exact false-green this guard is about.
+            failures.append(f"{rel}: parsed ZERO entries — guard would pass vacuously")
+            continue
+
+        seen_any_slug = True
+        for slug, vis in pairs:
+            checked += 1
+            if slug in RETIRED and vis == "listed":
+                failures.append(
+                    f"{rel}: '{slug}' is RETIRED ({RETIRED[slug]}) but visibility=listed "
+                    f"— a customer can still add it to a stack and buy it"
+                )
+
+    if not seen_any_slug:
+        print("FAIL: no catalog yielded any entry; the guard measured nothing.", file=sys.stderr)
+        return 1
+
+    if failures:
+        print(f"FAIL: {len(failures)} retired-product listing problem(s):", file=sys.stderr)
+        for f in failures:
+            print(f"  - {f}", file=sys.stderr)
+        print(
+            "\nFix: set visibility to 'unlisted' in the generated catalog(s). Do not "
+            "delete the record — other Blueprints may reference it, and unlisted is "
+            "the field the storefront already honours.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        f"PASS: {checked} catalog entrie(s) checked across {len(CATALOGS)} catalog(s); "
+        f"no retired product ({', '.join(sorted(RETIRED))}) is listed."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
**"QA Test App"**, category `testing`, was `visibility: listed` in both generated catalogs — reachable from the customer storefront with a live Add-to-stack button. It is also absent from the catalog-seed, so a customer who bought it would receive nothing: the oversell #6475 describes.

## Why only this one

Of the four products that guard names, `qa-app` is the only one needing no judgement. Whether `anthropic-adapter`, `librechat`, `netbird` and `stalwart-sovereign` should be **seeded** or **unlisted** is a catalog decision with revenue implications, and stays with #6475. A QA fixture on the storefront is unambiguously wrong.

## Also

Registers `qa-app` in `check-retired-products-not-listed.py`, so the storefront cannot silently re-list it without the gate going red.

## Controls

| check | result |
|---|---|
| `qa-app` in listed set | **False** |
| `openclaw`, `agenity` still listed | yes — one card removed, not a category |
| retired-products guard | `PASS` — 244 entries, no retired product listed |

Builds on #6472 (`sandbox` unlist + the guard itself).

Refs #6475, #5920