### PR TITLE
fix(wordpress-tenant): CNPG-operator carve-out + zero install-time egress — rebase of #6320 onto current main (Refs #4307)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1456,7 +1456,10 @@ spec:
       #   kyverno flux-managed managed-by label on the secondary mirror Job).
       # 1.4.1537 — lockstep for bp-agenity 0.5.31 (#6317: server-side Anthropic
       #   OAuth credential renewal + resync sidecar).
-      version: 1.4.1539
+      # 1.4.1540 — lockstep for bp-wordpress-tenant 0.4.25 (#6311, Refs #4307:
+      #   CNPG-operator status-probe carve-out + zero install-time egress; rebase
+      #   of PR #6320 onto current main).
+      version: 1.4.1540
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/platform/wordpress-tenant/blueprint.yaml
+++ b/platform/wordpress-tenant/blueprint.yaml
@@ -6,7 +6,12 @@ metadata:
     catalyst.openova.io/category: organization-app
     catalyst.openova.io/section: pts-7-org-tenant
 spec:
-  version: 0.4.23
+  # 0.4.25 (#6311, Refs #4307 #3988): CNPG-operator status-probe carve-out for
+  # the per-Org default-deny namespace + zero install-time third-party egress
+  # (artifacts baked into the runtime image). Rebase of PR #6320 onto current
+  # main; #6320 already claims 0.4.24 as an open PR, so this republish takes
+  # the next free patch. Lockstep with platform/wordpress-tenant/chart/Chart.yaml.
+  version: 0.4.25
   card:
     title: WordPress (per-Organization)
     summary: |

--- a/platform/wordpress-tenant/chart/Chart.yaml
+++ b/platform/wordpress-tenant/chart/Chart.yaml
@@ -345,7 +345,88 @@ name: bp-wordpress-tenant
 #   values file. Singleton installs render byte-identical (no annotation, no
 #   declaration required). Catalog-wide enforcement:
 #   scripts/check-dr-pairs-declare-promotion.sh.
-version: 0.4.23
+# 0.4.25 (#6311, Refs #4307 #3988 #4282 #3379): bp-wordpress-tenant could not
+#   converge in ANY Organization. Two independent defects, both fixed here.
+#   This is the rebase of PR #6320 onto current main; #6320 already claims
+#   0.4.24 as an open PR, so this republish takes the next free patch (0.4.25)
+#   per scripts/check-chart-version-not-claimed-by-open-pr.py. Same chart bytes
+#   as #6320 otherwise.
+#
+#   DEFECT 1 — no cnpg-system carve-out, so our own NetworkPolicy blinds the
+#   CNPG operator. This chart renders its Cluster into the Organization's own
+#   namespace, which carries the `default-deny-all` + `allow-same-org` pair
+#   stamped by the Organization controller's GitOps tree. `allow-same-org`
+#   re-opens SAME-NAMESPACE traffic only, so the cnpg-system operator — a
+#   different namespace — is denied the instance Pod's :8000/pg/status probe.
+#   The database is UP and serving while the operator is blind, and CNPG parks
+#   the Cluster at `Instance Status Extraction Error: HTTP communication issue`
+#   / readyInstances 1/1 / ConsistentSystemID=False → Ready=False → the HR
+#   never converges → the customer's purchased WordPress never comes up.
+#   MEASURED on hw296 with quota eliminated as a variable: the identical
+#   blueprint installed into an Org with headroom ran the exact Pods #5393
+#   rejects elsewhere (`wordpress-db-1-initdb` Completed, `wordpress-db-1` 1/1
+#   Running, zero quota rejections) and STILL landed Ready=False. Control
+#   sharing the suspect property: `walkone/postgres` — same deny pair, but
+#   carrying the #4282 carve-out — read `Cluster in healthy state` 3/3; 11 CNPG
+#   Clusters cluster-wide were healthy and this was the only one in the error
+#   phase.
+#   FIX — templates/networkpolicy-cnpg-operator-probe.yaml, the proven #4282
+#   shape from platform/postgres (whose header predicts this phase string
+#   verbatim). Opens ONLY :8000 + :9187 from ONLY `cnpg-system`. Additive:
+#   default-deny-all and allow-same-org are untouched. No broad 5432 rule (the
+#   #4442 `sharedConsumers` shape) — this Cluster's only consumers are
+#   same-namespace and allow-same-org already admits them. SINGLETON ONLY, like
+#   #4282: in active-hot-standby the replica streams WAL cross-cluster over
+#   ClusterMesh and an Ingress policyType selecting the Cluster Pods would
+#   default-deny that stream, while a remote-cluster peer cannot be expressed
+#   in a k8s NetworkPolicy at all (an ipBlock never matches a ClusterMesh
+#   remote endpoint identity — bp-postgres needs a dedicated identity-based
+#   CiliumNetworkPolicy for it). Rendering nothing in AHS keeps that path
+#   byte-identical rather than trading one break for another; the AHS carve-out
+#   stays open on #6311.
+#   SCOPE — 8 charts render a CNPG Cluster with no carve-out, but the deny pair
+#   exists only in per-Org namespaces. The load-bearing property is "can this
+#   chart's Cluster land in a namespace carrying that pair", and only two
+#   charts can: bp-postgres (routed per-Org by #4398, already carries the
+#   #4282 carve-out) and this one. The other 7 (bp-gitea, bp-guacamole,
+#   bp-llm-gateway, bp-openova-flow-server, bp-powerdns, bp-powerdns-admin,
+#   bp-temporal) are bootstrap-kit components in platform namespaces where no
+#   such pair is stamped — and where an unconditional probe NetworkPolicy would
+#   REGRESS them, because policyTypes:[Ingress] makes the Cluster Pods
+#   default-deny for every unlisted peer and their consumers live in OTHER
+#   namespaces (the #4442 regression, verbatim). They are deliberately
+#   untouched.
+#
+#   DEFECT 2 — install-time github.com fetch, which contradicts Pillar 5.
+#   The post-install oidc-config Job CrashLoopBackOff'd on
+#   `curl: (28) Connection timed out after 120001 milliseconds`. Cutover
+#   step-08 (`egress-block-test`) holds a 10-minute deny-egress NetworkPolicy
+#   against github.com / ghcr.io / harbor.openova.io and requires the cluster
+#   to reconcile green through it — that hold IS the sovereignty proof
+#   (ADR-0002). A customer Application that reaches GitHub to install cannot
+#   exist on a sovereign Sovereign. FOUR install-time fetch sites existed, not
+#   two: deployment.yaml's wp-plugin-install init (downloads.wordpress.org +
+#   github.com), oidc-config-job.yaml step 0 (github.com) and step 4
+#   (github.com), and step 7's `wp theme install` fallback — always reachable,
+#   because the Job's emptyDir masks the image's bundled themes.
+#   SEAM REUSED, NOT INVENTED — this repo mirrors exactly two artifact classes
+#   into a post-cutover Sovereign's Harbor: OCI container images and Helm
+#   charts (cutover step-03 `harbor-prewarm`). There is NO mirroring path for
+#   plain file artifacts. So the bytes now travel as layers of an image already
+#   in the prewarm set: `wordpress-tenant-pg`, which
+#   platform/self-sovereign-cutover/chart/Chart.yaml already names verbatim as
+#   a tag+digest-pinned prewarm source.
+#   FIX — image/Dockerfile bakes pinned pg4wp + openid-connect-generic into
+#   /usr/src/openova-wp-artifacts with build-time assertions (including a uid-33
+#   read/copy probe); both consumers copy from there and FAIL CLOSED if it is
+#   absent, with no network fallback; core's bundled themes are seeded into the
+#   Job so step 7 never fetches. The plugin slug is now the bare
+#   `openid-connect-generic` in BOTH places — the pre-existing mismatch (Job
+#   activated `openid-connect-generic`, PVC held `daggerhart-openid-connect-
+#   generic`) left active_plugins pointing at a file the runtime PVC never had.
+#   The oidc-config Job also gains imagePullSecrets: its new wp-artifacts init
+#   runs the PRIVATE ghcr image, and without them it ImagePullBackOffs.
+version: 0.4.25
 appVersion: "6"
 description: |
   Catalyst Blueprint scratch chart for in-vcluster WordPress, one

