### PR TITLE
fix(keycloak): register concrete per-Org console redirectUri (#6504 mid-host wildcard inert on KC 26.3)

### DIFF
--- a/clusters/_template/bootstrap-kit/09-keycloak.yaml
+++ b/clusters/_template/bootstrap-kit/09-keycloak.yaml
@@ -256,7 +256,14 @@ spec:
       #   against the shared sovereign realm (live hw301 console.acme.omani.homes),
       #   blocking every per-Org login AND the Pillar-4 agentic walk. Single-zone
       #   Sovereigns (no org-pool zone) render byte-identical.
-      version: 1.5.11
+      # 1.5.12 — #6509: the 1.5.11 mid-host wildcard `console.*.<zone>/*` was
+      #   INERT — Keycloak 26.3 only honors a TRAILING `*`, so a `*` in the HOST
+      #   segment matched literally and pool-domain logins STILL 400'd
+      #   `invalid_redirect_uri` (proven live hw302). catalyst-ui now keeps ONLY
+      #   the sovereign-admin host; the organization-controller registers each
+      #   Org's CONCRETE callback https://console.<slug>.<pool-tld>/* at reconcile
+      #   time (the only shape Keycloak honors for an unbounded Org set).
+      version: 1.5.12
       sourceRef:
         kind: HelmRepository
         name: bp-keycloak

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1468,7 +1468,12 @@ spec:
       #   (sovereign realm catalyst-ui registers the per-Org console callback
       #   https://console.*.<zone>/* for role==org-pool zones; live hw301
       #   console.acme.omani.homes 400'd `Invalid parameter: redirect_uri`).
-      version: 1.4.1550
+      # 1.4.1551 — #6509: catalog-seed advances bp-keycloak 1.5.11 -> 1.5.12. The
+      #   1.5.11 mid-host wildcard was INERT on Keycloak 26.3 (only a trailing `*`
+      #   is honored); pool-domain logins STILL 400'd (proven live hw302). The
+      #   organization-controller now registers each Org's CONCRETE console
+      #   callback https://console.<slug>.<pool-tld>/* at reconcile time.
+      version: 1.4.1551
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/core/controllers/organization/internal/controller/keycloak.go
+++ b/core/controllers/organization/internal/controller/keycloak.go
@@ -82,6 +82,44 @@ type KeycloakClient interface {
 	// reconciler calls this best-effort when the Org drops its
 	// federation config — absent-as-success is the contract.
 	DeleteIdentityProvider(ctx context.Context, alias string) error
+
+	// RegisterOrgConsoleRedirectURI appends the CONCRETE per-Org console
+	// callback `https://console.<slug>.<poolTLD>/*` (+ the matching web
+	// origin `https://console.<slug>.<poolTLD>`) to the sovereign realm's
+	// `catalyst-ui` client. Idempotent + dedup: a callback already present
+	// makes zero writes.
+	//
+	// #6509 — this REPLACES the inert mid-host wildcard #6504 emitted into
+	// the static realm import (`https://console.*.<pool>/*`). Keycloak 26.3
+	// only honors a TRAILING `*` — a `*` in the HOST segment is matched
+	// literally, so the wildcard never matched a real per-Org subdomain and
+	// every per-Org console login 400'd `invalid_redirect_uri`. Registering
+	// each Org's concrete host on reconcile is the only mechanism Keycloak
+	// actually honors.
+	RegisterOrgConsoleRedirectURI(ctx context.Context, slug, poolTLD string) error
+
+	// DeregisterOrgConsoleRedirectURI removes the concrete per-Org console
+	// callback (+ web origin) from the `catalyst-ui` client. The reconciler
+	// calls this from the tenant-networking teardown when the Organization
+	// is deleted so dead callbacks do not accumulate on the shared client.
+	// Absent-as-success (a missing callback / absent client returns nil).
+	DeregisterOrgConsoleRedirectURI(ctx context.Context, slug, poolTLD string) error
+}
+
+// catalystUIClientID is the OIDC clientId of the public PKCE SPA client the
+// per-Org operator console (console.<slug>.<poolTLD>) discovers + redirects
+// against in the SOVEREIGN realm. Its redirectUris gate whether Keycloak
+// accepts the per-Org console callback (#6509).
+const catalystUIClientID = "catalyst-ui"
+
+// orgConsoleRedirectURI builds the CONCRETE per-Org console callback + web
+// origin for an Org's console host `console.<slug>.<poolTLD>`. The redirectUri
+// carries a TRAILING `/*` (the ONLY wildcard position Keycloak 26.3 honors —
+// #6509); the web origin is the bare scheme+host. Shared by the reconciler and
+// the register/deregister methods so both sides compute the identical strings.
+func orgConsoleRedirectURI(slug, poolTLD string) (redirect, origin string) {
+	host := fmt.Sprintf("console.%s.%s", slug, poolTLD)
+	return "https://" + host + "/*", "https://" + host
 }
 
 // KCIdentityProvider mirrors the F1 catalyst-api IdentityProvider type
@@ -793,6 +831,232 @@ func (k *LiveKeycloak) putIdentityProviderMapper(ctx context.Context, tok, alias
 	default:
 		return fmt.Errorf("keycloak: PUT mapper %d: %s", resp.StatusCode, respBody)
 	}
+}
+
+// ── catalyst-ui per-Org console redirectUri registration (#6509) ─────────
+//
+// The per-Org operator console (console.<slug>.<poolTLD>) discovers OIDC
+// against the SOVEREIGN realm with client_id=catalyst-ui. Keycloak validates
+// the browser redirect_uri against that client's redirectUris list, and 26.3
+// only honors a TRAILING `*` — so the concrete per-Org host must be appended
+// to the client at reconcile time. Register + deregister GET the client's FULL
+// representation (as a raw-message map so every untouched attribute round-trips
+// byte-for-byte), edit only redirectUris + webOrigins, and PUT it back. Both
+// short-circuit write-free when the client is already in the desired state.
+
+// RegisterOrgConsoleRedirectURI appends the concrete per-Org console callback.
+func (k *LiveKeycloak) RegisterOrgConsoleRedirectURI(ctx context.Context, slug, poolTLD string) error {
+	if slug == "" || poolTLD == "" {
+		return errors.New("keycloak.RegisterOrgConsoleRedirectURI: empty slug or poolTLD")
+	}
+	redirect, origin := orgConsoleRedirectURI(slug, poolTLD)
+
+	tok, err := k.serviceAccountToken(ctx)
+	if err != nil {
+		return fmt.Errorf("keycloak.RegisterOrgConsoleRedirectURI: %w", err)
+	}
+	rep, id, err := k.getClientByClientID(ctx, tok, catalystUIClientID)
+	if err != nil {
+		return fmt.Errorf("keycloak.RegisterOrgConsoleRedirectURI: get client: %w", err)
+	}
+	if rep == nil {
+		// The catalyst-ui client is authored by the realm import; if it is
+		// not present yet Keycloak is still importing. Surface as an error so
+		// the reconcile requeues and retries once the import lands.
+		return fmt.Errorf("keycloak.RegisterOrgConsoleRedirectURI: client %q not found in realm %q", catalystUIClientID, k.realm)
+	}
+
+	redirects, err := rawStringSlice(rep["redirectUris"])
+	if err != nil {
+		return fmt.Errorf("keycloak.RegisterOrgConsoleRedirectURI: decode redirectUris: %w", err)
+	}
+	origins, err := rawStringSlice(rep["webOrigins"])
+	if err != nil {
+		return fmt.Errorf("keycloak.RegisterOrgConsoleRedirectURI: decode webOrigins: %w", err)
+	}
+
+	newRedirects, addedR := appendDedup(redirects, redirect)
+	newOrigins, addedO := appendDedup(origins, origin)
+	if !addedR && !addedO {
+		// Already registered — steady state makes zero writes.
+		return nil
+	}
+	if err := setRawStringSlice(rep, "redirectUris", newRedirects); err != nil {
+		return err
+	}
+	if err := setRawStringSlice(rep, "webOrigins", newOrigins); err != nil {
+		return err
+	}
+	if err := k.putClient(ctx, tok, id, rep); err != nil {
+		return fmt.Errorf("keycloak.RegisterOrgConsoleRedirectURI: put client: %w", err)
+	}
+	return nil
+}
+
+// DeregisterOrgConsoleRedirectURI removes the concrete per-Org console callback.
+func (k *LiveKeycloak) DeregisterOrgConsoleRedirectURI(ctx context.Context, slug, poolTLD string) error {
+	if slug == "" || poolTLD == "" {
+		// Nothing addressable to remove — treat as success (mirrors the
+		// finalizer-teardown absent-as-success contract).
+		return nil
+	}
+	redirect, origin := orgConsoleRedirectURI(slug, poolTLD)
+
+	tok, err := k.serviceAccountToken(ctx)
+	if err != nil {
+		return fmt.Errorf("keycloak.DeregisterOrgConsoleRedirectURI: %w", err)
+	}
+	rep, id, err := k.getClientByClientID(ctx, tok, catalystUIClientID)
+	if err != nil {
+		return fmt.Errorf("keycloak.DeregisterOrgConsoleRedirectURI: get client: %w", err)
+	}
+	if rep == nil {
+		// Absent client → nothing to clean up (absent-as-success).
+		return nil
+	}
+
+	redirects, err := rawStringSlice(rep["redirectUris"])
+	if err != nil {
+		return fmt.Errorf("keycloak.DeregisterOrgConsoleRedirectURI: decode redirectUris: %w", err)
+	}
+	origins, err := rawStringSlice(rep["webOrigins"])
+	if err != nil {
+		return fmt.Errorf("keycloak.DeregisterOrgConsoleRedirectURI: decode webOrigins: %w", err)
+	}
+
+	newRedirects, removedR := removeString(redirects, redirect)
+	newOrigins, removedO := removeString(origins, origin)
+	if !removedR && !removedO {
+		return nil
+	}
+	if err := setRawStringSlice(rep, "redirectUris", newRedirects); err != nil {
+		return err
+	}
+	if err := setRawStringSlice(rep, "webOrigins", newOrigins); err != nil {
+		return err
+	}
+	if err := k.putClient(ctx, tok, id, rep); err != nil {
+		return fmt.Errorf("keycloak.DeregisterOrgConsoleRedirectURI: put client: %w", err)
+	}
+	return nil
+}
+
+// getClientByClientID resolves a client by its OIDC clientId and returns its
+// FULL representation as a raw-message map (so untouched fields round-trip
+// verbatim on PUT) plus the internal Keycloak UUID needed for the PUT URL. A
+// missing client returns (nil, "", nil) — absent, not an error.
+func (k *LiveKeycloak) getClientByClientID(ctx context.Context, tok, clientID string) (map[string]json.RawMessage, string, error) {
+	u := fmt.Sprintf("%s/admin/realms/%s/clients?clientId=%s",
+		k.addr, url.PathEscape(k.realm), url.QueryEscape(clientID))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return nil, "", err
+	}
+	req.Header.Set("Authorization", "Bearer "+tok)
+	resp, err := k.http.Do(req)
+	if err != nil {
+		return nil, "", fmt.Errorf("keycloak: GET clients: %w", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return nil, "", fmt.Errorf("keycloak: GET clients %d: %s", resp.StatusCode, body)
+	}
+	var reps []map[string]json.RawMessage
+	if err := json.Unmarshal(body, &reps); err != nil {
+		return nil, "", fmt.Errorf("keycloak: decode clients: %w", err)
+	}
+	if len(reps) == 0 {
+		return nil, "", nil
+	}
+	rep := reps[0]
+	var id string
+	if raw, ok := rep["id"]; ok {
+		if err := json.Unmarshal(raw, &id); err != nil {
+			return nil, "", fmt.Errorf("keycloak: decode client id: %w", err)
+		}
+	}
+	if id == "" {
+		return nil, "", errors.New("keycloak: client representation missing id")
+	}
+	return rep, id, nil
+}
+
+// putClient PUTs the (edited) full client representation back.
+func (k *LiveKeycloak) putClient(ctx context.Context, tok, id string, rep map[string]json.RawMessage) error {
+	body, err := json.Marshal(rep)
+	if err != nil {
+		return err
+	}
+	u := fmt.Sprintf("%s/admin/realms/%s/clients/%s",
+		k.addr, url.PathEscape(k.realm), url.PathEscape(id))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, u, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+tok)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := k.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("keycloak: PUT client: %w", err)
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(resp.Body)
+	switch resp.StatusCode {
+	case http.StatusNoContent, http.StatusOK:
+		return nil
+	default:
+		return fmt.Errorf("keycloak: PUT client %d: %s", resp.StatusCode, respBody)
+	}
+}
+
+// rawStringSlice decodes a raw JSON value into []string. A nil/absent key
+// decodes to an empty slice (not an error) so a client with no redirectUris
+// yet is handled cleanly.
+func rawStringSlice(raw json.RawMessage) ([]string, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	var out []string
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// setRawStringSlice re-marshals a []string back onto the raw-message map.
+func setRawStringSlice(rep map[string]json.RawMessage, key string, vals []string) error {
+	b, err := json.Marshal(vals)
+	if err != nil {
+		return fmt.Errorf("keycloak: encode %s: %w", key, err)
+	}
+	rep[key] = b
+	return nil
+}
+
+// appendDedup appends want to vals only if absent, returning (result, added).
+func appendDedup(vals []string, want string) ([]string, bool) {
+	for _, v := range vals {
+		if v == want {
+			return vals, false
+		}
+	}
+	return append(vals, want), true
+}
+
+// removeString drops every occurrence of want from vals, returning (result,
+// removed). The result is a fresh slice so the caller never aliases the input.
+func removeString(vals []string, want string) ([]string, bool) {
+	out := make([]string, 0, len(vals))
+	removed := false
+	for _, v := range vals {
+		if v == want {
+			removed = true
+			continue
+		}
+		out = append(out, v)
+	}
+	return out, removed
 }
 
 // idpDrift compares the slice of IdP fields the controller writes.

--- a/core/controllers/organization/internal/controller/keycloak_console_redirect_6509_test.go
+++ b/core/controllers/organization/internal/controller/keycloak_console_redirect_6509_test.go
@@ -1,0 +1,227 @@
+// keycloak_console_redirect_6509_test.go — proves the org-controller
+// registers the CONCRETE per-Org console callback onto the sovereign realm's
+// catalyst-ui client (#6509), NOT the inert mid-host wildcard #6504 emitted.
+//
+// Root cause under test: Keycloak 26.3 only honors a TRAILING `*` in a
+// redirectUri; a `*` in the HOST segment (`https://console.*.<pool>/*`) is
+// matched literally and never covers a real per-Org subdomain, so every
+// per-Org console login 400'd `invalid_redirect_uri`. RegisterOrgConsoleRedirectURI
+// appends the concrete host `https://console.<slug>.<poolTLD>/*` — the only
+// shape Keycloak actually accepts.
+package controller
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// kcClientRep is the slice of the Keycloak client representation this test
+// inspects on the round-trip. The LiveKeycloak impl round-trips the FULL
+// representation as raw JSON, so unlisted fields here are preserved untouched.
+type kcClientRep struct {
+	ID           string   `json:"id"`
+	ClientID     string   `json:"clientId"`
+	Name         string   `json:"name"`
+	RedirectUris []string `json:"redirectUris"`
+	WebOrigins   []string `json:"webOrigins"`
+}
+
+// fakeKCAdmin is an in-process Keycloak Admin API stub implementing just the
+// token + get-clients + put-client endpoints RegisterOrgConsoleRedirectURI /
+// DeregisterOrgConsoleRedirectURI call. It holds one catalyst-ui client whose
+// redirectUris/webOrigins mutate on PUT so idempotency is observable.
+type fakeKCAdmin struct {
+	realm    string
+	cu       kcClientRep
+	putCount int
+	// otherFields is an extra attribute seeded on the client to prove the
+	// full-representation round-trip preserves fields the impl never touches.
+	otherFields string
+}
+
+func newFakeKCAdmin(realm, sovereignFQDN string) *fakeKCAdmin {
+	return &fakeKCAdmin{
+		realm: realm,
+		cu: kcClientRep{
+			ID:           "uuid-catalyst-ui",
+			ClientID:     "catalyst-ui",
+			Name:         "Catalyst UI (Sovereign console)",
+			RedirectUris: []string{"https://console." + sovereignFQDN + "/*"},
+			WebOrigins:   []string{"https://console." + sovereignFQDN},
+		},
+		otherFields: "preserve-me",
+	}
+}
+
+func (f *fakeKCAdmin) handler(t *testing.T) http.HandlerFunc {
+	t.Helper()
+	return func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost &&
+			r.URL.Path == "/realms/"+f.realm+"/protocol/openid-connect/token":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"access_token":"test-token"}`))
+
+		case r.Method == http.MethodGet &&
+			r.URL.Path == "/admin/realms/"+f.realm+"/clients":
+			if got := r.URL.Query().Get("clientId"); got != "catalyst-ui" {
+				t.Errorf("unexpected clientId query: %q", got)
+			}
+			// Emit a representation carrying an attribute the impl never
+			// touches, to prove PUT preserves it.
+			out := []map[string]any{{
+				"id":           f.cu.ID,
+				"clientId":     f.cu.ClientID,
+				"name":         f.cu.Name,
+				"redirectUris": f.cu.RedirectUris,
+				"webOrigins":   f.cu.WebOrigins,
+				"someOtherKey": f.otherFields,
+			}}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(out)
+
+		case r.Method == http.MethodPut &&
+			r.URL.Path == "/admin/realms/"+f.realm+"/clients/"+f.cu.ID:
+			body, _ := io.ReadAll(r.Body)
+			var rep map[string]json.RawMessage
+			if err := json.Unmarshal(body, &rep); err != nil {
+				t.Fatalf("PUT body not a JSON object: %v", err)
+			}
+			// The untouched attribute MUST survive the round-trip.
+			if _, ok := rep["someOtherKey"]; !ok {
+				t.Errorf("PUT dropped an untouched client attribute (someOtherKey): %s", body)
+			}
+			var updated kcClientRep
+			if err := json.Unmarshal(body, &updated); err != nil {
+				t.Fatalf("PUT body decode: %v", err)
+			}
+			f.cu.RedirectUris = updated.RedirectUris
+			f.cu.WebOrigins = updated.WebOrigins
+			f.putCount++
+			w.WriteHeader(http.StatusNoContent)
+
+		default:
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}
+}
+
+func containsStr(ss []string, want string) bool {
+	for _, s := range ss {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}
+
+// TestRegisterOrgConsoleRedirectURI_Concrete proves the CORE requirement:
+// slug "acme" + pool "omani.homes" registers the concrete
+// https://console.acme.omani.homes/* (a trailing `*`, no mid-host `*`), while
+// preserving the pre-existing sovereign-admin host.
+func TestRegisterOrgConsoleRedirectURI_Concrete(t *testing.T) {
+	const (
+		realm    = "sovereign"
+		sovFQDN  = "hw302.omantel.biz"
+		wantURI  = "https://console.acme.omani.homes/*"
+		wantOrig = "https://console.acme.omani.homes"
+		sovURI   = "https://console.hw302.omantel.biz/*"
+	)
+	adm := newFakeKCAdmin(realm, sovFQDN)
+	srv := httptest.NewServer(adm.handler(t))
+	defer srv.Close()
+
+	kc := NewLiveKeycloak(srv.URL, realm, "org-controller-sa", "secret")
+
+	if err := kc.RegisterOrgConsoleRedirectURI(context.Background(), "acme", "omani.homes"); err != nil {
+		t.Fatalf("RegisterOrgConsoleRedirectURI: %v", err)
+	}
+
+	// The concrete, trailing-* per-Org callback is now on the client.
+	if !containsStr(adm.cu.RedirectUris, wantURI) {
+		t.Errorf("concrete per-Org redirectUri not registered.\n got: %v\nwant contains: %s",
+			adm.cu.RedirectUris, wantURI)
+	}
+	if !containsStr(adm.cu.WebOrigins, wantOrig) {
+		t.Errorf("per-Org webOrigin not registered.\n got: %v\nwant contains: %s",
+			adm.cu.WebOrigins, wantOrig)
+	}
+	// It must NOT be a mid-host wildcard — that is the exact #6504 defect.
+	if containsStr(adm.cu.RedirectUris, "https://console.*.omani.homes/*") {
+		t.Errorf("registered a mid-host wildcard (inert on Keycloak 26.3) instead of a concrete host: %v",
+			adm.cu.RedirectUris)
+	}
+	// The working sovereign-admin host must be preserved (never regress it).
+	if !containsStr(adm.cu.RedirectUris, sovURI) {
+		t.Errorf("sovereign-admin console redirectUri was dropped: %v", adm.cu.RedirectUris)
+	}
+	if adm.putCount != 1 {
+		t.Errorf("expected exactly 1 PUT on first registration, got %d", adm.putCount)
+	}
+
+	// Idempotency: a second register of the same host makes ZERO writes.
+	if err := kc.RegisterOrgConsoleRedirectURI(context.Background(), "acme", "omani.homes"); err != nil {
+		t.Fatalf("second RegisterOrgConsoleRedirectURI: %v", err)
+	}
+	if adm.putCount != 1 {
+		t.Errorf("steady-state re-register must not PUT again, got putCount=%d", adm.putCount)
+	}
+}
+
+// TestDeregisterOrgConsoleRedirectURI removes exactly the concrete per-Org
+// callback and leaves the sovereign-admin host intact; a second deregister is
+// a write-free no-op (absent-as-success).
+func TestDeregisterOrgConsoleRedirectURI(t *testing.T) {
+	const (
+		realm   = "sovereign"
+		sovFQDN = "hw302.omantel.biz"
+		orgURI  = "https://console.acme.omani.homes/*"
+		sovURI  = "https://console.hw302.omantel.biz/*"
+	)
+	adm := newFakeKCAdmin(realm, sovFQDN)
+	// Seed the client as if the up-path already registered the per-Org host.
+	adm.cu.RedirectUris = append(adm.cu.RedirectUris, orgURI)
+	adm.cu.WebOrigins = append(adm.cu.WebOrigins, "https://console.acme.omani.homes")
+	srv := httptest.NewServer(adm.handler(t))
+	defer srv.Close()
+
+	kc := NewLiveKeycloak(srv.URL, realm, "org-controller-sa", "secret")
+
+	if err := kc.DeregisterOrgConsoleRedirectURI(context.Background(), "acme", "omani.homes"); err != nil {
+		t.Fatalf("DeregisterOrgConsoleRedirectURI: %v", err)
+	}
+	if containsStr(adm.cu.RedirectUris, orgURI) {
+		t.Errorf("per-Org redirectUri not removed: %v", adm.cu.RedirectUris)
+	}
+	if !containsStr(adm.cu.RedirectUris, sovURI) {
+		t.Errorf("deregister wrongly removed the sovereign-admin host: %v", adm.cu.RedirectUris)
+	}
+	if adm.putCount != 1 {
+		t.Errorf("expected exactly 1 PUT on deregister, got %d", adm.putCount)
+	}
+
+	// Absent-as-success: deregistering again makes no further write.
+	if err := kc.DeregisterOrgConsoleRedirectURI(context.Background(), "acme", "omani.homes"); err != nil {
+		t.Fatalf("second DeregisterOrgConsoleRedirectURI: %v", err)
+	}
+	if adm.putCount != 1 {
+		t.Errorf("no-op deregister must not PUT again, got putCount=%d", adm.putCount)
+	}
+}
+
+// TestOrgConsoleRedirectURI_Builder locks the exact string shape the task
+// specifies: console.<slug>.<poolTLD> with a trailing /* redirect + bare origin.
+func TestOrgConsoleRedirectURI_Builder(t *testing.T) {
+	redirect, origin := orgConsoleRedirectURI("acme", "omani.homes")
+	if redirect != "https://console.acme.omani.homes/*" {
+		t.Errorf("redirect = %q, want https://console.acme.omani.homes/*", redirect)
+	}
+	if origin != "https://console.acme.omani.homes" {
+		t.Errorf("origin = %q, want https://console.acme.omani.homes", origin)
+	}
+}

--- a/core/controllers/organization/internal/controller/organization_controller.go
+++ b/core/controllers/organization/internal/controller/organization_controller.go
@@ -1082,7 +1082,46 @@ func (r *Reconciler) reconcileConsoleServing(ctx context.Context, org *orgapi.Or
 		log.Error(err, "tenant console HTTPRoute reconcile (transient — requeue)")
 		degraded = true
 	}
+	// #6509 — register the CONCRETE per-Org console callback
+	// `https://console.<slug>.<poolTLD>/*` on the sovereign realm's
+	// catalyst-ui client. Without this the per-Org console login 400s
+	// `invalid_redirect_uri` at Keycloak: the browser redirects with
+	// client_id=catalyst-ui and Keycloak validates redirect_uri against that
+	// client's redirectUris, but #6504's mid-host wildcard
+	// (`console.*.<pool>/*`) is INERT on Keycloak 26.3 (only a trailing `*`
+	// is honored). Best-effort + degraded-requeue, sibling of the DNS/TLS/route
+	// trio above: a Keycloak blip retries on the 30s cadence and must not block
+	// the Org's other outputs. No-op when the Org has no pool parentDomain.
+	if err := r.reconcileConsoleRedirectURI(ctx, org); err != nil {
+		log.Error(err, "per-Org console redirectUri registration (transient — requeue)")
+		degraded = true
+	}
 	return degraded
+}
+
+// reconcileConsoleRedirectURI registers the concrete per-Org console callback
+// on the sovereign realm's catalyst-ui client (#6509). No-op when the Org has
+// not engaged the tenant-networking up-path (no pool parentDomain) — such an
+// Org signs in on the Sovereign-admin host, already covered by the static
+// `https://console.<sovereignFQDN>/*` redirectUri. The console subdomain
+// defaults to spec.slug, matching reconcileTenantRoute's host derivation, so a
+// custom spec.tenantPublic.subdomain registers the host actually served.
+func (r *Reconciler) reconcileConsoleRedirectURI(ctx context.Context, org *orgapi.Organization) error {
+	if r.Keycloak == nil {
+		// No Keycloak wired (Catalyst-Zero / a unit test exercising only the
+		// console-serving trio) — nothing to register.
+		return nil
+	}
+	tp := org.Spec.TenantPublic
+	parentDomain := strings.TrimSpace(tp.ParentDomain)
+	if parentDomain == "" {
+		return nil
+	}
+	subdomain := strings.TrimSpace(tp.Subdomain)
+	if subdomain == "" {
+		subdomain = org.Spec.Slug
+	}
+	return r.Keycloak.RegisterOrgConsoleRedirectURI(ctx, subdomain, parentDomain)
 }
 
 // readyOrgMessage words the Organization's Ready=True condition message off the

