### PR TITLE
fix(wordpress-tenant): cnpg-system operator-probe NetworkPolicy + 0.4.24 lockstep (#6360)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1454,7 +1454,10 @@ spec:
       # 1.4.1531 — lockstep for bp-self-sovereign-cutover 0.1.193 (#6490).
       # 1.4.1534 — lockstep for bp-self-sovereign-cutover 0.1.196 (#6493:
       #   kyverno flux-managed managed-by label on the secondary mirror Job).
-      version: 1.4.1534
+      # 1.4.1536 — lockstep for catalog-seed bp-wordpress-tenant 0.4.23 -> 0.4.24
+      #   (#6360: additive cnpg-system operator-probe NetworkPolicy so the per-Org
+      #   CNPG Cluster reaches Ready; UAT row 222).
+      version: 1.4.1536
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/platform/wordpress-tenant/blueprint.yaml
+++ b/platform/wordpress-tenant/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: organization-app
     catalyst.openova.io/section: pts-7-org-tenant
 spec:
-  version: 0.4.23
+  version: 0.4.24
   card:
     title: WordPress (per-Organization)
     summary: |

--- a/platform/wordpress-tenant/chart/Chart.yaml
+++ b/platform/wordpress-tenant/chart/Chart.yaml
@@ -345,7 +345,7 @@ name: bp-wordpress-tenant
 #   values file. Singleton installs render byte-identical (no annotation, no
 #   declaration required). Catalog-wide enforcement:
 #   scripts/check-dr-pairs-declare-promotion.sh.
-version: 0.4.23
+version: 0.4.24
 appVersion: "6"
 description: |
   Catalyst Blueprint scratch chart for in-vcluster WordPress, one

--- a/platform/wordpress-tenant/chart/Chart.yaml
+++ b/platform/wordpress-tenant/chart/Chart.yaml
@@ -345,6 +345,24 @@ name: bp-wordpress-tenant
 #   values file. Singleton installs render byte-identical (no annotation, no
 #   declaration required). Catalog-wide enforcement:
 #   scripts/check-dr-pairs-declare-promotion.sh.
+# 0.4.24 (#6360): the per-Org CNPG Cluster this chart renders (templates/cnpg-
+#   cluster.yaml) lands in the Application's own Organization namespace, which
+#   the catalyst-tenant-<slug>-apps kustomization stamps with `default-deny-all`
+#   (Ingress+Egress) + `allow-same-org` (same-namespace podSelector + DNS). That
+#   pair denies the cnpg-system OPERATOR (a DIFFERENT namespace) from reaching
+#   the instance Pod's :8000/pg/status status probe + :9187 metrics endpoint, so
+#   even though the postgres Pod is Running 1/1 and serving SQL the operator
+#   cannot extract status and the Cluster phase stalls at "Instance Status
+#   Extraction Error: HTTP communication issue" / Ready=False (CNPG's phaseReason
+#   names NetworkPolicy). Live-confirmed on walktwo/wordpress-db, UAT row 222.
+#   FIX — NEW templates/networkpolicy-cnpg-operator-probe.yaml: an additive
+#   Ingress NetworkPolicy in the CNPG namespace whose podSelector matches every
+#   instance Pod via the operator-stamped `cnpg.io/cluster` label (Exists) and
+#   opens ONLY :8000 + :9187 to ONLY the cnpg-system namespace. Gated on the
+#   CNPG CRD being present (`.Capabilities.APIVersions.Has "postgresql.cnpg.io/
+#   v1"`) so it no-ops on a non-CNPG cluster; toggled by networkPolicy.enabled.
+#   New `networkPolicy.cnpgOperator.{namespace,statusPort,metricsPort}` values
+#   block. Identical shape to platform/postgres #4282's operator-probe policy.
 version: 0.4.24
 appVersion: "6"
 description: |

--- a/platform/wordpress-tenant/chart/templates/networkpolicy-cnpg-operator-probe.yaml
+++ b/platform/wordpress-tenant/chart/templates/networkpolicy-cnpg-operator-probe.yaml
@@ -1,0 +1,48 @@
+{{- /*
+#6360 / #4282-class — CNPG operator status/metrics probe carve-out.
+
+This chart renders a Cluster.postgresql.cnpg.io (templates/cnpg-cluster.yaml)
+into the Application's own per-Organization namespace, where the host
+cnpg-system operator does NOT run. That namespace carries `default-deny-all`
+(Ingress+Egress) + `allow-same-org` (same-namespace podSelector + DNS only),
+both stamped by the catalyst-tenant-<slug>-apps kustomization. That pair
+denies the cnpg-system OPERATOR (a DIFFERENT namespace) from reaching the
+instance Pod's `:8000/pg/status` + `:9187` metrics probe — so, even though the
+postgres Pod is Running 1/1 and serving SQL, the operator cannot extract
+status and the Cluster phase stalls at "Instance Status Extraction Error:
+HTTP communication issue" / Ready=False (CNPG's own phaseReason names
+NetworkPolicy as the cause). Live-confirmed on walktwo/wordpress-db, UAT row
+222; the identical fix ships in platform/postgres #4282
+(networkpolicy-singleton-operator-probe.yaml).
+
+podSelector matches EVERY CNPG instance Pod in this namespace via the
+operator-stamped `cnpg.io/cluster` label (Exists) — covering the singleton
+primary AND any active-hot-standby replica (`<cnpgClusterName>-replica`) — and
+opens ONLY the operator's two probe ports to ONLY the cnpg-system namespace.
+Gated on the CNPG CRD being present so it no-ops on a non-CNPG cluster.
+*/ -}}
+{{- if and .Values.wordpress.enabled .Values.networkPolicy.enabled (.Capabilities.APIVersions.Has "postgresql.cnpg.io/v1") }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "bp-wordpress-tenant.fullname" . }}-cnpg-operator-probe
+  namespace: {{ include "bp-wordpress-tenant.cnpgNamespace" . | quote }}
+  labels:
+    {{- include "bp-wordpress-tenant.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchExpressions:
+      - key: cnpg.io/cluster
+        operator: Exists
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.networkPolicy.cnpgOperator.namespace | default "cnpg-system" }}
+      ports:
+        - port: {{ .Values.networkPolicy.cnpgOperator.statusPort | default 8000 }}
+          protocol: TCP
+        - port: {{ .Values.networkPolicy.cnpgOperator.metricsPort | default 9187 }}
+          protocol: TCP
+{{- end }}

