### PR TITLE
fix(stalwart-tenant): self-signed TLS fallback in CRD-less vclusters (#6483, row 234)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1451,7 +1451,7 @@ spec:
       #   staged commit and push, and makes the Phase-3 pre-strip read-back the
       #   single fail-closed gate (#5436 relocated, not weakened). Lockstep w/
       #   products/catalyst/chart/Chart.yaml.
-      version: 1.4.1528
+      version: 1.4.1529
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/platform/stalwart-tenant/blueprint.yaml
+++ b/platform/stalwart-tenant/blueprint.yaml
@@ -69,7 +69,7 @@ spec:
   # splan_bundle_sizing.md's "cannot be upgraded in place" finding. Switched
   # the PVC template to a new stableLabels helper carrying only
   # version-independent labels. Refs #5615 #960.
-  version: 0.1.15
+  version: 0.1.16
   card:
     title: Stalwart (per-Organization)
     summary: |

--- a/platform/stalwart-tenant/chart/Chart.yaml
+++ b/platform/stalwart-tenant/chart/Chart.yaml
@@ -214,7 +214,15 @@ name: bp-stalwart-tenant
 #   tests/volumeclaimtemplate-stable-labels.sh renders the chart at two
 #   different versions and asserts the volumeClaimTemplates block is
 #   byte-identical. Refs #5615 #960.
-version: 0.1.15
+#
+# 0.1.16 (#6483): render the cert-manager Certificate only where its CRD is
+#   installed (`.Capabilities.APIVersions.Has "cert-manager.io/v1/Certificate"`)
+#   and ship a self-signed TLS fallback Secret at `stalwart.tls.secretName`
+#   when the CRD is absent, so the StatefulSet's `/etc/stalwart/tls` mount is
+#   satisfied and the pod starts in a CRD-less per-Org vcluster instead of the
+#   release failing to render ("no matches for kind Certificate in version
+#   cert-manager.io/v1"). Refs #6483.
+version: 0.1.16
 appVersion: "0.15.5"
 description: |
   Catalyst Blueprint scratch chart for a per-Org (per-vcluster) dedicated

--- a/platform/stalwart-tenant/chart/templates/certificate-fallback-secret.yaml
+++ b/platform/stalwart-tenant/chart/templates/certificate-fallback-secret.yaml
@@ -1,0 +1,50 @@
+{{- /*
+#6483 — self-signed TLS fallback for CRD-less targets (e.g. a per-Org tenant
+deployed INTO a vcluster, which has no cert-manager.io CRDs).
+
+certificate.yaml only emits the cert-manager Certificate where the CRDs exist.
+Where they do NOT, an unconditional Certificate fails the whole Helm install
+("no matches for kind Certificate in version cert-manager.io/v1/Certificate") — the pod
+never starts and the tenant has no mail surface (#6483, hw300uatwalk). Here we
+render a self-signed leaf at the same secretName so the StatefulSet still mounts
+tls.crt/tls.key and comes up. Operators who reflect a real per-Org wildcard set
+`stalwart.tls.certificate.enabled=false` and this does not render either.
+
+`lookup` reuses an already-materialised Secret so the self-signed pair is stable
+across reconciles (genSignedCert is otherwise non-deterministic and would churn
+the StatefulSet). `lookup` returns empty under `helm template`/dry-run, so the
+render/CI path exercises the generate branch.
+*/}}
+{{- if and .Values.stalwart.enabled .Values.stalwart.tls.certificate.enabled }}
+{{- $domain := include "bp-stalwart-tenant.tenantDomain" . -}}
+{{- $host := include "bp-stalwart-tenant.webmailHost" . -}}
+{{- if and $domain $host (not ($.Capabilities.APIVersions.Has "cert-manager.io/v1/Certificate")) }}
+{{- $secretName := .Values.stalwart.tls.secretName -}}
+{{- $existing := (lookup "v1" "Secret" .Release.Namespace $secretName) -}}
+{{- $crt := "" -}}
+{{- $key := "" -}}
+{{- if and $existing $existing.data (index $existing.data "tls.crt") (index $existing.data "tls.key") -}}
+  {{- $crt = index $existing.data "tls.crt" -}}
+  {{- $key = index $existing.data "tls.key" -}}
+{{- else -}}
+  {{- $altNames := list $host -}}
+  {{- if ne $host $domain -}}{{- $altNames = append $altNames $domain -}}{{- end -}}
+  {{- $ca := genCA (printf "%s-ca" $host) 3650 -}}
+  {{- $cert := genSignedCert $host nil $altNames 3650 $ca -}}
+  {{- $crt = $cert.Cert | b64enc -}}
+  {{- $key = $cert.Key | b64enc -}}
+{{- end -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $secretName | quote }}
+  labels:
+    {{- include "bp-stalwart-tenant.labels" . | nindent 4 }}
+  annotations:
+    openova.io/cert-source: "self-signed-fallback-6483"
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ $crt | quote }}
+  tls.key: {{ $key | quote }}
+{{- end }}
+{{- end }}