--- a/core/controllers/organization/internal/controller/organization_controller_test.go
+++ b/core/controllers/organization/internal/controller/organization_controller_test.go
@@ -67,6 +67,12 @@ type fakeKeycloak struct {
 	idpEnsureCalls    int
 	idpDeleteCalls    int
 	mapperEnsureCalls int
+
+	// Per-Org console redirectUri surface (#6509).
+	consoleRedirects       map[string]bool // registered concrete redirect URIs
+	consoleRegisterCalls   int
+	consoleDeregisterCalls int
+	consoleRegisterErr     error // when set, RegisterOrgConsoleRedirectURI returns it
 }
 
 func (f *fakeKeycloak) EnsureRealm(ctx context.Context, slug string) (string, error) {
@@ -147,6 +153,32 @@ func (f *fakeKeycloak) DeleteIdentityProvider(ctx context.Context, alias string)
 	}
 	if f.mappers != nil {
 		delete(f.mappers, alias)
+	}
+	return nil
+}
+
+func (f *fakeKeycloak) RegisterOrgConsoleRedirectURI(ctx context.Context, slug, poolTLD string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.consoleRegisterCalls++
+	if f.consoleRegisterErr != nil {
+		return f.consoleRegisterErr
+	}
+	if f.consoleRedirects == nil {
+		f.consoleRedirects = map[string]bool{}
+	}
+	redirect, _ := orgConsoleRedirectURI(slug, poolTLD)
+	f.consoleRedirects[redirect] = true
+	return nil
+}
+
+func (f *fakeKeycloak) DeregisterOrgConsoleRedirectURI(ctx context.Context, slug, poolTLD string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.consoleDeregisterCalls++
+	if f.consoleRedirects != nil {
+		redirect, _ := orgConsoleRedirectURI(slug, poolTLD)
+		delete(f.consoleRedirects, redirect)
 	}
 	return nil
 }

