### PR TITLE
fix(catalyst): wire CATALYST_JANITOR_DESTRUCTIVE into the raw-Kustomize api-deployment (#4454, row 228)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1451,7 +1451,7 @@ spec:
       #   staged commit and push, and makes the Phase-3 pre-strip read-back the
       #   single fail-closed gate (#5436 relocated, not weakened). Lockstep w/
       #   products/catalyst/chart/Chart.yaml.
-      version: 1.4.1520
+      version: 1.4.1525
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3968,7 +3968,7 @@ name: bp-catalyst-platform
 #   file's 1.4.1325 entry records as permanently burned. The republish
 #   therefore lands on 1.4.1468 — ahead of main's 1.4.1467, absent from GHCR,
 #   and claimed by no open PR.)
-version: 1.4.1520
+version: 1.4.1525
 # 1.4.1481 — #6293: catalog-seed advances bp-self-sovereign-cutover
 #   0.1.186 -> 0.1.187, the release that stops step-06 from patching five
 #   HelmRepositories it does not own and then grading itself on whether they
@@ -4155,7 +4155,7 @@ version: 1.4.1520
 # scripts/check-chart-version-forward.sh (#5743) fails unless the two match —
 # main was carrying a pre-existing 1.4.1330/1.4.1329 split, so this bump heals
 # it in the same commit, exactly as the documented self-heal contract does.
-appVersion: 1.4.1520
+appVersion: 1.4.1525
 # 1.4.239 — Wave 3 / Issue #2140 (2026-05-23): Huawei provider
 # implementation lands behind the Wave 2 CloudProvider interface.
 # Adds the OpenTofu module at infra/providers/huawei/ (VPC + Subnet +

--- a/products/catalyst/chart/templates/api-deployment-kustomize.yaml
+++ b/products/catalyst/chart/templates/api-deployment-kustomize.yaml
@@ -344,6 +344,24 @@ spec:
             # credentials redacted; see internal/store/store.go.
             - name: CATALYST_DEPLOYMENTS_DIR
               value: /var/lib/catalyst/deployments
+            # CATALYST_JANITOR_DESTRUCTIVE — parity with the Helm sibling
+            # (api-deployment.yaml:527). The self-reap janitor is an
+            # in-process goroutine (cmd/api/main.go -> internal/handler/
+            # janitor.go); every cloud sweep runs LOG-ONLY unless this env
+            # reads "true" (janitor.go:136). The Helm sibling emits it
+            # ALWAYS so a running Pod is READABLE ("log-only" vs "chart
+            # cannot express it"); this raw-Kustomize file — applied
+            # verbatim, Helm directives NOT rendered — emitted NOTHING, so
+            # a Kustomize-mode catalyst-api could never leave log-only in
+            # any configuration, and row 228's "janitor log shows the
+            # orphaned VPC(s) swept" half was unsatisfiable by construction.
+            # Emitted "false" here (safe default): arming to "true" is a
+            # deliberate per-deployment overlay decision that MUST carry a
+            # CATALYST_JANITOR_ACTIVE_DEPLOYMENT_IDS protect-list — never
+            # hardcoded on in this shared base (#4466, after the b9f9590b
+            # self-reap took all 12 ECS nodes ~2.5 min post-convergence).
+            - name: CATALYST_JANITOR_DESTRUCTIVE
+              value: "false"
             # CATALYST_PHASE1_MIN_BOOTSTRAP_KIT_HRS — defensive floor
             # only. The load-bearing termination gate is now the
             # informer's HasSynced signal (after WaitForCacheSync the


### PR DESCRIPTION
**The fundamental a live audit surfaced:** the self-reap janitor (in-process goroutine, `cmd/api/main.go` → `internal/handler/janitor.go`) fires every 5 min but every cloud sweep runs **log-only** unless `CATALYST_JANITOR_DESTRUCTIVE="true"`. On the live mothership it was watching **62+ orphan OBS buckets pile up while reaping zero** — the exact 'janitor not cleaning' fundamental.

## The wiring gap

`api-deployment.yaml` (Helm) emits this env **always** (line 527). `api-deployment-kustomize.yaml` — applied **verbatim** by kustomize-controller, Helm directives NOT rendered, `.helmignore`d — emitted **nothing**. Porting the Helm `{{- with }}` block here would render literal broken YAML; the correct raw-Kustomize fix is a literal entry.

So a Kustomize-mode catalyst-api could never leave log-only **in any configuration** — which is why **UAT row 228**'s 'janitor log shows the orphaned VPC(s) swept' half was *unsatisfiable by construction*.

## Safety

Emitted `"false"`, **not** `"true"`. Arming is a per-deployment overlay decision that must carry a `CATALYST_JANITOR_ACTIVE_DEPLOYMENT_IDS` protect-list — never hardcoded on in this shared base (#4466, after the b9f9590b self-reap took all 12 ECS nodes ~2.5 min post-convergence). This closes wiring+readability; arming is applied over the base per env.

Refs #4454, #4466