--- a/platform/wordpress-tenant/chart/templates/deployment.yaml
+++ b/platform/wordpress-tenant/chart/templates/deployment.yaml
@@ -12,10 +12,13 @@ Boot sequence (per docs/INVIOLABLE-PRINCIPLES.md #2 — ship target-state shape,
      those bytes. The init container detects an unseeded PVC by looking
      for `themes/` and seeds it from the image once, idempotently.
 
-  2. initContainer `wp-oidc-plugin-install`: downloads + extracts
-     `openid-connect-generic` (latest stable) from
-     downloads.wordpress.org into `wp-content/plugins/` on the PVC.
-     Idempotent — skips if the plugin dir already exists.
+  2. initContainer `wp-plugin-install`: copies `openid-connect-generic`
+     + the `pg4wp` Postgres adapter from the runtime image's baked
+     `/usr/src/openova-wp-artifacts/` into `wp-content/` on the PVC.
+     Idempotent — skips if the target dir already exists. #6311: this
+     used to download them from downloads.wordpress.org + github.com at
+     install time, which contradicts cutover step-08's deny-egress hold
+     (Pillar 5). There is deliberately NO network fallback.
 
   3. main container `wordpress`: the official image starts; its
      entrypoint writes `wp-config.php` from WORDPRESS_DB_* env vars,
@@ -133,19 +136,34 @@ spec:
           volumeMounts:
             - name: wp-content
               mountPath: /pvc
-        # ── 2. Install plugins from wordpress.org / GitHub onto the PVC ─
-        # Two plugins are pre-installed at boot, both idempotent
+        # ── 2. Seed plugins onto the PVC FROM THE IMAGE (#6311) ─────────
+        # Two artifacts are pre-installed at boot, both idempotent
         # (skip if already present on the PVC):
         #
-        #   a) `openid-connect-generic` — the SSO plugin that drives
-        #      Keycloak OIDC login flow. Source: wordpress.org plugin
-        #      registry.
-        #   b) `pg4wp` (mu-plugin) — translates WordPress's MySQL
-        #      queries to PostgreSQL so the official `wordpress:*`
-        #      image runs against bp-cnpg without a MySQL footprint
-        #      in the Organization tenant namespace. Source: PostgreSQL-For-
-        #      Wordpress on GitHub. Installed under wp-content/pg4wp
-        #      and chain-loaded via wp-content/db.php drop-in.
+        #   a) `openid-connect-generic` — the SSO plugin that drives the
+        #      Keycloak OIDC login flow.
+        #   b) `pg4wp` — translates WordPress's MySQL queries to PostgreSQL
+        #      so the WordPress image runs against bp-cnpg without a MySQL
+        #      footprint in the Organization's namespace. Installed under
+        #      wp-content/pg4wp and chain-loaded via the wp-content/db.php
+        #      drop-in.
+        #
+        # SOURCE — the RUNTIME IMAGE, never the network (#6311, Refs #3988).
+        # Until 0.4.24 this initContainer curl'd (a) from
+        # downloads.wordpress.org and (b) from github.com AT INSTALL TIME.
+        # Cutover step-08 (`egress-block-test`) exists precisely to hold a
+        # 10-minute deny-egress NetworkPolicy against github.com / ghcr.io /
+        # harbor.openova.io and require the cluster to reconcile green
+        # through it — a customer Application that reaches GitHub to install
+        # cannot exist on a sovereign Sovereign (Pillar 5, ADR-0002).
+        #
+        # Both artifacts are now baked into
+        # `/usr/src/openova-wp-artifacts/` by
+        # platform/wordpress-tenant/image/Dockerfile and travel to a
+        # post-cutover Sovereign inside the image itself — the ONLY artifact
+        # classes cutover step-03 (`harbor-prewarm`) mirrors are OCI images
+        # and Helm charts, and `wordpress-tenant-pg` is already in that
+        # prewarm set by name. No new mirroring mechanism was introduced.
         - name: wp-plugin-install
           image: {{ include "bp-wordpress-tenant.wordpressImage" . | quote }}
           imagePullPolicy: {{ .Values.wordpress.image.pullPolicy }}
@@ -161,41 +179,50 @@ spec:
             - -c
             - |
               set -eu
-              # Extract plugin/adapter zips with PHP's bundled ZipArchive
-              # instead of the `unzip` binary. The wordpress:*-php* image
-              # already ships the `zip` PHP extension (a WordPress core
-              # requirement), so NO package install is needed.
+              # #6311: the artifacts are BAKED INTO THIS IMAGE. There is no
+              # download step and no zip extraction here any more — the two
+              # `curl` calls this block used to run (downloads.wordpress.org
+              # for the OIDC plugin, github.com for pg4wp) were install-time
+              # egress and contradicted the cutover step-08 deny-egress hold.
+              # Everything below is a local `cp` from the image's read-only
+              # /usr/src/openova-wp-artifacts onto the wp-content PVC.
               #
-              # This supersedes the earlier `apt-get install unzip`, which is
-              # fatally fragile on locked-down Sovereigns for TWO independent
-              # reasons (both observed live on kom4dc / omantel.biz demo Org):
-              #   1. apt's http transport drops privileges to the `_apt` user
-              #      via setgroups/setegid/seteuid — forbidden under the
-              #      dropped-ALL-capabilities containerSecurityContext
-              #      ("setgroups 65534 failed - Operation not permitted" →
-              #      "Method http has died" code 112 → init CrashLoopBackOff);
-              #   2. egress-restricted clusters cannot reach deb.debian.org at
-              #      all ("Ign … trixie InRelease" → "Unable to locate package
-              #      unzip"), so the package index never loads.
-              # PHP ZipArchive sidesteps both — no apt, no extra Linux caps,
-              # no Debian-mirror egress. Stacks on #4147 (runAsUser:0).
-              php_unzip() {  # $1=zip  $2=destdir
-                php -r '$z=new ZipArchive(); $r=$z->open($argv[1]); if($r!==true){fwrite(STDERR,"ZipArchive open failed (".$r."): ".$argv[1]."\n");exit(1);} if(!$z->extractTo($argv[2])){fwrite(STDERR,"ZipArchive extractTo failed: ".$argv[2]."\n");exit(1);} $z->close();' "$1" "$2"
-              }
+              # FAIL CLOSED, never fall back to the network: if the baked
+              # directory is absent, the running image predates chart 0.4.25
+              # and the values.yaml image pin is hollow. Surfacing that as a
+              # loud init failure is correct — a silent network fallback is
+              # exactly the sovereignty violation this change removes.
+              WP_ARTIFACTS=/usr/src/openova-wp-artifacts
+              if [ ! -d "${WP_ARTIFACTS}" ]; then
+                echo "FATAL: ${WP_ARTIFACTS} missing from the runtime image." >&2
+                echo "  The chart requires the baked pg4wp + openid-connect-generic" >&2
+                echo "  artifacts (#6311). Check wordpress.image.{tag,digest} in" >&2
+                echo "  values.yaml against platform/wordpress-tenant/image/." >&2
+                exit 1
+              fi
               # ── (a) openid-connect-generic plugin ──────────────────
-              OIDC_DIR=/pvc/plugins/daggerhart-openid-connect-generic
+              # Slug is the BARE `openid-connect-generic` — the same directory
+              # name the oidc-config hook Job's `wp plugin activate` writes
+              # into WordPress's `active_plugins` option row. The pre-#6311
+              # wordpress.org slug (`daggerhart-openid-connect-generic`) did
+              # NOT match it, so that option row pointed at a path this PVC
+              # never contained and the plugin never loaded at runtime.
+              OIDC_DIR=/pvc/plugins/openid-connect-generic
               if [ -d "${OIDC_DIR}" ]; then
                 echo "openid-connect-generic already installed — skipping."
               else
-                echo "Downloading openid-connect-generic..."
-                cd /tmp
-                # Plugin slug on WordPress.org is `daggerhart-openid-connect-generic`
-                # (the bare `openid-connect-generic` slug 404s).
-                curl -fsSL -o oidc.zip \
-                  https://downloads.wordpress.org/plugin/daggerhart-openid-connect-generic.latest-stable.zip
+                echo "Seeding openid-connect-generic from the image..."
                 mkdir -p /pvc/plugins
-                php_unzip oidc.zip /pvc/plugins/
-                rm -f /tmp/oidc.zip
+                # `cp -R`, NOT `cp -a`: the baked source is root-owned in the
+                # image, while this init runs as uid 33 and the PVC copy must
+                # end up owned by uid 33 (WordPress writes into wp-content).
+                # `-a` implies `-p`, which asks to preserve ROOT ownership —
+                # either denied outright under the dropped-ALL-capabilities
+                # securityContext, or "successful" and leaving a root-owned
+                # tree the runtime user cannot write. `cp -R` copies content
+                # and lets the new files take the copying uid. Verified by the
+                # uid-33 build-time probe in image/Dockerfile.
+                cp -R "${WP_ARTIFACTS}/plugins/openid-connect-generic" "${OIDC_DIR}"
                 echo "openid-connect-generic installed."
               fi
               # ── (b) pg4wp drop-in (Postgres adapter) ───────────────
@@ -203,30 +230,17 @@ spec:
               # Postgres (per ticket #800 scope). pg4wp ships a
               # `wp-content/db.php` drop-in + `pg4wp/` library that
               # together intercept `wpdb` at the PHP level and map
-              # MySQL queries to Postgres. Repo:
-              # https://github.com/PostgreSQL-For-Wordpress/postgresql-for-wordpress
+              # MySQL queries to Postgres.
               PG4WP_DIR=/pvc/pg4wp
               if [ -d "${PG4WP_DIR}" ] && [ -f /pvc/db.php ]; then
                 echo "pg4wp already installed — skipping."
               else
-                echo "Downloading pg4wp..."
-                cd /tmp
-                # Pin to a stable tag, not main, per
-                # docs/INVIOLABLE-PRINCIPLES.md #4 (no floating refs).
-                # v3.3.1 is the latest published release/tag (the prior pin
-                # v3.7.0 does not exist → archive 404).
-                curl -fsSL -o pg4wp.zip \
-                  https://github.com/PostgreSQL-For-Wordpress/postgresql-for-wordpress/archive/refs/tags/v3.3.1.zip
-                php_unzip pg4wp.zip /tmp/
-                # Extracted layout:
-                #   /tmp/postgresql-for-wordpress-3.3.1/pg4wp/
-                #   /tmp/postgresql-for-wordpress-3.3.1/pg4wp/db.php
-                # Copy `pg4wp/` into wp-content/ and the `db.php`
-                # drop-in alongside it (WP looks for db.php at
-                # wp-content/db.php).
-                cp -a /tmp/postgresql-for-wordpress-3.3.1/pg4wp /pvc/
-                cp /tmp/postgresql-for-wordpress-3.3.1/pg4wp/db.php /pvc/db.php
-                rm -rf /tmp/postgresql-for-wordpress-3.3.1 /tmp/pg4wp.zip
+                echo "Seeding pg4wp from the image..."
+                # rm -rf first so a half-seeded PVC (pg4wp/ present, db.php
+                # absent) cannot make `cp` nest the copy at /pvc/pg4wp/pg4wp.
+                rm -rf "${PG4WP_DIR}"
+                cp -R "${WP_ARTIFACTS}/pg4wp" "${PG4WP_DIR}"
+                cp "${WP_ARTIFACTS}/db.php" /pvc/db.php
                 echo "pg4wp installed."
               fi
               # No chown needed: this init runs as uid 33 (the chart's

--- a/platform/wordpress-tenant/chart/templates/networkpolicy-cnpg-operator-probe.yaml
+++ b/platform/wordpress-tenant/chart/templates/networkpolicy-cnpg-operator-probe.yaml
@@ -1,0 +1,133 @@
+{{- /*
+CNPG-operator status-probe carve-out for the per-Org WordPress database
+(#6311, Refs #3988; the proven shape is platform/postgres/chart/templates/
+networkpolicy-singleton-operator-probe.yaml, #4282 root-cause-D).
+
+WHY THIS EXISTS — measured on hw296, quota eliminated as a variable
+────────────────────────────────────────────────────────────────────
+This chart renders its CNPG `Cluster` INTO the Organization's own
+namespace. Every per-Org namespace carries the `default-deny-all` +
+`allow-same-org` NetworkPolicy pair stamped by the Organization
+controller's GitOps tree (core/controllers/organization/internal/gitops/
+manifests.go `networkPolicyTemplate`). `allow-same-org` re-opens
+SAME-NAMESPACE pod-to-pod only — the cnpg-system OPERATOR lives in a
+DIFFERENT namespace, so its `:8000/pg/status` probe against the instance
+Pod is denied.
+
+The database is UP and serving the whole time; only the operator is
+blinded. CNPG then parks the Cluster at exactly:
+
+    Instance Status Extraction Error: HTTP communication issue
+    readyInstances 1/1
+    ConsistentSystemID=False (NotFound)
+
+which is Ready=False → the HelmRelease never converges → the customer's
+purchased WordPress never comes up. Live evidence: hw296 `walktwo/
+wordpress-db` in that phase with `wordpress-db-1-initdb` Completed and
+`wordpress-db-1` 1/1 Running and ZERO quota rejections, while the control
+`walkone/postgres` — same deny pair, but carrying the #4282 carve-out —
+read `Cluster in healthy state` 3/3. Cluster-wide 11 CNPG Clusters were
+healthy; this was the only one in the error phase.
+
+WHAT IT OPENS — additive and narrow
+───────────────────────────────────
+ONLY the cnpg-system operator's status (:8000) + metrics (:9187) ports,
+and only from the operator namespace. `default-deny-all` and
+`allow-same-org` are NOT weakened — NetworkPolicies union, so this adds
+a peer and removes nothing.
+
+No broad consumer 5432 rule is rendered (the #4442 `sharedConsumers`
+shape in bp-postgres): the only consumer of this Cluster is the WordPress
+Deployment + hook Jobs in the SAME namespace, which `allow-same-org`
+already admits.
+
+SINGLETON ONLY — deliberate, mirroring #4282
+────────────────────────────────────────────
+Renders only when `database.mode` resolves to `singleton` (the chart
+DEFAULT, and the mode the defect was measured in). In
+`active-hot-standby` the replica streams WAL from the primary across
+Cilium ClusterMesh from ANOTHER cluster; a `policyTypes: [Ingress]`
+policy selecting the Cluster Pods would default-deny that stream, and a
+remote-cluster peer CANNOT be expressed in a k8s NetworkPolicy — an
+`ipBlock` never matches a ClusterMesh remote endpoint's identity
+(bp-postgres needs a dedicated identity-based CiliumNetworkPolicy,
+`topology.networkPolicy.crossRegionPeerClusters`, for exactly this).
+Rendering nothing in AHS mode leaves that path byte-identical to today
+rather than trading a status-probe fix for a broken replication stream.
+The AHS carve-out is tracked separately in #6311.
+
+Gated additionally on the `postgresql.cnpg.io/v1` capability + the same
+`wordpress.enabled` / `database.cluster.enabled` pair as cnpg-cluster.yaml,
+so this template can never render a policy selecting a Cluster that was
+not itself rendered.
+*/ -}}
+{{- if and .Values.wordpress.enabled .Values.database.cluster.enabled .Values.networkPolicy.enabled .Values.networkPolicy.cnpgOperator.enabled }}
+{{- if .Capabilities.APIVersions.Has "postgresql.cnpg.io/v1" }}
+{{- if ne (include "bp-wordpress-tenant.dbMode" .) "active-hot-standby" }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ printf "%s-allow-cnpg-operator-probe" .Values.database.cnpgClusterName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "bp-wordpress-tenant.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      cnpg.io/cluster: {{ .Values.database.cnpgClusterName | quote }}
+  policyTypes: [Ingress, Egress]
+  ingress:
+    # CNPG operator status + metrics probe. Without this the operator
+    # cannot extract instance status from the per-Org default-deny
+    # namespace and the Cluster parks at "Instance Status Extraction
+    # Error: HTTP communication issue" / Ready=False while the Postgres
+    # Pod is 1/1 Running and serving SQL (#6311, #4282).
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.networkPolicy.cnpgOperator.operatorNamespace }}
+      ports:
+        - port: {{ .Values.networkPolicy.cnpgOperator.operatorStatusPort }}
+          protocol: TCP
+        - port: {{ .Values.networkPolicy.cnpgOperator.operatorMetricsPort }}
+          protocol: TCP
+  egress:
+    # CLUSTER DNS — the #5617 / #4437 class invariant, enforced by
+    # scripts/check-netpol-egress-completeness.py.
+    #
+    # A per-Org `<slug>` namespace carries a CiliumNetworkPolicy
+    # `allow-gateway-and-apiserver` with `endpointSelector: {}` and an EGRESS
+    # section naming kube-apiserver + same-namespace endpoints and NOTHING
+    # else — no DNS. Cilium unions every policy selecting an endpoint, and the
+    # moment ANY of them carries an egress section that endpoint's egress is
+    # deny-by-default outside the union. So in a per-Org namespace a workload
+    # that ships no DNS egress of its own is mute on its first name lookup.
+    # That is exactly how #5617 bit live on hw292 Org `uatco`: bp-oidc-gate
+    # shipped an ingress-only policy and every OAuth callback 500'd on
+    # `lookup keycloak.keycloak.svc.cluster.local on 10.96.0.10:53: i/o
+    # timeout` AFTER a successful login.
+    #
+    # The CNPG instance manager resolves service names constantly (the `-rw` /
+    # `-r` Services, its peers, the operator), so this group must carry DNS.
+    # The rule is purely ADDITIVE: NetworkPolicies union, so naming an egress
+    # half here can only ADD `53 -> kube-system` to what `allow-same-org` and
+    # the per-Org CNP already permit — it removes nothing from the instance's
+    # existing reach. Both UDP and TCP: a truncated UDP answer falls back to
+    # TCP, and a UDP-only rule is one of the shapes the class guard rejects.
+    #
+    # DNS-ONLY on purpose. This is a database engine; it has no business
+    # dialling arbitrary destinations, and a blanket egress peer here would be
+    # the over-broad "fix" the guard's own fixtures reject.
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.networkPolicy.cnpgOperator.dnsNamespace }}
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+{{- end }}
+{{- end }}
+{{- end }}

--- a/platform/wordpress-tenant/chart/templates/networkpolicy.yaml
+++ b/platform/wordpress-tenant/chart/templates/networkpolicy.yaml
@@ -70,12 +70,15 @@ spec:
           protocol: UDP
         - port: 53
           protocol: TCP
-    # ── HTTPS egress (Keycloak realm URL if external, plugin/theme
-    #    fetches at first install) ────────────────────────────────
-    # The cluster's egress-gateway enforces destination policy
-    # globally; this rule just opens the wire. Used by the WP plugin
-    # installer initContainer to pull `openid-connect-generic` +
-    # `pg4wp` zips from wordpress.org / GitHub. Cloud-egress IPs
+    # ── HTTPS egress (an EXTERNAL Keycloak realm URL; User-initiated
+    #    plugin/theme installs from /wp-admin) ────────────────────
+    # NOT used at install time any more (#6311): pg4wp, the OIDC plugin
+    # and core's bundled themes now travel inside the runtime image and
+    # are copied locally, so a fresh Organization converges with this
+    # rule denied — which is what cutover step-08's deny-egress hold
+    # requires. The rule stays for the two remaining legitimate uses
+    # above; the cluster's egress-gateway enforces destination policy
+    # globally and this rule just opens the wire. Cloud-egress IPs
     # only — internal RFC1918 ranges are excluded so this rule
     # cannot accidentally reach intra-cluster services on :443.
     - to:

--- a/platform/wordpress-tenant/chart/templates/oidc-config-job.yaml
+++ b/platform/wordpress-tenant/chart/templates/oidc-config-job.yaml
@@ -82,8 +82,113 @@ spec:
         catalyst.openova.io/blueprint: bp-wordpress-tenant
     spec:
       restartPolicy: OnFailure
+      {{- with .Values.wordpress.image.pullSecrets }}
+      # #6311: this Job's MAIN container runs the PUBLIC dockerhub
+      # `wordpress:cli-*` image, but its `wp-artifacts` initContainer runs the
+      # PRIVATE `wordpress-tenant-pg` runtime image (that is where the baked
+      # pg4wp + OIDC-plugin artifacts live). Without these pull secrets the
+      # initContainer ImagePullBackOffs, the post-install hook never runs, Helm
+      # times out and the HelmRelease sticks Ready=False — the same failure
+      # shape #4154 fixed for the Deployment and admin-user Job.
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       securityContext:
         {{- toYaml .Values.wordpress.podSecurityContext | nindent 8 }}