--- a/core/controllers/organization/internal/controller/tenant_networking_teardown.go
+++ b/core/controllers/organization/internal/controller/tenant_networking_teardown.go
@@ -132,5 +132,38 @@ func (r *Reconciler) teardownTenantNetworking(ctx context.Context, org *orgapi.O
 		r.Log.Error(err, "tenant-networking teardown: pool DNS", "organization", org.Name)
 		note(err)
 	}
+	// 5. Concrete per-Org console callback on the sovereign realm's catalyst-ui
+	// client (#6509). The up-path (reconcileConsoleRedirectURI) appended
+	// `https://console.<slug>.<parent>/*` to that SHARED client's redirectUris;
+	// like the Gateway listener pair it carries no ownerRef the GC follows, so
+	// without an explicit deregister dead callbacks accumulate on catalyst-ui on
+	// every Org delete. Best-effort + absent-as-success, same subdomain
+	// derivation as the up-path.
+	if err := r.teardownConsoleRedirectURI(ctx, org); err != nil {
+		r.Log.Error(err, "tenant-networking teardown: console redirectUri", "organization", org.Name)
+		note(err)
+	}
 	return firstErr
+}
+
+// teardownConsoleRedirectURI removes the concrete per-Org console callback the
+// up-path registered on the catalyst-ui client (#6509). No-op when the Org
+// engaged no pool parentDomain. Best-effort + absent-as-success (handled inside
+// DeregisterOrgConsoleRedirectURI).
+func (r *Reconciler) teardownConsoleRedirectURI(ctx context.Context, org *orgapi.Organization) error {
+	if r.Keycloak == nil {
+		// No Keycloak wired (Catalyst-Zero / a unit test exercising only the
+		// networking teardown) — nothing to deregister.
+		return nil
+	}
+	tp := org.Spec.TenantPublic
+	parentDomain := strings.TrimSpace(tp.ParentDomain)
+	if parentDomain == "" {
+		return nil
+	}
+	subdomain := strings.TrimSpace(tp.Subdomain)
+	if subdomain == "" {
+		subdomain = org.Spec.Slug
+	}
+	return r.Keycloak.DeregisterOrgConsoleRedirectURI(ctx, subdomain, parentDomain)
 }

