### PR TITLE
fix(cutover): label the secondary gitea-mirror Job managed-by=flux so kyverno admits it (Refs #6493)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -1079,7 +1079,11 @@ spec:
       #   pivots the secondary at its in-cluster gitea-http svc). Render-gated on
       #   secondaryRegions.mirrorToSecondaryGitea, wired below from
       #   SOVEREIGN_ENABLE_CNPG_PAIR so single-region provs are untouched.
-      version: 0.1.195
+      # 0.1.196 (#6493): the secondary gitea-mirror Job carries
+      #   app.kubernetes.io/managed-by: flux so ns gitea's kyverno flux-managed
+      #   ClusterPolicy admits step-01's set -e apply (it excludes ns catalyst but
+      #   not ns gitea); without it the cutover halted at step-01 (hw301).
+      version: 0.1.196
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1452,7 +1452,9 @@ spec:
       #   single fail-closed gate (#5436 relocated, not weakened). Lockstep w/
       #   products/catalyst/chart/Chart.yaml.
       # 1.4.1531 — lockstep for bp-self-sovereign-cutover 0.1.193 (#6490).
-      version: 1.4.1533
+      # 1.4.1534 — lockstep for bp-self-sovereign-cutover 0.1.196 (#6493:
+      #   kyverno flux-managed managed-by label on the secondary mirror Job).
+      version: 1.4.1534
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.195
+  version: 0.1.196
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -4169,7 +4169,20 @@ name: bp-self-sovereign-cutover
 #   gitea-http svc using THAT region's own gitea-admin-secret. RENDER-GATED on
 #   secondaryRegions.mirrorToSecondaryGitea (default false, overlay wires it from
 #   SOVEREIGN_ENABLE_CNPG_PAIR) so single-region provs render byte-identical.
-version: 0.1.195
+# 0.1.196 (#6493) — the secondary gitea-mirror Job carries app.kubernetes.io/managed-by: flux.
+#   ns gitea (UNLIKE ns catalyst) is matched by the cluster kyverno ClusterPolicy
+#   flux-managed (rule workload-must-be-flux-managed): the policy matches kind Job
+#   and excludes ns catalyst, so the PRIMARY step-01 Job passes, but the SECONDARY
+#   Job (introduced by #6491 for the #6490 cross-region leg) — stamped into ns
+#   gitea in each secondary region — carried none of the accepted labels, so
+#   step-01's `set -e` kubectl apply of it was DENIED at admission and the whole
+#   cutover halted at step-01 (live-confirmed on hw301). The Job now carries the
+#   managed-by: flux label the policy's own deny message names as the escape,
+#   which is truthful since the Job ships in the flux-delivered
+#   bp-self-sovereign-cutover HelmRelease; the label sits on the Job metadata only
+#   (the policy matches kind Job, not the Pod). The API blueprints.json + the
+#   generated UI catalog move to 0.1.196 in lockstep.
+version: 0.1.196
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/secondary-mirror-script-configmap.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/secondary-mirror-script-configmap.yaml
@@ -168,6 +168,21 @@ data:
       name: cutover-gitea-mirror-secondary-__REGION__
       namespace: {{ .Values.secondaryRegions.secondaryGiteaNamespace | quote }}
       labels:
+        {{- /*
+        #6493 — ns gitea (UNLIKE ns catalyst) is matched by the cluster kyverno
+        ClusterPolicy flux-managed (rule workload-must-be-flux-managed): the
+        policy matches kind Job and excludes ns catalyst, so the PRIMARY step-01
+        Job passes, but ns gitea is NOT excluded. The policy's own deny message
+        names app.kubernetes.io/managed-by: flux as an accepted escape, and this
+        Job IS part of the flux-delivered bp-self-sovereign-cutover HelmRelease,
+        so the label is truthful. This secondary Job (introduced by #6491 for the
+        #6490 cross-region leg) carried none of the accepted labels, so step-01's
+        `set -e` kubectl apply of it into the secondary's gitea ns was DENIED at
+        admission and the whole cutover halted at step-01 (live-confirmed on
+        hw301). The label sits on the Job metadata ONLY — the policy matches kind
+        Job, not the Pod, so the pod-template labels below deliberately omit it.
+        */}}
+        app.kubernetes.io/managed-by: flux
         app.kubernetes.io/part-of: self-sovereign-cutover
         app.kubernetes.io/component: secondary-gitea-mirror
         catalyst.openova.io/secondary-region: "__REGION__"

--- a/platform/self-sovereign-cutover/chart/tests/step6490-secondary-gitea-mirror.sh
+++ b/platform/self-sovereign-cutover/chart/tests/step6490-secondary-gitea-mirror.sh
@@ -142,6 +142,17 @@ if grep -qF 'namespace: "gitea"' "${TMP}/secjob.yaml"; then
 else
   fail "secondary mirror Job namespace is not the gitea namespace"
 fi
+# #6493 — ns gitea (unlike ns catalyst) is matched by the cluster kyverno
+# ClusterPolicy flux-managed (rule workload-must-be-flux-managed). The Job MUST
+# carry app.kubernetes.io/managed-by: flux (the escape the policy's own deny
+# message names) or step-01's `set -e` apply into that ns is DENIED at admission
+# and the whole cutover halts. This greps the REAL rendered Job (secjob.yaml
+# sliced from the ON render above), so removing the label turns it red.
+if grep -qF 'app.kubernetes.io/managed-by: flux' "${TMP}/secjob.yaml"; then
+  pass "secondary mirror Job carries app.kubernetes.io/managed-by: flux — the kyverno flux-managed escape (#6493)"
+else
+  fail "secondary mirror Job lacks app.kubernetes.io/managed-by: flux — ns gitea's kyverno flux-managed ClusterPolicy DENIES step-01's set -e apply and the cutover halts (#6493)"
+fi
 if grep -qF 'git push --force' "${TMP}/secmirror.sh"; then
   pass "secondary-mirror.sh force-pushes the bare clone to the region-local Gitea"
 else

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-19T14:08:35.244Z",
+  "generatedAt": "2026-08-19T17:59:03.182Z",
   "blueprints": [
     {
       "id": "bp-agenity",
@@ -4640,7 +4640,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "0.1.195",
+      "version": "0.1.196",
       "section": "pts-2-3-per-sovereign-supporting-services",
       "depends": [
         "bp-gitea",

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -4775,7 +4775,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "0.1.195",
+    "version": "0.1.196",
     "section": "pts-2-3-per-sovereign-supporting-services",
     "depends": [
       "bp-gitea",

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3971,7 +3971,11 @@ name: bp-catalyst-platform
 # 1.4.1531 — lockstep bump for bp-self-sovereign-cutover 0.1.193 (#6490:
 #   secondary-region gitea-mirror). Umbrella version tracks its sub-charts per
 #   Inviolable Principle #13.
-version: 1.4.1533
+# 1.4.1534 — #6493: catalog-seed bp-self-sovereign-cutover pin 0.1.195 -> 0.1.196
+#   (kyverno flux-managed managed-by label on the secondary mirror Job so
+#   step-01's set -e apply into ns gitea is admitted; without it the cutover
+#   halted at step-01). Umbrella tracks its sub-charts per Inviolable Principle #13.
+version: 1.4.1534
 # 1.4.1481 — #6293: catalog-seed advances bp-self-sovereign-cutover
 #   0.1.186 -> 0.1.187, the release that stops step-06 from patching five
 #   HelmRepositories it does not own and then grading itself on whether they
@@ -4158,7 +4162,7 @@ version: 1.4.1533
 # scripts/check-chart-version-forward.sh (#5743) fails unless the two match —
 # main was carrying a pre-existing 1.4.1330/1.4.1329 split, so this bump heals
 # it in the same commit, exactly as the documented self-heal contract does.
-appVersion: 1.4.1533
+appVersion: 1.4.1534
 # 1.4.239 — Wave 3 / Issue #2140 (2026-05-23): Huawei provider
 # implementation lands behind the Wave 2 CloudProvider interface.
 # Adds the OpenTofu module at infra/providers/huawei/ (VPC + Subnet +

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5115,7 +5115,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.1.195"
+  version: "0.1.196"
   visibility: unlisted
   card:
     title: "Self-Sovereignty Cutover"
@@ -5132,7 +5132,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-self-sovereign-cutover
-    version: "0.1.195"
+    version: "0.1.196"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
## Root cause (live-confirmed on hw301, #6493)

On a 2-region Sovereign the sovereignty cutover halts at **step-01**. The
secondary-region gitea-mirror Job — introduced by #6491 for the #6490
cross-region leg, and stamped into namespace **gitea** in each secondary region —
is DENIED at admission by the cluster kyverno ClusterPolicy **flux-managed**
(rule `workload-must-be-flux-managed`).

That policy matches kind **Job** and excludes namespace `catalyst` (so the
PRIMARY step-01 Job passes) but does **not** exclude namespace `gitea`. It admits
a Job only if it carries one of `app.kubernetes.io/managed-by: flux`, a non-empty
`helm.toolkit.fluxcd.io/name`, or `kustomize.toolkit.fluxcd.io/name`. The
secondary Job template carried none of the three, so `kubectl apply` was refused.
step-01 runs under `set -e`, so it dies on that refusal and the entire cutover
fails — holding UAT rows G11 / 166.

## Fix

Add `app.kubernetes.io/managed-by: flux` as the first label on the secondary
mirror Job's `metadata.labels`. It is the escape the policy's own deny message
names, and it is truthful: the Job ships inside the flux-delivered
`bp-self-sovereign-cutover` HelmRelease. The label sits on the **Job metadata
only** — the policy matches kind Job, not the Pod — so the pod-template labels
deliberately omit it.

The single-region render is unchanged: the whole leg stays gated behind
`secondaryRegions.mirrorToSecondaryGitea` (default false), and the step6490
suite's existing OFF-render byte-identity checks still hold.

## Guard given teeth

`platform/self-sovereign-cutover/chart/tests/step6490-secondary-gitea-mirror.sh`
now asserts the rendered secondary Job manifest carries
`app.kubernetes.io/managed-by: flux`. It greps the real ON render (the sliced
`secjob.yaml`), so removing the label turns it red — verified: with the label
removed the suite exits 1 on exactly this assertion; restored, it is green.

## Lockstep (bp-self-sovereign-cutover 0.1.195 -> 0.1.196, umbrella 1.4.1533 -> 1.4.1534)

Every pin the cutover-version-floor guard reads moved together:

- `platform/self-sovereign-cutover/chart/Chart.yaml` — `version`
- `platform/self-sovereign-cutover/blueprint.yaml` — `spec.version`
- `products/catalyst/chart/templates/catalog-seed/blueprints.yaml` — CARD `spec.version` + DELIVERY `source.version`
- generated catalog `products/catalyst/bootstrap/api/internal/catalog/blueprints.json` + `products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts` (regenerated with `node scripts/build-catalog.mjs`, deterministic)
- `clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml`

Umbrella (touched because `products/catalyst/chart/templates/` changed):

- `products/catalyst/chart/Chart.yaml` — `version` **and** `appVersion` (kept matched per the #5743 convention) 1.4.1533 -> 1.4.1534
- `clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml` — pin 1.4.1533 -> 1.4.1534

## Gate results (all green)

- `check-cutover-version-floor.py` — PASS (all 7 pins at 0.1.196, above the 0.1.172 floor)
- `check-chart-version-bumped.sh origin/main HEAD` — PASS (cutover 0.1.195->0.1.196, umbrella 1.4.1533->1.4.1534)
- `check-bootstrap-kit-pin-sync.sh` — PASS (all pins in sync)
- `check-chart-version-forward.sh` — PASS for both charts (forward + version/appVersion matched)
- seed-drift Go tests `TestCatalogSeed_DeliveryPinsNotBehindComponentCharts` + `TestCatalogSeed_DisplayVersionNotBehindDeliveryPin` — PASS (full `tests/e2e/bootstrap-kit` suite green)
- `check-catalog-seed-lockstep.sh` — PASS · `check-catalog-seed-source-coverage.py` — PASS
- `check-release-lockstep-writer.py` — PASS (all five lockstep sites converge)
- generated-catalog drift — clean (regeneration reproduces the committed files)
- `helm template` of the cutover chart (default + secondary-on) and the umbrella — all render

Refs #6493