+      initContainers:
+        # ── Seed the baked third-party artifacts into the ephemeral
+        #    wp-content (#6311, Refs #3988) ────────────────────────────────
+        # This Job mounts its OWN emptyDir (#4220), so the artifacts the
+        # runtime Deployment seeds onto the persistent PVC are not visible
+        # here — it used to `curl` them at install time instead, from
+        # github.com, and CrashLoopBackOff'd on
+        #   curl: (28) Connection timed out after 120001 milliseconds
+        # Cutover step-08 (`egress-block-test`) holds a 10-minute deny-egress
+        # NetworkPolicy against exactly github.com / ghcr.io /
+        # harbor.openova.io, so an install-time GitHub fetch is a Pillar-5
+        # violation regardless of whether a given cluster happens to have
+        # egress (ADR-0002).
+        #
+        # This initContainer runs the RUNTIME image (the one that carries the
+        # baked artifacts — the wp-cli image is upstream and does not) and
+        # copies them into the shared emptyDir. The main container then finds
+        # `wp-content/db.php` and `wp-content/plugins/openid-connect-generic`
+        # already present and its idempotent guards short-circuit.
+        - name: wp-artifacts
+          image: {{ include "bp-wordpress-tenant.wordpressImage" . | quote }}
+          imagePullPolicy: {{ .Values.wordpress.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.wordpress.containerSecurityContext | nindent 12 }}
+          env:
+            # Provenance only (#6311). The BYTES come from the image; these
+            # declare which version the chart EXPECTS the image to carry, so a
+            # drift between `oidc.plugin.version` and the image's baked
+            # VERSIONS file surfaces in the Job log instead of silently
+            # shipping a different plugin build. Warn, never fail: the image
+            # is the source of truth and a lagging values pin must not block
+            # a customer's install.
+            - name: OIDC_PLUGIN_REPO
+              value: {{ .Values.oidc.plugin.repo | quote }}
+            - name: OIDC_PLUGIN_VERSION
+              value: {{ .Values.oidc.plugin.version | quote }}
+          command:
+            - /bin/bash
+            - -c
+            - |
+              set -eu
+              WP_ARTIFACTS=/usr/src/openova-wp-artifacts
+              # FAIL CLOSED — never fall back to the network. An absent
+              # directory means the running image predates chart 0.4.25 and
+              # the values.yaml image pin is hollow; that must be loud.
+              if [ ! -d "${WP_ARTIFACTS}" ]; then
+                echo "FATAL: ${WP_ARTIFACTS} missing from the runtime image (#6311)." >&2
+                echo "  Check wordpress.image.{tag,digest} in values.yaml." >&2
+                exit 1
+              fi
+              echo "[wp-artifacts] baked artifact versions:"
+              cat "${WP_ARTIFACTS}/VERSIONS" || true
+              if ! grep -q "openid-connect-generic=${OIDC_PLUGIN_VERSION} " \
+                     "${WP_ARTIFACTS}/VERSIONS" 2>/dev/null; then
+                echo "[wp-artifacts] WARN: chart declares openid-connect-generic" \
+                     "${OIDC_PLUGIN_VERSION} (${OIDC_PLUGIN_REPO}) but the image" \
+                     "carries a different build — the IMAGE wins. Re-bake" \
+                     "platform/wordpress-tenant/image/Dockerfile to realign."
+              fi
+              # `cp -R`, NOT `cp -a`: the baked source is root-owned in the
+              # image while this container runs as uid 33 and the copies must
+              # be uid-33-owned for wp-cli to use them. `-a` implies `-p`,
+              # which asks to preserve ROOT ownership — denied under the
+              # dropped-ALL-capabilities securityContext, or "successful" and
+              # leaving a tree the wp-cli container cannot write.
+              mkdir -p /wp-content/plugins
+              cp "${WP_ARTIFACTS}/db.php" /wp-content/db.php
+              rm -rf /wp-content/pg4wp
+              cp -R "${WP_ARTIFACTS}/pg4wp" /wp-content/pg4wp
+              rm -rf /wp-content/plugins/openid-connect-generic
+              cp -R "${WP_ARTIFACTS}/plugins/openid-connect-generic" \
+                    /wp-content/plugins/openid-connect-generic
+              # Themes — the THIRD install-time egress site (#6311). This Job's
+              # emptyDir masks the image's own wp-content, so `wp theme
+              # is-installed` in step 7 was always false and the fallback
+              # `wp theme install <theme>` fetched the theme zip from
+              # wordpress.org. Seeding core's bundled themes from the image
+              # makes that branch unreachable on the default theme.
+              if [ ! -d /wp-content/themes ] && [ -d /usr/src/wordpress/wp-content/themes ]; then
+                cp -R /usr/src/wordpress/wp-content/themes /wp-content/themes
+              fi
+              echo "[wp-artifacts] pg4wp + openid-connect-generic + core themes seeded from the image"
+          volumeMounts:
+            - name: wp-content
+              mountPath: /wp-content
+          resources:
+            requests:
+              cpu: 25m
+              memory: 64Mi
+            limits:
+              # Kept well inside the per-Org `plan-quota` headroom (#4951) —
+              # this is a short `cp` of a few MiB.
+              cpu: 100m
+              memory: 128Mi
       containers:
         - name: oidc-config
           image: {{ include "bp-wordpress-tenant.wpCliImage" . | quote }}
@@ -133,17 +238,10 @@ spec:
             # surface in observability immediately.
             - name: OIDC_IDP_HINT
               value: {{ .Values.ssoIdpHint | default "" | quote }}
-            # Refs #4322: openid-connect-generic plugin source. The Job
-            # VENDORS the plugin from this pinned GitHub release archive
-            # into its ephemeral wp-content (step 4 below) instead of
-            # running `wp plugin install` (which fetches from wordpress.org
-            # over egress and hangs the hook → HR Ready=False on an
-            # air-gapped / slow-egress Sovereign). Same deterministic,
-            # version-pinned mechanism as the pg4wp seed in step 0.
-            - name: OIDC_PLUGIN_REPO
-              value: {{ .Values.oidc.plugin.repo | quote }}
-            - name: OIDC_PLUGIN_VERSION
-              value: {{ .Values.oidc.plugin.version | quote }}
+            # #6311: `oidc.plugin.{repo,version}` moved to the `wp-artifacts`
+            # initContainer, which is where they are now meaningful — it
+            # compares them against the image's baked VERSIONS file. This
+            # container no longer fetches anything, so it no longer needs them.
           command:
             - /bin/sh
             - -c
@@ -170,42 +268,27 @@ spec:
               # pg4wp db.php drop-in for Postgres connectivity, seeded below.
               cd /var/www/html
 
-              # 0. Seed the pg4wp Postgres adapter drop-in into THIS Job's
-              #    ephemeral wp-content (same source + version as the
-              #    deployment's wp-plugin-install initContainer). WordPress
-              #    chain-loads wp-content/db.php on every boot; without it
-              #    wp-cli speaks MySQL and `wp db check` fails against the
-              #    bp-cnpg Postgres backend.
+              # 0. Verify the pg4wp Postgres adapter drop-in is present.
+              #    WordPress chain-loads wp-content/db.php on every boot;
+              #    without it wp-cli speaks MySQL and `wp db check` fails
+              #    against the bp-cnpg Postgres backend.
+              #
+              #    #6311: the drop-in is placed here by the `wp-artifacts`
+              #    initContainer, copied from the runtime image's baked
+              #    /usr/src/openova-wp-artifacts. This step used to `curl`
+              #    the pg4wp release archive from github.com AT INSTALL TIME
+              #    and CrashLoopBackOff on
+              #      curl: (28) Connection timed out after 120001 milliseconds
+              #    — an install-time GitHub dependency that cutover step-08's
+              #    deny-egress hold is designed to forbid (Pillar 5, ADR-0002).
+              #    There is deliberately NO network fallback: a missing
+              #    drop-in means a hollow image pin and must fail loudly.
               if [ ! -f wp-content/db.php ]; then
-                echo "[oidc-config] seeding pg4wp db.php drop-in (Postgres adapter)"
-                mkdir -p wp-content
-                # The release tag is `v3.3.1` — the GitHub archive path keeps
-                # the `v` prefix (this is the SAME URL the deployment's
-                # wp-plugin-install initContainer uses). The bare `3.3.1.zip`
-                # (no `v`) returns HTTP 404, which left this Job FATAL
-                # ("curl: (22) The requested URL returned error: 404") on the
-                # FIRST post-install/post-upgrade hook of a fresh Org — the hook
-                # never seeded db.php, `wp` could not reach the bp-cnpg Postgres
-                # backend, the hook errored, Helm timed out and the HelmRelease
-                # stuck Ready=False (root-caused live on the tkt0625 fresh Org,
-                # omantel.biz region-a). GitHub still extracts the archive to
-                # `postgresql-for-wordpress-3.3.1` (the `v` is stripped from the
-                # top-level directory name), so the cp paths below are unchanged.
-                # --max-time bounds the fetch (mirrors the OIDC-plugin
-                # vendor in step 4): a black-holed GitHub egress route can
-                # then only FAIL FAST (→ OnFailure retry within backoffLimit)
-                # instead of hanging the hook indefinitely → Helm timeout.
-                curl -fsSL --max-time 120 -o /tmp/pg4wp.zip \
-                  https://github.com/PostgreSQL-For-Wordpress/postgresql-for-wordpress/archive/refs/tags/v3.3.1.zip
-                # wp-cli's bundled PHP can unzip without a system `unzip`.
-                php -r '$z=new ZipArchive();$z->open("/tmp/pg4wp.zip");$z->extractTo("/tmp/");$z->close();'
-                cp -a /tmp/postgresql-for-wordpress-3.3.1/pg4wp wp-content/
-                cp /tmp/postgresql-for-wordpress-3.3.1/pg4wp/db.php wp-content/db.php
-                rm -rf /tmp/postgresql-for-wordpress-3.3.1 /tmp/pg4wp.zip
-                echo "[oidc-config] pg4wp db.php seeded"
-              else
-                echo "[oidc-config] pg4wp db.php already present"
+                echo "[oidc-config] FATAL: wp-content/db.php absent — the wp-artifacts" >&2
+                echo "  initContainer did not seed the baked pg4wp drop-in (#6311)." >&2
+                exit 1
               fi
+              echo "[oidc-config] pg4wp db.php present (seeded from the image)"
 
               # 1. Materialise wp-config.php — same contract as the
               #    runtime container's WORDPRESS_CONFIG_EXTRA so the
@@ -290,52 +373,46 @@ spec:
               #    HelmRelease Ready=False (root-caused live on the tkt0626
               #    fresh Org, omantel.biz, chart 0.4.17).
               #
-              #    Fix: VENDOR the plugin from a pinned GitHub release
-              #    archive into THIS Job's wp-content — exactly the
-              #    deterministic, version-pinned mechanism step 0 uses for
-              #    pg4wp. No wordpress.org runtime fetch. GitHub archives
-              #    extract to `<name>-<version>` (un-prefixed tag), so we
-              #    copy from `openid-connect-generic-<version>/`.
+              #    #6311 fix: the plugin files are placed in this Job's
+              #    wp-content by the `wp-artifacts` initContainer, copied
+              #    from the runtime image's baked
+              #    /usr/src/openova-wp-artifacts/plugins. The previous code
+              #    `curl`ed a pinned GitHub release archive here AT INSTALL
+              #    TIME, which is the same Pillar-5 violation as step 0's
+              #    pg4wp fetch — cutover step-08 holds a deny-egress
+              #    NetworkPolicy against github.com for 10 minutes and
+              #    requires the cluster to reconcile green through it.
+              #    This step now only ACTIVATES what is already on disk.
               #
               #    Activation only flips the `active_plugins` option row,
               #    which lives in POSTGRES (not on the ephemeral PVC) — so
               #    once the plugin dir exists here, `wp plugin activate`
-              #    persists the activation for the runtime Pod (whose
-              #    initContainer seeds the real plugin files onto the
-              #    persistent PVC).
+              #    persists the activation for the runtime Pod, whose
+              #    `wp-plugin-install` initContainer seeds the SAME slug
+              #    (`openid-connect-generic`) onto the persistent PVC from
+              #    the SAME baked source. The slugs must match or the option
+              #    row points at a file the runtime PVC does not contain.
               #
-              #    The whole step is WRAPPED so a fetch/activate failure
-              #    LOGS and CONTINUES — it MUST NOT fail the release. A
-              #    fully air-gapped Sovereign with no egress at all still
-              #    reaches Ready (the OIDC settings written in step 5 live
-              #    in Postgres; the runtime initContainer handles the files).
+              #    The step is WRAPPED so an activate failure LOGS and
+              #    CONTINUES — it MUST NOT fail the release, because the
+              #    OIDC settings written in step 5 live in Postgres and the
+              #    runtime initContainer owns the persistent files.
               OIDC_SLUG="openid-connect-generic"
               install_oidc_plugin() {
                 if wp plugin is-installed "${OIDC_SLUG}" --allow-root >/dev/null 2>&1; then
-                  echo "[oidc-config] ${OIDC_SLUG} already present — activating"
+                  echo "[oidc-config] ${OIDC_SLUG} present — activating"
                   wp plugin activate "${OIDC_SLUG}" --allow-root >/dev/null
                   return 0
                 fi
-                # NEVER `wp plugin install` (wordpress.org egress fetch that
-                # hangs the hook). Vendor the pinned GitHub release instead.
-                OIDC_URL="https://github.com/${OIDC_PLUGIN_REPO}/archive/refs/tags/${OIDC_PLUGIN_VERSION}.zip"
-                OIDC_DIR="openid-connect-generic-${OIDC_PLUGIN_VERSION}"
-                echo "[oidc-config] vendoring ${OIDC_SLUG} from ${OIDC_URL}"
-                # --max-time bounds the fetch so a black-holed egress route
-                # can NEVER stall the hook — it fails fast and we continue.
-                if ! curl -fsSL --max-time 120 -o /tmp/oidc.zip "${OIDC_URL}"; then
-                  echo "[oidc-config] WARN: could not fetch ${OIDC_SLUG} from GitHub" \
-                       "(air-gapped / egress blocked?) — the runtime Pod's" \
-                       "wp-plugin-install initContainer seeds it onto the" \
-                       "persistent PVC; continuing without failing the release"
-                  return 0
-                fi
-                php -r '$z=new ZipArchive();$z->open("/tmp/oidc.zip");$z->extractTo("/tmp/");$z->close();'
-                mkdir -p wp-content/plugins
-                cp -a "/tmp/${OIDC_DIR}" "wp-content/plugins/${OIDC_SLUG}"
-                rm -rf "/tmp/${OIDC_DIR}" /tmp/oidc.zip
-                wp plugin activate "${OIDC_SLUG}" --allow-root >/dev/null
-                echo "[oidc-config] ${OIDC_SLUG} vendored + activated"
+                # NEVER `wp plugin install` and NEVER a network fetch — the
+                # bytes come from the image (#6311). Reaching here means the
+                # wp-artifacts initContainer did not seed them.
+                echo "[oidc-config] WARN: ${OIDC_SLUG} not on disk — the wp-artifacts" \
+                     "initContainer did not seed it; the runtime Pod's" \
+                     "wp-plugin-install initContainer still seeds the persistent" \
+                     "PVC from the same baked source. Continuing without failing" \
+                     "the release."
+                return 0
               }
               if ! install_oidc_plugin; then
                 echo "[oidc-config] WARN: ${OIDC_SLUG} install/activate failed —" \
@@ -391,13 +468,31 @@ spec:
               wp option update default_role "${OIDC_DEFAULT_ROLE}" --allow-root >/dev/null
               echo "[oidc-config] default_role set to ${OIDC_DEFAULT_ROLE}"
 
-              # 7. Theme activation — install + activate idempotently.
+              # 7. Theme activation.
+              #
+              #    #6311: the fallback used to be `wp theme install
+              #    <theme> --activate`, which fetches the theme zip from
+              #    wordpress.org. It was ALWAYS reachable, not a rare edge:
+              #    this Job's emptyDir masks the image's bundled themes, so
+              #    `wp theme is-installed` was false on every fresh Org and
+              #    the fetch fired every time. The `wp-artifacts`
+              #    initContainer now seeds core's bundled themes from the
+              #    runtime image, so the default theme is present locally.
+              #
+              #    No network fallback remains. A `defaultTheme` the image
+              #    does not bundle is an operator misconfiguration — WARN and
+              #    leave WordPress on its own default rather than reaching
+              #    out to wordpress.org mid-install (Pillar 5, cutover
+              #    step-08 deny-egress hold).
               if wp theme is-installed "${WP_DEFAULT_THEME}" --allow-root >/dev/null 2>&1; then
                 wp theme activate "${WP_DEFAULT_THEME}" --allow-root >/dev/null
