### PR TITLE
fix(gitops): funnel door emits the openova-MCP bearer + verify-pubkey wiring (agenity Pillar-4)

### DIFF
--- a/core/services/provisioning/gitops/agenity_mcp_bearer_parity_test.go
+++ b/core/services/provisioning/gitops/agenity_mcp_bearer_parity_test.go
@@ -1,0 +1,97 @@
+package gitops
+
+import (
+	"strings"
+	"testing"
+)
+
+// #4276 hop 7/7b — a funnel-born Org's openova-MCP booted DEGRADED because this
+// generator emitted NO openovaMCP bearer/verify-pubkey wiring at all, while the
+// BSS door (organization_gitops.go orgTenantBPAgenity) always had it.
+//
+// #6372 fixed the SAME door-drift class for the anthropic block one hop up but
+// left this block missing, so a funnel Org still could not run the agentic path
+// even after its Anthropic credential was seeded: the openova-mcp had no bearer
+// (create_application → -32001 unauthenticated) and no RS256 verify pubkey
+// (verify=rs256 with no key → tools/list empty, tools/call 401).
+//
+// MEASURED on hw301 Org acme: the StatefulSet projected OPENOVA_MCP_RS256_PUBKEY_PEM
+// from the chart-default catalyst-handover-jwt Secret — absent in the per-Org ns
+// and optional:true — so the MCP started in DEGRADED mode and the agent had no
+// create_application tool.
+//
+// THE DOORS DISAGREED. This test pins the funnel door to the producer contract
+// so they cannot drift again.
+func TestAgenityFunnelEmitsMCPBearerWiring(t *testing.T) {
+	for _, plan := range []string{"s", "m"} {
+		t.Run("plan="+plan, func(t *testing.T) {
+			out := cartOrgFor(t, "acme", plan, []string{"agenity"})
+			body, ok := out[testBasePath+"/acme/app-agenity.yaml"]
+			if !ok {
+				t.Skip("agenity not rendered on this tier")
+			}
+
+			// The bearer + verify-pubkey wiring the openova-mcp needs. Every one
+			// of these is load-bearing: bearerSecret/rs256PubkeySecret point the
+			// StatefulSet at the materialised per-Org Secret, and the mcpBearer
+			// ExternalSecret is what materialises it from the seedMCPBearer path.
+			for _, want := range []string{
+				"openovaMCP:",
+				"bearerSecret:",
+				"name: agenity-mcp-bearer",
+				"key: bearer",
+				"rs256PubkeySecret:",
+				"key: pubkeyPem",
+				"mcpBearer:",
+				"remoteKey: catalyst/agenity/acme/mcp-bearer",
+				"remoteBearerProperty: bearer",
+				"remotePubkeyProperty: pubkeyPem",
+				"secretStoreRef: vault-region1",
+				"secretStoreKind: ClusterSecretStore",
+			} {
+				if !strings.Contains(body, want) {
+					t.Errorf("funnel agenity overlay is MISSING %q (#4276 hop 7/7b).\n"+
+						"Without it the openova-mcp boots DEGRADED (no bearer, no verify\n"+
+						"pubkey) and the solo agent has no create_application tool —\n"+
+						"while a BSS-born Org in the same Sovereign works.\nrendered:\n%s", want, body)
+				}
+			}
+
+			// The mcpBearer ExternalSecret must be ENABLED — a rendered-but-disabled
+			// block reads as "wired" while projecting nothing (the exact DEGRADED
+			// shape this fix removes). Assert the enablement, not just its presence.
+			if !strings.Contains(body, "enabled: true") {
+				t.Errorf("funnel agenity mcpBearer.externalSecret is not enabled — the block would render inert:\n%s", body)
+			}
+
+			// CONTROL: the bearer path must stay under catalyst/. That prefix is
+			// the only KV sub-tree a Sovereign may WRITE via catalyst-api-write;
+			// pointing elsewhere renders a block that can never resolve.
+			if strings.Contains(body, "remoteKey: catalyst/agenity/") &&
+				!strings.Contains(body, "remoteKey: catalyst/agenity/acme/mcp-bearer") {
+				t.Errorf("mcp-bearer remoteKey drifted off the per-Org catalyst/ path:\n%s", body)
+			}
+
+			// The X-Tenant-Host pin must be the ORG console host, not the Sovereign
+			// host — a Sovereign-host X-Tenant-Host 404s tenant-not-registered on
+			// every agent create_application (#4610).
+			if !strings.Contains(body, "tenantHost: console.acme.") {
+				t.Errorf("openovaMCP.tenantHost is not pinned to the Org console host (console.acme.<pool>):\n%s", body)
+			}
+		})
+	}
+}
+
+// CONTROL — the openovaMCP block must NOT leak into non-agenity overlays.
+func TestMCPBearerBlockIsAgenityOnly(t *testing.T) {
+	out := cartOrgFor(t, "acme", "m", []string{"wordpress", "openclaw", "stalwart-mail", "agenity"})
+	for _, f := range []string{"app-openclaw.yaml", "app-stalwart-mail.yaml", "app-wordpress.yaml"} {
+		body, ok := out[testBasePath+"/acme/"+f]
+		if !ok {
+			continue
+		}
+		if strings.Contains(body, "remoteKey: catalyst/agenity/") {
+			t.Errorf("%s wrongly carries the openova-MCP bearer wiring — it is agenity-only:\n%s", f, body)
+		}
+	}
+}