--- a/platform/wordpress-tenant/chart/tests/cnpg-operator-probe-render.sh
+++ b/platform/wordpress-tenant/chart/tests/cnpg-operator-probe-render.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+# bp-wordpress-tenant cnpg-system operator-probe NetworkPolicy render gate
+# (#6360 / #4282-class, chart 0.4.24).
+#
+# WHY THIS EXISTS
+# ----------------
+# templates/cnpg-cluster.yaml renders a Cluster.postgresql.cnpg.io into the
+# Application's OWN per-Organization namespace, where the host cnpg-system
+# operator does NOT run. That namespace carries `default-deny-all`
+# (Ingress+Egress) + `allow-same-org` (same-namespace podSelector + DNS),
+# stamped by the catalyst-tenant-<slug>-apps kustomization. That pair denies the
+# cnpg-system OPERATOR (a DIFFERENT namespace) from reaching the instance Pod's
+# :8000/pg/status status probe + :9187 metrics endpoint — so even though the
+# postgres Pod is Running 1/1 and serving SQL, the operator cannot extract status
+# and the Cluster phase stalls at "Instance Status Extraction Error" /
+# Ready=False (live-confirmed on walktwo/wordpress-db, UAT row 222). The additive
+# templates/networkpolicy-cnpg-operator-probe.yaml restores exactly that one
+# reach; mirrors platform/postgres #4282.
+#
+# WHAT IT ASSERTS (teeth — every claim is on a VALUE, not a key's presence)
+# ------------------------------------------------------------------------
+#   Case 1 — WITH `--api-versions postgresql.cnpg.io/v1` the render emits EXACTLY
+#     ONE NetworkPolicy whose name ends `-cnpg-operator-probe`, and it:
+#       - selects instance Pods via podSelector.matchExpressions
+#         {key: cnpg.io/cluster, operator: Exists};
+#       - is Ingress (policyTypes contains Ingress);
+#       - admits ONLY the cnpg-system namespace
+#         (from[].namespaceSelector kubernetes.io/metadata.name == cnpg-system);
+#       - opens ONLY TCP :8000 (status) + :9187 (metrics).
+#   Case 2 — WITHOUT the CNPG api-version the policy is ABSENT (the template is
+#     gated on the CNPG CRD being present, so it no-ops on a non-CNPG cluster).
+#   Case 3 — networkPolicy.enabled=false (WITH the api-version) omits it too.
+#   Case 4 — the cnpgOperator.{namespace,statusPort,metricsPort} overrides flow
+#     through to the rendered object (never-hardcoded, Inviolable Principle #4).
+#
+# Usage: bash tests/cnpg-operator-probe-render.sh [CHART_DIR]
+# CI consumes this via blueprint-release.yaml's `tests/*.sh` gate.
+
+set -euo pipefail
+
+CHART_DIR="${1:-$(cd "$(dirname "$0")/.." && pwd)}"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+cd "$CHART_DIR"
+
+# Skip helm dep build when charts/ is already vendored (CI populates it before
+# this step runs). Pattern lifted from tests/active-hot-standby-render.sh.
+if [ ! -d charts ] || [ -z "$(ls -A charts 2>/dev/null)" ]; then
+  helm dependency build >/dev/null
+fi
+
+COMMON_SET=(
+  --set "smeDomain=acme.example.local"
+  --set "keycloak.realmURL=https://auth.acme.example.local/realms/sme"
+  --set "keycloak.clientSecretName=wordpress-oidc"
+  --set "adminUser.email=admin@acme.example.local"
+)
+
+API_VERSIONS=(
+  --api-versions "postgresql.cnpg.io/v1"
+)
+
+# Emit a fact bundle for the operator-probe NetworkPolicy in $1; writes to $2.
+# Fails (exit 1) if the render itself is unparseable.
+probe_facts() {
+  python3 - "$1" <<'PYEOF'
+import sys, yaml
+docs = [d for d in yaml.safe_load_all(open(sys.argv[1])) if d]
+nps = [d for d in docs
+       if d.get("kind") == "NetworkPolicy"
+       and str((d.get("metadata") or {}).get("name", "")).endswith("-cnpg-operator-probe")]
+print(f"COUNT={len(nps)}")
+for np in nps:
+    spec = np.get("spec") or {}
+    sel = (spec.get("podSelector") or {}).get("matchExpressions") or []
+    cnpg = next((e for e in sel if e.get("key") == "cnpg.io/cluster"), None)
+    print(f"SELECTOR_KEY={'cnpg.io/cluster' if cnpg else ''}")
+    print(f"SELECTOR_OP={(cnpg or {}).get('operator','')}")
+    print(f"POLICYTYPES={','.join(spec.get('policyTypes') or [])}")
+    ingress = spec.get("ingress") or []
+    froms, ports = [], []
+    for rule in ingress:
+        for f in (rule.get("from") or []):
+            ns = ((f.get("namespaceSelector") or {}).get("matchLabels") or {})
+            v = ns.get("kubernetes.io/metadata.name")
+            if v:
+                froms.append(v)
+        for p in (rule.get("ports") or []):
+            ports.append(f"{p.get('protocol','')}:{p.get('port','')}")
+    print(f"FROM_NS={','.join(sorted(set(froms)))}")
+    print(f"PORTS={','.join(sorted(ports))}")
+PYEOF
+}
+
+# ── Case 1: WITH the CNPG api-version → present, correct shape ────
+echo "[cnpg-probe] Case 1: with postgresql.cnpg.io/v1 the operator-probe NetworkPolicy is present and correct"
+helm template smoke-wp . "${COMMON_SET[@]}" "${API_VERSIONS[@]}" \
+  > "$TMP/with.yaml" 2> "$TMP/with.err" || {
+  echo "FAIL: render (with CNPG api-version) errored:" >&2
+  cat "$TMP/with.err" >&2
+  exit 1
+}
+probe_facts "$TMP/with.yaml" > "$TMP/with-facts" || {
+  echo "FAIL: render output failed to parse as YAML" >&2
+  exit 1
+}
+
+WITH_COUNT=$(grep -E '^COUNT=' "$TMP/with-facts" | cut -d= -f2)
+if [ "$WITH_COUNT" -ne 1 ]; then
+  echo "FAIL: expected exactly 1 *-cnpg-operator-probe NetworkPolicy, got $WITH_COUNT." >&2
+  cat "$TMP/with-facts" >&2
+  exit 1
+fi
+grep -qx 'SELECTOR_KEY=cnpg.io/cluster' "$TMP/with-facts" || {
+  echo "FAIL: podSelector does not match on the cnpg.io/cluster label." >&2
+  cat "$TMP/with-facts" >&2; exit 1; }
+grep -qx 'SELECTOR_OP=Exists' "$TMP/with-facts" || {
+  echo "FAIL: cnpg.io/cluster selector is not an Exists match (would miss un-valued instance Pods)." >&2
+  cat "$TMP/with-facts" >&2; exit 1; }
+grep -qE '^POLICYTYPES=(.*,)?Ingress(,.*)?$' "$TMP/with-facts" || {
+  echo "FAIL: NetworkPolicy is not an Ingress policy." >&2
+  cat "$TMP/with-facts" >&2; exit 1; }
+grep -qx 'FROM_NS=cnpg-system' "$TMP/with-facts" || {
+  echo "FAIL: ingress.from admits a namespace other than (or instead of) cnpg-system." >&2
+  cat "$TMP/with-facts" >&2; exit 1; }
+grep -qx 'PORTS=TCP:8000,TCP:9187' "$TMP/with-facts" || {
+  echo "FAIL: ports are not exactly TCP:8000 (status) + TCP:9187 (metrics)." >&2
+  cat "$TMP/with-facts" >&2; exit 1; }
+echo "  PASS"
+
+# ── Case 2: WITHOUT the CNPG api-version → absent ────────────────
+echo "[cnpg-probe] Case 2: without the CNPG api-version the operator-probe NetworkPolicy is absent"
+helm template smoke-wp . "${COMMON_SET[@]}" \
+  > "$TMP/without.yaml" 2> "$TMP/without.err" || {
+  echo "FAIL: render (no CNPG api-version) errored:" >&2
+  cat "$TMP/without.err" >&2
+  exit 1
+}
+probe_facts "$TMP/without.yaml" > "$TMP/without-facts" || {
+  echo "FAIL: render output failed to parse as YAML" >&2
+  exit 1
+}
+WITHOUT_COUNT=$(grep -E '^COUNT=' "$TMP/without-facts" | cut -d= -f2)
+if [ "$WITHOUT_COUNT" -ne 0 ]; then
+  echo "FAIL: operator-probe NetworkPolicy rendered on a cluster with NO postgresql.cnpg.io/v1 CRD (should be gated off)." >&2
+  cat "$TMP/without-facts" >&2
+  exit 1
+fi
+echo "  PASS"
+
+# ── Case 3: networkPolicy.enabled=false → absent (WITH api-version) ─
+echo "[cnpg-probe] Case 3: networkPolicy.enabled=false omits the operator-probe NetworkPolicy"
+helm template smoke-wp . "${COMMON_SET[@]}" "${API_VERSIONS[@]}" \
+  --set "networkPolicy.enabled=false" \
+  > "$TMP/off.yaml" 2> "$TMP/off.err" || {
+  echo "FAIL: render (networkPolicy disabled) errored:" >&2
+  cat "$TMP/off.err" >&2
+  exit 1
+}
+probe_facts "$TMP/off.yaml" > "$TMP/off-facts" || {
+  echo "FAIL: render output failed to parse as YAML" >&2
+  exit 1
+}
+OFF_COUNT=$(grep -E '^COUNT=' "$TMP/off-facts" | cut -d= -f2)
+if [ "$OFF_COUNT" -ne 0 ]; then
+  echo "FAIL: operator-probe NetworkPolicy rendered while networkPolicy.enabled=false." >&2
+  cat "$TMP/off-facts" >&2
+  exit 1
+fi
+echo "  PASS"
+
+# ── Case 4: cnpgOperator overrides flow through (never hardcode, #4) ─
+echo "[cnpg-probe] Case 4: cnpgOperator namespace/ports overrides reach the rendered object"
+helm template smoke-wp . "${COMMON_SET[@]}" "${API_VERSIONS[@]}" \
+  --set "networkPolicy.cnpgOperator.namespace=cnpg-operators" \
+  --set "networkPolicy.cnpgOperator.statusPort=8010" \
+  --set "networkPolicy.cnpgOperator.metricsPort=9188" \
+  > "$TMP/ovr.yaml" 2> "$TMP/ovr.err" || {
+  echo "FAIL: render (cnpgOperator overrides) errored:" >&2
+  cat "$TMP/ovr.err" >&2
+  exit 1
+}
+probe_facts "$TMP/ovr.yaml" > "$TMP/ovr-facts" || {
+  echo "FAIL: render output failed to parse as YAML" >&2
+  exit 1
+}
+grep -qx 'FROM_NS=cnpg-operators' "$TMP/ovr-facts" || {
+  echo "FAIL: cnpgOperator.namespace override did not reach the ingress.from namespaceSelector." >&2
+  cat "$TMP/ovr-facts" >&2; exit 1; }
+grep -qx 'PORTS=TCP:8010,TCP:9188' "$TMP/ovr-facts" || {
+  echo "FAIL: cnpgOperator status/metrics port overrides did not reach the ingress.ports." >&2
+  cat "$TMP/ovr-facts" >&2; exit 1; }
+echo "  PASS"
+
+echo "[cnpg-probe] All bp-wordpress-tenant cnpg-system operator-probe render gates green."