+                echo "[oidc-config] theme ${WP_DEFAULT_THEME} active"
               else
-                wp theme install "${WP_DEFAULT_THEME}" --activate --allow-root
+                echo "[oidc-config] WARN: theme ${WP_DEFAULT_THEME} is not bundled in" \
+                     "the runtime image — leaving the WordPress default active." \
+                     "Bake the theme into platform/wordpress-tenant/image/ or set" \
+                     "defaultTheme to a bundled theme; this Job will NOT fetch it."
               fi
-              echo "[oidc-config] theme ${WP_DEFAULT_THEME} active"
 
               # 8. siteurl + home — overwrite the WP install defaults so
               #    links resolve through the ingress host.

--- a/platform/wordpress-tenant/chart/tests/6311-cnpg-operator-probe-netpol.sh
+++ b/platform/wordpress-tenant/chart/tests/6311-cnpg-operator-probe-netpol.sh
@@ -1,0 +1,291 @@
+#!/usr/bin/env bash
+# bp-wordpress-tenant — CNPG-operator status-probe carve-out (#6311, Refs #3988 #4282).
+#
+# WHAT THIS LOCKS
+# ───────────────
+# This chart renders its CNPG `Cluster` into the Organization's own namespace,
+# which carries the `default-deny-all` + `allow-same-org` NetworkPolicy pair
+# stamped by the Organization controller's GitOps tree. `allow-same-org`
+# re-opens SAME-NAMESPACE traffic only, so the cnpg-system OPERATOR — a
+# different namespace — cannot reach the instance Pod's :8000/pg/status probe.
+# CNPG then parks the Cluster at
+#     Instance Status Extraction Error: HTTP communication issue
+#     readyInstances 1/1 / ConsistentSystemID=False (NotFound)
+# i.e. Ready=False while Postgres is 1/1 Running and serving SQL. Measured live
+# on hw296 `walktwo/wordpress-db` with quota eliminated as a variable; the
+# control `walkone/postgres` — same deny pair, but carrying the #4282 carve-out
+# — read `Cluster in healthy state` 3/3.
+#
+# Every assertion below is VACUITY-PROVED: `--vacuity` re-runs each one against
+# a render with exactly ONE behaviour mutated back to the pre-fix shape and
+# requires it to FAIL. An assertion that cannot go red is not a test.
+#
+# Usage: bash tests/6311-cnpg-operator-probe-netpol.sh [CHART_DIR]
+
+set -euo pipefail
+
+# ABSOLUTE, resolved BEFORE any `cd` — see the note in
+# 6311-no-install-time-egress.sh. CI invokes `bash <script> <chart_dir>` with a
+# chart_dir relative to the repo root, and this script cd's into it, so a
+# relative path would make the repo-root computation below silently wrong.
+CHART_DIR="$(cd "${1:-$(dirname "$0")/..}" && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+cd "$CHART_DIR"
+if [ ! -d charts ] || [ -z "$(ls -A charts 2>/dev/null)" ]; then
+  helm dependency build >/dev/null
+fi
+
+CNPG_API=(--api-versions "postgresql.cnpg.io/v1")
+
+# ──────────────────────────────────────────────────────────────────────────
+# The assertion body, factored out so the SAME code runs against the real
+# render and against each mutated render. This is what makes the vacuity
+# proof honest: a mutation cannot pass because the check drifted.
+# ──────────────────────────────────────────────────────────────────────────
+assert_carveout() {  # $1 = rendered manifest path
+  python3 - "$1" "$CHART_DIR" <<'PYEOF'
+import sys, os, yaml, importlib.util
+docs = [d for d in yaml.safe_load_all(open(sys.argv[1])) if d]
+REPO = os.path.abspath(os.path.join(sys.argv[2], "..", "..", ".."))
+
+nps = [d for d in docs if d.get('kind') == 'NetworkPolicy']
+probe = next((d for d in nps
+              if d['metadata']['name'].endswith('-allow-cnpg-operator-probe')), None)
+assert probe, ("A1 the CNPG-operator probe carve-out NetworkPolicy is not "
+               "rendered — the Cluster will park at 'Instance Status "
+               "Extraction Error: HTTP communication issue' (#6311)")
+
+# A2 — it must select the CNPG instance Pods by the operator's own label,
+#      not by the chart's app labels (the Postgres Pods carry cnpg.io/cluster,
+#      never app.kubernetes.io/name: bp-wordpress-tenant).
+sel = probe['spec'].get('podSelector', {}).get('matchLabels', {})
+cluster = next((d for d in docs if d.get('kind') == 'Cluster'), None)
+assert cluster, "A2 no CNPG Cluster rendered — the carve-out would guard nothing"
+want = cluster['metadata']['name']
+assert sel.get('cnpg.io/cluster') == want, (
+    f"A2 podSelector must match cnpg.io/cluster={want!r}, got {sel!r}")
+
+# A3 — the peer must be the OPERATOR NAMESPACE. A same-namespace podSelector
+#      would be inert: allow-same-org already covers same-namespace traffic,
+#      and the operator is what is being denied.
+ing = probe['spec'].get('ingress') or []
+assert len(ing) >= 1, "A3 carve-out has no ingress rule"
+peers = [p for rule in ing for p in (rule.get('from') or [])]
+ns_labels = [p['namespaceSelector']['matchLabels'] for p in peers
+             if 'namespaceSelector' in p]
+assert any(l.get('kubernetes.io/metadata.name') == 'cnpg-system' for l in ns_labels), (
+    f"A3 carve-out must admit the cnpg-system operator namespace, got {ns_labels!r}")
+assert not any('podSelector' in p for p in peers), (
+    "A3 the carve-out must not add a same-namespace podSelector peer — "
+    "allow-same-org already covers that and it would mask a broken operator peer")
+
+# A4 — both probe ports. 8000 is the status endpoint the phase string comes
+#      from; 9187 is the metrics endpoint. Opening only one leaves the
+#      operator half-blind.
+ports = {p['port'] for rule in ing for p in (rule.get('ports') or [])}
+assert 8000 in ports, f"A4 operator status port 8000 not opened (got {sorted(ports)})"
+assert 9187 in ports, f"A4 operator metrics port 9187 not opened (got {sorted(ports)})"
+
+# A5 — NARROW. The carve-out must not become a blanket allow: no
+#      `namespaceSelector: {}` on the ingress half, and no 5432 (the
+#      bp-postgres #4442 sharedConsumers shape is wrong here — this Cluster's
+#      only consumers are same-namespace and allow-same-org already admits
+#      them).
+assert not any(p.get('namespaceSelector') == {} for p in peers), (
+    "A5 carve-out must not open every namespace (namespaceSelector: {})")
+assert 5432 not in ports, (
+    "A5 carve-out must not open 5432 — same-namespace consumers are already "
+    "admitted by allow-same-org; a broad 5432 rule is the #4442 shared-engine "
+    "shape and does not apply to a per-Org install")
+
+# A7 — the #5617 / #4437 CLASS invariant: a policy that names an egress half
+#      makes the selected endpoint deny-by-default on egress outside the
+#      union, and a per-Org namespace's CiliumNetworkPolicy already constrains
+#      egress WITHOUT naming DNS. So this group MUST carry cluster DNS on both
+#      53/UDP and 53/TCP, or the CNPG instance manager's first name lookup
+#      times out (live: hw292 Org `uatco`, #5617).
+#
+#      The predicate is IMPORTED from the class guard rather than re-written
+#      here. Re-hand-rolling a guard's condition is how a check silently stops
+#      matching the guard it claims to mirror — the guard already rejects five
+#      near-miss shapes (hollow `egress: []`, 53 pointed at the policy's own
+#      namespace, UDP without TCP, DNS via ipBlock 0.0.0.0/0 which cannot
+#      match a pod identity under Cilium) and this test inherits all of them.
+spec = importlib.util.spec_from_file_location(
+    "netpol_guard",
+    os.path.join(REPO, "scripts", "check-netpol-egress-completeness.py"))
+guard = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(guard)
+
+assert probe['spec'].get('policyTypes') == ['Ingress', 'Egress'], (
+    "A7 carve-out must name BOTH halves — an ingress-only policy in a per-Org "
+    "namespace is the #5617 shape; got "
+    f"{probe['spec'].get('policyTypes')!r}")
+dns_ns = guard.dns_namespace()
+egress_rules = [('NetworkPolicy', r) for r in (probe['spec'].get('egress') or [])]
+ok, reason = guard.group_allows_dns(egress_rules, dns_ns)
+assert ok, f"A7 carve-out egress does not reach cluster DNS: {reason}"
+
+# A8 — the egress half is DNS-ONLY. This is a database engine; a blanket
+#      egress peer would be the over-broad "fix" the guard's own fixtures
+#      reject, and it would let the instance dial arbitrary destinations.
+egress_ports = {p['port'] for r in (probe['spec'].get('egress') or [])
+                for p in (r.get('ports') or [])}
+assert egress_ports == {53}, (
+    f"A8 carve-out egress must be DNS-only, got ports {sorted(egress_ports)}")
+egress_peers = [p for r in (probe['spec'].get('egress') or []) for p in (r.get('to') or [])]
+assert egress_peers, "A8 egress rule names no destination — it selects nothing"
+assert not any(p.get('namespaceSelector') == {} or 'ipBlock' in p
+               for p in egress_peers), (
+    "A8 carve-out egress must not use a blanket namespaceSelector or an "
+    "ipBlock (a CIDR never matches an in-cluster pod identity under Cilium, "
+    "#4360 — it would not be DNS coverage at all)")
+
+# A6 — ADDITIVE. The chart must not have weakened or replaced the pod-level
+#      policy it already ships; the WordPress app policy must still be there
+#      with its Ingress+Egress restriction intact.
+app_np = next((d for d in nps
+               if d['metadata']['name'].endswith('-allow-cnpg-operator-probe') is False
+               and d['spec'].get('policyTypes') == ['Ingress', 'Egress']), None)
+assert app_np, ("A6 the chart's own WordPress NetworkPolicy disappeared — the "
+                "carve-out must be additive, never a replacement")
+
+print("  carve-out: podSelector=%s ns=cnpg-system ingress-ports=%s "
+      "policyTypes=%s egress=%s"
+      % (want, sorted(ports), probe['spec']['policyTypes'], reason))
+PYEOF
+}
+
+# ──────────────────────────────────────────────────────────────────────────
+# REAL RENDER — every assertion must pass.
+# ──────────────────────────────────────────────────────────────────────────
+echo "[6311-netpol] Case 1: default (singleton) render carries the CNPG-operator carve-out"
+helm template smoke-wp . "${CNPG_API[@]}" > "$TMP/canonical.yaml"
+assert_carveout "$TMP/canonical.yaml"
+echo "  PASS"
+
+# ──────────────────────────────────────────────────────────────────────────
+# GATE-VACUITY — the render gates must actually gate. Each of these renders
+# is a state the chart genuinely supports; the carve-out must be absent from
+# every one, for a stated reason.
+# ──────────────────────────────────────────────────────────────────────────
+echo "[6311-netpol] Case 2: gates — the carve-out renders ONLY where it belongs"
+gate_absent() {  # $1 = label  $2.. = extra helm args
+  local label="$1"; shift
+  helm template smoke-wp . "$@" > "$TMP/gate.yaml"
+  if grep -q 'allow-cnpg-operator-probe' "$TMP/gate.yaml"; then
+    echo "FAIL: carve-out rendered when it must not — ${label}" >&2
+    exit 1
+  fi
+  echo "  absent as required: ${label}"
+}
+# No CNPG CRD on the cluster → no Cluster is rendered → a policy selecting it
+# would select nothing (and cnpg-cluster.yaml uses the same capability gate).
+gate_absent "no postgresql.cnpg.io/v1 capability"
+# The Cluster itself is off.
+gate_absent "database.cluster.enabled=false" "${CNPG_API[@]}" --set database.cluster.enabled=false
+# The whole NetworkPolicy surface is off (non-Cilium dev cluster).
+gate_absent "networkPolicy.enabled=false" "${CNPG_API[@]}" --set networkPolicy.enabled=false
+# Explicit opt-out for a cluster with no default-deny baseline.
+gate_absent "networkPolicy.cnpgOperator.enabled=false" "${CNPG_API[@]}" \
+  --set networkPolicy.cnpgOperator.enabled=false
+# active-hot-standby: the replica streams WAL cross-cluster over ClusterMesh;
+# an Ingress policyType selecting the Cluster Pods would default-deny that
+# stream, and a remote-cluster peer cannot be expressed in a k8s NetworkPolicy
+# (an ipBlock never matches a ClusterMesh remote endpoint identity). Rendering
+# nothing keeps that path byte-identical rather than trading one break for
+# another. Mirrors bp-postgres, whose #4282 template is singleton-only too.
+gate_absent "database.mode=active-hot-standby" "${CNPG_API[@]}" \
+  --set database.mode=active-hot-standby \
+  --set pg.activeHotStandby.promotion.mechanism=manual \
+  --set pg.activeHotStandby.primaryRegion=hz-fsn-rtz-prod \
+  --set pg.activeHotStandby.replicaRegion=hz-hel-rtz-prod
+echo "  PASS"
+
+# ──────────────────────────────────────────────────────────────────────────
+# VACUITY PROOF — mutate ONE behaviour at a time back to a pre-fix / broken
+# shape and require the SAME assertion body to FAIL. Run with --vacuity, or
+# as part of the default run (it is cheap: pure `helm template` + text edit).
+# ──────────────────────────────────────────────────────────────────────────
+echo "[6311-netpol] Case 3: vacuity proof — every assertion goes RED on its own mutation"
+mutate_must_fail() {  # $1 = label  $2 = python mutation; must end in dump() or write_text()
+  local label="$1" mutation="$2"
+  python3 - "$TMP/canonical.yaml" "$TMP/mutated.yaml" <<PYEOF
+import sys, yaml
+src, dst = sys.argv[1], sys.argv[2]
+text = open(src).read()
+docs = [d for d in yaml.safe_load_all(text) if d]
+
+def probe():
+    return next(d for d in docs if d.get('kind') == 'NetworkPolicy'
+                and d['metadata']['name'].endswith('-allow-cnpg-operator-probe'))
+
+def dump():
+    open(dst, 'w').write("\n---\n".join(yaml.safe_dump(d) for d in docs))
+
+def write_text():
+    open(dst, 'w').write(text)
+
+${mutation}
+PYEOF
+  if assert_carveout "$TMP/mutated.yaml" >/dev/null 2>&1; then
+    echo "FAIL: assertions PASSED against the mutated render — ${label}" >&2
+    echo "      That assertion is vacuous: it cannot detect its own defect." >&2
+    exit 1
+  fi
+  echo "  RED as required: ${label}"
+}
+
+# A1 — remove the carve-out entirely (this IS the pre-fix chart).
+mutate_must_fail "A1 carve-out deleted (pre-fix chart)" \
+  "text = text.replace('-allow-cnpg-operator-probe', '-some-other-policy'); write_text()"
+# A2 — select the wrong Pods (chart app labels instead of cnpg.io/cluster).
+mutate_must_fail "A2 podSelector points at the wrong label" \
+  "probe()['spec']['podSelector']['matchLabels'] = {'app.kubernetes.io/name': 'bp-wordpress-tenant'}; dump()"
+# A3 — point the peer at the wrong namespace (the exact shape that leaves the
+#      operator denied while the policy LOOKS present).
+mutate_must_fail "A3 operator namespace wrong" \
+  "probe()['spec']['ingress'][0]['from'][0]['namespaceSelector']['matchLabels']['kubernetes.io/metadata.name'] = 'kube-system'; dump()"
+# A3 — add an inert same-namespace podSelector peer instead of relying on the
+#      operator namespace peer (looks like a fix, changes nothing).
+mutate_must_fail "A3 same-namespace podSelector peer added" \
+  "probe()['spec']['ingress'][0]['from'].append({'podSelector': {}}); dump()"
+# A4 — open only the metrics port, not the status port the phase string comes from.
+mutate_must_fail "A4 status port 8000 missing" \
+  "probe()['spec']['ingress'][0]['ports'] = [{'port': 9187, 'protocol': 'TCP'}]; dump()"
+# A4 — and the converse.
+mutate_must_fail "A4 metrics port 9187 missing" \
+  "probe()['spec']['ingress'][0]['ports'] = [{'port': 8000, 'protocol': 'TCP'}]; dump()"
+# A5 — blanket namespaceSelector: {} on ingress (the over-broad 'fix').
+mutate_must_fail "A5 blanket namespaceSelector: {} added to ingress" \
+  "probe()['spec']['ingress'].append({'from': [{'namespaceSelector': {}}], 'ports': [{'port': 8000, 'protocol': 'TCP'}]}); dump()"
+# A5 — the #4442 shared-consumer 5432 rule, which does not apply per-Org.
+mutate_must_fail "A5 broad 5432 consumer rule added" \
+  "probe()['spec']['ingress'].append({'from': [{'namespaceSelector': {}}], 'ports': [{'port': 5432, 'protocol': 'TCP'}]}); dump()"
+# A7 — drop the egress half entirely: the ingress-only #5617 shape the class
+#      guard rejects, and the shape this policy shipped before the guard bit.
+mutate_must_fail "A7 egress half dropped (the #5617 ingress-only shape)" \
+  "p = probe(); p['spec']['policyTypes'] = ['Ingress']; p['spec'].pop('egress', None); dump()"
+# A7 — hollow `egress: []` (the #5639 shape: `grep -q egress` would pass).
+mutate_must_fail "A7 hollow egress: [] (grep-passes, resolves nothing)" \
+  "probe()['spec']['egress'] = []; dump()"
+# A7 — 53/UDP only, no TCP fallback for truncated answers.
+mutate_must_fail "A7 53/UDP only, no TCP" \
+  "probe()['spec']['egress'][0]['ports'] = [{'port': 53, 'protocol': 'UDP'}]; dump()"
+# A7 — DNS pointed at the policy's OWN namespace instead of cluster DNS.
+mutate_must_fail "A7 DNS pointed at the Org namespace, not cluster DNS" \
+  "probe()['spec']['egress'][0]['to'] = [{'podSelector': {}}]; dump()"
+# A7 — DNS via ipBlock 0.0.0.0/0, which never matches a pod identity (#4360).
+mutate_must_fail "A7 DNS via ipBlock 0.0.0.0/0 (#4360 — matches no pod)" \
+  "probe()['spec']['egress'][0]['to'] = [{'ipBlock': {'cidr': '0.0.0.0/0'}}]; dump()"
+# A8 — a blanket egress destination on a database engine.
+mutate_must_fail "A8 blanket egress destination added" \
+  "probe()['spec']['egress'].append({'to': [{'namespaceSelector': {}}], 'ports': [{'port': 443, 'protocol': 'TCP'}]}); dump()"
+# A6 — the carve-out REPLACES the chart's own app policy instead of adding to it.
+mutate_must_fail "A6 chart's own WordPress NetworkPolicy removed" \
+  "docs[:] = [d for d in docs if not (d.get('kind') == 'NetworkPolicy' and d['spec'].get('policyTypes') == ['Ingress', 'Egress'])]; dump()"
+echo "  PASS"
+
+echo "[6311-netpol] All #6311 CNPG-operator carve-out gates green."

