### PR TITLE
fix(cutover): region-local gitea-mirror uses a header, not a URL-injected admin password (#6490)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -1083,7 +1083,13 @@ spec:
       #   app.kubernetes.io/managed-by: flux so ns gitea's kyverno flux-managed
       #   ClusterPolicy admits step-01's set -e apply (it excludes ns catalyst but
       #   not ns gitea); without it the cutover halted at step-01 (hw301).
-      version: 0.1.196
+      # 0.1.197 (#6490): the region-local gitea-mirror git push/ls-remote (secondary
+      #   mirror + primary resync) authenticate with an http.extraHeader
+      #   Authorization: Basic — the same header the API calls use — instead of
+      #   URL-injecting ${GITEA_USERNAME}:${GITEA_PASSWORD}@, which FATALed the push
+      #   when the region-local Gitea admin password held a URL-special char (hw301
+      #   region-B: API basic-auth succeeded, git push "Could not read from remote").
+      version: 0.1.197
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1459,11 +1459,16 @@ spec:
       # 1.4.1540 — lockstep for bp-wordpress-tenant 0.4.25 (#6311, Refs #4307:
       #   CNPG-operator status-probe carve-out + zero install-time egress; rebase
       #   of PR #6320 onto current main).
+      # 1.4.1547 — lockstep for bp-self-sovereign-cutover 0.1.197 (#6490: the
+      #   region-local gitea-mirror git push/ls-remote authenticate with an
+      #   http.extraHeader Authorization: Basic instead of URL-injecting the admin
+      #   password, which broke the push on a URL-special-char password). Rebased
+      #   over 1.4.1546 (#6504) so it takes the next free patch.
       # 1.4.1544 — #3374 #3988: catalog-seed advances bp-keycloak 1.5.10 -> 1.5.11
       #   (sovereign realm catalyst-ui registers the per-Org console callback
       #   https://console.*.<zone>/* for role==org-pool zones; live hw301
       #   console.acme.omani.homes 400'd `Invalid parameter: redirect_uri`).
-      version: 1.4.1546
+      version: 1.4.1547
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.196
+  version: 0.1.197
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -4182,7 +4182,7 @@ name: bp-self-sovereign-cutover
 #   bp-self-sovereign-cutover HelmRelease; the label sits on the Job metadata only
 #   (the policy matches kind Job, not the Pod). The API blueprints.json + the
 #   generated UI catalog move to 0.1.196 in lockstep.
-version: 0.1.196
+version: 0.1.197
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/11-mirror-resync-cronjob.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/11-mirror-resync-cronjob.yaml
@@ -193,7 +193,9 @@ spec:
                    Credential hygiene mirrors 01-gitea-mirror-job.yaml:
                    never echo $GITEA_PASSWORD on stdout. The BasicAuth
                    header is base64-encoded into a single env-local
-                   variable; git push uses URL embedding only.
+                   variable; git push/ls-remote authenticate with that same
+                   `http.extraHeader` — NOT URL embedding, which breaks when
+                   the admin password holds a URL-special char (#6490).
                   */}}
                   redacted_url="${GITEA_INTERNAL_URL}/${GITEA_ORG}/${GITEA_REPO}.git"
                   echo "[mirror-resync] upstream=${UPSTREAM_REPO_URL} branch=${UPSTREAM_BRANCH}"
@@ -242,7 +244,7 @@ spec:
                   git config --global user.email "mirror-resync@${gitea_host}"
                   git config --global advice.detachedHead false
 
-                  local_url=$(printf '%s' "${GITEA_INTERNAL_URL}" | sed -E "s,^(https?://),\1${GITEA_USERNAME}:${GITEA_PASSWORD}@,")"/${GITEA_ORG}/${GITEA_REPO}.git"
+                  push_url="${GITEA_INTERNAL_URL}/${GITEA_ORG}/${GITEA_REPO}.git"
                   workdir=$(mktemp -d)
                   cd "${workdir}"
                   echo "[mirror-resync] cloning ${UPSTREAM_REPO_URL} (bare)"