--- a/platform/stalwart-tenant/chart/templates/certificate.yaml
+++ b/platform/stalwart-tenant/chart/templates/certificate.yaml
@@ -29,7 +29,15 @@ set `stalwart.tls.certificate.enabled=false` and point
 {{- if and .Values.stalwart.enabled .Values.stalwart.tls.certificate.enabled }}
 {{- $domain := include "bp-stalwart-tenant.tenantDomain" . -}}
 {{- $host := include "bp-stalwart-tenant.webmailHost" . -}}
-{{- if and $domain $host }}
+{{- /*
+ #6483: only emit the cert-manager Certificate where the CRDs exist. A per-Org
+ tenant deployed INTO a vcluster has no cert-manager.io CRDs, and an
+ unconditional Certificate fails the whole Helm install ("no matches for kind
+ Certificate") → no mail surface. When cert-manager is absent, the sibling
+ certificate-fallback-secret.yaml renders a self-signed leaf at the same
+ secretName so the StatefulSet still mounts a cert.
+*/}}
+{{- if and $domain $host ($.Capabilities.APIVersions.Has "cert-manager.io/v1/Certificate") }}
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-19T12:12:33.390Z",
+  "generatedAt": "2026-08-19T12:44:38.938Z",
   "blueprints": [
     {
       "id": "bp-agenity",
@@ -4960,7 +4960,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "listed",
-      "version": "0.1.15",
+      "version": "0.1.16",
       "section": "pts-4-5-communication",
       "depends": [
         "bp-keycloak",

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -5095,7 +5095,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "listed",
-    "version": "0.1.15",
+    "version": "0.1.16",
     "section": "pts-4-5-communication",
     "depends": [
       "bp-keycloak",

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3968,7 +3968,7 @@ name: bp-catalyst-platform
 #   file's 1.4.1325 entry records as permanently burned. The republish
 #   therefore lands on 1.4.1468 — ahead of main's 1.4.1467, absent from GHCR,
 #   and claimed by no open PR.)
-version: 1.4.1528
+version: 1.4.1529
 # 1.4.1481 — #6293: catalog-seed advances bp-self-sovereign-cutover
 #   0.1.186 -> 0.1.187, the release that stops step-06 from patching five
 #   HelmRepositories it does not own and then grading itself on whether they
@@ -4155,7 +4155,7 @@ version: 1.4.1528
 # scripts/check-chart-version-forward.sh (#5743) fails unless the two match —
 # main was carrying a pre-existing 1.4.1330/1.4.1329 split, so this bump heals
 # it in the same commit, exactly as the documented self-heal contract does.
-appVersion: 1.4.1528
+appVersion: 1.4.1529
 # 1.4.239 — Wave 3 / Issue #2140 (2026-05-23): Huawei provider
 # implementation lands behind the Wave 2 CloudProvider interface.
 # Adds the OpenTofu module at infra/providers/huawei/ (VPC + Subnet +

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -2778,7 +2778,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.1.15"
+  version: "0.1.16"
   visibility: listed
   card:
     title: "Stalwart (per-Organization)"
@@ -2819,7 +2819,7 @@ is event-driven (ADR-0003 §3).
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-stalwart-tenant
-    version: "0.1.15"
+    version: "0.1.16"
   topology:
     supported:
     - active-passive


### PR DESCRIPTION
Root-caused live on hw300uatwalk: bp-stalwart-tenant renders a cert-manager Certificate into the Org vcluster (no cert-manager CRDs) → Helm InstallFailed → no mail surface (UAT row 234). Gates the Certificate on `Capabilities.APIVersions.Has cert-manager.io/v1/Certificate` + adds a lookup-reused self-signed fallback Secret at the same secretName when cert-manager is absent. Render-verified both branches. Refs #6483