--- a/platform/wordpress-tenant/chart/tests/6311-no-install-time-egress.sh
+++ b/platform/wordpress-tenant/chart/tests/6311-no-install-time-egress.sh
@@ -1,0 +1,325 @@
+#!/usr/bin/env bash
+# bp-wordpress-tenant — zero install-time egress to third-party artifact hosts
+# (#6311, Refs #3988 #3379).
+#
+# WHAT THIS LOCKS
+# ───────────────
+# Cutover step-08 (`egress-block-test`) holds a 10-minute deny-egress
+# NetworkPolicy against `github.com`, `ghcr.io` and `harbor.openova.io` and
+# requires the cluster to reconcile GREEN through it — that hold IS the
+# sovereignty proof (ADR-0002, Pillar 5). A customer Application whose install
+# path reaches GitHub therefore cannot exist on a sovereign Sovereign.
+#
+# Before this fix bp-wordpress-tenant fetched at install time from THREE sites:
+#   - deployment.yaml `wp-plugin-install` init  → downloads.wordpress.org (OIDC
+#     plugin) and github.com (pg4wp)
+#   - oidc-config-job.yaml step 0               → github.com (pg4wp)
+#   - oidc-config-job.yaml step 4               → github.com (OIDC plugin)
+# and a fourth latent one — step 7's `wp theme install` fallback, reachable
+# because the Job's emptyDir masks the image's bundled themes.
+# The live symptom was the oidc-config Job CrashLoopBackOff on
+#   curl: (28) Connection timed out after 120001 milliseconds
+#
+# THE SEAM REUSED (not invented): this repo mirrors exactly two artifact
+# classes into a post-cutover Sovereign's Harbor — OCI **container images** and
+# **Helm charts** (cutover step-03 `harbor-prewarm`). There is no mirroring
+# path for plain file artifacts. So the bytes now travel as layers of an image
+# that is ALREADY in the prewarm set: `wordpress-tenant-pg`, baked by
+# platform/wordpress-tenant/image/Dockerfile into
+# /usr/src/openova-wp-artifacts.
+#
+# Every assertion is VACUITY-PROVED below: each one is re-run against a render
+# with exactly one behaviour mutated back to the pre-fix shape and must FAIL.
+#
+# Usage: bash tests/6311-no-install-time-egress.sh [CHART_DIR]
+
+set -euo pipefail
+
+# ABSOLUTE, resolved BEFORE any `cd`. The release gate and chart-tests-pr both
+# invoke `bash <script> <chart_dir>` with a chart_dir RELATIVE to the repo root,
+# and this script cd's into it — so a relative path left every later
+# `$CHART_DIR/...` reference resolving against the new cwd. That is how the
+# first CI run died on
+#   FileNotFoundError: platform/wordpress-tenant/chart/../image/Dockerfile
+# while passing locally, where the default argument is already absolute.
+CHART_DIR="$(cd "${1:-$(dirname "$0")/..}" && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+cd "$CHART_DIR"
+if [ ! -d charts ] || [ -z "$(ls -A charts 2>/dev/null)" ]; then
+  helm dependency build >/dev/null
+fi
+
+# ──────────────────────────────────────────────────────────────────────────
+# Assertion body — shared by the real render and every mutation.
+# ──────────────────────────────────────────────────────────────────────────
+assert_no_egress() {  # $1 = rendered manifest path
+  python3 - "$1" <<'PYEOF'
+import sys, yaml
+
+docs = [d for d in yaml.safe_load_all(open(sys.argv[1])) if d]
+
+def pod_specs(d):
+    k = d.get('kind')
+    if k in ('Deployment', 'StatefulSet', 'Job'):
+        return [d['spec']['template']['spec']]
+    if k == 'CronJob':
+        return [d['spec']['jobTemplate']['spec']['template']['spec']]
+    return []
+
+specs = [(d, s) for d in docs for s in pod_specs(d)]
+assert specs, "no workloads rendered — this scan would pass vacuously"
+
+def containers(spec):
+    return (spec.get('initContainers') or []) + (spec.get('containers') or [])
+
+def exec_lines(c):
+    """Executable shell lines only. Comments are stripped deliberately: the
+    prose in these templates names the very hosts and commands being
+    forbidden (that is how the change documents itself), so a raw substring
+    scan would false-positive on its own rationale."""
+    body = "\n".join(c.get('command') or []) + "\n" + "\n".join(c.get('args') or [])
+    out = []
+    for ln in body.splitlines():
+        s = ln.strip()
+        if not s or s.startswith('#'):
+            continue
+        out.append(s)
+    return out
+
+scanned = 0
+offenders = []
+FORBIDDEN_HOSTS = ('github.com', 'wordpress.org', 'raw.githubusercontent.com',
+                   'ghcr.io', 'deb.debian.org')
+for doc, spec in specs:
+    for c in containers(spec):
+        for ln in exec_lines(c):
+            scanned += 1
+            for host in FORBIDDEN_HOSTS:
+                # `wordpress.org.local` is the DERIVED ingress host of the
+                # default test render (orgDomain=org.local) — a hostname the
+                # chart serves, not one it fetches from. Only flag a forbidden
+                # host when the line is actually a fetch.
+                if host in ln and any(
+                        tok in ln for tok in ('curl', 'wget', 'http://', 'https://')):
+                    if host == 'wordpress.org' and 'wordpress.org.local' in ln \
+                            and 'wordpress.org/' not in ln:
+                        continue
+                    offenders.append((doc['kind'], doc['metadata']['name'],
+                                      c['name'], host, ln[:120]))
+
+assert scanned > 50, (
+    f"B0 only {scanned} executable lines scanned — the scan is too shallow to "
+    "be believed; the chart's install scripts are hundreds of lines")
+
+# B1 — no install-time fetch from any third-party artifact host, in ANY
+#      container of ANY workload. Scanning only the main container is how a
+#      reintroduced fetch would hide in an initContainer.
+assert not offenders, (
+    "B1 install-time egress to a third-party artifact host — cutover step-08's "
+    "deny-egress hold would fail here (#6311):\n" +
+    "\n".join(f"  {k}/{n} [{c}] -> {h}: {ln}" for k, n, c, h, ln in offenders))
+
+# B2 — no `wp plugin install` / `wp theme install` (wp-cli's own network
+#      installers; they fetch from wordpress.org without naming the host, so
+#      the host scan above cannot see them).
+wp_net = [(d['metadata']['name'], c['name'], ln)
+          for d, s in specs for c in containers(s) for ln in exec_lines(c)
+          if ln.startswith('wp plugin install') or ln.startswith('wp theme install')]
+assert not wp_net, (
+    "B2 wp-cli network installer invoked at install time (fetches from "
+    f"wordpress.org): {wp_net}")
+
+# B3 — the artifacts must be SOURCED from the image's baked path, in both
+#      consumers. An absent fetch is not enough: something has to supply the
+#      bytes, or WordPress simply has no Postgres driver.
+BAKED = '/usr/src/openova-wp-artifacts'
+consumers = {}
+for d, s in specs:
+    for c in containers(s):
+        if any(BAKED in ln for ln in exec_lines(c)):
+            consumers.setdefault(d['kind'], set()).add(c['name'])
+assert 'wp-plugin-install' in consumers.get('Deployment', set()), (
+    "B3 the runtime Deployment's wp-plugin-install initContainer must seed "
+    f"the PVC from {BAKED}")
+assert 'wp-artifacts' in consumers.get('Job', set()), (
+    "B3 the oidc-config Job must carry a wp-artifacts initContainer seeding "
+    f"its ephemeral wp-content from {BAKED}")
+
+# B4 — the wp-artifacts initContainer must run the RUNTIME image. The wp-cli
+#      image is upstream and carries nothing baked, so sourcing from it would
+#      be a copy from an empty path that only fails at runtime.
+job = next(d for d, _ in specs if d['kind'] == 'Job'
+           and d['metadata']['name'].endswith('-oidc-config'))
+art = next(c for c in (job['spec']['template']['spec'].get('initContainers') or [])
+           if c['name'] == 'wp-artifacts')
+assert 'wordpress-tenant-pg' in art['image'], (
+    f"B4 wp-artifacts must run the runtime image, got {art['image']}")
+assert any(m['name'] == 'wp-content' for m in (art.get('volumeMounts') or [])), \
+    "B4 wp-artifacts must mount the shared wp-content volume or it seeds nothing"
+
+# B5 — FAIL CLOSED, never fall back to the network. Both consumers must abort
+#      when the baked path is absent (a hollow image pin), because a silent
+#      fallback is exactly the sovereignty violation being removed.
+for kind, cname in (('Deployment', 'wp-plugin-install'), ('Job', 'wp-artifacts')):
+    c = next(c for d, s in specs if d['kind'] == kind
+             for c in containers(s) if c['name'] == cname)
+    lines = exec_lines(c)
+    joined = "\n".join(lines)
+    assert f'if [ ! -d "$' in joined and 'exit 1' in joined, (
+        f"B5 {kind}/{cname} must fail closed when {BAKED} is absent, not fall "
+        "back to a network fetch")
+
+print(f"  scanned {scanned} executable lines across "
+      f"{sum(len(containers(s)) for _, s in specs)} containers; "
+      "zero third-party fetches; artifacts sourced from the image")
+PYEOF
+}
+
+echo "[6311-egress] Case 1: default render performs ZERO install-time third-party fetches"
+helm template smoke-wp . --api-versions "postgresql.cnpg.io/v1" > "$TMP/canonical.yaml"
+assert_no_egress "$TMP/canonical.yaml"
+echo "  PASS"
+
+echo "[6311-egress] Case 2: the same holds with an air-gapped-style overlay (harbor registry prefix)"
+helm template smoke-wp . --api-versions "postgresql.cnpg.io/v1" \
+  --set global.imageRegistry=harbor.t99.omani.works/proxy-ghcr \
+  --set orgDomain=acme.omani.homes > "$TMP/overlay.yaml"
+assert_no_egress "$TMP/overlay.yaml"
+echo "  PASS"
+
+echo "[6311-egress] Case 3: the Dockerfile actually bakes what the chart copies"
+assert_dockerfile() {  # $1 = Dockerfile path
+  python3 - "$1" <<'PYEOF'
+import sys, re
+df = open(sys.argv[1]).read()
+# C1 — the baked path the chart copies from must be produced here.
+assert '/usr/src/openova-wp-artifacts' in df, \
+  "C1 Dockerfile does not create /usr/src/openova-wp-artifacts"
+# C2 — both artifacts, pinned by an explicit version ARG (no floating ref,
+#      docs/PRINCIPLES.md #4).
+for arg in ('PG4WP_VERSION', 'OIDC_PLUGIN_VERSION', 'OIDC_PLUGIN_REPO'):
+    m = re.search(rf'^ARG {arg}=(\S+)', df, re.M)
+    assert m, f"C2 Dockerfile must pin {arg} as an ARG"
+    assert 'main' not in m.group(1) and 'latest' not in m.group(1), \
+      f"C2 {arg} must be a pinned release, got {m.group(1)}"
+# C3 — a build-time assertion on the exact three paths the chart copies, so an
+#      image that silently ships without them can never be published (the chart
+#      has no network fallback any more).
+for path in ('/usr/src/openova-wp-artifacts/db.php',
+             '/usr/src/openova-wp-artifacts/pg4wp/driver_pgsql.php',
+             '/usr/src/openova-wp-artifacts/plugins/openid-connect-generic/openid-connect-generic.php'):
+    assert f'test -s {path}' in df, \
+      f"C3 Dockerfile must assert {path} exists at build time"
+# C4 — the plugin must be baked under the BARE slug, which is what the Job's
+#      `wp plugin activate` writes into WordPress's active_plugins option row.
+assert re.search(r'/plugins/openid-connect-generic(?![-\w])', df), \
+  "C4 the plugin must be baked under the bare `openid-connect-generic` slug"
+print("  Dockerfile bakes both artifacts, version-pinned, with build-time assertions")
+PYEOF
+}
+assert_dockerfile "$CHART_DIR/../image/Dockerfile"
+echo "  PASS"
+
+echo "[6311-egress] Case 3b: vacuity proof — each Dockerfile assertion goes RED on its own mutation"
+df_mutate_must_fail() {  # $1 = label  $2 = python: mutates `df`, then write()
+  local label="$1" mutation="$2"
+  python3 - "$CHART_DIR/../image/Dockerfile" "$TMP/Dockerfile.mutated" <<PYEOF
+import sys
+df = open(sys.argv[1]).read()
+def write():
+    open(sys.argv[2], 'w').write(df)
+${mutation}
+PYEOF
+  if assert_dockerfile "$TMP/Dockerfile.mutated" >/dev/null 2>&1; then
+    echo "FAIL: Dockerfile assertions PASSED against the mutated file — ${label}" >&2
+    exit 1
+  fi
+  echo "  RED as required: ${label}"
+}
+# C1 — the baked directory is not produced at all (the pre-fix Dockerfile).
+df_mutate_must_fail "C1 baked artifact path absent (pre-fix Dockerfile)" \
+  "df = df.replace('/usr/src/openova-wp-artifacts', '/usr/src/somewhere-else'); write()"
+# C2 — a floating ref instead of a pinned release.
+df_mutate_must_fail "C2 PG4WP_VERSION floated to main" \
+  "df = df.replace('ARG PG4WP_VERSION=3.3.1', 'ARG PG4WP_VERSION=main'); write()"
+df_mutate_must_fail "C2 OIDC_PLUGIN_VERSION floated to latest" \
+  "import re; df = re.sub(r'ARG OIDC_PLUGIN_VERSION=\S+', 'ARG OIDC_PLUGIN_VERSION=latest', df); write()"
+# C3 — the build-time assertion is dropped, so an image missing the artifacts
+#      could publish and every per-Org install would fail on a hollow pin.
+df_mutate_must_fail "C3 build-time assertion on db.php removed" \
+  "df = df.replace('test -s /usr/src/openova-wp-artifacts/db.php;', 'true;'); write()"
+df_mutate_must_fail "C3 build-time assertion on the plugin removed" \
+  "df = df.replace('test -s /usr/src/openova-wp-artifacts/plugins/openid-connect-generic/openid-connect-generic.php', 'true'); write()"
+# C4 — baked under the old wordpress.org slug, which does not match the slug
+#      the Job writes into WordPress's active_plugins option row.
+df_mutate_must_fail "C4 plugin baked under the wordpress.org slug" \
+  "df = df.replace('plugins/openid-connect-generic', 'plugins/daggerhart-openid-connect-generic'); write()"
+echo "  PASS"
+
+echo "[6311-egress] Case 4: vacuity proof — every assertion goes RED on its own mutation"
+mutate_must_fail() {  # $1 = label  $2 = python mutation; must end in dump()
+  local label="$1" mutation="$2"
+  python3 - "$TMP/canonical.yaml" "$TMP/mutated.yaml" <<PYEOF
+import sys, yaml
+src, dst = sys.argv[1], sys.argv[2]
+docs = [d for d in yaml.safe_load_all(open(src)) if d]
+
+def job():
+    return next(d for d in docs if d.get('kind') == 'Job'
+                and d['metadata']['name'].endswith('-oidc-config'))
+
+def deploy():
+    return next(d for d in docs if d.get('kind') == 'Deployment')
+
+def container(doc, name):
+    spec = doc['spec']['template']['spec']
+    return next(c for c in (spec.get('initContainers') or []) + spec['containers']
+                if c['name'] == name)
+
+def dump():
+    open(dst, 'w').write("\n---\n".join(yaml.safe_dump(d) for d in docs))
+
+${mutation}
+PYEOF
+  if assert_no_egress "$TMP/mutated.yaml" >/dev/null 2>&1; then
+    echo "FAIL: assertions PASSED against the mutated render — ${label}" >&2
+    echo "      That assertion is vacuous: it cannot detect its own defect." >&2
+    exit 1
+  fi
+  echo "  RED as required: ${label}"
+}
+
+# B1 — reintroduce the exact pre-fix pg4wp fetch, in the Job (step 0's shape).
+mutate_must_fail "B1 github.com pg4wp fetch reintroduced in the Job" \
+  "c = container(job(), 'oidc-config'); c['command'][-1] += '\ncurl -fsSL --max-time 120 -o /tmp/pg4wp.zip https://github.com/PostgreSQL-For-Wordpress/postgresql-for-wordpress/archive/refs/tags/v3.3.1.zip\n'; dump()"
+# B1 — reintroduce it in an INIT container, which a main-container-only scan
+#      would miss entirely.
+mutate_must_fail "B1 wordpress.org fetch reintroduced in an initContainer" \
+  "c = container(deploy(), 'wp-plugin-install'); c['command'][-1] += '\ncurl -fsSL -o oidc.zip https://downloads.wordpress.org/plugin/daggerhart-openid-connect-generic.latest-stable.zip\n'; dump()"
+# B2 — wp-cli's own network installer (no hostname on the line at all).
+mutate_must_fail "B2 wp plugin install reintroduced" \
+  "c = container(job(), 'oidc-config'); c['command'][-1] += '\nwp plugin install openid-connect-generic --activate --allow-root\n'; dump()"
+mutate_must_fail "B2 wp theme install reintroduced" \
+  "c = container(job(), 'oidc-config'); c['command'][-1] += '\nwp theme install twentytwentyfive --activate --allow-root\n'; dump()"
+# B3 — drop the Job's artifact initContainer (nothing supplies the bytes).
+mutate_must_fail "B3 wp-artifacts initContainer removed from the Job" \
+  "s = job()['spec']['template']['spec']; s['initContainers'] = [c for c in s['initContainers'] if c['name'] != 'wp-artifacts']; dump()"
+# B3 — drop the Deployment's baked-path seed.
+mutate_must_fail "B3 Deployment no longer seeds from the baked path" \
+  "c = container(deploy(), 'wp-plugin-install'); c['command'][-1] = c['command'][-1].replace('/usr/src/openova-wp-artifacts', '/tmp/nowhere'); dump()"
+# B4 — point wp-artifacts at the upstream wp-cli image, which carries nothing.
+mutate_must_fail "B4 wp-artifacts runs the upstream wp-cli image" \
+  "container(job(), 'wp-artifacts')['image'] = 'wordpress:cli-2.12.0-php8.3'; dump()"
+# B4 — mount nothing, so the copy lands in the container's own filesystem.
+mutate_must_fail "B4 wp-artifacts does not mount wp-content" \
+  "container(job(), 'wp-artifacts')['volumeMounts'] = []; dump()"
+# B5 — replace the fail-closed guard with a silent network fallback.
+mutate_must_fail "B5 fail-closed guard replaced by a fallback in the Job" \
+  "c = container(job(), 'wp-artifacts'); c['command'][-1] = c['command'][-1].replace('exit 1', 'curl -fsSL -o /tmp/x.zip https://github.com/x/y/archive/refs/tags/v1.zip'); dump()"
+mutate_must_fail "B5 fail-closed guard removed from the Deployment init" \
+  "c = container(deploy(), 'wp-plugin-install'); c['command'][-1] = c['command'][-1].replace('exit 1', 'true'); dump()"
+echo "  PASS"
+
+echo "[6311-egress] All #6311 no-install-time-egress gates green."

