### PR TITLE
fix(provisioning): thread org-pool/tenant parent domain into the umbrella (TENANT_PARENT_DOMAIN) — missing half of #6504

### DIFF
--- a/infra/providers/_shared/cloudinit-control-plane.tftpl
+++ b/infra/providers/_shared/cloudinit-control-plane.tftpl
@@ -688,6 +688,27 @@ write_files:
 %{ if length(distinct([for z in yamldecode(parent_domains_yaml) : z.name])) > 1 ~}
             PARENT_DOMAINS_FILTER: '${jsonencode(distinct([for z in yamldecode(parent_domains_yaml) : z.name]))}'
 %{ endif ~}
+            # TENANT_PARENT_DOMAIN (#3374 #3988, Refs #6504) — the single
+            # org-pool TLD new Organizations default to for their per-Org
+            # console + app subdomains (console.<slug>.<pool-tld>). bootstrap-kit
+            # slot-13 threads this into bp-catalyst-platform's
+            # orgServices.provisioning.tenantParentDomain ($${TENANT_PARENT_DOMAIN:-});
+            # the per-Org provisioning consumer stamps spec.tenantPublic ONLY when
+            # it is set, so WITHOUT it every customer Org mints with NO public
+            # route and the customer console + purchased app return
+            # ERR_CONNECTION_REFUSED — the funnel-terminal failure #3859 fixed the
+            # chart wiring for, but the $${TENANT_PARENT_DOMAIN} substitute itself
+            # was never emitted, so the value stayed empty on every Sovereign.
+            # Derived from the FIRST role==org-pool zone in the SAME
+            # parent_domains_yaml the parentZones substitute uses (single source →
+            # tenantParentDomain can never diverge from the zones bp-keycloak #6504
+            # renders console.*.<zone>/* catalyst-ui callbacks for). Emitted ONLY
+            # when an org-pool zone exists, so a single-zone Sovereign renders
+            # byte-identically (slot-13 default $${TENANT_PARENT_DOMAIN:-} → "").
+            # Go mirror: provisioner.Request.TenantParentDomain().
+%{ if length([for z in yamldecode(parent_domains_yaml) : z.name if z.role == "org-pool"]) > 0 ~}
+            TENANT_PARENT_DOMAIN: '${[for z in yamldecode(parent_domains_yaml) : z.name if z.role == "org-pool"][0]}'
+%{ endif ~}
             SOVEREIGN_CNPG_INSTANCES: "${sovereign_cnpg_instances}"
             CONTINUUM_ENABLED: "${continuum_enabled}"
             CLUSTER_MESH_NAME: "${cluster_mesh_name}"

--- a/products/catalyst/bootstrap/api/internal/provisioner/parent_domains_test.go
+++ b/products/catalyst/bootstrap/api/internal/provisioner/parent_domains_test.go
@@ -745,3 +745,137 @@ func TestDefaultRegistrarKindFromEnv(t *testing.T) {
 		t.Errorf("empty env should fall back to default: got %q, want %q", got, defaultRegistrarKind)
 	}
 }
