### PR TITLE
fix(keycloak): per-Org console login 400s Invalid parameter: redirect_uri — sovereign realm catalyst-ui lacked the pool-domain callback (Refs #3374 #3988)

### DIFF
--- a/clusters/_template/bootstrap-kit/09-keycloak.yaml
+++ b/clusters/_template/bootstrap-kit/09-keycloak.yaml
@@ -248,7 +248,15 @@ spec:
       #   ClusterIP resolves with zero endpoints and routes to catalyst-api once
       #   slot 13 lands. Also: the config-cli Job now prints the SERVER's error
       #   body on a failed import instead of a bare 400.
-      version: 1.5.10
+      # 1.5.11 — #3374 #3988: the sovereign realm's catalyst-ui client now
+      #   registers the per-Org console callback https://console.*.<zone>/* for
+      #   every role==org-pool parent zone (threaded via the new `parentZones`
+      #   value from ${PARENT_DOMAINS_YAML} above). Without it a customer login
+      #   at console.<slug>.<pool-tld> 400'd `Invalid parameter: redirect_uri`
+      #   against the shared sovereign realm (live hw301 console.acme.omani.homes),
+      #   blocking every per-Org login AND the Pillar-4 agentic walk. Single-zone
+      #   Sovereigns (no org-pool zone) render byte-identical.
+      version: 1.5.11
       sourceRef:
         kind: HelmRepository
         name: bp-keycloak
@@ -318,6 +326,19 @@ spec:
         name: bp-keycloak
         namespace: flux-system
     sovereignFQDN: ${SOVEREIGN_FQDN}
+    # parentZones (#3374 #3988): the Sovereign's parent-domain pool, the SAME
+    # ${PARENT_DOMAINS_YAML} substitute powerdns (slot 11) / external-dns
+    # (slot 12) / sovereign-tls-vars (slot 12a) already consume. The sovereign
+    # realm import reads this to register the per-Org console callback
+    # https://console.*.<zone>/* on the catalyst-ui client for every
+    # role==org-pool zone — without it the per-Org operator console
+    # (console.<slug>.<pool-tld>) OIDC login 400s `Invalid parameter:
+    # redirect_uri` against the shared sovereign realm (live hw301
+    # console.acme.omani.homes). cloud-init always pre-renders the substitute
+    # (single-entry primary array in the zero-touch flow) so it is never unset;
+    # a single-zone Sovereign has no org-pool zone → catalyst-ui renders
+    # byte-identically.
+    parentZones: ${PARENT_DOMAINS_YAML}
     # sovereignRealm.ownerEmail (founder NS-3 #3263): the deployment owner's
     # email — cloud-init threads tofu's org_email into the bootstrap-kit
     # Kustomization substitute map as SOVEREIGN_OWNER_EMAIL. The realm import

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1459,7 +1459,11 @@ spec:
       # 1.4.1540 — lockstep for bp-wordpress-tenant 0.4.25 (#6311, Refs #4307:
       #   CNPG-operator status-probe carve-out + zero install-time egress; rebase
       #   of PR #6320 onto current main).
-      version: 1.4.1543
+      # 1.4.1544 — #3374 #3988: catalog-seed advances bp-keycloak 1.5.10 -> 1.5.11
+      #   (sovereign realm catalyst-ui registers the per-Org console callback
+      #   https://console.*.<zone>/* for role==org-pool zones; live hw301
+      #   console.acme.omani.homes 400'd `Invalid parameter: redirect_uri`).
+      version: 1.4.1544
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/platform/keycloak/blueprint.yaml
+++ b/platform/keycloak/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.5.10
+  version: 1.5.11
   card:
     title: keycloak
     summary: Keycloak — user identity. Topology decided by Sovereign CRD spec.keycloakTopology (per-organization for Organizations, shared-sovereign for corporate).

--- a/platform/keycloak/chart/Chart.yaml
+++ b/platform/keycloak/chart/Chart.yaml
@@ -556,7 +556,33 @@ name: bp-keycloak
 # client secrets. The happy path pays nothing and the Job still exits with the
 # original code.
 #   Guarded by tests/catalyst-pin-backchannel-resolvable-6172.sh.
-version: 1.5.10
+# 1.5.11 (#3374 #3988): per-Org console login 400'd `Invalid parameter:
+# redirect_uri`. On a shared-realm Sovereign the per-Org operator console
+# (org-console SPA) is served at console.<slug>.<pool-tld> and discovers OIDC
+# against the sovereign realm with client_id=catalyst-ui (bp-catalyst-platform
+# slot wires .Values.sso realm=sovereign clientId=catalyst-ui; tenant_discover.go
+# returns the same), so its browser redirect_uri is
+# https://console.<slug>.<pool-tld>/auth/callback. The sovereign realm's
+# catalyst-ui client listed ONLY the sovereign-admin host
+# (https://console.<sovereignFQDN>/*), so every pool-domain login was rejected
+# by Keycloak -- LIVE on hw301 console.acme.omani.homes: the customer cannot
+# reach their console, which also blocks the Pillar-4 agentic walk that needs
+# the org session. The sovereign-admin console (console.<sovereignFQDN>) was
+# unaffected because its host matched.
+#   Fix: for every parent zone with role==org-pool, the sovereign realm import
+# now registers the analogous host-wildcard console callback
+# https://console.*.<zone>/* (+ matching webOrigin + post-logout) on the
+# catalyst-ui client -- mirroring the tenant realm's catalyst-ui host-wildcard
+# (configmap-tenant-realm.yaml) and reusing the SAME role==org-pool selection
+# sovereign-tls-vars uses for the pool listeners (data, not code, generic for
+# any pool TLD). Threaded via the new top-level `parentZones` value from the
+# ${PARENT_DOMAINS_YAML} substitute powerdns/external-dns/sovereign-tls-vars
+# already consume; empty on a single-zone Sovereign -> catalyst-ui renders
+# byte-identical, so no non-pool Sovereign changes.
+#   Guarded by tests/per-org-console-pool-redirect-3374.sh (Case A asserts the
+# pool callbacks present -- FAILS on the pre-fix template; Case B/C assert the
+# single-zone / primary-only render is unchanged).
+version: 1.5.11
 description: |
   1.5.2 (#4246): the per-tenant `openclaw-oidc-client-secret` Secret now
   emits BOTH `client-secret` AND `OIDC_CLIENT_SECRET` keys (it previously

--- a/platform/keycloak/chart/templates/configmap-sovereign-realm.yaml
+++ b/platform/keycloak/chart/templates/configmap-sovereign-realm.yaml
@@ -184,6 +184,43 @@ tenant emit; tenant takes precedence here.
     )
 -}}
 {{- $userProfileConfigJSON := toJson $userProfileDoc -}}