--- a/platform/wordpress-tenant/chart/tests/imagepullsecrets-render.sh
+++ b/platform/wordpress-tenant/chart/tests/imagepullsecrets-render.sh
@@ -85,14 +85,36 @@ if ! grep -q "name: ghcr-pull" <<<"$admin_job"; then
 fi
 echo "[bp-wordpress-tenant] Case 2: PASS"
 
-# ── Case 3: oidc-config Job (PUBLIC cli image) has NO imagePullSecrets ────
-echo "[bp-wordpress-tenant] Case 3: oidc-config Job — no imagePullSecrets (public cli image)"
+# ── Case 3: oidc-config Job carries ghcr-pull — its wp-artifacts init runs
+#            the PRIVATE runtime image (#6311, supersedes the pre-0.4.24
+#            "public cli image only" assumption) ────────────────────────────
+# Until #6311 this Job ran ONLY the public dockerhub `wordpress:cli-*` image,
+# so it deliberately carried no pull secret. It now also runs a `wp-artifacts`
+# initContainer on the PRIVATE `wordpress-tenant-pg` runtime image — that is
+# where the baked pg4wp + openid-connect-generic artifacts live, and the whole
+# point of #6311 is that they are never fetched over the network. Without the
+# pull secret that initContainer ImagePullBackOffs, the post-install hook never
+# runs, Helm times out and the HelmRelease sticks Ready=False.
+#
+# The requirement is DERIVED, not asserted by fiat: the case first proves the
+# Job actually references the private image, then requires the secret.
+echo "[bp-wordpress-tenant] Case 3: oidc-config Job — imagePullSecrets present (private artifact image)"
 oidc_job=$(job_by_name "$out" "-oidc-config")
 if [ -z "$oidc_job" ]; then
   echo "FAIL: oidc-config Job did not render"; exit 1
 fi
-if grep -q "imagePullSecrets:" <<<"$oidc_job"; then
-  echo "FAIL: oidc-config Job (public wordpress:cli-* image) must not carry imagePullSecrets"; exit 1
+if ! grep -q "wordpress-tenant-pg" <<<"$oidc_job"; then
+  echo "FAIL: oidc-config Job does not reference the private wordpress-tenant-pg image;"
+  echo "      the #6311 wp-artifacts initContainer must run it (nothing else carries"
+  echo "      the baked pg4wp + OIDC plugin bytes)"; exit 1
+fi
+if ! grep -q "imagePullSecrets:" <<<"$oidc_job"; then
+  echo "FAIL: oidc-config Job references the PRIVATE wordpress-tenant-pg image but"
+  echo "      carries no imagePullSecrets — the wp-artifacts initContainer will"
+  echo "      ImagePullBackOff and the post-install hook will never run (#6311)"; exit 1
+fi
+if ! grep -q "name: ghcr-pull" <<<"$oidc_job"; then
+  echo "FAIL: oidc-config Job imagePullSecrets does not reference ghcr-pull"; exit 1
 fi
 echo "[bp-wordpress-tenant] Case 3: PASS"
 
@@ -136,6 +158,13 @@ if ! grep -q "name: my-private-registry-creds" <<<"$deployment_block6"; then
 fi
 if grep -q "name: ghcr-pull" <<<"$deployment_block6"; then
   echo "FAIL: custom override leaked default ghcr-pull reference"; exit 1
+fi
+# #6311: the override must reach the oidc-config Job too — it is now a private-
+# image consumer, so a Sovereign that renames the secret must not be left with
+# one workload pointing at a Secret that does not exist there.
+oidc_job6=$(job_by_name "$out6" "-oidc-config")
+if ! grep -q "name: my-private-registry-creds" <<<"$oidc_job6"; then
+  echo "FAIL: custom imagePullSecret name not propagated to the oidc-config Job (#6311)"; exit 1
 fi
 echo "[bp-wordpress-tenant] Case 5: PASS"
 

--- a/platform/wordpress-tenant/chart/tests/oidc-config.sh
+++ b/platform/wordpress-tenant/chart/tests/oidc-config.sh
@@ -231,42 +231,57 @@ mount = next((m for m in mounts if m['name'] == 'wp-content'), None)
 assert mount, "wp-content volume not mounted into container"
 assert mount['mountPath'] == '/var/www/html/wp-content', \
   f"unexpected mountPath: {mount['mountPath']}"
-# The Job's command MUST self-seed the pg4wp db.php drop-in (so wp-cli
-# speaks Postgres without depending on the runtime PVC's seeded copy).
+# The Job MUST still end up with the pg4wp db.php drop-in in its OWN
+# wp-content (so wp-cli speaks Postgres without depending on the runtime
+# PVC's copy) — the requirement #4220 established is unchanged.
 cmd = "\n".join(spec['containers'][0].get('command') or []) \
     + "\n".join(spec['containers'][0].get('args') or [])
-assert 'pg4wp' in cmd and 'db.php' in cmd, \
-  "oidc-config Job command must self-seed the pg4wp db.php drop-in"
-# 0.4.17 (Refs #4220): the pg4wp GitHub archive tag is `v3.3.1` — the bare
-# `tags/3.3.1.zip` (no `v`) 404s, which left a fresh Org's HR Ready=False
-# (the hook errored on its first run). Assert the `v`-prefixed URL and reject
-# the un-prefixed form so the regression cannot recur.
-assert 'archive/refs/tags/v3.3.1.zip' in cmd, \
-  "oidc-config Job must fetch pg4wp from the v-prefixed tag (v3.3.1.zip), not a 404 path"
-assert 'archive/refs/tags/3.3.1.zip' not in cmd, \
-  "oidc-config Job must NOT use the un-prefixed pg4wp tag (3.3.1.zip 404s)"
-print(f"  emptyDir wp-content -> {mount['mountPath']}; pg4wp db.php self-seeded (v3.3.1)")
+assert 'pg4wp' in cmd or 'db.php' in cmd, \
+  "oidc-config Job must still depend on the pg4wp db.php drop-in"
+# #6311 supersedes the 0.4.17/#4220 URL assertion. That assertion pinned the
+# `v`-prefixed GitHub archive tag because the Job FETCHED pg4wp at install
+# time; it no longer does — cutover step-08 holds a deny-egress NetworkPolicy
+# against github.com, so an install-time fetch is a Pillar-5 violation and the
+# Job was CrashLoopBackOff'ing on `curl: (28) Connection timed out`. The bytes
+# now arrive from the runtime image's baked /usr/src/openova-wp-artifacts via
+# the `wp-artifacts` initContainer; the version pin moved to the Dockerfile's
+# PG4WP_VERSION ARG, where tests/6311-no-install-time-egress.sh asserts it.
+seed = next((c for c in (spec.get('initContainers') or [])
+             if c['name'] == 'wp-artifacts'), None)
+assert seed, "oidc-config Job must carry the wp-artifacts seeding initContainer (#6311)"
+seed_cmd = "\n".join(seed.get('command') or []) + "\n".join(seed.get('args') or [])
+assert '/usr/src/openova-wp-artifacts' in seed_cmd, \
+  "wp-artifacts initContainer must seed from the image's baked artifact path"
+assert 'db.php' in seed_cmd, "wp-artifacts initContainer must seed the pg4wp db.php drop-in"
+assert 'archive/refs/tags' not in cmd and 'archive/refs/tags' not in seed_cmd, \
+  "the Job must NOT fetch a release archive at install time (#6311)"
+print(f"  emptyDir wp-content -> {mount['mountPath']}; pg4wp db.php seeded from the image")
 PYEOF
 echo "  PASS"
 