--- a/core/services/provisioning/gitops/helmrelease_apps.go
+++ b/core/services/provisioning/gitops/helmrelease_apps.go
@@ -785,6 +785,13 @@ func sovereignHostFromRealmIssuer(issuer string) string {
 // dependsOn on a never-rendered bp-keycloak wedges the release in
 // DependencyNotReady forever (the divergence this file's header describes).
 //
+// It carries BOTH per-Org credential blocks the BSS door does: the anthropic
+// ExternalSecret (#6372) and the openovaMCP bearer + RS256 verify-pubkey wiring
+// (#4276 hop 7/7b). The latter was the residual door-drift #6372 left behind —
+// without it a funnel Org's openova-mcp boots DEGRADED (no bearer, no verify
+// key) and the agent has no create_application tool, even after Anthropic is
+// seeded (measured hw301 Org acme).
+//
 // oidcGate.issuerHost is the SOVEREIGN host, not the Org zone (#6314). The
 // browser-facing issuer is auth.<sovereign-fqdn>; the Org zone would render
 // auth.<slug>.<parent>, a host with no HTTPRoute — envoy 404 at sign-in. That
@@ -879,6 +886,60 @@ spec:
         remoteKey: catalyst/anthropic/token
         remoteProperty: apiKey
         remoteCredentialsProperty: credentialsJson
+    # ── #4276 hop 7/7b — the openova-MCP bearer + RS256 verify pubkey ────────
+    # THE SAME DOOR-PARITY DEFECT #6372 fixed one block up, one hop deeper.
+    # #6372 taught this funnel generator to emit the anthropic block the BSS
+    # door always had; it did NOT teach it the openovaMCP block the BSS door
+    # (organization_gitops.go orgTenantBPAgenity) ALSO always had, so a
+    # funnel-born Org still could not run the agentic path even once its
+    # Anthropic credential was seeded.
+    #
+    # Without this block the StatefulSet leaves openovaMCP.bearerSecret unset
+    # and rs256PubkeySecret at the chart default (catalyst-handover-jwt, a host
+    # catalyst-system Secret that is ABSENT in the per-Org namespace and
+    # optional:true), so the openova-mcp boots DEGRADED — verify=rs256 with no
+    # pubkey env → tools/list empty, tools/call 401 — and every spawned agent
+    # reaches the MCP with NO bearer (-32001 unauthenticated). MEASURED on
+    # hw301 Org acme: OPENOVA_MCP_RS256_PUBKEY_PEM resolved from the absent
+    # catalyst-handover-jwt and the agent had no create_application tool.
+    #
+    # The producer already writes what this reads: the catalyst-api org-pipeline
+    # seedMCPBearer (sovereign_mcp_bearer_seed.go) mints an Org-scoped session
+    # JWT (tier=org-admin, org_id=<slug>, role=openova-user, typ=session,
+    # RS256-signed by the Sovereign handover signer) PLUS the matching RS256
+    # verify pubkey (PKIX PEM) and writes BOTH to the per-Org OpenBao path
+    # secret/catalyst/agenity/<slug>/mcp-bearer (properties bearer + pubkeyPem)
+    # on every Org reconcile. The chart's externalsecret-mcp-bearer.yaml pulls
+    # them into the per-Org Secret agenity-mcp-bearer; bearerSecret +
+    # rs256PubkeySecret point the StatefulSet at it so it projects
+    # OPENOVA_MCP_BEARER + OPENOVA_MCP_RS256_PUBKEY_PEM. The bearer and the key
+    # that verifies it are the mint + public half of the SAME handover signer,
+    # so seeding them through one path sidesteps the JWK-vs-PEM cross-namespace
+    # mismatch (#4228). Path MUST stay under catalyst/ — the only KV sub-tree a
+    # Sovereign can WRITE (catalyst-api-write); vault-region1's role is
+    # read-only. Mirrored from the BSS door so the two doors cannot drift again.
+    openovaMCP:
+      # The ORG console host the MCP forwards as X-Tenant-Host on the org-scoped
+      # install path (#4610). The catalyst-api URL host (console.<sovereignFqdn>)
+      # is NOT a registered tenant, so a Sovereign-host X-Tenant-Host 404s
+      # tenant-not-registered on every agent create_application. Pinned to the
+      # Org host, byte-identical with the BSS door's {{.ConsoleHost}}.
+      tenantHost: console.%s.%s
+      bearerSecret:
+        name: agenity-mcp-bearer
+        key: bearer
+      rs256PubkeySecret:
+        name: agenity-mcp-bearer
+        key: pubkeyPem
+      mcpBearer:
+        externalSecret:
+          enabled: true
+          secretStoreRef: vault-region1
+          secretStoreKind: ClusterSecretStore
+          remoteKey: catalyst/agenity/%s/mcp-bearer
+          remoteBearerProperty: bearer
+          remotePubkeyProperty: pubkeyPem
 `, helmRepoBlock("bp-agenity"), opt.slug, opt.slug, opt.kubeConfigBlock(),
-		orgZone, opt.slug, issuerHostLine, host)
+		orgZone, opt.slug, issuerHostLine, host,
+		opt.slug, opt.parentDomain, opt.slug)
 }


### PR DESCRIPTION
Investigated two per-Org secret-provisioning gaps that hold the Pillar-4 agentic experience red on hw301 (Org acme): UAT rows G8, G9, 219, 220, 221, 222, 223. They are INDEPENDENT root causes, not a shared one.

## Gap A — openova-MCP boots DEGRADED (rows G9, 219, 220, 221, 222) — FIXED HERE

Root cause: the funnel/cart emitter `generateAgenityHR` (core/services/provisioning/gitops/helmrelease_apps.go) renders the bp-agenity HelmRelease WITHOUT the `openovaMCP` bearer + RS256 verify-pubkey block that the BSS door `orgTenantBPAgenity` (products/catalyst/bootstrap/api/internal/handler/organization_gitops.go) has always carried. This is the residual half of the exact door-drift #6372 fixed for the anthropic block — #6372 taught the funnel door the anthropic ExternalSecret but not the MCP bearer/pubkey ExternalSecret.

Because the block was absent, a funnel-born Org's StatefulSet left `openovaMCP.bearerSecret` unset and `rs256PubkeySecret` at the chart default `catalyst-handover-jwt` — a host catalyst-system Secret that is absent in the per-Org namespace and rendered optional:true. So `openova-mcp` started DEGRADED (verify=rs256 with no pubkey env, tools/list empty, tools/call rejected 401) and every spawned agent hit the MCP with no bearer (-32001 unauthenticated). This matches the hw301 live evidence exactly: `OPENOVA_MCP_RS256_PUBKEY_PEM` was a secretKeyRef at the absent `catalyst-handover-jwt`.

Fix: mirror the BSS door's `openovaMCP` block into `generateAgenityHR` — `bearerSecret`/`rs256PubkeySecret` at `agenity-mcp-bearer`, the per-Org `mcpBearer.externalSecret` at `catalyst/agenity/<slug>/mcp-bearer`, and `tenantHost` pinned to the Org console host. The producer `seedMCPBearer` (sovereign_mcp_bearer_seed.go) already mints + writes that OpenBao path (bearer + pubkeyPem) on every Org-create AND reconcile (runOrganizationPipeline + sovereign_seed_reconciler), independent of the Anthropic credential, so the ExternalSecret has real content to sync. The MCP then boots ACTIVE with `create_application`.

This is a pure Go string change in the emitter: no chart bump, no lockstep, no catalog regen. A parity test (agenity_mcp_bearer_parity_test.go) pins the two doors together so they cannot drift again (proven non-vacuous: it fails without the emitter change).

Judgment call on the JWKS-URL alternative: the openova-mcp binary's `OPENOVA_MCP_RS256_PUBKEY_SET` and `_PEM` env vars accept only LITERAL key material — a PKIX/PKCS1 PEM, an RSA JWK, or a JWKS document (parseRSAPublicKeySet in cmd/openova-mcp/main.go). They do NOT fetch a URL; a URL string parses to zero keys and degrades. Wiring the Org console JWKS URL would need a new fetch path in the binary. The self-sourced per-Org ExternalSecret (seedMCPBearer to OpenBao to agenity-mcp-bearer to OPENOVA_MCP_RS256_PUBKEY_PEM) already exists and works with no reflection and no binary change, so it is the robust durable fix.

## Gap B — Anthropic credential not auto-seeded (rows G8, 223) — env/founder artifact on hw301, NOT a code defect

The producer chain is complete and correctly wired: the mothership push `seedSovereignAnthropicCredentials` (kubeconfig.go, at kubeconfig postback) creates catalyst-system/sovereign-anthropic-credentials on the fresh Sovereign from the mothership's own CATALYST_ANTHROPIC_API_KEY / CATALYST_ANTHROPIC_CREDENTIALS_JSON; the Sovereign-side `seedAnthropicToken` (Org-create + reconciler) reads it live and writes OpenBao catalyst/anthropic/token; the agenity ExternalSecret reads that path.

`classifyAnthropicCredential` (anthropic_credential_class.go) deliberately treats a key-only credential (apiKey set, no claudeAiOauth credentialsJson blob) as NOT usable, because the spawned claude-code authenticates from the OAuth blob, not a bare key. So a mothership carrying only CATALYST_ANTHROPIC_API_KEY causes the mothership push to skip-unusable, the Sovereign Secret is never created, seedAnthropicToken sees absent, OpenBao catalyst/anthropic/token stays empty, and the agenity-anthropic-token ExternalSecret is SecretSyncedError — exactly the hw301 symptom. Making key-only usable would ship a Secret that inspects as populated and 401s at first use (the #6245 fake-green the classifier exists to refuse), so there is no correct code fix here.

This matches the standing adjudication in docs/ledger/PATH-TO-100.md (lines 29, 505, 1033): rows 219/220/222/G8/G9 need the founder-supplied Anthropic OAuth credential; seedAnthropicToken loud-skips without it; "the one genuinely external dependency in the ledger." Remediation is to populate the mothership's CATALYST_ANTHROPIC_CREDENTIALS_JSON (sovereign.anthropic.* chart values) or catalyst-system/sovereign-anthropic-credentials — not an engineering change. No fix invented here per the investigate-first mandate. (Separately, PATH-TO-100 line 505 notes the seeded OAuth blob is short-lived and unrefreshed — a distinct rotation follow-up, not the empty-path symptom on hw301.)

## Provenance note
hw301 Org acme's StatefulSet projecting the pubkey from the chart-default catalyst-handover-jwt is the fingerprint of a render that omitted the openovaMCP block, i.e. the funnel door (or a stale image predating it). The current-main BSS door already carries the block; the funnel door did not. This PR closes the funnel-door gap regardless; a Sovereign already provisioned by the old door picks up the fix on re-render / fresh prov (no live-cluster write in this PR).

## Gates
- go build ./... (core/services/provisioning) — PASS
- go vet ./gitops — PASS
- go test ./... (whole provisioning module) — PASS
- New parity test TestAgenityFunnelEmitsMCPBearerWiring + control — PASS; proven non-vacuous (fails on origin/main without the emitter change)
- Existing #6372 anthropic parity tests — still PASS
- gofmt: my additions are clean; a pre-existing double-blank-line at helmrelease_apps.go:~683 already fails gofmt on origin/main and is left untouched to keep this change focused
- No chart / blueprint.yaml / catalog / bootstrap-kit files touched — chart lockstep gates N/A

Refs #6501 #3988 #4277