+{{- /* ── Per-Org console pool-domain callbacks for catalyst-ui (#3374 #3988) ──
+     The per-Org operator console (org-console SPA) is served at
+     console.<slug>.<pool-tld> and — on a shared-realm Sovereign — discovers
+     OIDC against THIS sovereign realm with client_id=catalyst-ui (the
+     bp-catalyst-platform slot wires .Values.sso realm=sovereign
+     clientId=catalyst-ui; tenant_discover.go returns the same). Its browser
+     redirect_uri is https://console.<slug>.<pool-tld>/auth/callback. The
+     catalyst-ui client below only lists the sovereign-admin host
+     (https://console.<sovereignFQDN>/*), so a pool-domain login 400s
+     `Invalid parameter: redirect_uri` — LIVE on hw301 console.acme.omani.homes,
+     blocking every customer login (standalone P0) and the Pillar-4 agentic walk.
+
+     Fix: for each parent zone with role==org-pool, register the analogous
+     host-wildcard console callback https://console.*.<zone>/* (+ matching web
+     origin). This mirrors the tenant realm's catalyst-ui host-wildcard
+     (`https://*.<zone>/*`, configmap-tenant-realm.yaml) and reuses the SAME
+     role==org-pool selection sovereign-tls-vars uses for the pool listeners
+     (data, not code — generic for any pool TLD). parentZones is threaded from
+     ${PARENT_DOMAINS_YAML} (same source powerdns/external-dns/sovereign-tls-vars
+     consume); empty on a single-zone Sovereign → catalyst-ui renders
+     byte-identical to before, so no non-pool Sovereign changes. */ -}}
+{{- $poolConsoleRedirects := list -}}
+{{- $poolConsoleOrigins := list -}}
+{{- range $z := (default (list) .Values.parentZones) -}}
+  {{- if and $z.name (eq (default "primary" $z.role) "org-pool") -}}
+    {{- $poolConsoleRedirects = append $poolConsoleRedirects (printf "https://console.*.%s/*" $z.name) -}}
+    {{- $poolConsoleOrigins = append $poolConsoleOrigins (printf "https://console.*.%s" $z.name) -}}
+  {{- end -}}
+{{- end -}}
+{{- /* post.logout.redirect.uris is a `##`-delimited list in Keycloak; keep the
+     sovereign-admin host first (byte-identical when no org-pool zones) and
+     append each pool console pattern so a customer can also log OUT to their
+     own console host. */ -}}
+{{- $postLogout := printf "https://console.%s/*" .Values.sovereignFQDN -}}
+{{- range $u := $poolConsoleRedirects -}}
+  {{- $postLogout = printf "%s##%s" $postLogout $u -}}
+{{- end -}}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -526,9 +563,15 @@ data:
           "serviceAccountsEnabled": false,
           "redirectUris": [
             "https://console.{{ .Values.sovereignFQDN }}/*"
+            {{- range $u := $poolConsoleRedirects }},
+            {{ $u | quote }}
+            {{- end }}
           ],
           "webOrigins": [
             "https://console.{{ .Values.sovereignFQDN }}"
+            {{- range $o := $poolConsoleOrigins }},
+            {{ $o | quote }}
+            {{- end }}
           ],
           "defaultClientScopes": [
             "web-origins",
@@ -549,7 +592,7 @@ data:
           "attributes": {
             "pkce.code.challenge.method": "S256",
             "access.token.lifespan": "900",
-            "post.logout.redirect.uris": "https://console.{{ .Values.sovereignFQDN }}/*"
+            "post.logout.redirect.uris": {{ $postLogout | quote }}
           }
         },
         {{- /*

--- a/platform/keycloak/chart/tests/per-org-console-pool-redirect-3374.sh
+++ b/platform/keycloak/chart/tests/per-org-console-pool-redirect-3374.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# bp-keycloak per-Org console pool-domain redirect gate (#3374 #3988).
+#
+# WHY THIS EXISTS
+# ----------------
+# On a shared-realm Sovereign the per-Org operator console (org-console SPA) is
+# served at console.<slug>.<pool-tld> and discovers OIDC against the SOVEREIGN
+# realm with client_id=catalyst-ui (bp-catalyst-platform slot wires
+# .Values.sso realm=sovereign clientId=catalyst-ui; tenant_discover.go returns
+# the same). The browser redirect_uri is
+#   https://console.<slug>.<pool-tld>/auth/callback
+#
+# The sovereign realm's catalyst-ui client historically listed ONLY the
+# sovereign-admin host (https://console.<sovereignFQDN>/*). A pool-domain login
+# therefore 400s at Keycloak with `Invalid parameter: redirect_uri` — LIVE on
+# hw301 console.acme.omani.homes, blocking every customer login AND the Pillar-4
+# agentic walk that needs the org session.
+#
+# The fix registers, for every parent zone with role==org-pool, the host-wildcard
+# console callback https://console.*.<zone>/* (+ matching webOrigin + post-logout)
+# on the catalyst-ui client, threaded from the same ${PARENT_DOMAINS_YAML} pool
+# the powerdns / external-dns / sovereign-tls-vars slots already consume.
+#
+# NON-VACUITY
+# -----------
+# Case A asserts the pool callbacks are PRESENT when parentZones carries org-pool
+# zones — this assertion FAILS on the pre-fix template (which ignores
+# parentZones), so the gate genuinely catches a regression.
+# Case B asserts the render is UNCHANGED (no pool callbacks, single sovereign
+# host) when parentZones is empty — proving single-zone Sovereigns are byte-safe.
+# Case C asserts a role==primary zone is NOT treated as a pool zone (selection
+# keys strictly off role, data-not-code).
+#
+# Usage: bash tests/per-org-console-pool-redirect-3374.sh [CHART_DIR]
+
+set -euo pipefail
+
+CHART_DIR="${1:-$(cd "$(dirname "$0")/.." && pwd)}"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+cd "$CHART_DIR"
+if [ ! -d charts ] || [ -z "$(ls -A charts 2>/dev/null)" ]; then
+  helm dependency build >/dev/null
+fi
+
+PYTHON="${PYTHON:-python3}"
+if ! command -v "$PYTHON" >/dev/null; then
+  echo "FAIL: python3 is required for JSON-parse assertions in this test." >&2
+  exit 1
+fi
+
+FQDN="hw301.omantel.biz"
+
+echo "[pool-redirect] Case A: org-pool zones register console.*.<pool>/* on catalyst-ui"
+helm template smoke-kc . \
+  --set sovereignFQDN="$FQDN" \
+  --set 'parentZones[0].name=hw301.omantel.biz' --set 'parentZones[0].role=primary' \
+  --set 'parentZones[1].name=omani.homes'       --set 'parentZones[1].role=org-pool' \
+  --set 'parentZones[2].name=omani.rest'        --set 'parentZones[2].role=org-pool' \
+  --set 'parentZones[3].name=omani.trade'       --set 'parentZones[3].role=org-pool' \
+  > "$TMP/with.yaml"
+
+"$PYTHON" - "$TMP/with.yaml" "$FQDN" <<'PY'
+import sys, yaml, json
+src, fqdn = sys.argv[1], sys.argv[2]
+docs = list(yaml.safe_load_all(open(src)))
+cms = [d for d in docs if d and d.get('kind') == 'ConfigMap'
+       and 'sovereign-realm.json' in (d.get('data') or {})]
+assert len(cms) == 1, f"expected exactly 1 realm-config CM, got {len(cms)}"
+realm = json.loads(cms[0]['data']['sovereign-realm.json'])
+cu = {c['clientId']: c for c in realm['clients']}['catalyst-ui']
+
+# Sovereign-admin host still present (never regress the working path).
+assert f"https://console.{fqdn}/*" in cu['redirectUris'], \
+    f"sovereign-admin console redirect dropped: {cu['redirectUris']}"
+assert f"https://console.{fqdn}" in cu['webOrigins'], \
+    f"sovereign-admin console webOrigin dropped: {cu['webOrigins']}"
+
+# Every org-pool zone gets its host-wildcard console callback + origin.
+for pool in ("omani.homes", "omani.rest", "omani.trade"):
+    ru = f"https://console.*.{pool}/*"
+    wo = f"https://console.*.{pool}"
+    assert ru in cu['redirectUris'], \
+        f"missing per-Org console redirectUri {ru!r}: {cu['redirectUris']}"
+    assert wo in cu['webOrigins'], \
+        f"missing per-Org console webOrigin {wo!r}: {cu['webOrigins']}"
+    assert wo in cu['attributes']['post.logout.redirect.uris'], \
+        f"missing per-Org post-logout {wo!r}: {cu['attributes']['post.logout.redirect.uris']}"
+
+# The PRIMARY zone must NOT be registered as a pool console callback (role gate).
+assert f"https://console.*.{fqdn}/*" not in cu['redirectUris'], \
+    f"primary zone wrongly registered as a pool console callback: {cu['redirectUris']}"
+print("  [assert] catalyst-ui carries all 3 pool console callbacks + origins")
+PY
+echo "  PASS"
+
+echo "[pool-redirect] Case B: empty parentZones → catalyst-ui unchanged (byte-safe)"
+helm template smoke-kc . --set sovereignFQDN="$FQDN" > "$TMP/without.yaml"
+"$PYTHON" - "$TMP/without.yaml" "$FQDN" <<'PY'
+import sys, yaml, json
+src, fqdn = sys.argv[1], sys.argv[2]
+docs = list(yaml.safe_load_all(open(src)))
+cms = [d for d in docs if d and d.get('kind') == 'ConfigMap'
+       and 'sovereign-realm.json' in (d.get('data') or {})]
+realm = json.loads(cms[0]['data']['sovereign-realm.json'])
+cu = {c['clientId']: c for c in realm['clients']}['catalyst-ui']
+assert cu['redirectUris'] == [f"https://console.{fqdn}/*"], \
+    f"single-zone catalyst-ui redirectUris changed (should be sovereign host only): {cu['redirectUris']}"
+assert cu['webOrigins'] == [f"https://console.{fqdn}"], \
+    f"single-zone catalyst-ui webOrigins changed: {cu['webOrigins']}"
+assert cu['attributes']['post.logout.redirect.uris'] == f"https://console.{fqdn}/*", \
+    f"single-zone catalyst-ui post-logout changed: {cu['attributes']['post.logout.redirect.uris']}"
+print("  [assert] single-zone render carries no pool callbacks")
+PY
+echo "  PASS"
+
+echo "[pool-redirect] Case C: a non-pool (primary-only) zone list adds nothing"
+helm template smoke-kc . \
+  --set sovereignFQDN="$FQDN" \
+  --set 'parentZones[0].name=hw301.omantel.biz' --set 'parentZones[0].role=primary' \
+  > "$TMP/primary-only.yaml"
+"$PYTHON" - "$TMP/primary-only.yaml" "$FQDN" <<'PY'
+import sys, yaml, json
+src, fqdn = sys.argv[1], sys.argv[2]
+docs = list(yaml.safe_load_all(open(src)))
+cms = [d for d in docs if d and d.get('kind') == 'ConfigMap'
+       and 'sovereign-realm.json' in (d.get('data') or {})]
+realm = json.loads(cms[0]['data']['sovereign-realm.json'])
+cu = {c['clientId']: c for c in realm['clients']}['catalyst-ui']
+assert cu['redirectUris'] == [f"https://console.{fqdn}/*"], \
+    f"primary-only zone list wrongly added pool callbacks: {cu['redirectUris']}"
+print("  [assert] primary-only zone list leaves catalyst-ui at the sovereign host")
+PY
+echo "  PASS"
+
+echo "[pool-redirect] All bp-keycloak per-Org console pool-redirect gates green."

--- a/platform/keycloak/chart/values.yaml
+++ b/platform/keycloak/chart/values.yaml
@@ -40,6 +40,21 @@ catalystBlueprint:
 # Per-Sovereign bootstrap-kit HelmRelease overlay supplies this.
 sovereignFQDN: ""
 
+# parentZones: the Sovereign's parent-domain pool, threaded from the same
+# ${PARENT_DOMAINS_YAML} Flux substitute that powerdns (slot 11), external-dns
+# (slot 12) and sovereign-tls-vars (slot 12a) consume. A YAML list of
+# {name, role} maps, e.g.
+#   [{name: "omantel.biz", role: "primary"}, {name: "omani.homes", role: "org-pool"}]
+# configmap-sovereign-realm.yaml reads this to register the per-Org console
+# callback https://console.*.<zone>/* on the catalyst-ui client for every
+# role==org-pool zone — the per-Org operator console (console.<slug>.<pool-tld>)
+# discovers OIDC against the sovereign realm with client_id=catalyst-ui and
+# otherwise 400s `Invalid parameter: redirect_uri` (#3374 #3988; live hw301
+# console.acme.omani.homes). Empty default → single-zone Sovereigns render the
+# catalyst-ui client byte-identically (no pool callbacks added). Selection keys
+# only off the zone role (data, not code), so it is generic for any pool TLD.
+parentZones: []
+
 # catalystAPIInternalURL — the in-cluster base URL for the catalyst-pin
 # identity provider's BACKCHANNEL legs (#6087, UAT row 219).
 #

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-20T01:34:51.451Z",
+  "generatedAt": "2026-08-20T03:38:46.444Z",
   "blueprints": [
     {
       "id": "bp-agenity",
@@ -2235,7 +2235,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "1.5.10",
+      "version": "1.5.11",
       "section": "pts-2-3-per-sovereign-supporting-services",
       "depends": [
         "bp-postgres"

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -2370,7 +2370,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "1.5.10",
+    "version": "1.5.11",
     "section": "pts-2-3-per-sovereign-supporting-services",
     "depends": [
       "bp-postgres"

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -3988,7 +3988,14 @@ name: bp-catalyst-platform
 #   onto current main; 0.4.24 is claimed by the still-open #6320 so this republish
 #   takes the next free patch. Umbrella tracks its sub-charts per Inviolable
 #   Principle #13.
-version: 1.4.1543
+# 1.4.1544 — #3374 #3988: catalog-seed advances bp-keycloak 1.5.10 -> 1.5.11,
+#   which registers the per-Org console callback https://console.*.<zone>/* on
+#   the sovereign realm's catalyst-ui client for every role==org-pool parent
+#   zone. Without it a customer login at console.<slug>.<pool-tld> 400'd
+#   `Invalid parameter: redirect_uri` (live hw301 console.acme.omani.homes),
+#   blocking every per-Org login AND the Pillar-4 agentic walk. Umbrella tracks
+#   its sub-charts per Inviolable Principle #13.
+version: 1.4.1544
 # 1.4.1481 — #6293: catalog-seed advances bp-self-sovereign-cutover
 #   0.1.186 -> 0.1.187, the release that stops step-06 from patching five
 #   HelmRepositories it does not own and then grading itself on whether they
@@ -4175,7 +4182,7 @@ version: 1.4.1543
 # scripts/check-chart-version-forward.sh (#5743) fails unless the two match —
 # main was carrying a pre-existing 1.4.1330/1.4.1329 split, so this bump heals
 # it in the same commit, exactly as the documented self-heal contract does.
-appVersion: 1.4.1543
+appVersion: 1.4.1544
 # 1.4.239 — Wave 3 / Issue #2140 (2026-05-23): Huawei provider
 # implementation lands behind the Wave 2 CloudProvider interface.
 # Adds the OpenTofu module at infra/providers/huawei/ (VPC + Subnet +

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -597,7 +597,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "1.5.10"
+  version: "1.5.11"
   visibility: listed
   card:
     title: "Keycloak"
@@ -625,7 +625,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-keycloak
-    version: "1.5.10"
+    version: "1.5.11"
   # G117.1+G117.4+G117.6 #2744-followup (2026-06-03): bp-keycloak
   # catalog-seed needs topology + endpoints + sso so application-
   # controller can fan out HRs and operator console can mint silent-SSO


### PR DESCRIPTION
## Live evidence (hw301, Org `acme`)

Navigating to `https://console.acme.omani.homes/` bounced to the sovereign
realm (`https://auth.hw301.omantel.biz/realms/sovereign`) and Keycloak returned
**`Invalid parameter: redirect_uri`** — the customer cannot log into their
per-Org console. The sovereign-admin console (`https://console.hw301.omantel.biz`)
logs in fine.

## Root cause (config gap in the sovereign realm's `catalyst-ui` client)

On a shared-realm Sovereign the per-Org operator console (org-console SPA) is
served at `console.<slug>.<pool-tld>` and discovers OIDC against the **sovereign
realm** with `client_id=catalyst-ui`:

- `clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml` wires the
  org-console `sso: { realm: sovereign, clientId: catalyst-ui }`.
- `products/catalyst/bootstrap/api/internal/handler/tenant_discover.go` returns
  the same `catalyst-ui` client for the discovered host.

The SPA derives `redirect_uri = https://console.<slug>.<pool-tld>/auth/callback`.
But the sovereign realm's `catalyst-ui` client
(`platform/keycloak/chart/templates/configmap-sovereign-realm.yaml`) listed
**only** the sovereign-admin host:

```
"redirectUris": [ "https://console.<sovereignFQDN>/*" ]
```

So Keycloak rejected every pool-domain callback (`console.acme.omani.homes/auth/callback`).
The sovereign-admin host matched, which is why only the per-Org consoles failed.
This is a standalone customer-facing P0 **and** it blocks the Pillar-4 agentic
walk (no org session → no agenity day-2 re-render).

Confirmed: **client id = `catalyst-ui`**, **missing redirect uri =
`https://console.acme.omani.homes/auth/callback`** (generally
`console.<slug>.<pool-tld>/auth/callback` for the pool TLDs omani.homes /
omani.rest / omani.trade).

## Fix — realm-config (not per-Org provisioning)

The per-Org console shares the single sovereign `catalyst-ui` client (no per-Org
Keycloak client mutation happens on this path), so the durable fix is at the
realm-config layer. For every parent zone with `role: org-pool`, the sovereign
realm import now registers the host-wildcard console callback
`https://console.*.<zone>/*` (plus matching `webOrigins` and `post.logout.redirect.uris`)
on `catalyst-ui`:

```
"redirectUris": [
  "https://console.<sovereignFQDN>/*",
  "https://console.*.omani.homes/*",
  "https://console.*.omani.rest/*",
  "https://console.*.omani.trade/*"
]
```

Why this shape:

- It mirrors the **tenant realm's** own `catalyst-ui` host-wildcard
  (`https://*.<zone>/*` in `configmap-tenant-realm.yaml`) — the established
  in-repo pattern on Keycloak 26.3.
- Selection keys strictly off `role == org-pool`, the **same data-driven
  selection** `sovereign-tls-vars` already uses to bind the pool listeners —
  generic for any pool TLD, nothing hardcoded (Inviolable Principle #4).
- The pool is threaded from a new top-level `parentZones` value fed by
  `${PARENT_DOMAINS_YAML}` — the exact substitute powerdns / external-dns /
  sovereign-tls-vars already consume. **Empty on a single-zone Sovereign →
  `catalyst-ui` renders byte-identical** (proven below), so no non-pool
  Sovereign changes.

### Files

- `platform/keycloak/chart/templates/configmap-sovereign-realm.yaml` — the fix.
- `platform/keycloak/chart/values.yaml` — new `parentZones: []` default.
- `clusters/_template/bootstrap-kit/09-keycloak.yaml` — thread
  `parentZones: ${PARENT_DOMAINS_YAML}`.
- `platform/keycloak/chart/tests/per-org-console-pool-redirect-3374.sh` — new gate.
- Chart lockstep: bp-keycloak `1.5.10 → 1.5.11`; catalog-seed synced +
  regenerated; bp-catalyst-platform `1.4.1543 → 1.4.1544` + slot-13 pin.

### Test (non-vacuous)

`tests/per-org-console-pool-redirect-3374.sh`:

- **Case A** — with org-pool zones, asserts each `https://console.*.<pool>/*`
  redirect + origin + post-logout is present. This assertion **FAILS on the
  pre-fix template** (verified: rendering `origin/main` with `parentZones` set
  produces only `["https://console.<sovereignFQDN>/*"]`), so the gate genuinely
  catches a regression.
- **Case B** — empty `parentZones` → `catalyst-ui` is exactly the sovereign host
  (byte-safe for single-zone Sovereigns).
- **Case C** — a `role: primary` zone is not treated as a pool zone.

Also verified: full-render diff of the sovereign realm ConfigMap vs `origin/main`
at default values is empty except for the random generated secrets.

## Gates

| Gate | Result |
|---|---|
| `tests/per-org-console-pool-redirect-3374.sh` (new) | PASS (A/B/C) |
| non-vacuity (Case A fails on pre-fix template) | CONFIRMED |
| existing keycloak realm tests (tenant-realm-oidc-clients, sovereign-realm-owner-admin-seed, sovereign-realm-federated-no-required-actions, realm-flow-subflow-resolution, g117-5-tier1-sso-clients, oidc-kubectl-client) | PASS (no regression) |
| `helm lint platform/keycloak/chart` | PASS |
| `check-chart-version-bumped.sh` | PASS (bp-keycloak 1.5.10→1.5.11, bp-catalyst-platform 1.4.1543→1.4.1544) |
| `check-chart-version-forward.sh` | PASS |
| `check-chart-version-not-claimed-by-open-pr.py` | PASS (0/55 open PRs claim either version) |
| `check-bootstrap-kit-pin-sync.sh` | PASS (both pins == chart) |
| `check-catalog-seed-lockstep.sh` | PASS |
| `check-catalog-seed-source-coverage.py` | PASS |
| catalog regen idempotent (byte-identical re-run; `generatedAt` #5520-stable) | PASS |
| `go build ./internal/catalog/...` (embeds regenerated blueprints.json) | PASS |
| `check-no-banned-words.sh` | PASS |

## Related residual (NOT fixed here — distinct root cause)

The sovereign-admin "Enter org" support-session
(`products/catalyst/bootstrap/api/internal/handler/org_enter_org.go`) hands over
to the non-resolving `console.<slug>.<sovereign-fqdn>` host and its handover token
carries an `aud` for that wrong host (`invalid audience` at the correct pool
host). That is a **host-derivation + audience-minting** bug in the catalyst-api
handover flow: it falls back to `console.<slug>.<sovFQDN>` when
`deriveConsoleHost(rec)` returns empty, and mints `aud` for that fallback. It
does **not** share this PR's root cause (the Keycloak `catalyst-ui`
redirect-uri config) and is left for a separate change.

## Scope note

This PR lands the durable SSO redirect-uri fix. It does **not** by itself flip
the agentic UAT rows on hw301 green — that still needs the org login to work end
to end plus the agenity re-render and a chat walk on a Sovereign carrying
bp-keycloak ≥ 1.5.11.

Refs #3374 #3988