-echo "[oidc-config] Case 8: oidc plugin is VENDORED from a pinned GitHub release — the hook never depends on a wordpress.org fetch (#4322)"
-# #4322: this Job mounts an EPHEMERAL emptyDir (Case 7), so the plugin the
-# runtime Deployment seeds onto the persistent PVC is NOT visible here. The
-# previous `wp plugin install openid-connect-generic --activate` therefore
-# ALWAYS fetched the plugin zip from wordpress.org over egress and HUNG the
-# hook until its deadline on a slow-egress / air-gapped Sovereign → the
-# post-upgrade hook timed out → HelmRelease Ready=False. The fix VENDORS the
-# plugin from a pinned GitHub release archive (same mechanism as the pg4wp
-# db.php seed) and TOLERATES a fetch failure (logs + continues) so the release
-# reaches Ready WITHOUT any external plugin download.
+echo "[oidc-config] Case 8: oidc plugin comes from the IMAGE — the hook fetches nothing at install time (#6311, supersedes #4322)"
+# #4322 removed the `wp plugin install` wordpress.org fetch by VENDORING the
+# plugin from a pinned GitHub release archive at install time. #6311 removes
+# that too: cutover step-08 (`egress-block-test`) holds a 10-minute deny-egress
+# NetworkPolicy against github.com / ghcr.io / harbor.openova.io and requires
+# the cluster to reconcile green through it, so an install-time GitHub fetch is
+# a Pillar-5 violation — and it was CrashLoopBackOff'ing live on
+# `curl: (28) Connection timed out after 120001 milliseconds`.
 #
-# Assert (on the rendered oidc-config Job command):
-#   - NO `wp plugin install` (the wordpress.org egress fetch that hangs).
-#   - NO `wordpress.org` / `downloads.wordpress.org` reference at all.
-#   - The plugin is vendored from the pinned GitHub release archive whose
-#     repo + version come from oidc.plugin.{repo,version}.
-#   - The step is fetch-bounded (`--max-time`) and tolerant (a fetch failure
-#     does not abort the script — it continues so the HR reaches Ready).
+# The plugin + pg4wp bytes now travel INSIDE the runtime image
+# (/usr/src/openova-wp-artifacts, baked by platform/wordpress-tenant/image/
+# Dockerfile) and are copied into this Job's ephemeral wp-content by the
+# `wp-artifacts` initContainer. That reuses the ONLY artifact-mirroring seam
+# this repo has — cutover step-03 `harbor-prewarm` mirrors OCI images and Helm
+# charts, and `wordpress-tenant-pg` is already in that set.
+#
+# Assert (on the rendered oidc-config Job):
+#   - NO `wp plugin install`, NO `wordpress.org`, NO `github.com` on ANY
+#     executable line of ANY container in the Job.
+#   - A `wp-artifacts` initContainer runs the RUNTIME image and copies from
+#     /usr/src/openova-wp-artifacts into the shared wp-content volume.
+#   - The main container still ACTIVATES the plugin, and still tolerates a
+#     missing plugin (logs + continues) so the HR reaches Ready.
 python3 - "$TMP/canonical.yaml" <<'PYEOF'
 import sys, yaml
 docs = list(yaml.safe_load_all(open(sys.argv[1])))
@@ -281,43 +296,65 @@ container = spec['containers'][0]
 cmd = "\n".join(container.get('command') or []) \
     + "\n".join(container.get('args') or [])
 
-# (1) The hook MUST NOT INVOKE `wp plugin install` (the wordpress.org egress
-#     fetch that hangs the hook). We check command LINES, not prose — the
-#     surrounding comments legitimately explain why we avoid that command, so a
-#     naive substring match would false-positive on `# ... wp plugin install`.
-invocation_lines = [
-    ln.lstrip() for ln in cmd.splitlines()
-    if ln.lstrip() and not ln.lstrip().startswith('#')
-]
+# Executable lines across EVERY container in the Job (init + main). Comments are
+# excluded on purpose: the surrounding prose legitimately names the commands and
+# hosts we are forbidding, so a naive substring match would false-positive on
+# its own explanation. Scanning only the main container would also have missed
+# a fetch reintroduced in an initContainer — the seam this case now guards.
+def exec_lines(c):
+    text = "\n".join(c.get('command') or []) + "\n" + "\n".join(c.get('args') or [])
+    return [ln.strip() for ln in text.splitlines()
+            if ln.strip() and not ln.strip().startswith('#')]
+
+all_containers = (spec.get('initContainers') or []) + spec['containers']
+invocation_lines = [ln for c in all_containers for ln in exec_lines(c)]
+assert invocation_lines, "no executable lines found — the scan would pass vacuously"
+
+# (1) No `wp plugin install` (the wordpress.org egress fetch that hangs).
 assert not any(ln.startswith('wp plugin install') for ln in invocation_lines), \
   "oidc-config hook must NOT run `wp plugin install` (it fetches from " \
   "wordpress.org over egress and hangs the hook → HR Ready=False)"
 
-# (2) No command line may fetch from wordpress.org (air-gapped Sovereigns cannot
-#     reach it — a runtime fetch from there is structurally wrong).
-assert not any('wordpress.org' in ln for ln in invocation_lines), \
-  "oidc-config hook must not depend on a wordpress.org plugin fetch"
+# (2) No install-time fetch from ANY external artifact host — this is the
+#     Pillar-5 contract cutover step-08 enforces at runtime (#6311).
+for host in ('wordpress.org', 'github.com'):
+    offenders = [ln for ln in invocation_lines if host in ln]
+    assert not offenders, (
+        f"oidc-config Job must not fetch from {host} at install time "
+        f"(cutover step-08 deny-egress hold, Pillar 5) — offending line(s): "
+        f"{offenders[:3]}")
 
-# (3) The plugin MUST be vendored from a PINNED GitHub release archive, with
-#     repo + version threaded from oidc.plugin.{repo,version} via env.
-env = {e['name']: e.get('value') for e in (container.get('env') or [])}
+# (3) The artifacts MUST arrive via a `wp-artifacts` initContainer running the
+#     RUNTIME image (the wp-cli image is upstream and carries nothing baked),
+#     copying from the baked path into the shared wp-content volume.
+inits = {c['name']: c for c in (spec.get('initContainers') or [])}
+art = inits.get('wp-artifacts')
+assert art, "oidc-config Job must carry a `wp-artifacts` initContainer (#6311)"
+assert 'wordpress-tenant-pg' in art['image'], \
+  ("the wp-artifacts initContainer must run the RUNTIME image that carries the "
+   f"baked artifacts, got {art['image']}")
+art_cmd = "\n".join(art.get('command') or []) + "\n".join(art.get('args') or [])
+assert '/usr/src/openova-wp-artifacts' in art_cmd, \
+  "wp-artifacts initContainer must copy from the image's baked artifact path"
+assert any(m['name'] == 'wp-content' for m in (art.get('volumeMounts') or [])), \
+  "wp-artifacts initContainer must mount the shared wp-content volume"
+
+# (4) The main container still activates, and still tolerates absence so a
+#     partially-seeded Pod cannot fail the release.
+assert 'wp plugin activate' in cmd, \
+  "oidc-config hook must `wp plugin activate` the image-seeded plugin"
+assert 'continuing without failing' in cmd or 'continuing so the release' in cmd, \
+  "the OIDC plugin activate must LOG + CONTINUE on failure (never fail the " \
+  "release) so the HR reaches Ready"
+
+# (5) Provenance env stays threaded from oidc.plugin.{repo,version} — the
+#     wp-artifacts initContainer compares it against the image's baked VERSIONS
+#     file and warns on drift.
+env = {e['name']: e.get('value') for e in (art.get('env') or [])}
 assert env.get('OIDC_PLUGIN_REPO'), "OIDC_PLUGIN_REPO env not rendered from oidc.plugin.repo"
 assert env.get('OIDC_PLUGIN_VERSION'), "OIDC_PLUGIN_VERSION env not rendered from oidc.plugin.version"
-assert 'github.com/${OIDC_PLUGIN_REPO}/archive/refs/tags/${OIDC_PLUGIN_VERSION}.zip' in cmd, \
-  "oidc-config hook must vendor the OIDC plugin from the pinned GitHub release archive"
-assert 'wp plugin activate' in cmd, \
-  "oidc-config hook must `wp plugin activate` the vendored plugin"
-
-# (4) The fetch MUST be time-bounded AND the step MUST be tolerant (continue on
-#     failure) so a black-holed egress route can never stall/fail the release.
-assert '--max-time' in cmd, \
-  "the OIDC plugin fetch must be --max-time bounded so a black-holed egress " \
-  "route cannot stall the hook"
-assert 'continuing without failing the release' in cmd or 'continuing so the release' in cmd, \
-  "the OIDC plugin install must LOG + CONTINUE on failure (never fail the " \
-  "release) so the HR reaches Ready without an external plugin download"
-print(f"  OIDC plugin vendored from GitHub ({env['OIDC_PLUGIN_REPO']} "
-      f"{env['OIDC_PLUGIN_VERSION']}); no wordpress.org fetch; tolerant + bounded")
+print(f"  OIDC plugin seeded from the image ({env['OIDC_PLUGIN_REPO']} "
+      f"{env['OIDC_PLUGIN_VERSION']} declared); zero install-time egress")
 PYEOF
 echo "  PASS"
 

--- a/platform/wordpress-tenant/chart/values.yaml
+++ b/platform/wordpress-tenant/chart/values.yaml
@@ -598,6 +598,40 @@ networkPolicy:
     # namespace; operator overrides if it lives elsewhere.
     keycloakNamespaceLabel: "keycloak"
     keycloakPort: 8443
+  # ─── CNPG-operator status-probe carve-out (#6311, Refs #3988 #4282) ────
+  # This chart lands its CNPG Cluster in the Organization's OWN namespace,
+  # which carries the `default-deny-all` + `allow-same-org` pair stamped by
+  # the Organization controller's GitOps tree. `allow-same-org` re-opens
+  # SAME-NAMESPACE traffic only, so the cnpg-system OPERATOR (a different
+  # namespace) cannot reach the instance Pod's :8000/pg/status probe — the
+  # Cluster then parks at "Instance Status Extraction Error: HTTP
+  # communication issue" / Ready=False while Postgres is 1/1 Running and
+  # serving SQL (measured on hw296 walktwo/wordpress-db with quota
+  # eliminated as a variable; the control walkone/postgres, which carries
+  # the #4282 carve-out, read "Cluster in healthy state" 3/3).
+  #
+  # templates/networkpolicy-cnpg-operator-probe.yaml opens ONLY those two
+  # operator ports from ONLY the operator namespace — additive; it does not
+  # weaken default-deny-all or allow-same-org. No broad consumer 5432 rule
+  # (the bp-postgres #4442 `sharedConsumers` shape) is needed here: this
+  # Cluster's only consumers are the WordPress Deployment + hook Jobs in the
+  # SAME namespace, already admitted by allow-same-org.
+  #
+  # Set false only on a cluster whose per-Org namespaces carry NO
+  # default-deny baseline (then the carve-out is inert anyway).
+  cnpgOperator:
+    enabled: true
+    operatorNamespace: cnpg-system
+    operatorStatusPort: 8000
+    operatorMetricsPort: 9187
+    # Cluster-DNS namespace for the policy's egress half (#5617 / #4437 class,
+    # enforced by scripts/check-netpol-egress-completeness.py). Naming an
+    # egress section makes the selected endpoint deny-by-default on egress
+    # outside the union, and a per-Org namespace's CiliumNetworkPolicy already
+    # constrains egress WITHOUT naming DNS — so a workload that ships no DNS
+    # egress of its own cannot resolve anything. Additive: this can only widen
+    # what allow-same-org and the per-Org CNP already permit.
+    dnsNamespace: kube-system
 # ─── ServiceMonitor ─────────────────────────────────────────────────────
 # Default false per docs/BLUEPRINT-AUTHORING.md §11.2 (Observability
 # toggles must default false). Operator opts in via per-cluster overlay

--- a/platform/wordpress-tenant/image/Dockerfile
+++ b/platform/wordpress-tenant/image/Dockerfile
@@ -44,3 +44,104 @@ RUN set -eux; \
 # This is the regression guard for #4152 — a future base-image bump that drops
 # the extension can never silently ship.
 RUN php -m | grep -E 'pdo_pgsql|^pgsql$'