--- a/platform/keycloak/blueprint.yaml
+++ b/platform/keycloak/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.5.11
+  version: 1.5.12
   card:
     title: keycloak
     summary: Keycloak — user identity. Topology decided by Sovereign CRD spec.keycloakTopology (per-organization for Organizations, shared-sovereign for corporate).

--- a/platform/keycloak/chart/Chart.yaml
+++ b/platform/keycloak/chart/Chart.yaml
@@ -582,7 +582,28 @@ name: bp-keycloak
 #   Guarded by tests/per-org-console-pool-redirect-3374.sh (Case A asserts the
 # pool callbacks present -- FAILS on the pre-fix template; Case B/C assert the
 # single-zone / primary-only render is unchanged).
-version: 1.5.11
+# 1.5.12 (#6509 #3374 #3988): the 1.5.11 mid-host wildcard was INERT. Keycloak
+# 26.3 only honors a TRAILING `*` in a redirectUri; a `*` in the HOST segment
+# (`https://console.*.<zone>/*`) is matched LITERALLY, so it never covered a
+# real per-Org subdomain and every pool-domain login STILL 400'd
+# `invalid_redirect_uri` -- proven live on hw302 (a CONCRETE
+# `console.uatprobe.omani.homes/*` on catalyst-ui -> 303 login redirect; the
+# wildcard-covered `console.testorg.omani.homes` -> 400; a bogus `evil.example`
+# -> 400). A static realm import also cannot enumerate the unbounded, dynamic
+# set of Orgs a Sovereign hosts.
+#   Fix: the sovereign realm's catalyst-ui client keeps ONLY the sovereign-admin
+# host (https://console.<sovereignFQDN>/* -- a trailing `*`, which works); the
+# inert per-zone `console.*.<zone>/*` redirectUris/webOrigins/post-logout
+# appends are REMOVED. The organization-controller now registers each Org's
+# CONCRETE console callback https://console.<slug>.<pool-tld>/* onto that same
+# catalyst-ui client at reconcile time (RegisterOrgConsoleRedirectURI) and
+# removes it on Org delete -- the only mechanism Keycloak actually honors.
+# `parentZones` is retained for the powerdns/external-dns/sovereign-tls-vars
+# slots that still consume it but no longer feeds catalyst-ui.
+#   Guarded by tests/per-org-console-pool-redirect-3374.sh (Case A now asserts
+# the inert mid-host wildcard is ABSENT -- FAILS on the 1.5.11 template) +
+# core/controllers organization keycloak_console_redirect_6509_test.go.
+version: 1.5.12
 description: |
   1.5.2 (#4246): the per-tenant `openclaw-oidc-client-secret` Secret now
   emits BOTH `client-secret` AND `OIDC_CLIENT_SECRET` keys (it previously

--- a/platform/keycloak/chart/templates/configmap-sovereign-realm.yaml
+++ b/platform/keycloak/chart/templates/configmap-sovereign-realm.yaml
@@ -184,43 +184,37 @@ tenant emit; tenant takes precedence here.
     )
 -}}
 {{- $userProfileConfigJSON := toJson $userProfileDoc -}}