--- a/platform/wordpress-tenant/chart/values.yaml
+++ b/platform/wordpress-tenant/chart/values.yaml
@@ -598,6 +598,20 @@ networkPolicy:
     # namespace; operator overrides if it lives elsewhere.
     keycloakNamespaceLabel: "keycloak"
     keycloakPort: 8443
+  # ─── CNPG operator status/metrics probe (#6360 / #4282-class) ──────────
+  # The chart renders a Cluster.postgresql.cnpg.io into this per-Org
+  # namespace, which carries `default-deny-all` + `allow-same-org`
+  # (same-namespace podSelector). That pair denies the cnpg-system OPERATOR
+  # (a DIFFERENT namespace) from reaching the instance Pod's :8000/pg/status
+  # + :9187 metrics probe, so the Cluster stalls at "Instance Status
+  # Extraction Error" / Ready=False even though the postgres Pod serves SQL —
+  # live-confirmed on walktwo/wordpress-db (UAT row 222). The additive
+  # operator-probe NetworkPolicy (templates/networkpolicy-cnpg-operator-probe
+  # .yaml) restores that one reach; mirrors platform/postgres #4282.
+  cnpgOperator:
+    namespace: cnpg-system
+    statusPort: 8000
+    metricsPort: 9187
 # ─── ServiceMonitor ─────────────────────────────────────────────────────
 # Default false per docs/BLUEPRINT-AUTHORING.md §11.2 (Observability
 # toggles must default false). Operator opts in via per-cluster overlay

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-19T17:59:03.182Z",
+  "generatedAt": "2026-08-19T21:59:44.373Z",
   "blueprints": [
     {
       "id": "bp-agenity",
@@ -5767,7 +5767,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "listed",
-      "version": "0.4.23",
+      "version": "0.4.24",
       "section": "pts-7-org-tenant",
       "depends": [
         "bp-postgres",

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -5902,7 +5902,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "listed",
-    "version": "0.4.23",
+    "version": "0.4.24",
     "section": "pts-7-org-tenant",
     "depends": [
       "bp-postgres",

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,5 +1,15 @@
 apiVersion: v2
 name: bp-catalyst-platform
+# 1.4.1536 — #6360: catalog-seed bp-wordpress-tenant pin 0.4.23 -> 0.4.24 (and
+#   the bp-wordpress bare-slug alias, same chart bytes). Adds the additive
+#   cnpg-system operator-probe NetworkPolicy so the per-Org CNPG Cluster the
+#   wordpress-tenant chart renders into a default-deny namespace reaches Ready —
+#   the operator's :8000/pg/status + :9187 probe was denied by
+#   default-deny-all + allow-same-org, so the Cluster stalled at "Instance
+#   Status Extraction Error" / Ready=False over a healthy DB (UAT row 222;
+#   mirrors platform/postgres #4282). Seed-pin bump only on this side; no
+#   bootstrap-kit slot pins bp-wordpress-tenant (opt-in per-Org Application
+#   Blueprint), so the pin-sync gate has nothing to move.
 # KNOWN-BAD, SUPERSEDED ARTIFACT — 1.4.1325 (Refs #5743). A push race between
 #   two independent deploy-bots (catalyst-build.yaml + services-build.yaml,
 #   see scripts/bump-chart-version.sh's header for the mechanism) put
@@ -3975,7 +3985,7 @@ name: bp-catalyst-platform
 #   (kyverno flux-managed managed-by label on the secondary mirror Job so
 #   step-01's set -e apply into ns gitea is admitted; without it the cutover
 #   halted at step-01). Umbrella tracks its sub-charts per Inviolable Principle #13.
-version: 1.4.1534
+version: 1.4.1536
 # 1.4.1481 — #6293: catalog-seed advances bp-self-sovereign-cutover
 #   0.1.186 -> 0.1.187, the release that stops step-06 from patching five
 #   HelmRepositories it does not own and then grading itself on whether they
@@ -4162,7 +4172,7 @@ version: 1.4.1534
 # scripts/check-chart-version-forward.sh (#5743) fails unless the two match —
 # main was carrying a pre-existing 1.4.1330/1.4.1329 split, so this bump heals
 # it in the same commit, exactly as the documented self-heal contract does.
-appVersion: 1.4.1534
+appVersion: 1.4.1536
 # 1.4.239 — Wave 3 / Issue #2140 (2026-05-23): Huawei provider
 # implementation lands behind the Wave 2 CloudProvider interface.
 # Adds the OpenTofu module at infra/providers/huawei/ (VPC + Subnet +

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -75,7 +75,13 @@ spec:
   # byte-identical. Enforced catalog-wide by
   # scripts/check-dr-pairs-declare-promotion.sh. Lockstep with
   # platform/wordpress-tenant/blueprint.yaml + the bare-slug alias entry below.
-  version: "0.4.23"
+  # #6360: →0.4.24 — additive cnpg-system operator-probe NetworkPolicy so the
+  # per-Org CNPG Cluster the chart renders into a default-deny namespace reaches
+  # Ready (the operator's :8000/pg/status + :9187 probe was denied → "Instance
+  # Status Extraction Error" / Ready=False over a healthy DB, UAT row 222;
+  # mirrors platform/postgres #4282). Lockstep with
+  # platform/wordpress-tenant/blueprint.yaml + the bare-slug alias entry below.
+  version: "0.4.24"
   visibility: listed
   card:
     title: "WordPress (per-Organization)"
@@ -104,7 +110,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-wordpress-tenant
-    version: "0.4.23"
+    version: "0.4.24"
   # G117.1+G117.4+G117.5 #2744-followup (2026-06-03): lockstep with
   # platform/wordpress-tenant/blueprint.yaml. Uses {{.AppName}} so
   # multi-instance tenants get distinct hostnames per Application.
@@ -217,7 +223,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.4.23"
+  version: "0.4.24"
   visibility: listed
   card:
     title: "WordPress"
@@ -239,7 +245,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-wordpress-tenant
-    version: "0.4.23"
+    version: "0.4.24"
   # Lockstep with the bp-wordpress-tenant entry above + platform/wordpress-tenant/
   # blueprint.yaml. Same chart bytes; this is the bare-slug entrypoint only.
   topology:


### PR DESCRIPTION
## Root cause (UAT row 222, #6360; mirrors platform/postgres #4282)

bp-wordpress-tenant renders a Cluster.postgresql.cnpg.io into the Application's
own per-Organization namespace, where the host cnpg-system operator does NOT
run. That namespace is stamped with default-deny-all (Ingress+Egress) +
allow-same-org (same-namespace podSelector + DNS) by the
catalyst-tenant-&lt;slug&gt;-apps kustomization. That pair denies the cnpg-system
operator (a different namespace) from reaching the instance Pod's :8000/pg/status
status probe + :9187 metrics endpoint, so even though the postgres Pod is
Running 1/1 and serving SQL, the operator cannot extract status and the Cluster
phase stalls at "Instance Status Extraction Error: HTTP communication issue" /
Ready=False (CNPG's phaseReason names NetworkPolicy). Live-confirmed on
walktwo/wordpress-db.

## Fix

The core commit on this branch added
platform/wordpress-tenant/chart/templates/networkpolicy-cnpg-operator-probe.yaml
— an additive Ingress NetworkPolicy in the CNPG namespace whose podSelector
matches every instance Pod via the operator-stamped cnpg.io/cluster label
(Exists) and opens ONLY :8000 + :9187 to ONLY the cnpg-system namespace. It is
gated on the CNPG CRD being present (.Capabilities.APIVersions.Has
"postgresql.cnpg.io/v1") so it no-ops on a non-CNPG cluster, and is toggled by
networkPolicy.enabled. New networkPolicy.cnpgOperator.{namespace,statusPort,
metricsPort} values block. Identical shape to platform/postgres #4282's
operator-probe policy. Singleton and non-CNPG installs render unchanged.

This PR completes the version lockstep so the fix is actually published and
served.

## Lockstep sites moved (bp-wordpress-tenant 0.4.23 -&gt; 0.4.24)

- platform/wordpress-tenant/chart/Chart.yaml — version 0.4.23 -&gt; 0.4.24 (in
  the core commit); this PR adds the 0.4.24 changelog entry the core commit
  omitted.
- platform/wordpress-tenant/blueprint.yaml — spec.version 0.4.23 -&gt; 0.4.24.
- products/catalyst/chart/templates/catalog-seed/blueprints.yaml — all four
  bp-wordpress-tenant pins: the tenant entry (spec.version + source.version)
  and the bp-wordpress bare-slug alias (spec.version + source.version). No
  other Blueprint's 0.4.23 was touched.
- products/catalyst/chart/Chart.yaml — umbrella version + appVersion
  1.4.1534 -&gt; 1.4.1536 (origin/main was at 1.4.1535; picked current+1), with a
  changelog entry, because the catalog-seed template lives inside this chart.
- clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml — slot-13
  umbrella pin 1.4.1534 -&gt; 1.4.1536 in lockstep (pin-sync + umbrella-republish
  gates).
- Regenerated products/catalyst/bootstrap/api/internal/catalog/blueprints.json
  and products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
  via node scripts/build-catalog.mjs (deterministic, no hand-edit).

There is no bootstrap-kit slot pinning bp-wordpress-tenant (opt-in per-Org
Application Blueprint), so the pin-sync gate has nothing to move on that chart.

## Test with teeth

Added platform/wordpress-tenant/chart/tests/cnpg-operator-probe-render.sh:
- WITH --api-versions postgresql.cnpg.io/v1 the render must emit exactly ONE
  NetworkPolicy named *-cnpg-operator-probe with a cnpg.io/cluster Exists
  podSelector, policyType Ingress, from ns cnpg-system, ports exactly TCP 8000
  + TCP 9187.
- WITHOUT the CNPG api-version the policy is ABSENT.
- networkPolicy.enabled=false omits it.
- cnpgOperator namespace/port overrides flow through to the rendered object.

Confirmed the test FAILS (exit 1) when the template is deleted, and GREEN when
restored.

## Gate results (all run locally, all green)

- check-chart-version-bumped.sh origin/main HEAD: PASS (wordpress-tenant chart
  0.4.23 -&gt; 0.4.24; umbrella 1.4.1534 -&gt; 1.4.1536). --self-test PASS.
- check-chart-version-forward.sh 1.4.1535 1.4.1535 1.4.1536 1.4.1536: PASS
  (forward, version==appVersion).
- check-catalog-seed-lockstep.sh: PASS (checked 68, fail 0).
- check-catalog-seed-source-coverage.py: PASS (89 charted, 71 seeded, 0
  undeclared gaps).
- check-umbrella-republish-gate.py --ref HEAD: PASS (160 pins / 80 Blueprints;
  umbrella at 1.4.1536 re-bumped at/after every pin). --self-test PASS.
- check-bootstrap-kit-pin-sync.sh (full + --changed-only --base origin/main):
  PASS (slot-13 1.4.1536 == chart 1.4.1536).
- check-catalog-generated-drift: PASS (regenerate twice, byte-identical; no
  working-tree drift).
- Go seed tests: TestCatalogSeed_DeliveryPinsNotBehindComponentCharts +
  TestCatalogSeed_DisplayVersionNotBehindDeliveryPin: ok.
  TestDefaultHRAppPins_MatchCatalogSeed + GuardIsNotVacuous: ok. DR-pair
  symmetry #6149: ok.
- check-dr-pairs-declare-promotion.sh: PASS (bp-wordpress-tenant declares
  manual, fails closed on dr-promoter/continuum, singleton unchanged).
- helm template bp-wordpress-tenant (with CNPG api-version): renders 11 objects,
  operator-probe NetworkPolicy stamped bp-wordpress-tenant-0.4.24.
- helm template umbrella catalog-seed: 81 Blueprints, all four wordpress pins at
  0.4.24.
- Existing wordpress-tenant tests (active-hot-standby-render, oidc-config,
  observability-toggle, imagepullsecrets-render): all PASS.

Refs #6360
