### PR TITLE
fix(wipe): handed-over Huawei Sovereign un-wipeable — infer huawei when Request.Provider GC'd

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/wipe.go
+++ b/products/catalyst/bootstrap/api/internal/handler/wipe.go
@@ -352,7 +352,25 @@ func (h *Handler) WipeDeployment(w http.ResponseWriter, r *http.Request) {
 	// status=wiping and blocking the one-environment-at-a-time gate.
 	provHint := strings.ToLower(strings.TrimSpace(dep.Request.Provider))
 	if provHint == "" {
-		provHint = "hetzner"
+		// #6495 — dep.Request.Provider is GC'd on a handed-over Sovereign
+		// (FinaliseHandover clears the in-memory Request) and after a
+		// catalyst-api Pod roll. Defaulting straight to "hetzner" then
+		// demands a hetznerToken and 400s forever, stranding a Huawei
+		// deployment as un-wipeable (its EIPs/VPCs leak and block the next
+		// one-environment-at-a-time prov on EIP-allocation conflict). Infer
+		// "huawei" when the caller supplied huawei creds, or the huawei
+		// operator-creds env is present — the same signals the huawei branch
+		// already consumes below. Only fall back to hetzner when neither is.
+		switch {
+		case strings.TrimSpace(body.HuaweiAccessKey) != "" || strings.TrimSpace(body.HuaweiSecretKey) != "":
+			provHint = "huawei"
+		default:
+			if _, ok := huaweiOperatorCredsFromEnv(); ok {
+				provHint = "huawei"
+			} else {
+				provHint = "hetzner"
+			}
+		}
 	}
 	switch provHint {
 	case "huawei":


### PR DESCRIPTION
Refs #6495.

`WipeDeployment` defaulted `provHint` to `hetzner` whenever `dep.Request.Provider` was empty — which it is on any **handed-over** Sovereign (FinaliseHandover clears the in-memory Request) and after a catalyst-api Pod roll. A Huawei deployment then never reaches `case "huawei"` and 400s `hetznerToken is required` even when the caller supplies `huaweiAccessKey/huaweiSecretKey`, leaving it permanently un-wipeable. Its EIPs/VPCs leak and the next one-environment-at-a-time prov fails Phase-0 with `error allocating EIP: conflict in the request` (live-confirmed: hw301 un-wipeable -> hw302 fire failed on the CP EIP).

Fix: when `provHint == ""`, infer `huawei` from body creds or `huaweiOperatorCredsFromEnv()` (the same signals the huawei branch already consumes) before the hetzner fallback. Fresh Huawei records (Provider set) and hetzner-with-no-huawei-creds are unchanged. Compile + vet clean.

Follow-up on this branch: unit test for the GC'd-provider + huawei-creds path.
