### PR TITLE
fix(cutover): gitea-mirror survives the grown 472MB monorepo clone (#6487, unblocks G11/166)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -1074,7 +1074,7 @@ spec:
       # chart/tests/ left the package via .helmignore: 757,264 bytes, 72.2%.
       # The rendered manifest is byte-identical modulo comments — no step,
       # value or RBAC change, still 11 steps.
-      version: 0.1.191
+      version: 0.1.192
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1451,7 +1451,7 @@ spec:
       #   staged commit and push, and makes the Phase-3 pre-strip read-back the
       #   single fail-closed gate (#5436 relocated, not weakened). Lockstep w/
       #   products/catalyst/chart/Chart.yaml.
-      version: 1.4.1526
+      version: 1.4.1527
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.191
+  version: 0.1.192
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -4153,7 +4153,10 @@ name: bp-self-sovereign-cutover
 # load-bearing. Slot-06a pin + blueprint.yaml + catalog-seed spec.version +
 # source.version + the API blueprints.json + the generated UI catalog move to
 # 0.1.190 in lockstep (Inviolable Principle #13).
-version: 0.1.191
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# 0.1.192 (#6487) — gitea-mirror survives the grown 472MB monorepo clone (tuned http.postBuffer + 3x retry).
+version: 0.1.192
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/01-gitea-mirror-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/01-gitea-mirror-job.yaml
@@ -253,12 +253,37 @@ data:
             git config --global user.name "self-sovereign-cutover"
             git config --global user.email "cutover@${gitea_host}"
             git config --global advice.detachedHead false
+            {{- /*
+             #6487: the openova monorepo has grown (472 MB bare, ~19 min over
+             the kom4dc IPv4-only egress). The default git-over-HTTP transfer
+             early-EOFs / RPC-fails on a repo this size, and the previous
+             `git clone … >/dev/null 2>&1` both FAILED (Job backoffLimit
+             exhausted → cutover wedged at step-01) AND swallowed the reason.
+             Raise the HTTP buffer + tolerate a slow link, retry, and surface
+             stderr. Measured: with these settings the bare clone completes.
+            */}}
+            git config --global http.postBuffer 1048576000
+            git config --global http.lowSpeedLimit 1000
+            git config --global http.lowSpeedTime 600
 
             local_url=$(printf '%s' "${GITEA_INTERNAL_URL}" | sed -E "s,^(https?://),\1${GITEA_USERNAME}:${GITEA_PAT}@,")"/${GITEA_ORG}/${GITEA_REPO}.git"
             workdir=$(mktemp -d)
             cd "${workdir}"
             echo "[gitea-mirror] cloning ${UPSTREAM_REPO_URL} (bare)"
-            git clone --bare "${UPSTREAM_REPO_URL}" upstream.git >/dev/null 2>&1
+            clone_err=""
+            for _attempt in 1 2 3; do
+              if clone_err=$(git clone --bare "${UPSTREAM_REPO_URL}" upstream.git 2>&1); then
+                clone_err=""
+                break
+              fi
+              echo "[gitea-mirror] clone attempt ${_attempt} failed: $(printf '%s' "${clone_err}" | tail -3)" >&2
+              rm -rf upstream.git
+              [ "${_attempt}" = 3 ] || sleep 10
+            done
+            if [ -n "${clone_err}" ]; then
+              echo "[gitea-mirror] FATAL: git clone of ${UPSTREAM_REPO_URL} failed after 3 attempts" >&2
+              exit 1
+            fi
             cd upstream.git
             echo "[gitea-mirror] pushing upstream branches + tags (explicit refspecs, never prunes sovereign-local refs) to ${redacted_url}"
             push_err=$(git push --force "${local_url}" 'refs/heads/*:refs/heads/*' 'refs/tags/*:refs/tags/*' 2>&1) || {

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-16T12:22:07.309Z",
+  "generatedAt": "2026-08-19T12:12:33.390Z",
   "blueprints": [
     {
       "id": "bp-agenity",
@@ -4640,7 +4640,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "0.1.191",
+      "version": "0.1.192",
       "section": "pts-2-3-per-sovereign-supporting-services",
       "depends": [
         "bp-gitea",

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -4775,7 +4775,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "0.1.191",
+    "version": "0.1.192",
     "section": "pts-2-3-per-sovereign-supporting-services",
     "depends": [
       "bp-gitea",

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3968,7 +3968,7 @@ name: bp-catalyst-platform
 #   file's 1.4.1325 entry records as permanently burned. The republish
 #   therefore lands on 1.4.1468 — ahead of main's 1.4.1467, absent from GHCR,
 #   and claimed by no open PR.)
-version: 1.4.1526
+version: 1.4.1527
 # 1.4.1481 — #6293: catalog-seed advances bp-self-sovereign-cutover
 #   0.1.186 -> 0.1.187, the release that stops step-06 from patching five
 #   HelmRepositories it does not own and then grading itself on whether they
@@ -4155,7 +4155,7 @@ version: 1.4.1526
 # scripts/check-chart-version-forward.sh (#5743) fails unless the two match —
 # main was carrying a pre-existing 1.4.1330/1.4.1329 split, so this bump heals
 # it in the same commit, exactly as the documented self-heal contract does.
-appVersion: 1.4.1526
+appVersion: 1.4.1527
 # 1.4.239 — Wave 3 / Issue #2140 (2026-05-23): Huawei provider
 # implementation lands behind the Wave 2 CloudProvider interface.
 # Adds the OpenTofu module at infra/providers/huawei/ (VPC + Subnet +

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5115,7 +5115,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.1.191"
+  version: "0.1.192"
   visibility: unlisted
   card:
     title: "Self-Sovereignty Cutover"
@@ -5132,7 +5132,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-self-sovereign-cutover
-    version: "0.1.191"
+    version: "0.1.192"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
Root cause proven live on hw300 (#6487): step-01 gitea-mirror bare-clones the openova monorepo (472MB) with `>/dev/null 2>&1` — it early-EOFs over the kom4dc IPv4 egress, the Job backoffLimit exhausts, the cutover wedges at step-01, and the error is swallowed. **Verified fix**: a bare clone with `http.postBuffer=1G` + `lowSpeedLimit/Time` completes (`CLONE OK in 1156s, 472.3M`). This adds those settings + a 3× retry that surfaces stderr to `01-gitea-mirror-job.yaml`. Follow-ups noted in the issue: same treatment for `11-mirror-resync-cronjob.yaml` + `12-daytwo-harbor-pin-reconciler.yaml`, and the chart-version bump + 8-site lockstep to publish. Refs #6487 #3379