-{{- /* ── Per-Org console pool-domain callbacks for catalyst-ui (#3374 #3988) ──
+{{- /* ── Per-Org console pool-domain callbacks for catalyst-ui (#3374 #3988 #6509) ──
      The per-Org operator console (org-console SPA) is served at
      console.<slug>.<pool-tld> and — on a shared-realm Sovereign — discovers
      OIDC against THIS sovereign realm with client_id=catalyst-ui (the
      bp-catalyst-platform slot wires .Values.sso realm=sovereign
      clientId=catalyst-ui; tenant_discover.go returns the same). Its browser
-     redirect_uri is https://console.<slug>.<pool-tld>/auth/callback. The
-     catalyst-ui client below only lists the sovereign-admin host
-     (https://console.<sovereignFQDN>/*), so a pool-domain login 400s
-     `Invalid parameter: redirect_uri` — LIVE on hw301 console.acme.omani.homes,
-     blocking every customer login (standalone P0) and the Pillar-4 agentic walk.
+     redirect_uri is https://console.<slug>.<pool-tld>/auth/callback.
 
-     Fix: for each parent zone with role==org-pool, register the analogous
-     host-wildcard console callback https://console.*.<zone>/* (+ matching web
-     origin). This mirrors the tenant realm's catalyst-ui host-wildcard
-     (`https://*.<zone>/*`, configmap-tenant-realm.yaml) and reuses the SAME
-     role==org-pool selection sovereign-tls-vars uses for the pool listeners
-     (data, not code — generic for any pool TLD). parentZones is threaded from
-     ${PARENT_DOMAINS_YAML} (same source powerdns/external-dns/sovereign-tls-vars
-     consume); empty on a single-zone Sovereign → catalyst-ui renders
-     byte-identical to before, so no non-pool Sovereign changes. */ -}}
-{{- $poolConsoleRedirects := list -}}
-{{- $poolConsoleOrigins := list -}}
-{{- range $z := (default (list) .Values.parentZones) -}}
-  {{- if and $z.name (eq (default "primary" $z.role) "org-pool") -}}
-    {{- $poolConsoleRedirects = append $poolConsoleRedirects (printf "https://console.*.%s/*" $z.name) -}}
-    {{- $poolConsoleOrigins = append $poolConsoleOrigins (printf "https://console.*.%s" $z.name) -}}
-  {{- end -}}
-{{- end -}}
-{{- /* post.logout.redirect.uris is a `##`-delimited list in Keycloak; keep the
-     sovereign-admin host first (byte-identical when no org-pool zones) and
-     append each pool console pattern so a customer can also log OUT to their
-     own console host. */ -}}
+     #6509 — the pool console callback is NO LONGER registered here as a
+     mid-host wildcard. #6504 emitted `https://console.*.<zone>/*` into this
+     static realm import, but Keycloak 26.3 ONLY honors a TRAILING `*` — a `*`
+     in the HOST segment is matched LITERALLY, so the wildcard never matched a
+     real per-Org subdomain and every pool-domain login still 400'd
+     `invalid_redirect_uri` (proven live on hw302: a CONCRETE
+     `console.uatprobe.omani.homes/*` on the client → 303 login redirect;
+     the wildcard-covered `console.testorg.omani.homes` → 400). Because a Sovereign
+     hosts an unbounded, dynamic set of Orgs, no static import line can enumerate
+     them. The organization-controller now registers each Org's CONCRETE console
+     callback `https://console.<slug>.<pool-tld>/*` on this same catalyst-ui
+     client at reconcile time (RegisterOrgConsoleRedirectURI) and removes it on
+     Org delete — the only mechanism Keycloak actually honors.
+
+     This template therefore keeps ONLY the sovereign-admin host below
+     (https://console.<sovereignFQDN>/* — a trailing `*`, which DOES work); the
+     per-Org hosts are appended at runtime. parentZones is retained for the
+     other slots that consume it but no longer feeds catalyst-ui. */ -}}
+{{- /* post.logout.redirect.uris is a `##`-delimited list in Keycloak. Only the
+     sovereign-admin host is listed statically; the org-controller does not
+     currently manage per-Org post-logout entries (the pool logout returns to
+     the sovereign host, then the SPA re-discovers), so no wildcard leaks here. */ -}}
 {{- $postLogout := printf "https://console.%s/*" .Values.sovereignFQDN -}}