@@ -252,7 +254,7 @@ spec:
                   fi
                   cd upstream.git
                   echo "[mirror-resync] pushing all refs to ${redacted_url}"
-                  push_err=$(git push --mirror --force "${local_url}" 2>&1) || {
+                  push_err=$(git -c http.extraHeader="Authorization: Basic ${basic_auth}" push --mirror --force "${push_url}" 2>&1) || {
                     echo "[mirror-resync] git push to local Gitea failed" >&2
                     printf '%s\n' "${push_err}" | sed -E "s,${GITEA_PASSWORD}+,REDACTED,g" >&2
                     exit 1

--- a/platform/self-sovereign-cutover/chart/templates/secondary-mirror-script-configmap.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/secondary-mirror-script-configmap.yaml
@@ -108,7 +108,14 @@ data:
     git config --global http.lowSpeedLimit 1000
     git config --global http.lowSpeedTime 600
 
-    local_url=$(printf '%s' "${GITEA_INTERNAL_URL}" | sed -E "s,^(https?://),\1${GITEA_USERNAME}:${GITEA_PASSWORD}@,")"/${GITEA_ORG}/${GITEA_REPO}.git"
+    # Authenticate the git push/ls-remote over HTTP with the SAME BasicAuth
+    # header the curl API calls above use — NOT URL-injected credentials. A
+    # region-local Gitea admin password containing a URL-special char
+    # (/ @ : & % …) breaks either the sed replacement or git's URL parse, so
+    # the API calls succeed (header-authenticated) while the push FATALs with
+    # "Could not read from remote repository" (#6490, live-confirmed hw301
+    # region-B). The push URL carries NO credentials.
+    push_url="${GITEA_INTERNAL_URL}/${GITEA_ORG}/${GITEA_REPO}.git"
     workdir=$(mktemp -d)
     cd "${workdir}"
     echo "[secondary-mirror] cloning ${UPSTREAM_REPO_URL} (bare)"
@@ -128,7 +135,7 @@ data:
     fi
     cd upstream.git
     echo "[secondary-mirror] pushing upstream branches + tags to the region-local Gitea"
-    push_err=$(git push --force "${local_url}" 'refs/heads/*:refs/heads/*' 'refs/tags/*:refs/tags/*' 2>&1) || {
+    push_err=$(git -c http.extraHeader="Authorization: Basic ${basic_auth}" push --force "${push_url}" 'refs/heads/*:refs/heads/*' 'refs/tags/*:refs/tags/*' 2>&1) || {
       echo "[secondary-mirror] FATAL: git push to the region-local Gitea failed" >&2
       printf '%s\n' "${push_err}" | sed -E "s,${GITEA_PASSWORD}+,REDACTED,g" >&2
       exit 1
@@ -138,7 +145,7 @@ data:
     # 4. ls-remote self-verify — the #6490 ordering gate. The region's Gitea must
     #    serve a COMPLETE ref advertisement (the class that truncated at pkt-line
     #    3 cross-region); prove it locally before step-05 pivots Flux at it.
-    if ! git ls-remote --heads "${local_url}" >/tmp/.lsr 2>/tmp/.lsr.err; then
+    if ! git -c http.extraHeader="Authorization: Basic ${basic_auth}" ls-remote --heads "${push_url}" >/tmp/.lsr 2>/tmp/.lsr.err; then
       echo "[secondary-mirror] FATAL: git ls-remote of the pushed repo failed — its ref advertisement is not servable (the pkt-line 3 EOF class, #6490)" >&2
       sed -E "s,${GITEA_PASSWORD}+,REDACTED,g" /tmp/.lsr.err >&2 || true
       exit 1

--- a/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
+++ b/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
@@ -5484,4 +5484,48 @@ fi
 grep -q 'names a HEALTHY HelmRelease' "$TMP/c95/out.txt" || { echo "FAIL: CONTROL — the platform stale-override rejection lost its class name (#5391/#6273)" >&2; exit 1; }
 echo "  PASS (#6273: BOTH Phase A0 passes partition by ownership — the HelmRelease pass and the override-free wl_pending pass each WARN-and-proceed on Organization namespaces with every offender named, its TERMINAL tag intact and the re-install cost stated; platform offenders stay FATAL, named and classified, are counted alone in the headline, and the VACUITY CONTROL proves that FATAL flips to a warning when the one discriminating input flips; leak controls: identical workloads in harbor still fatal, unlabelled namespaces still fatal, stale override on a platform release still rejected)"
 
+echo "[cutover-contract] Case 96: the region-local gitea-mirror git push/ls-remote authenticate with an Authorization header, NEVER URL-injected credentials — a Gitea admin password holding a URL-special char breaks URL-injection but not the header (#6490, Refs #3379, UAT row 166)"
+# Live hw301 region-B (me-east-215-b-1): the secondary-mirror's curl API calls
+# (base64 Authorization: Basic header) SUCCEEDED — "org already present", "repo
+# already present" — while `git push` FATALed "Could not read from remote
+# repository", because the push path is different: it injected
+# ${GITEA_USERNAME}:${GITEA_PASSWORD}@ into the URL, and the region-local Gitea
+# admin password held a URL-special char (/ @ : & % …) that broke either the sed
+# replacement or git's URL parse. The durable fix: git push + git ls-remote
+# carry the SAME `http.extraHeader="Authorization: Basic ${basic_auth}"` the curl
+# API calls use, and the remote URL carries NO credentials. This guards the two
+# admin-BasicAuth mirror sites; the PAT-authed primary step-01 (01-gitea-mirror)
+# is a separate contract (#5262 — a hex PAT is immune to URL-special chars).
+c96_fail=0
+# (a) the SECONDARY-region mirror ConfigMap (render-gated on mirrorToSecondaryGitea).
+helm template smoke-secmirror . --set secondaryRegions.mirrorToSecondaryGitea=true \
+  --show-only templates/secondary-mirror-script-configmap.yaml > "$TMP/r_6490_secondary.yaml"
+F="$TMP/r_6490_secondary.yaml"
+if ! grep -qF 'git -c http.extraHeader="Authorization: Basic ${basic_auth}" push --force "${push_url}"' "$F"; then
+  echo "FAIL: secondary-mirror push does not carry the Authorization: Basic http.extraHeader (#6490)" >&2; c96_fail=1
+fi
+if ! grep -qF 'git -c http.extraHeader="Authorization: Basic ${basic_auth}" ls-remote --heads "${push_url}"' "$F"; then
+  echo "FAIL: secondary-mirror ls-remote does not carry the Authorization: Basic http.extraHeader (#6490)" >&2; c96_fail=1
+fi
+if ! grep -qF 'push_url="${GITEA_INTERNAL_URL}/${GITEA_ORG}/${GITEA_REPO}.git"' "$F"; then
+  echo "FAIL: secondary-mirror push_url is not the credential-free remote URL (#6490)" >&2; c96_fail=1
+fi
+# anti-regression (non-vacuous — TRUE on the old URL-injection script, FALSE now):
+# no credential-in-URL injection may survive anywhere in the script.
+if grep -qF '${GITEA_USERNAME}:${GITEA_PASSWORD}@' "$F"; then
+  echo "FAIL: secondary-mirror still URL-injects the admin password — breaks on a URL-special-char password (#6490 regression)" >&2; c96_fail=1
+fi
+# (b) the PRIMARY-region resync CronJob's own push (same admin-BasicAuth site).
+helm template smoke-resync . --set mirrorResync.enabled=true \
+  --show-only templates/11-mirror-resync-cronjob.yaml > "$TMP/r_6490_resync.yaml"
+G="$TMP/r_6490_resync.yaml"
+if ! grep -qF 'git -c http.extraHeader="Authorization: Basic ${basic_auth}" push --mirror --force "${push_url}"' "$G"; then
+  echo "FAIL: mirror-resync push does not carry the Authorization: Basic http.extraHeader (#6490)" >&2; c96_fail=1
+fi
+if grep -qF '${GITEA_USERNAME}:${GITEA_PASSWORD}@' "$G"; then
+  echo "FAIL: mirror-resync still URL-injects the admin password — breaks on a URL-special-char password (#6490 regression)" >&2; c96_fail=1
+fi
+if [ "$c96_fail" -ne 0 ]; then exit 1; fi
+echo "  PASS (#6490: the secondary-mirror + primary resync git push/ls-remote authenticate via an http.extraHeader Authorization: Basic — the same header the curl API calls use — against a credential-free remote URL; zero admin-password URL-injection survives, so a URL-special-char Gitea admin password no longer FATALs the push)"
+
 echo "[cutover-contract] All gates green."

--- a/platform/self-sovereign-cutover/chart/tests/step6490-secondary-gitea-mirror.sh
+++ b/platform/self-sovereign-cutover/chart/tests/step6490-secondary-gitea-mirror.sh
@@ -72,13 +72,32 @@ if git -C "${REPO_ROOT}" rev-parse --verify --quiet origin/main >/dev/null 2>&1;
   if [ -d "${MAIN_CHART}" ]; then
     helm template ssc "${MAIN_CHART}" --set sovereign.fqdn="${FQDN}" --set mirrorResync.enabled=true \
       >"${TMP}/main.yaml" 2>/dev/null
-    # Normalise the chart-version baked into helm.sh/chart labels — the 0.1.19x
-    # bump is expected and unrelated to the secondary leg; everything ELSE must
-    # match to the byte.
-    sed -E 's/bp-self-sovereign-cutover-[0-9]+\.[0-9]+\.[0-9]+/bp-self-sovereign-cutover-VERSION/g' "${TMP}/main.yaml" >"${TMP}/main.norm"
-    sed -E 's/bp-self-sovereign-cutover-[0-9]+\.[0-9]+\.[0-9]+/bp-self-sovereign-cutover-VERSION/g' "${TMP}/off.yaml"  >"${TMP}/off.norm"
+    # Normalise TWO axes that are EXPECTED to differ from origin/main and are NOT
+    # the secondary-leg leak this byte-check guards:
+    #   1. the chart-version baked into helm.sh/chart labels (the 0.1.19x bump);
+    #   2. the #6490 git-auth MECHANISM on the ALWAYS-rendered primary resync push
+    #      (11-mirror-resync-cronjob.yaml) — origin/main URL-injects
+    #      ${GITEA_USERNAME}:${GITEA_PASSWORD}@ into the remote while this branch
+    #      carries the Authorization: Basic http.extraHeader. That push renders in
+    #      single-region too, so it is NOT part of the secondaryRegions leg;
+    #      canonicalising BOTH forms (and BOTH url-var names) to one token keeps
+    #      this check able to catch any OTHER single-region drift while
+    #      accommodating the intended fix, which cutover-contract Case 96 verifies.
+    #      The regex keys on GITEA_PASSWORD / --mirror so it never touches step-01's
+    #      PAT-authed refspec push.
+    norm() {
+      sed -E \
+        -e 's#bp-self-sovereign-cutover-[0-9]+\.[0-9]+\.[0-9]+#bp-self-sovereign-cutover-VERSION#g' \
+        -e 's#^ *local_url=.*GITEA_PASSWORD.*$#                  MIRROR_URL_DEF#' \
+        -e 's#^ *push_url="\$\{GITEA_INTERNAL_URL\}/\$\{GITEA_ORG\}/\$\{GITEA_REPO\}\.git"$#                  MIRROR_URL_DEF#' \
+        -e 's#git -c http\.extraHeader="Authorization: Basic \$\{basic_auth\}" push --mirror#git push --mirror#' \
+        -e 's#push --mirror --force "\$\{(local_url|push_url)\}"#push --mirror --force "MIRROR_URL"#' \
+        "$1"
+    }
+    norm "${TMP}/main.yaml" >"${TMP}/main.norm"
+    norm "${TMP}/off.yaml"  >"${TMP}/off.norm"
     if diff -q "${TMP}/main.norm" "${TMP}/off.norm" >/dev/null; then
-      pass "the ENTIRE single-region render is byte-identical to origin/main (modulo the expected chart-version bump)"
+      pass "the ENTIRE single-region render is byte-identical to origin/main (modulo the chart-version bump and the #6490 resync git-auth mechanism, which Case 96 verifies)"
     else
       fail "single-region render DIFFERS from origin/main beyond the version bump — see diff:"
       diff "${TMP}/main.norm" "${TMP}/off.norm" | head -40
@@ -153,15 +172,26 @@ if grep -qF 'app.kubernetes.io/managed-by: flux' "${TMP}/secjob.yaml"; then
 else
   fail "secondary mirror Job lacks app.kubernetes.io/managed-by: flux — ns gitea's kyverno flux-managed ClusterPolicy DENIES step-01's set -e apply and the cutover halts (#6493)"
 fi
-if grep -qF 'git push --force' "${TMP}/secmirror.sh"; then
-  pass "secondary-mirror.sh force-pushes the bare clone to the region-local Gitea"
+# #6490 header-auth: the push + ls-remote authenticate with the SAME
+# Authorization: Basic http.extraHeader the curl API calls use — NOT a
+# URL-injected admin password, which FATALs ("Could not read from remote
+# repository") when the region-local Gitea password holds a URL-special char.
+if grep -qF 'http.extraHeader="Authorization: Basic ${basic_auth}" push --force' "${TMP}/secmirror.sh"; then
+  pass "secondary-mirror.sh force-pushes via the Authorization: Basic http.extraHeader (#6490)"
 else
-  fail "secondary-mirror.sh does not force-push to the region-local Gitea"
+  fail "secondary-mirror.sh does not header-authenticate the force-push (#6490)"
 fi
-if grep -qF 'git ls-remote --heads' "${TMP}/secmirror.sh"; then
-  pass "secondary-mirror.sh ls-remote self-verifies (the #6490 ordering gate)"
+if grep -qF 'http.extraHeader="Authorization: Basic ${basic_auth}" ls-remote --heads' "${TMP}/secmirror.sh"; then
+  pass "secondary-mirror.sh ls-remote self-verifies via the header (the #6490 ordering gate)"
 else
-  fail "secondary-mirror.sh lacks the git ls-remote success gate"
+  fail "secondary-mirror.sh lacks the header-authed git ls-remote success gate (#6490)"
+fi
+# anti-regression (non-vacuous — TRUE on the pre-#6490 URL-injection script):
+# zero URL-injected credentials may survive in the region-local push.
+if grep -qF '${GITEA_USERNAME}:${GITEA_PASSWORD}@' "${TMP}/secmirror.sh"; then
+  fail "secondary-mirror.sh still URL-injects the admin password — breaks on a URL-special-char password (#6490 regression)"
+else
+  pass "secondary-mirror.sh URL-injects no credentials — auth rides the header (#6490)"
 fi
 if grep -qF 'http.postBuffer 1048576000' "${TMP}/secmirror.sh"; then
   pass "secondary-mirror.sh carries the #6488 large-clone robustness (http.postBuffer + retry)"

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-20T03:38:46.444Z",
+  "generatedAt": "2026-08-20T04:40:07.638Z",
   "blueprints": [
     {
       "id": "bp-agenity",
@@ -4640,7 +4640,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "0.1.196",
+      "version": "0.1.197",
       "section": "pts-2-3-per-sovereign-supporting-services",
       "depends": [
         "bp-gitea",

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -4775,7 +4775,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "0.1.196",
+    "version": "0.1.197",
     "section": "pts-2-3-per-sovereign-supporting-services",
     "depends": [
       "bp-gitea",

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3988,6 +3988,12 @@ name: bp-catalyst-platform
 #   onto current main; 0.4.24 is claimed by the still-open #6320 so this republish
 #   takes the next free patch. Umbrella tracks its sub-charts per Inviolable
 #   Principle #13.
+# 1.4.1547 — lockstep for bp-self-sovereign-cutover 0.1.197 (#6490: the
+#   region-local gitea-mirror git push/ls-remote (secondary mirror + primary
+#   resync) authenticate with an http.extraHeader Authorization: Basic instead
+#   of URL-injecting the admin password, which FATALed the push when the
+#   region-local Gitea admin password held a URL-special char). Rebased over
+#   1.4.1546 (#6504) so it takes the next free patch.
 # 1.4.1544 — #3374 #3988: catalog-seed advances bp-keycloak 1.5.10 -> 1.5.11,
 #   which registers the per-Org console callback https://console.*.<zone>/* on
 #   the sovereign realm's catalyst-ui client for every role==org-pool parent
@@ -3995,7 +4001,7 @@ name: bp-catalyst-platform
 #   `Invalid parameter: redirect_uri` (live hw301 console.acme.omani.homes),
 #   blocking every per-Org login AND the Pillar-4 agentic walk. Umbrella tracks
 #   its sub-charts per Inviolable Principle #13.
-version: 1.4.1546
+version: 1.4.1547
 # 1.4.1481 — #6293: catalog-seed advances bp-self-sovereign-cutover
 #   0.1.186 -> 0.1.187, the release that stops step-06 from patching five
 #   HelmRepositories it does not own and then grading itself on whether they
@@ -4182,7 +4188,7 @@ version: 1.4.1546
 # scripts/check-chart-version-forward.sh (#5743) fails unless the two match —
 # main was carrying a pre-existing 1.4.1330/1.4.1329 split, so this bump heals
 # it in the same commit, exactly as the documented self-heal contract does.
-appVersion: 1.4.1546
+appVersion: 1.4.1547
 # 1.4.239 — Wave 3 / Issue #2140 (2026-05-23): Huawei provider
 # implementation lands behind the Wave 2 CloudProvider interface.
 # Adds the OpenTofu module at infra/providers/huawei/ (VPC + Subnet +

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5120,7 +5120,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.1.196"
+  version: "0.1.197"
   visibility: unlisted
   card:
     title: "Self-Sovereignty Cutover"
@@ -5137,7 +5137,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-self-sovereign-cutover
-    version: "0.1.196"
+    version: "0.1.197"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
## Problem — live-confirmed on hw301 region-B (me-east-215-b-1)

The self-sovereign-cutover region-local gitea-mirror authenticated `git push` /
`git ls-remote` by injecting the Gitea admin credential into the remote URL:

```
local_url=$(printf '%s' "${GITEA_INTERNAL_URL}" \
  | sed -E "s,^(https?://),\1${GITEA_USERNAME}:${GITEA_PASSWORD}@,")".../repo.git"
git push --force "${local_url}" 'refs/heads/*:refs/heads/*' 'refs/tags/*:refs/tags/*'
```

A region-local Gitea admin password holding a URL-special char (`/ @ : & % ...`)
breaks either the sed replacement or git's own URL parse, so the push FATALs with
`Could not read from remote repository`.

The tell that isolates the defect: on hw301 region-B the script's own curl API
calls SUCCEEDED — `[secondary-mirror] org already present`, `repo already present`
— because the API path sends a base64 `Authorization: Basic` header, while the
`git push` on the very same run FAILED, because the push path is different — it
URL-injects the password. API green + push red on one run points straight at the
URL-injection, not at auth or connectivity. This halts cutover step-01 on any
Sovereign whose region-local Gitea admin password contains a URL-special char.

## Fix — authenticate git with the same header the API calls use

Keep a credential-free remote URL and hand git the script's already-computed
base64 `basic_auth` as an HTTP header, exactly like the working curl calls:

```
push_url="${GITEA_INTERNAL_URL}/${GITEA_ORG}/${GITEA_REPO}.git"
git -c http.extraHeader="Authorization: Basic ${basic_auth}" push --force "${push_url}" \
    'refs/heads/*:refs/heads/*' 'refs/tags/*:refs/tags/*'
git -c http.extraHeader="Authorization: Basic ${basic_auth}" ls-remote --heads "${push_url}"
```

The sed URL-injection is removed. Existing password-redaction on error output is
retained as defense. All other behavior is preserved — DNS wait, retries,
org/repo create, the #6490 ls-remote completeness gate, the postBuffer/lowSpeed
git config, and the secondary's explicit-refspec push (never mirror mode, #5011).

Both admin-BasicAuth mirror sites are fixed so primary and secondary stay
consistent:

- `platform/self-sovereign-cutover/chart/templates/secondary-mirror-script-configmap.yaml`
  (the cross-region secondary leg — the hw301 failure)
- `platform/self-sovereign-cutover/chart/templates/11-mirror-resync-cronjob.yaml`
  (the primary-region mirror-resync CronJob's own push)

The PAT-authed primary step-01 (`01-gitea-mirror-job.yaml`) is deliberately left
unchanged: it authenticates with the step-09 minted `catalyst-gitea-token` PAT —
a hex token, structurally immune to URL-special chars — precisely because
admin-password BasicAuth hangs then 401s during the cutover window (#5262). It is
a separate contract, guarded by Case 67.

## Test

New `cutover-contract` **Case 96** renders both templates and asserts the push /
ls-remote carry the `Authorization: Basic` `http.extraHeader` against a
credential-free `push_url`, with an anti-regression assertion that no
`${GITEA_USERNAME}:${GITEA_PASSWORD}@` URL-injection survives. Non-vacuity proven
by rendering the pre-fix templates from `HEAD`: the header assertion is ABSENT
and the URL-injection assertion is PRESENT on the old script, so Case 96 fails on
it. `sh -n` passes on both rendered scripts.

## Lockstep bump

`bp-self-sovereign-cutover` **0.1.196 -> 0.1.197** across all five sites
(Chart.yaml, blueprint.yaml, catalog-seed card + source, generated catalog,
bootstrap-kit slot 06a), honoring the 0.1.172 sovereignty floor. The seed touch
forces the umbrella `bp-catalyst-platform` **1.4.1542 -> 1.4.1543** (Chart.yaml
version + appVersion, bootstrap-kit slot-13) and a `build-catalog.mjs` regen of
the committed catalog. Both versions chosen unclaimed by any open PR.

## Gate results

| Gate | Result |
| --- | --- |
| cutover-contract.sh (all 96 cases, incl. new Case 96) | PASS |
| Case 96 non-vacuity (fails on pre-fix render) | PROVEN |
| `sh -n` rendered secondary + resync scripts | PASS |
| check-cutover-version-floor.py (7 pins / 5 sites at 0.1.197 >= floor) | PASS |
| check-bootstrap-kit-pin-sync.sh (cutover 0.1.197, umbrella 1.4.1543) | PASS |
| check-catalog-seed-lockstep.sh | PASS |
| check-chart-version-bumped.sh | PASS (both charts) |
| check-chart-version-forward.sh | PASS (both charts) |
| seed-drift Go tests (core/services/provisioning/gitops) | PASS |
| generated-catalog determinism (committed == fresh regen) | PASS |
| check-chart-version-not-claimed-by-open-pr.py | 0.1.197 / 1.4.1543 unclaimed |

## Scope

This lands the durable code fix. It does not by itself flip UAT G11 / row 166 on
hw301 — that requires hw301's cutover re-fired on the fixed chart, or a fresh
prov.

Refs #3379 #6490
