### PR TITLE
fix(events): bound JetStream MaxDeliver so a doomed notification stops draining the noreply@ PIN budget (Refs #6464 #6506)

### DIFF
--- a/core/services/shared/events/bridge_subscriber.go
+++ b/core/services/shared/events/bridge_subscriber.go
@@ -44,6 +44,8 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -102,6 +104,15 @@ type MultiSubscriber struct {
 	// constructor surface mirrors what the existing call sites
 	// (events.NewConsumer(brokers, group, topics)) already know.
 	subjects []string
+
+	// maxDeliver bounds JetStream redelivery of a persistently-failing
+	// envelope (#6464 residual). Resolved once at construction from
+	// EVENTS_NATS_MAX_DELIVER (default defaultNATSMaxDeliver). MUST be a
+	// positive, finite integer — a value of -1 (JetStream's "infinite")
+	// is exactly the unbounded hot loop that held the noreply@ 25/hour
+	// send budget at zero and killed PIN sign-in fleet-wide; see
+	// resolveMaxDeliver + runNATS.
+	maxDeliver int
 
 	mu     sync.Mutex
 	closed bool
@@ -231,9 +242,10 @@ func NewMultiSubscriber(cfg MultiSubscriberConfig) (*MultiSubscriber, error) {
 	}
 
 	m := &MultiSubscriber{
-		group:    cfg.Group,
-		stream:   cfg.StreamName,
-		subjects: subs,
+		group:      cfg.Group,
+		stream:     cfg.StreamName,
+		subjects:   subs,
+		maxDeliver: resolveMaxDeliver(),
 	}
 	if natsEnabled {
 		m.nats = cfg.NATS
@@ -339,7 +351,20 @@ func (m *MultiSubscriber) runNATS(ctx context.Context, handler func(*Event) erro
 			AckWait:       30 * time.Second,
 			FilterSubject: subj,
 			DeliverPolicy: jetstream.DeliverAllPolicy,
-			MaxDeliver:    -1,
+			// #6464 residual — MaxDeliver was -1 (infinite). #6469 slowed the
+			// nak cadence (constant 5s -> exponential, capped 5m) but a
+			// message that can NEVER succeed still redelivered forever: an
+			// "app is ready" notification whose recipient quota is spent naks,
+			// backs off to the 5m cap, and retries every 5m for the life of
+			// the stream. With MaxDeliver:-1 the drain never stops, and the
+			// 5m spacing keeps the mailer's circuit breaker (3 refusals / 90s)
+			// from ever tripping, so every redelivery reaches the wire and the
+			// noreply@ 25/hour budget stays pinned at zero — PIN sign-in dead
+			// fleet-wide. Bounding MaxDeliver caps the total budget a single
+			// stuck envelope can burn: after m.maxDeliver attempts JetStream
+			// stops redelivering (MAX_DELIVERIES advisory), the drain becomes
+			// finite, and the send budget self-heals within the rolling hour.
+			MaxDeliver: m.maxDeliver,
 		})
 		if err != nil {
 			// Stop anything we already started so we don't leak.
@@ -466,6 +491,41 @@ func (m *MultiSubscriber) Close() {
 	if m.kafka != nil {
 		m.kafka.Close()
 	}
+}
+
+// maxDeliverEnv overrides the bounded JetStream redelivery ceiling per
+// docs/PRINCIPLES.md Inviolable Principle #4 (every knob runtime-
+// configurable at the Deployment level, no rebuild). A positive integer
+// wins; anything else (unset, empty, non-numeric, or <= 0 — which
+// includes JetStream's "-1 = infinite", the very value this fix exists
+// to forbid by default) falls back to defaultNATSMaxDeliver.
+const maxDeliverEnv = "EVENTS_NATS_MAX_DELIVER"
+
+// defaultNATSMaxDeliver is the bounded redelivery ceiling for a
+// persistently-failing envelope (#6464 residual). Paired with nakBackoff
+// (5s,10s,20s,40s,80s,160s,300s,300s,...) 10 attempts span ~20 minutes of
+// retries before JetStream stops redelivering — ample headroom for a real
+// transient (a Stalwart restart is 1-2 minutes) while guaranteeing a
+// structurally-doomed notification can burn at most 10 sends, not an
+// unbounded stream, of the shared noreply@ budget.
+const defaultNATSMaxDeliver = 10
+
+// resolveMaxDeliver reads the bounded redelivery ceiling from
+// maxDeliverEnv, defaulting to defaultNATSMaxDeliver. It NEVER returns a
+// non-positive value: -1 (infinite) is exactly the unbounded hot loop
+// that killed PIN sign-in fleet-wide (#6464), so an operator cannot
+// silently reinstate it through a stray env value — an explicit infinite
+// retry is not a supported configuration.
+func resolveMaxDeliver() int {
+	raw := strings.TrimSpace(os.Getenv(maxDeliverEnv))
+	if raw == "" {
+		return defaultNATSMaxDeliver
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n <= 0 {
+		return defaultNATSMaxDeliver
+	}
+	return n
 }
 
 // nakBackoff returns the redelivery delay for a failed handler, growing

--- a/core/services/shared/events/nak_backoff_6464_test.go
+++ b/core/services/shared/events/nak_backoff_6464_test.go
@@ -91,3 +91,64 @@ func TestNakBackoff_UnreadableMetadataFallsBackToBase(t *testing.T) {
 		}
 	}
 }
+
+// #6464 RESIDUAL — decaying the nak RATE (nakBackoff, #6469) is only half
+// the fix. With MaxDeliver:-1 (infinite) a message that can NEVER succeed
+// still redelivers forever: an "app is ready" notification whose recipient
+// quota is spent naks, backs off to the 5m cap, and retries every 5m for
+// the life of the stream. Worse, that 5m spacing keeps the mailer's
+// circuit breaker (3 refusals / 90s) from ever tripping, so every
+// redelivery reaches the wire and the noreply@ 25/hour budget stays pinned
+// at zero — PIN sign-in dead fleet-wide. The redelivery COUNT must be
+// bounded, not just its rate.
+func TestResolveMaxDeliver_DefaultIsBoundedNeverInfinite(t *testing.T) {
+	t.Setenv(maxDeliverEnv, "") // force the default path
+	got := resolveMaxDeliver()
+	if got != defaultNATSMaxDeliver {
+		t.Fatalf("default MaxDeliver is %d, want %d", got, defaultNATSMaxDeliver)
+	}
+	if got <= 0 {
+		t.Fatalf("default MaxDeliver is %d — a non-positive value is JetStream 'infinite', the exact unbounded loop that killed PIN sign-in (#6464)", got)
+	}
+}
+
+// CONTROL 1 — a valid positive override is honoured (Inviolable Principle
+// #4: the knob is runtime-configurable at the Deployment level).
+func TestResolveMaxDeliver_PositiveOverrideHonoured(t *testing.T) {
+	t.Setenv(maxDeliverEnv, "25")
+	if got := resolveMaxDeliver(); got != 25 {
+		t.Fatalf("override 25 gave %d — a valid positive ceiling must win", got)
+	}
+}
+
+// CONTROL 2 — the escape hatch must NOT let a stray value reinstate the
+// unbounded loop. -1 (JetStream infinite), 0, and garbage all fall back to
+// the safe bounded default; an explicit infinite retry is not supported.
+func TestResolveMaxDeliver_NonPositiveAndGarbageFallBackToDefault(t *testing.T) {
+	for _, raw := range []string{"-1", "0", "-1000", "abc", "  ", "1.5", "12x"} {
+		t.Setenv(maxDeliverEnv, raw)
+		got := resolveMaxDeliver()
+		if got != defaultNATSMaxDeliver {
+			t.Errorf("EVENTS_NATS_MAX_DELIVER=%q gave %d, want the bounded default %d — a stray value must never re-enable infinite redelivery (#6464)", raw, got, defaultNATSMaxDeliver)
+		}
+		if got <= 0 {
+			t.Fatalf("EVENTS_NATS_MAX_DELIVER=%q produced non-positive %d — that IS the infinite loop", raw, got)
+		}
+	}
+}
+
+// The bounded ceiling paired with nakBackoff must give a real transient
+// (e.g. a 1-2 minute Stalwart restart) room to recover before the message
+// is abandoned. Sum the nakBackoff delays across the default attempt
+// budget and assert the retry window comfortably exceeds a couple of
+// minutes — otherwise the cap trades the storm for dropped notifications
+// on every routine mail-server bounce.
+func TestMaxDeliver_RetryWindowSurvivesRoutineTransient(t *testing.T) {
+	var window time.Duration
+	for n := uint64(1); n < uint64(defaultNATSMaxDeliver); n++ {
+		window += nakBackoff(msgWithDelivered(n))
+	}
+	if window < 10*time.Minute {
+		t.Fatalf("default retry window is %v — too short to ride out a routine Stalwart restart without dropping the notification", window)
+	}
+}


### PR DESCRIPTION
## What

Bound JetStream `MaxDeliver` on the shared `MultiSubscriber` so a persistently-failing notification is dead-lettered after a finite number of attempts instead of redelivering forever. Env-configurable via `EVENTS_NATS_MAX_DELIVER` (default 10); the resolver never returns a non-positive value, so a stray env (including `-1`) can't silently reinstate the infinite loop.

## Why — this is the unfixed half of #6464

`#6464` root-caused the fleet-wide PIN-sign-in outage: a notification retry storm pins the shared `noreply@openova.io` 25/hour sender quota at zero, so Stalwart returns `452` to every PIN send and no one can obtain a sign-in code on any Sovereign.

- `#6465` taught the mailer to classify Stalwart's `452` as a rate-limit (backoff + circuit breaker).
- `#6469` replaced the constant 5s nak with exponential backoff (5s→…→5m cap).

Both fixed the retry **rate**. Neither bounded the retry **count** — `MultiSubscriber.runNATS` still created every durable consumer with `MaxDeliver: -1` (infinite). An `app_ready` notification whose recipient quota is spent naks, backs off to the 5m cap, and then retries **every 5 minutes forever**. The `#6469` comment itself flagged this ("Combined with MaxDeliver:-1 that is an unbounded hot loop") but only removed the "hot" part.

Worse, the 5-minute spacing is precisely why `#6465`'s breaker never helps: the breaker needs 3 refusals within 90s to trip; retries are now 5 minutes apart, so it never opens and **every** redelivery reaches the wire.

## Live evidence — the storm is STILL running (2026-08-20)

`kubectl -n stalwart logs stalwart-5df699dfbb-6fvz2` — flat over the full 6h window (a one-time exhaustion would be a burst then silence):

```
~10-12 rate-limit rejections / 10-min bucket, 302 total in 6h (~50/hr)
all: id="sender", limit=[25, 3600000ms], to="emrah.baysal@openova.io"
sender: noreply@openova.io (accountId 38) via mail.openova.io:587
```

The mothership's own `catalyst/catalyst-api` sent **zero** PINs in its 3h21m lifetime — the sender is a pre-cutover Sovereign relaying seeded `noreply@` creds through the mothership Stalwart. Its own mailer path (`sendPinEmailDefault`) is one-shot and cannot storm; the loop is the JetStream consumer.

## The fix

After `EVENTS_NATS_MAX_DELIVER` attempts JetStream stops redelivering (emits a `MAX_DELIVERIES` advisory); the drain becomes finite and the 25/hour budget self-heals within the rolling hour. 10 attempts × `nakBackoff` ≈ a 20-minute retry window — ample for a routine Stalwart restart (1–2 min), bounded for a structural failure. Applies to the shared `MultiSubscriber` (tenant / provisioning / notification / billing / domain), so no consumer can hot-loop forever.

Do NOT touch the Stalwart rate-limit config, Sieve, or SOGo filters — the mail server is founder-gated; the fix is in the application that sends too much.

## Tests

`core/services/shared/events` — added: default is bounded and positive; a positive override is honoured; `-1`/`0`/garbage fall back to the default (no silent infinite); the default retry window still rides out a routine transient. Full package + `go vet` green; `notification` and `provisioning` build clean.

## Deploy note

The sender is a Sovereign running a pre-fix image, so this fix (like `#6465`/`#6469`) takes effect only once the sending cluster rolls the new `notification`/services image. `CreateOrUpdateConsumer` updates the existing durable's `MaxDeliver` on the next pod start.

Refs #6506
Refs #6464