-{{- range $u := $poolConsoleRedirects -}}
-  {{- $postLogout = printf "%s##%s" $postLogout $u -}}
-{{- end -}}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -561,17 +555,17 @@ data:
           "directAccessGrantsEnabled": false,
           "implicitFlowEnabled": false,
           "serviceAccountsEnabled": false,
+          {{- /* #6509 — sovereign-admin host ONLY (a trailing `*`, which Keycloak
+             26.3 honors). Per-Org pool console callbacks
+             (https://console.<slug>.<pool>/*) are registered at reconcile time
+             by the organization-controller onto THIS client, not enumerated
+             here — a static import cannot list the unbounded, dynamic set of
+             Orgs, and the former mid-host wildcard was inert. */}}
           "redirectUris": [
             "https://console.{{ .Values.sovereignFQDN }}/*"
-            {{- range $u := $poolConsoleRedirects }},
-            {{ $u | quote }}
-            {{- end }}
           ],
           "webOrigins": [
             "https://console.{{ .Values.sovereignFQDN }}"
-            {{- range $o := $poolConsoleOrigins }},
-            {{ $o | quote }}
-            {{- end }}
           ],
           "defaultClientScopes": [
             "web-origins",

--- a/platform/keycloak/chart/tests/per-org-console-pool-redirect-3374.sh
+++ b/platform/keycloak/chart/tests/per-org-console-pool-redirect-3374.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# bp-keycloak per-Org console pool-domain redirect gate (#3374 #3988).
+# bp-keycloak per-Org console pool-domain redirect gate (#3374 #3988 #6509).
 #
 # WHY THIS EXISTS
 # ----------------
@@ -10,26 +10,32 @@
 # the same). The browser redirect_uri is
 #   https://console.<slug>.<pool-tld>/auth/callback
 #
-# The sovereign realm's catalyst-ui client historically listed ONLY the
-# sovereign-admin host (https://console.<sovereignFQDN>/*). A pool-domain login
-# therefore 400s at Keycloak with `Invalid parameter: redirect_uri` — LIVE on
-# hw301 console.acme.omani.homes, blocking every customer login AND the Pillar-4
-# agentic walk that needs the org session.
+# #6504 tried to cover every per-Org host by emitting a MID-HOST wildcard
+# callback `https://console.*.<zone>/*` into this static realm import. That is
+# INERT on Keycloak 26.3: Keycloak only honors a TRAILING `*` — a `*` in the
+# HOST segment is matched LITERALLY, so the wildcard never matched a real per-Org
+# subdomain and every pool-domain login STILL 400'd `invalid_redirect_uri`
+# (proven live on hw302: a CONCRETE `console.uatprobe.omani.homes/*` on the
+# client → 303 login redirect passes; the wildcard-covered
+# `console.testorg.omani.homes` → 400; a bogus `evil.example` → 400).
 #
-# The fix registers, for every parent zone with role==org-pool, the host-wildcard
-# console callback https://console.*.<zone>/* (+ matching webOrigin + post-logout)
-# on the catalyst-ui client, threaded from the same ${PARENT_DOMAINS_YAML} pool
-# the powerdns / external-dns / sovereign-tls-vars slots already consume.
+# #6509 fix: the sovereign realm's catalyst-ui client carries ONLY the
+# sovereign-admin host `https://console.<sovereignFQDN>/*` (a trailing `*`,
+# which DOES work). Each Org's CONCRETE console callback
+# `https://console.<slug>.<pool-tld>/*` is registered onto this same client at
+# reconcile time by the organization-controller (RegisterOrgConsoleRedirectURI)
+# and removed on Org delete — the only mechanism Keycloak actually honors for an
+# unbounded, dynamic set of Orgs. This gate therefore asserts the INERT mid-host
+# wildcard is GONE.
 #
 # NON-VACUITY
 # -----------
-# Case A asserts the pool callbacks are PRESENT when parentZones carries org-pool
-# zones — this assertion FAILS on the pre-fix template (which ignores
-# parentZones), so the gate genuinely catches a regression.
-# Case B asserts the render is UNCHANGED (no pool callbacks, single sovereign
-# host) when parentZones is empty — proving single-zone Sovereigns are byte-safe.
-# Case C asserts a role==primary zone is NOT treated as a pool zone (selection
-# keys strictly off role, data-not-code).
+# Case A carries org-pool zones and asserts NO `https://console.*.<zone>/*`
+# mid-host wildcard is present on catalyst-ui — this assertion FAILS on the
+# pre-#6509 (#6504) template, which appended exactly that wildcard, so the gate
+# genuinely catches a regression back to the broken mechanism.
+# Case B asserts the empty-parentZones render is the sovereign host only.
+# Case C asserts a role==primary zone adds nothing either.
 #
 # Usage: bash tests/per-org-console-pool-redirect-3374.sh [CHART_DIR]
 
@@ -50,12 +56,12 @@ if ! command -v "$PYTHON" >/dev/null; then
   exit 1
 fi
 
-FQDN="hw301.omantel.biz"
+FQDN="hw302.omantel.biz"
 
-echo "[pool-redirect] Case A: org-pool zones register console.*.<pool>/* on catalyst-ui"
+echo "[pool-redirect] Case A: org-pool zones do NOT emit an inert mid-host wildcard (#6509)"
 helm template smoke-kc . \
   --set sovereignFQDN="$FQDN" \
-  --set 'parentZones[0].name=hw301.omantel.biz' --set 'parentZones[0].role=primary' \
+  --set 'parentZones[0].name=hw302.omantel.biz' --set 'parentZones[0].role=primary' \
   --set 'parentZones[1].name=omani.homes'       --set 'parentZones[1].role=org-pool' \
   --set 'parentZones[2].name=omani.rest'        --set 'parentZones[2].role=org-pool' \
   --set 'parentZones[3].name=omani.trade'       --set 'parentZones[3].role=org-pool' \
@@ -71,31 +77,35 @@ assert len(cms) == 1, f"expected exactly 1 realm-config CM, got {len(cms)}"
 realm = json.loads(cms[0]['data']['sovereign-realm.json'])
 cu = {c['clientId']: c for c in realm['clients']}['catalyst-ui']
 
-# Sovereign-admin host still present (never regress the working path).
+# Sovereign-admin host still present (never regress the working trailing-* path).
 assert f"https://console.{fqdn}/*" in cu['redirectUris'], \
     f"sovereign-admin console redirect dropped: {cu['redirectUris']}"
 assert f"https://console.{fqdn}" in cu['webOrigins'], \
     f"sovereign-admin console webOrigin dropped: {cu['webOrigins']}"
 
-# Every org-pool zone gets its host-wildcard console callback + origin.
+# The INERT mid-host wildcard #6504 emitted must be GONE — a static import
+# cannot cover the unbounded set of Orgs, and this pattern never matched on
+# Keycloak 26.3. The org-controller registers concrete per-Org hosts at runtime.
 for pool in ("omani.homes", "omani.rest", "omani.trade"):
     ru = f"https://console.*.{pool}/*"
     wo = f"https://console.*.{pool}"
-    assert ru in cu['redirectUris'], \
-        f"missing per-Org console redirectUri {ru!r}: {cu['redirectUris']}"
-    assert wo in cu['webOrigins'], \
-        f"missing per-Org console webOrigin {wo!r}: {cu['webOrigins']}"
-    assert wo in cu['attributes']['post.logout.redirect.uris'], \
-        f"missing per-Org post-logout {wo!r}: {cu['attributes']['post.logout.redirect.uris']}"
+    assert ru not in cu['redirectUris'], \
+        f"inert mid-host wildcard redirectUri still present {ru!r}: {cu['redirectUris']}"
+    assert wo not in cu['webOrigins'], \
+        f"inert mid-host wildcard webOrigin still present {wo!r}: {cu['webOrigins']}"
+    assert wo not in cu['attributes'].get('post.logout.redirect.uris', ''), \
+        f"inert mid-host wildcard post-logout still present {wo!r}: {cu['attributes'].get('post.logout.redirect.uris')}"
 
-# The PRIMARY zone must NOT be registered as a pool console callback (role gate).
-assert f"https://console.*.{fqdn}/*" not in cu['redirectUris'], \
-    f"primary zone wrongly registered as a pool console callback: {cu['redirectUris']}"
-print("  [assert] catalyst-ui carries all 3 pool console callbacks + origins")
+# catalyst-ui carries the sovereign host ONLY — nothing per-Org is baked in.
+assert cu['redirectUris'] == [f"https://console.{fqdn}/*"], \
+    f"catalyst-ui redirectUris carry more than the sovereign host: {cu['redirectUris']}"
+assert cu['webOrigins'] == [f"https://console.{fqdn}"], \
+    f"catalyst-ui webOrigins carry more than the sovereign host: {cu['webOrigins']}"
+print("  [assert] catalyst-ui carries the sovereign host only; no inert mid-host wildcard")
 PY
 echo "  PASS"
 
-echo "[pool-redirect] Case B: empty parentZones → catalyst-ui unchanged (byte-safe)"
+echo "[pool-redirect] Case B: empty parentZones → catalyst-ui sovereign host only (byte-safe)"
 helm template smoke-kc . --set sovereignFQDN="$FQDN" > "$TMP/without.yaml"
 "$PYTHON" - "$TMP/without.yaml" "$FQDN" <<'PY'
 import sys, yaml, json
@@ -111,14 +121,14 @@ assert cu['webOrigins'] == [f"https://console.{fqdn}"], \
     f"single-zone catalyst-ui webOrigins changed: {cu['webOrigins']}"
 assert cu['attributes']['post.logout.redirect.uris'] == f"https://console.{fqdn}/*", \
     f"single-zone catalyst-ui post-logout changed: {cu['attributes']['post.logout.redirect.uris']}"
-print("  [assert] single-zone render carries no pool callbacks")
+print("  [assert] single-zone render carries the sovereign host only")
 PY
 echo "  PASS"
 
 echo "[pool-redirect] Case C: a non-pool (primary-only) zone list adds nothing"
 helm template smoke-kc . \
   --set sovereignFQDN="$FQDN" \
-  --set 'parentZones[0].name=hw301.omantel.biz' --set 'parentZones[0].role=primary' \
+  --set 'parentZones[0].name=hw302.omantel.biz' --set 'parentZones[0].role=primary' \
   > "$TMP/primary-only.yaml"
 "$PYTHON" - "$TMP/primary-only.yaml" "$FQDN" <<'PY'
 import sys, yaml, json
@@ -129,7 +139,7 @@ cms = [d for d in docs if d and d.get('kind') == 'ConfigMap'
 realm = json.loads(cms[0]['data']['sovereign-realm.json'])
 cu = {c['clientId']: c for c in realm['clients']}['catalyst-ui']
 assert cu['redirectUris'] == [f"https://console.{fqdn}/*"], \
-    f"primary-only zone list wrongly added pool callbacks: {cu['redirectUris']}"
+    f"primary-only zone list wrongly added callbacks: {cu['redirectUris']}"
 print("  [assert] primary-only zone list leaves catalyst-ui at the sovereign host")
 PY
 echo "  PASS"

--- a/platform/keycloak/chart/values.yaml
+++ b/platform/keycloak/chart/values.yaml
@@ -45,14 +45,15 @@ sovereignFQDN: ""
 # (slot 12) and sovereign-tls-vars (slot 12a) consume. A YAML list of
 # {name, role} maps, e.g.
 #   [{name: "omantel.biz", role: "primary"}, {name: "omani.homes", role: "org-pool"}]
-# configmap-sovereign-realm.yaml reads this to register the per-Org console
-# callback https://console.*.<zone>/* on the catalyst-ui client for every
-# role==org-pool zone — the per-Org operator console (console.<slug>.<pool-tld>)
-# discovers OIDC against the sovereign realm with client_id=catalyst-ui and
-# otherwise 400s `Invalid parameter: redirect_uri` (#3374 #3988; live hw301
-# console.acme.omani.homes). Empty default → single-zone Sovereigns render the
-# catalyst-ui client byte-identically (no pool callbacks added). Selection keys
-# only off the zone role (data, not code), so it is generic for any pool TLD.
+# NOTE (#6509): this NO LONGER feeds the catalyst-ui client. 1.5.11 tried to
+# register a per-zone mid-host wildcard `https://console.*.<zone>/*` for the
+# per-Org operator console (console.<slug>.<pool-tld>), but Keycloak 26.3 only
+# honors a TRAILING `*` — a `*` in the HOST segment is matched literally, so the
+# wildcard was inert and pool-domain logins still 400'd `invalid_redirect_uri`.
+# The organization-controller now registers each Org's CONCRETE callback
+# https://console.<slug>.<pool-tld>/* on catalyst-ui at reconcile time (the only
+# shape Keycloak honors for an unbounded, dynamic Org set). parentZones remains
+# consumed by the powerdns/external-dns/sovereign-tls-vars slots above.
 parentZones: []
 
 # catalystAPIInternalURL — the in-cluster base URL for the catalyst-pin

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-20T04:40:07.638Z",
+  "generatedAt": "2026-08-20T08:53:29.738Z",
   "blueprints": [
     {
       "id": "bp-agenity",
@@ -2235,7 +2235,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "1.5.11",
+      "version": "1.5.12",
       "section": "pts-2-3-per-sovereign-supporting-services",
       "depends": [
         "bp-postgres"

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -2370,7 +2370,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "1.5.11",
+    "version": "1.5.12",
     "section": "pts-2-3-per-sovereign-supporting-services",
     "depends": [
       "bp-postgres"

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -4001,7 +4001,14 @@ name: bp-catalyst-platform
 #   `Invalid parameter: redirect_uri` (live hw301 console.acme.omani.homes),
 #   blocking every per-Org login AND the Pillar-4 agentic walk. Umbrella tracks
 #   its sub-charts per Inviolable Principle #13.
-version: 1.4.1550
+# 1.4.1551 — #6509: catalog-seed advances bp-keycloak 1.5.11 -> 1.5.12. The
+#   1.5.11 mid-host wildcard console.*.<zone>/* was INERT on Keycloak 26.3
+#   (only a TRAILING `*` is honored), so pool-domain logins STILL 400'd
+#   `invalid_redirect_uri` (proven live hw302). catalyst-ui now keeps only the
+#   sovereign-admin host; the organization-controller registers each Org's
+#   CONCRETE callback https://console.<slug>.<pool-tld>/* at reconcile time.
+#   Umbrella tracks its sub-charts per Inviolable Principle #13.
+version: 1.4.1551
 # 1.4.1481 — #6293: catalog-seed advances bp-self-sovereign-cutover
 #   0.1.186 -> 0.1.187, the release that stops step-06 from patching five
 #   HelmRepositories it does not own and then grading itself on whether they
@@ -4188,7 +4195,7 @@ version: 1.4.1550
 # scripts/check-chart-version-forward.sh (#5743) fails unless the two match —
 # main was carrying a pre-existing 1.4.1330/1.4.1329 split, so this bump heals
 # it in the same commit, exactly as the documented self-heal contract does.
-appVersion: 1.4.1550
+appVersion: 1.4.1551
 # 1.4.239 — Wave 3 / Issue #2140 (2026-05-23): Huawei provider
 # implementation lands behind the Wave 2 CloudProvider interface.
 # Adds the OpenTofu module at infra/providers/huawei/ (VPC + Subnet +

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -597,7 +597,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "1.5.11"
+  version: "1.5.12"
   visibility: listed
   card:
     title: "Keycloak"
@@ -625,7 +625,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-keycloak
-    version: "1.5.11"
+    version: "1.5.12"
   # G117.1+G117.4+G117.6 #2744-followup (2026-06-03): bp-keycloak
   # catalog-seed needs topology + endpoints + sso so application-
   # controller can fan out HRs and operator console can mint silent-SSO


### PR DESCRIPTION
## Problem (proven live on hw302, Keycloak 26.3.3)

Per-Org console login (`https://console.<slug>.<pool-tld>/`, e.g. `console.acme.omani.homes`) 400s `invalid_redirect_uri` at the sovereign Keycloak realm.

Root cause: #6504's bp-keycloak change gave the sovereign realm's `catalyst-ui` client a **mid-host wildcard** redirectUri `https://console.*.<pool>/*`. **Keycloak 26.3 only honors a TRAILING `*`; a `*` in the HOST segment is matched literally**, so the wildcard never matches a real per-Org subdomain. Proven live: a *concrete* `https://console.uatprobe.omani.homes/*` on the client → login redirect passes (303); the wildcard-covered `console.testorg.omani.homes` → 400; a bogus `evil.example` → 400 (control holds). A static realm import also cannot enumerate the unbounded, dynamic set of Orgs a Sovereign hosts.

## Fix

The organization-controller now registers each Org's **concrete** console callback `https://console.<slug>.<pool-tld>/*` (+ web origin) onto the sovereign realm's `catalyst-ui` client at reconcile time, and removes it on Org deletion.

- `core/controllers/organization/.../keycloak.go` — `KeycloakClient` gains `RegisterOrgConsoleRedirectURI(ctx, slug, poolTLD)` + `DeregisterOrgConsoleRedirectURI(...)`; `LiveKeycloak` implements them against the Keycloak Admin API. GET `catalyst-ui` by `clientId`, round-trip the **full** representation as a raw-message map (untouched fields survive byte-for-byte), append/remove only `redirectUris` + `webOrigins`, PUT back. Idempotent + dedup: steady state makes zero writes; absent callback / absent client on deregister → success.
- `organization_controller.go` — wired best-effort into `reconcileConsoleServing` (sibling of the DNS/TLS/HTTPRoute trio; retries on the 30s degraded-requeue cadence; no-op when the Org has no pool `parentDomain`; nil-Keycloak-safe). Console subdomain defaults to `spec.slug`, matching `reconcileTenantRoute`'s host derivation.
- `tenant_networking_teardown.go` — deregister added as step 5 of the tenant-networking teardown cascade so dead callbacks don't accumulate on the shared client.
- `platform/keycloak` — the inert mid-host wildcard emission is **removed**; `catalyst-ui` keeps only the sovereign-admin host `https://console.<sovereignFQDN>/*` (a trailing `*`, which works). `parentZones` is retained for the powerdns/external-dns/sovereign-tls-vars slots that still consume it.

## Tests

- `keycloak_console_redirect_6509_test.go` (new): slug `acme` + pool `omani.homes` → registration produces `https://console.acme.omani.homes/*` (concrete, no mid-host `*`), preserves the sovereign-admin host, is idempotent, and dedups; deregister removes exactly the per-Org entry and is absent-as-success; the full client representation round-trips (an untouched attribute survives the PUT).
- `per-org-console-pool-redirect-3374.sh` rewritten: Case A now asserts the inert mid-host wildcard is **absent** (fails on the 1.5.11 template — non-vacuous).
- `go build ./...` + `go test ./...` green across the `core/controllers` module (41 packages).

## Lockstep / versions

- `bp-keycloak` 1.5.11 → **1.5.12** (Chart.yaml, blueprint.yaml, bootstrap-kit slot 09, catalog-seed, regenerated `blueprints.json` + `catalog.generated.ts`).
- umbrella `bp-catalyst-platform` 1.4.1550 → **1.4.1551** (Chart.yaml version+appVersion, bootstrap-kit slot 13) — catalog-seed template changed.
- Gates run locally green: `check-chart-version-bumped.sh`, `check-catalog-seed-lockstep.sh`, `check-catalog-seed-source-coverage.py`, catalog regen drift-free.

Refs #6509 #3374 #3988