+
+// TestWriteTfvars_ThreadsEveryOrgPoolZoneIntoParentZones is the
+// regression guard for the per-Org console login P0 (#3374 #3988,
+// Refs #6504, live hw301 console.acme.omani.homes → HTTP 400 "Invalid
+// parameter: redirect_uri").
+//
+// bp-keycloak #6504 (chart 1.5.11) taught the sovereign realm's
+// catalyst-ui client to register a per-Org console callback
+// https://console.*.<zone>/* for every parentZones entry whose
+// role==org-pool — but it can only act on the zones that actually reach
+// the umbrella's parentZones substitute. parentZones is fed from
+// ${PARENT_DOMAINS_YAML}, which is fed from the parent_domains_yaml tofu
+// var this function writes. So the necessary-and-load-bearing precondition
+// for #6504 is: a deployment carrying a primary + N org-pool TLDs MUST
+// render parent_domains_yaml with exactly one role==org-pool entry per
+// pool TLD. This test locks that contract at N==3.
+func TestWriteTfvars_ThreadsEveryOrgPoolZoneIntoParentZones(t *testing.T) {
+	dir, err := os.MkdirTemp("", "writeTfvars-orgpool-n-*")
+	if err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	defer os.RemoveAll(dir)
+
+	poolTLDs := []string{"omani.homes", "omani.rest", "omani.trade"}
+	req := Request{
+		SovereignFQDN:    "hw301.omantel.biz",
+		OrgName:          "Omantel",
+		OrgEmail:         "ops@omantel.biz",
+		HetznerToken:     "tok",
+		HetznerProjectID: "p1",
+		Region:           "fsn1",
+		WorkerCount:      2,
+		ParentDomains: []ParentDomain{
+			{Name: "omantel.biz", Role: ParentDomainRolePrimary, RegistrarKind: "dynadot"},
+			{Name: "omani.homes", Role: ParentDomainRoleOrgPool, RegistrarKind: "dynadot"},
+			{Name: "omani.rest", Role: ParentDomainRoleOrgPool, RegistrarKind: "dynadot"},
+			{Name: "omani.trade", Role: ParentDomainRoleOrgPool, RegistrarKind: "dynadot"},
+		},
+	}
+	if err := writeTfvars(dir, req); err != nil {
+		t.Fatalf("writeTfvars: %v", err)
+	}
+	raw, err := os.ReadFile(dir + "/tofu.auto.tfvars.json")
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	got, _ := parsed["parent_domains_yaml"].(string)
+	if got == "" {
+		t.Fatalf("parent_domains_yaml MUST carry the org-pool zones; empty drops them and bp-keycloak #6504 has no org-pool zone to render console callbacks for")
+	}
+	var entries []map[string]any
+	if err := json.Unmarshal([]byte(got), &entries); err != nil {
+		t.Fatalf("parent_domains_yaml must be JSON-flow / YAML-decodable: %v\nRaw: %s", err, got)
+	}
+	// Exactly one role==org-pool entry per pool TLD, plus the primary.
+	if len(entries) != 4 {
+		t.Fatalf("parent_domains_yaml should carry 4 entries (primary + 3 org-pool), got %d. Raw: %s", len(entries), got)
+	}
+	seenPool := map[string]bool{}
+	for _, e := range entries {
+		name, _ := e["name"].(string)
+		role, _ := e["role"].(string)
+		if role == ParentDomainRoleOrgPool {
+			seenPool[name] = true
+		}
+	}
+	for _, tld := range poolTLDs {
+		if !seenPool[tld] {
+			t.Errorf("parent_domains_yaml is missing a role==org-pool entry for pool TLD %q — bp-keycloak #6504 will not render console.*.%s/*. Raw: %s", tld, tld, got)
+		}
+	}
+	if len(seenPool) != len(poolTLDs) {
+		t.Errorf("parent_domains_yaml carried %d org-pool entries, want exactly %d (one per pool TLD). Raw: %s", len(seenPool), len(poolTLDs), got)
+	}
+}
+
+// TestTenantParentDomain_DerivesFirstOrgPool proves the tenantParentDomain
+// half of the same #3374/#3988 threading: the org-pool TLD new Organizations
+// default to (bootstrap-kit slot-13
+// orgServices.provisioning.tenantParentDomain ← ${TENANT_PARENT_DOMAIN}) is
+// the FIRST role==org-pool parent domain, and "" when the Sovereign brought
+// none (single-zone → byte-identical render, empty default). This is the Go
+// mirror of the cloud-init TENANT_PARENT_DOMAIN derivation; keeping the two in
+// lockstep is why the helper exists.
+func TestTenantParentDomain_DerivesFirstOrgPool(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []ParentDomain
+		want string
+	}{
+		{
+			name: "no org-pool zone → empty (single-zone Sovereign)",
+			in: []ParentDomain{
+				{Name: "solo.example.io", Role: ParentDomainRolePrimary},
+			},
+			want: "",
+		},
+		{
+			name: "nil slice → empty",
+			in:   nil,
+			want: "",
+		},
+		{
+			name: "first org-pool wins (primary skipped)",
+			in: []ParentDomain{
+				{Name: "omantel.biz", Role: ParentDomainRolePrimary},
+				{Name: "omani.homes", Role: ParentDomainRoleOrgPool},
+				{Name: "omani.rest", Role: ParentDomainRoleOrgPool},
+				{Name: "omani.trade", Role: ParentDomainRoleOrgPool},
+			},
+			want: "omani.homes",
+		},
+		{
+			name: "name is lowercased + trimmed",
+			in: []ParentDomain{
+				{Name: "omantel.biz", Role: ParentDomainRolePrimary},
+				{Name: "  OMANI.REST  ", Role: ParentDomainRoleOrgPool},
+			},
+			want: "omani.rest",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Request{ParentDomains: tc.in}.TenantParentDomain()
+			if got != tc.want {
+				t.Errorf("TenantParentDomain() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/provisioner/provisioner.go
+++ b/products/catalyst/bootstrap/api/internal/provisioner/provisioner.go
@@ -3642,6 +3642,34 @@ func (r Request) OrgPoolParentDomains() []ParentDomain {
 	return out
 }
 
+// TenantParentDomain returns the single org-pool TLD new Organizations
+// default to for their per-Org console + app subdomains
+// (console.<slug>.<pool-tld>, <app>.<slug>.<pool-tld>) — the FIRST entry in
+// r.ParentDomains carrying ParentDomainRoleOrgPool, lower-cased + trimmed, or
+// "" when the Sovereign brought no org-pool zone (single-zone / BYO).
+//
+// This is the Go mirror of the cloud-init TENANT_PARENT_DOMAIN substitute
+// (infra/providers/_shared/cloudinit-control-plane.tftpl, bootstrap-kit
+// block), which derives the same "first org-pool zone" from
+// var.parent_domains_yaml. bootstrap-kit slot-13 threads that substitute into
+// bp-catalyst-platform's orgServices.provisioning.tenantParentDomain, and the
+// per-Org provisioning consumer stamps spec.tenantPublic ONLY when it is set —
+// so the value MUST come from the same ParentDomains source that feeds the
+// parentZones substitute (and therefore bp-keycloak #6504's
+// console.*.<zone>/* catalyst-ui callbacks), or the two diverge and a
+// customer login at console.<slug>.<pool-tld> 400s Invalid parameter:
+// redirect_uri against the shared sovereign realm (#3374 #3988, live hw301).
+// Kept in lockstep with that template; both derive from ParentDomains by
+// construction.
+func (r Request) TenantParentDomain() string {
+	for _, pd := range r.ParentDomains {
+		if pd.Role == ParentDomainRoleOrgPool {
+			return strings.ToLower(strings.TrimSpace(pd.Name))
+		}
+	}
+	return ""
+}
+
 // defaultRegistrarKindFromEnv returns the registrar adapter id used
 // when synthesising a Day-1 ParentDomain entry from the legacy
 // single-FQDN payload. Reads CATALYST_DEFAULT_REGISTRAR_KIND with


### PR DESCRIPTION
## Problem — per-Org console login P0 (missing half of #6504)

A customer login at `console.<slug>.<pool-tld>` (e.g. `console.acme.omani.homes`)
redirects to the sovereign realm's `catalyst-ui` client and Keycloak returns
**HTTP 400 "Invalid parameter: redirect_uri"** — the pool-domain console host is
not in catalyst-ui's registered redirectUris. Live on hw301. Blocks every
per-Org login and the Pillar-4 agentic walk.

`bp-keycloak` #6504 (chart `1.5.11`) shipped the necessary half: catalyst-ui now
registers `https://console.*.<zone>/*` for every `parentZones` entry whose
`role == org-pool`. **This PR ships the missing half — actually feeding the
org-pool / tenant parent domain into the umbrella.**

## Root cause — a MISSING FIELD, not a dropped thread

Two umbrella values must carry the org-pool zones:

| Umbrella value | Source substitute | State before this PR |
|---|---|---|
| `parentZones` (slots 09/11/12/12a/13) | `${PARENT_DOMAINS_YAML}` ← `parent_domains_yaml` tofu var (from `req.ParentDomains`) | already carries every `role: org-pool` entry via `writeTfvars` — **works** |
| `orgServices.provisioning.tenantParentDomain` (slot 13) | `${TENANT_PARENT_DOMAIN:-}` | **never emitted by cloud-init/tofu → empty on EVERY Sovereign** |

`#3859` wired the chart to *read* `tenantParentDomain` (the per-Org provisioning
consumer stamps `spec.tenantPublic` only when it is set — without it the
customer console + purchased-app HTTPRoutes never render, `ERR_CONNECTION_REFUSED`),
but nothing ever *fed* the `${TENANT_PARENT_DOMAIN}` substitute. So it defaulted
to empty everywhere.

## Fix

Mirrors the adjacent `PARENT_DOMAINS_FILTER` derivation already in the template:

- **`infra/providers/_shared/cloudinit-control-plane.tftpl`** (the `bootstrap-kit`
  substitute block, where slot-13 lives) now derives `TENANT_PARENT_DOMAIN` from
  the **first `role == org-pool` zone in the SAME `parent_domains_yaml`** the
  `parentZones` substitute consumes. Single source of truth → `tenantParentDomain`
  can never diverge from the zones bp-keycloak #6504 renders callbacks for.
  Emitted **only** when an org-pool zone exists, so a single-zone Sovereign
  renders **byte-identically** (`${TENANT_PARENT_DOMAIN:-}` → `""`).
- **`provisioner.Request.TenantParentDomain()`** — the Go mirror of that
  derivation, sibling to `PrimaryParentDomain()` / `OrgPoolParentDomains()`,
  kept in lockstep with the template.
- **Test** locking the #6504 precondition (a deployment with a primary + N
  org-pool TLDs renders `parent_domains_yaml` with one `role: org-pool` entry
  per pool TLD) plus the new first-org-pool derivation.

The consumer + chart wiring (`core/services/provisioning`,
`products/catalyst/chart/.../provisioning.yaml`, `values.yaml`) were already
correct — they read the value; the gap was purely that the value was never
produced. No chart/version/pin/catalog change (the chart already reads
`${TENANT_PARENT_DOMAIN:-}`), so no lockstep gates triggered.

## Validation

- `go build ./...` + `go test ./...` (`provisioner` + `handler` packages) — green.
- `tofu` render of `cloudinit-control-plane.tftpl` via the `infra/.../tests`
  harness:
  - single-zone (hetzner + huawei): renders clean, `TENANT_PARENT_DOMAIN` **omitted** (byte-identical).
  - multi-zone (org-pool present): emits `TENANT_PARENT_DOMAIN: 'pool.test'` (first org-pool zone).
- Targets future/fresh provs only; not delivered to the live hw301 (region-A unreachable).

Refs #3374 #3988 #6504