+
+# ─── Baked third-party WordPress artifacts (#6311, Refs #3988) ───────────────
+#
+# WHY: before this, BOTH the runtime Deployment's `wp-plugin-install`
+# initContainer AND the post-install `oidc-config` hook Job fetched these two
+# artifacts over the wire AT INSTALL TIME — from `github.com` and
+# `downloads.wordpress.org`. That directly contradicts Pillar 5: cutover
+# step-08 (`egress-block-test`) holds a deny-egress NetworkPolicy against
+# `github.com`, `ghcr.io` and `harbor.openova.io` for 10 minutes and requires
+# the cluster to reconcile green through it. A customer Application that
+# reaches GitHub to install cannot exist on a sovereign Sovereign. Live
+# symptom before the fix: the `oidc-config` Job CrashLoopBackOff on
+# `curl: (28) Connection timed out after 120001 milliseconds`.
+#
+# WHICH SEAM: this repo mirrors exactly TWO artifact classes into a post-
+# cutover Sovereign's local Harbor — OCI **container images** and **Helm
+# charts** (cutover step-03 `harbor-prewarm` skopeo-pushes both). There is NO
+# mirroring seam for plain file artifacts (no `oras`, no zip/tarball mirror
+# anywhere in platform/self-sovereign-cutover/). So the correct reuse is to
+# carry these bytes as LAYERS OF AN IMAGE THAT IS ALREADY MIRRORED — and
+# `wordpress-tenant-pg` is already in the prewarm set by name (see
+# platform/self-sovereign-cutover/chart/Chart.yaml, which calls out
+# `wordpress-tenant-pg:<tag>@sha256:…` verbatim as a tag+digest-pinned source).
+# No new mechanism is introduced.
+#
+# Fetching here is BUILD time on a GitHub Actions runner, not install time on
+# a Sovereign — the sovereignty contract is about what a Sovereign reaches for
+# while converging, and after this change it reaches for nothing.
+#
+# Consumers copy from /usr/src/openova-wp-artifacts (never from the network):
+#   - templates/deployment.yaml         `wp-plugin-install` initContainer
+#   - templates/oidc-config-job.yaml    `wp-artifacts` initContainer
+# Both are pinned by the image digest in values.yaml, so the artifact versions
+# are pinned transitively — no floating ref (docs/PRINCIPLES.md #4).
+# Extraction-path notes (kept OUT of the RUN body — a `#` line inside a
+# backslash continuation is a Dockerfile parser edge case, not a shell comment):
+#   - pg4wp's release tag KEEPS its `v` prefix, while GitHub strips the `v`
+#     from the extracted top-level directory (`postgresql-for-wordpress-3.3.1`).
+#   - openid-connect-generic's tags are UN-prefixed, so the extracted directory
+#     is `openid-connect-generic-<version>`.
+#   - The plugin is baked under the BARE `openid-connect-generic` slug because
+#     that is the directory name the oidc-config Job's `wp plugin activate`
+#     writes into WordPress's `active_plugins` option row. A differently-named
+#     runtime directory (the old wordpress.org slug
+#     `daggerhart-openid-connect-generic`) leaves that row pointing at a file
+#     that does not exist, so the plugin never loads at runtime.
+ARG PG4WP_VERSION=3.3.1
+ARG OIDC_PLUGIN_REPO=oidc-wp/openid-connect-generic
+ARG OIDC_PLUGIN_VERSION=3.11.3
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends ca-certificates curl unzip; \
+    mkdir -p /usr/src/openova-wp-artifacts/plugins; \
+    curl -fsSL -o /tmp/pg4wp.zip \
+      "https://github.com/PostgreSQL-For-Wordpress/postgresql-for-wordpress/archive/refs/tags/v${PG4WP_VERSION}.zip"; \
+    unzip -q /tmp/pg4wp.zip -d /tmp; \
+    cp -a "/tmp/postgresql-for-wordpress-${PG4WP_VERSION}/pg4wp" /usr/src/openova-wp-artifacts/pg4wp; \
+    cp "/tmp/postgresql-for-wordpress-${PG4WP_VERSION}/pg4wp/db.php" /usr/src/openova-wp-artifacts/db.php; \
+    curl -fsSL -o /tmp/oidc.zip \
+      "https://github.com/${OIDC_PLUGIN_REPO}/archive/refs/tags/${OIDC_PLUGIN_VERSION}.zip"; \
+    unzip -q /tmp/oidc.zip -d /tmp; \
+    cp -a "/tmp/openid-connect-generic-${OIDC_PLUGIN_VERSION}" \
+          /usr/src/openova-wp-artifacts/plugins/openid-connect-generic; \
+    printf 'pg4wp=%s\nopenid-connect-generic=%s (%s)\n' \
+      "${PG4WP_VERSION}" "${OIDC_PLUGIN_VERSION}" "${OIDC_PLUGIN_REPO}" \
+      > /usr/src/openova-wp-artifacts/VERSIONS; \
+    rm -rf /tmp/pg4wp.zip /tmp/oidc.zip \
+           "/tmp/postgresql-for-wordpress-${PG4WP_VERSION}" \
+           "/tmp/openid-connect-generic-${OIDC_PLUGIN_VERSION}"; \
+    apt-get purge -y --auto-remove unzip; \
+    rm -rf /var/lib/apt/lists/*
+
+# Build-time assertions: fail the image build if a baked artifact is missing,
+# empty, or unreadable by the runtime uid. This is the regression guard for
+# #6311 — the chart no longer has a network fallback, so an image that silently
+# ships without these would break every per-Org WordPress install rather than
+# degrade it. The paths asserted are exactly the three the chart copies from.
+#
+# The second stanza is the one that matters operationally: the artifacts are
+# written by root here, but every consumer (the Deployment's
+# `wp-plugin-install` init and the oidc-config Job's `wp-artifacts` init) runs
+# as uid 33 under a dropped-ALL-capabilities securityContext. Asserting that
+# uid 33 can actually READ and COPY them is a positive proof; a blanket
+# `chmod -R a+rX` would have been an assumption dressed as a fix — and would
+# also have been the only step in this file that cannot run under a rootless
+# builder.
+RUN set -eux; \
+    test -s /usr/src/openova-wp-artifacts/db.php; \
+    test -s /usr/src/openova-wp-artifacts/pg4wp/driver_pgsql.php; \
+    test -s /usr/src/openova-wp-artifacts/plugins/openid-connect-generic/openid-connect-generic.php
+RUN set -eux; \
+    mkdir -p /tmp/uid33probe; \
+    chown 33:33 /tmp/uid33probe; \
+    su -s /bin/sh -c 'set -eu; \
+      cp -R /usr/src/openova-wp-artifacts/pg4wp /tmp/uid33probe/pg4wp; \
+      cp -R /usr/src/openova-wp-artifacts/plugins/openid-connect-generic /tmp/uid33probe/oidc; \
+      cp /usr/src/openova-wp-artifacts/db.php /tmp/uid33probe/db.php' www-data; \
+    test -s /tmp/uid33probe/db.php; \
+    test -s /tmp/uid33probe/pg4wp/driver_pgsql.php; \
+    test -s /tmp/uid33probe/oidc/openid-connect-generic.php; \
+    rm -rf /tmp/uid33probe

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-19T23:17:24.573Z",
+  "generatedAt": "2026-08-20T00:51:04.612Z",
   "blueprints": [
     {
       "id": "bp-agenity",
@@ -5767,7 +5767,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "listed",
-      "version": "0.4.23",
+      "version": "0.4.25",
       "section": "pts-7-org-tenant",
       "depends": [
         "bp-postgres",

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -5902,7 +5902,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "listed",
-    "version": "0.4.23",
+    "version": "0.4.25",
     "section": "pts-7-org-tenant",
     "depends": [
       "bp-postgres",

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3981,7 +3981,14 @@ name: bp-catalyst-platform
 #   RUNNING workspace (creds-resync sidecar + 15m ESO refreshInterval), so rows
 #   219/220/221/G8/G9 stop flapping on an expired token. Umbrella tracks its
 #   sub-charts per Inviolable Principle #13.
-version: 1.4.1539
+# 1.4.1540 — #6311 (Refs #4307): catalog-seed advances bp-wordpress-tenant
+#   0.4.23 -> 0.4.25 — the CNPG-operator status-probe carve-out for the per-Org
+#   default-deny namespace + zero install-time third-party egress (pg4wp +
+#   openid-connect-generic baked into the runtime image). Rebase of PR #6320
+#   onto current main; 0.4.24 is claimed by the still-open #6320 so this republish
+#   takes the next free patch. Umbrella tracks its sub-charts per Inviolable
+#   Principle #13.
+version: 1.4.1540
 # 1.4.1481 — #6293: catalog-seed advances bp-self-sovereign-cutover
 #   0.1.186 -> 0.1.187, the release that stops step-06 from patching five
 #   HelmRepositories it does not own and then grading itself on whether they
@@ -4168,7 +4175,7 @@ version: 1.4.1539
 # scripts/check-chart-version-forward.sh (#5743) fails unless the two match —
 # main was carrying a pre-existing 1.4.1330/1.4.1329 split, so this bump heals
 # it in the same commit, exactly as the documented self-heal contract does.
-appVersion: 1.4.1539
+appVersion: 1.4.1540
 # 1.4.239 — Wave 3 / Issue #2140 (2026-05-23): Huawei provider
 # implementation lands behind the Wave 2 CloudProvider interface.
 # Adds the OpenTofu module at infra/providers/huawei/ (VPC + Subnet +

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -75,7 +75,12 @@ spec:
   # byte-identical. Enforced catalog-wide by
   # scripts/check-dr-pairs-declare-promotion.sh. Lockstep with
   # platform/wordpress-tenant/blueprint.yaml + the bare-slug alias entry below.
-  version: "0.4.23"
+  # #6311 (Refs #4307): →0.4.25 — CNPG-operator status-probe carve-out for the
+  # per-Org default-deny namespace + zero install-time third-party egress
+  # (pg4wp + openid-connect-generic baked into the runtime image). Rebase of
+  # PR #6320 onto current main; 0.4.24 is claimed by the still-open #6320, so
+  # this republish takes the next free patch.
+  version: "0.4.25"
   visibility: listed
   card:
     title: "WordPress (per-Organization)"
@@ -104,7 +109,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-wordpress-tenant
-    version: "0.4.23"
+    version: "0.4.25"
   # G117.1+G117.4+G117.5 #2744-followup (2026-06-03): lockstep with
   # platform/wordpress-tenant/blueprint.yaml. Uses {{.AppName}} so
   # multi-instance tenants get distinct hostnames per Application.
@@ -217,7 +222,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.4.23"
+  version: "0.4.25"
   visibility: listed
   card:
     title: "WordPress"
@@ -239,7 +244,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-wordpress-tenant
-    version: "0.4.23"
+    version: "0.4.25"
   # Lockstep with the bp-wordpress-tenant entry above + platform/wordpress-tenant/
   # blueprint.yaml. Same chart bytes; this is the bare-slug entrypoint only.
   topology:


### PR DESCRIPTION
## What this lands

This lands the wordpress-tenant fix from PR #6320 (UAT row 222) onto **current
main**. #6320's branch was ~635 commits behind main and conflicting, so its
wordpress-tenant chart content is reproduced cleanly here and the chart lockstep
is re-derived on current main. **Credit to #6320** — the chart bytes are its
work; this PR only re-bases them and re-computes the version lockstep. Refs #4307.
**Supersedes #6320** (this PR is landable on current main; #6320 is not).

The wordpress-tenant chart diff is **byte-identical** to #6320 (verified against
its merge-base). Only the version numbers differ, because the lockstep is
recomputed on current main.

## DEFECT ONE — CNPG-operator status-probe carve-out

A per-Org `Cluster.postgresql.cnpg.io` renders into the Organization's own
namespace, which carries the `default-deny-all` + `allow-same-org` NetworkPolicy
pair stamped by the Organization controller's GitOps tree. `allow-same-org`
re-opens same-namespace traffic only, so the `cnpg-system` operator (a different
namespace) is denied the instance Pod's `:8000/pg/status` probe and `:9187`
metrics. Postgres is 1/1 Running and serving SQL, but the operator is blind, so
CNPG parks the Cluster at "Instance Status Extraction Error: HTTP communication
issue" / `Ready=False` and the HelmRelease never converges — the purchased
WordPress never comes up.

Fix: new `templates/networkpolicy-cnpg-operator-probe.yaml` (the proven #4282
shape from platform/postgres). It opens **only** `:8000` + `:9187` from **only**
`cnpg-system`, is purely additive (default-deny-all and allow-same-org are
untouched), carries cluster DNS on its egress half per the #5617/#4437 class
invariant, and renders **singleton-only** — in active-hot-standby an Ingress
policyType selecting the Cluster Pods would default-deny the cross-cluster WAL
stream (a ClusterMesh remote peer cannot be expressed in a k8s NetworkPolicy), so
rendering nothing there keeps that path byte-identical. Gated on the
`postgresql.cnpg.io/v1` capability and the same
`wordpress.enabled`/`database.cluster.enabled` pair as `cnpg-cluster.yaml`.

## DEFECT TWO — zero install-time third-party egress

The wordpress `oidc-config` post-install Job (and the runtime Deployment init)
fetched pg4wp + `openid-connect-generic` at **install time** from `github.com` /
`downloads.wordpress.org` — four fetch sites in all — and CrashLoopBackOff'd on
`curl: (28) Connection timed out`. That contradicts cutover step-08's 10-minute
deny-egress hold against `github.com`/`ghcr.io`/`harbor.openova.io` (the Pillar-5
sovereignty proof, ADR-0002).

Fix: `image/Dockerfile` bakes both artifacts (version-pinned, with build-time
assertions including a uid-33 read/copy probe) into
`/usr/src/openova-wp-artifacts`. Both consumers now `cp` from there and **fail
closed** with no network fallback. The oidc-config Job gains a `wp-artifacts`
initContainer on the private runtime image plus `imagePullSecrets`. The plugin
slug is unified to the bare `openid-connect-generic` in both places (the previous
mismatch left `active_plugins` pointing at a path the runtime PVC never held).
The artifacts travel to a post-cutover Sovereign inside an image already in the
cutover step-03 `harbor-prewarm` set (`wordpress-tenant-pg`) — no new mirroring
mechanism.

## Lockstep re-derived on current main

- `platform/wordpress-tenant` chart + blueprint: `0.4.23 -> 0.4.25` — 0.4.24 is
  claimed by the still-open #6320, so
  `check-chart-version-not-claimed-by-open-pr` picks the next free patch.
- catalog-seed `blueprints.yaml`: all 4 wordpress-tenant pins `-> 0.4.25`.
- umbrella `products/catalyst/chart`: version+appVersion `1.4.1539 -> 1.4.1540`
  (current+1; highest open-PR claim is 1.4.1536).
- bootstrap-kit slot `13-bp-catalyst-platform`: `-> 1.4.1540`.
- regenerated `blueprints.json` + `catalog.generated.ts` (build-catalog.mjs).

## Gate results (all green)

| Gate | Result |
|---|---|
| 6311-cnpg-operator-probe-netpol.sh (incl. AHS gate + 15 vacuity mutations) | PASS |
| 6311-no-install-time-egress.sh (incl. Dockerfile + 16 vacuity mutations) | PASS |
| imagepullsecrets-render.sh | PASS |
| oidc-config.sh | PASS |
| check-chart-version-bumped.sh | PASS |
| check-chart-version-forward.sh (umbrella) | PASS |
| check-catalog-seed-lockstep.sh | PASS |
| check-bootstrap-kit-pin-sync.sh | PASS |
| check-dr-pairs-declare-promotion.sh | PASS |
| check-netpol-egress-completeness.py (guard Phase-2 logic on wordpress-tenant: 0 violations; new carve-out group dns=Y) | PASS |
| seed-drift Go tests (provisioning gitops + placement crossregion) | PASS |
| generated-catalog determinism (regen twice, byte-identical) | PASS |
| chart-version-not-claimed-by-open-pr (0.4.25 + 1.4.1540 both free) | PASS |

Singleton render confirmed: `wordpress-db-allow-cnpg-operator-probe` selects
`cnpg.io/cluster: wordpress-db`, ingress from `cnpg-system` on ports 8000+9187,
egress DNS 53/UDP+TCP to kube-system, gated on the CNPG CRD; absent in
active-hot-standby.

## Note

UAT row 222 also needs founder-gated #5393 (per-Org quota) to fully close — that
is outside this change; this PR lands the wordpress code fix.

Refs #4307
