### PR TITLE
fix(agenity): creds-resync sidecar liveness+readiness probes so kyverno probes-present admits the StatefulSet (#6513)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1473,7 +1473,12 @@ spec:
       #   is honored); pool-domain logins STILL 400'd (proven live hw302). The
       #   organization-controller now registers each Org's CONCRETE console
       #   callback https://console.<slug>.<pool-tld>/* at reconcile time.
-      version: 1.4.1552
+      # 1.4.1553 — #6513: catalog-seed advances bp-agenity 0.5.31 -> 0.5.32 —
+      #   the creds-resync sidecar gains liveness + readiness probes so the
+      #   per-Org agenity StatefulSet passes kyverno probes-present (0.5.31
+      #   shipped it probe-less → DENIED at admission, install never came up,
+      #   hw302; blocked the Pillar-4 agentic walk).
+      version: 1.4.1553
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/core/services/provisioning/gitops/helmrelease_apps.go
+++ b/core/services/provisioning/gitops/helmrelease_apps.go
@@ -723,7 +723,7 @@ spec:
 // the catalog seed to 0.5.31 (server-side Anthropic OAuth credential renewal +
 // resync sidecar); this funnel pin moves in lockstep so a purchase installs the
 // renewing chart, not the one whose credential dies every ~5h.
-const DefaultHRAppChartVersions = "openclaw=0.2.19,stalwart-mail=0.1.16,newapi=1.4.153,agenity=0.5.31"
+const DefaultHRAppChartVersions = "openclaw=0.2.19,stalwart-mail=0.1.16,newapi=1.4.153,agenity=0.5.32"
 
 // ParseHRAppVersions parses the CATALYST_HR_APP_CHART_VERSIONS wire format
 // ("slug=version,slug=version") into the HelmReleaseAppVersions map (#4706).

--- a/products/agenity/blueprint.yaml
+++ b/products/agenity/blueprint.yaml
@@ -18,7 +18,11 @@ spec:
   # Keycloak backchannel + upstream) — the per-Org namespace is default-deny
   # and the gate's ingress-only CNP left the OAuth callback 500ing on a DNS
   # timeout. Lockstep with products/agenity/chart + the catalog-seed pin.
-  version: 0.5.31
+  # 0.5.32 (#6513): the creds-resync sidecar gains a liveness + readiness probe
+  # so the StatefulSet passes the kyverno probes-present policy — 0.5.31 shipped
+  # it probe-less and every per-Org install was DENIED at admission (proven live
+  # hw302). Lockstep with products/agenity/chart/Chart.yaml + the catalog-seed pin.
+  version: 0.5.32
   card:
     title: Agenity
     summary: |

--- a/products/agenity/chart/Chart.yaml
+++ b/products/agenity/chart/Chart.yaml
@@ -1,5 +1,25 @@
 apiVersion: v2
 name: bp-agenity
+# 0.5.32 (#6513): give the creds-resync sidecar a livenessProbe AND a
+# readinessProbe. 0.5.31 shipped the sidecar (below) with NEITHER, and the
+# kyverno probes-present ClusterPolicy (platform/kyverno-policies K1) DENIES a
+# StatefulSet unless EVERY container declares both — so the per-Org agenity
+# StatefulSet was rejected at admission and the workspace never came up (proven
+# live on hw302; the bp-openova-mcp per-Org install uses the SAME image but has
+# no such sidecar, so it installed fine — isolating the sidecar's missing probes
+# as the sole blocker). The sidecar is a headless copy-forward loop with no HTTP
+# port, so both probes are exec and chosen so neither can regress a running
+# workspace: readiness checks that the OPTIONAL /creds Secret mount is visible
+# (always present, so it can never false-fail the pod NotReady and hide the
+# dashboard), and liveness is a trivial `true` (a dead loop = container exit, so
+# container-alive == loop-alive). It deliberately does NOT probe credential-file
+# freshness — a healthy sidecar leaves the file untouched whenever no newer
+# expiresAt has arrived, so that would kill a working sidecar. The sidecar's
+# copy-forward function and the credentialResync default are UNCHANGED. Pinned by
+# chart/tests/creds-resync-probes.sh, which renders the chart and asserts BOTH
+# probes on creds-resync AND the kyverno invariant that every container carries
+# both, with a vacuity control. Template + test change; appVersion (image)
+# UNCHANGED.
 # 0.5.31 (#6317): DELIVER a refreshed credential to a RUNNING workspace, and
 # stop waiting an hour for it. 0.5.26/0.5.27 taught this chart to diagnose an
 # expired credential honestly; neither could do anything about one, because
@@ -267,7 +287,7 @@ type: application
 # same gateway bp-wordpress-tenant + the org console route attach to, #4054).
 # The old default rendered Accepted=False/InvalidHTTPRoute and the host 404'd
 # until the parentRef was hand-overridden. appVersion (image) unchanged.
-version: 0.5.31
+version: 0.5.32
 # 0.5.22 (#5617): the per-Org oidc-gate companion gains its EGRESS
 # CiliumNetworkPolicy (templates/oidc-gate.yaml `oidc-gate-<cid>-egress`).
 # The gate shipped an ingress-only gateway CNP into a DEFAULT-DENY per-Org

--- a/products/agenity/chart/templates/statefulset.yaml
+++ b/products/agenity/chart/templates/statefulset.yaml
@@ -490,6 +490,40 @@ spec:
             {{- toYaml ((.Values.anthropic.credentialResync).resources | default dict) | nindent 12 }}
           securityContext:
             allowPrivilegeEscalation: false
+          # ── kyverno probes-present (#6513) ───────────────────────────────
+          # The probes-present ClusterPolicy (platform/kyverno-policies K1)
+          # DENIES a StatefulSet unless EVERY container declares BOTH a
+          # livenessProbe AND a readinessProbe — that is exactly what blocked
+          # this sidecar's first install: 0.5.31 shipped creds-resync with no
+          # probes, so a per-Org agenity StatefulSet was rejected at admission
+          # and the Pod never came up (proven live, hw302). The sidecar is a
+          # headless copy-forward loop with no HTTP port, so both probes are
+          # exec — one per rung, and neither can regress the running workspace:
+          #   • readiness — the Secret mount it watches is visible. `/creds` is
+          #     ALWAYS present (the anthropic-creds volume is an OPTIONAL secret
+          #     that still mounts an empty dir when the Secret is absent), so
+          #     this can never false-fail the pod NotReady and hide the
+          #     dashboard the main container must keep serving. It confirms the
+          #     sidecar can see the very thing it is here to watch.
+          #   • liveness — the container can still exec. The resync is a single
+          #     `sh -c` process, so if that loop dies the container exits; while
+          #     it runs, `true` succeeds. We deliberately do NOT probe the
+          #     freshness of /claudehome/.claude/.credentials.json: a HEALTHY
+          #     sidecar correctly leaves that file untouched whenever the Secret
+          #     carries no newer expiresAt (the NEWER-ONLY predicate above), so
+          #     a freshness probe would kill a working sidecar. Probe handler
+          #     only — the copy-forward function is unchanged. These render
+          #     under the SAME gate as the container, so they exist iff it does.
+          readinessProbe:
+            exec:
+              command: ["test", "-d", "/creds"]
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          livenessProbe:
+            exec:
+              command: ["true"]
+            initialDelaySeconds: 10
+            periodSeconds: 30
         {{- end }}
       volumes:
         {{- if not .Values.persistence.enabled }}

--- a/products/agenity/chart/tests/creds-resync-probes.sh
+++ b/products/agenity/chart/tests/creds-resync-probes.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# creds-resync-probes.sh — prove the creds-resync sidecar carries BOTH a
+# livenessProbe and a readinessProbe, so the per-Org agenity StatefulSet is
+# ADMITTED by the kyverno probes-present ClusterPolicy.
+#
+# WHY THIS TEST EXISTS (#6513)
+#
+#   0.5.31 introduced the creds-resync sidecar (templates/statefulset.yaml,
+#   under anthropic.credentialResync.enabled — default true) with NEITHER
+#   probe. The probes-present policy (platform/kyverno-policies K1) DENIES a
+#   Deployment/StatefulSet/DaemonSet unless EVERY container declares both a
+#   livenessProbe AND a readinessProbe — its rule is a JMESPath count equality:
+#       containers[?livenessProbe]  | length(@)  ==  containers | length(@)
+#       containers[?readinessProbe] | length(@)  ==  containers | length(@)
+#   So one probe-less sidecar denied the whole StatefulSet at admission and a
+#   per-Org agenity install never came up (proven live, hw302). None of that is
+#   visible from "the chart renders" — the render is fine; admission is not.
+#
+#   This test renders the chart and asserts the SAME invariant the policy
+#   evaluates: with the sidecar enabled, every container in the StatefulSet
+#   carries both probes. Case 5 is a VACUITY control — it strips the sidecar's
+#   probes back out of the render and proves the invariant then FAILS, so a
+#   future edit that drops a probe cannot pass this test green.
+#
+# Runs under the release/PR toolchain (helm + mikefarah yq, both pinned). It
+# renders ONLY templates/statefulset.yaml (a single document), so it never
+# touches the multi-document `// "alt"` yq-version skew that cost a published
+# chart (#6235).
+#
+# Refs #6513 #6317 #3988
+set -euo pipefail
+
+chart_dir="${1:-$(cd "$(dirname "$0")/.." && pwd)}"
+helm="${HELM_BIN:-helm}"
+yq="${YQ_BIN:-yq}"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+fail=0
+note() { printf '  %s\n' "$*"; }
+ok()   { printf 'PASS  %s\n' "$*"; }
+bad()  { printf 'FAIL  %s\n' "$*"; fail=1; }
+
+# Render the StatefulSet only (single doc). credentialsKey is what makes the
+# init container + the anthropic-creds mount + the resync sidecar render at
+# all; credentialResync.enabled is the sidecar's own gate (default true, set
+# explicitly here so the test states its own preconditions).
+render() { # render <extra --set args...> -> stdout
+  "$helm" template ag "$chart_dir" \
+    --set anthropic.credentialsKey=credentialsJson \
+    --api-versions "cilium.io/v2" \
+    --api-versions "external-secrets.io/v1beta1" \
+    --show-only templates/statefulset.yaml \
+    "$@" 2>/dev/null
+}
+
+# The exact count the kyverno policy computes. Prints "total liveness readiness".
+counts() { # counts <file>
+  local f="$1"
+  printf '%s %s %s' \
+    "$("$yq" '.spec.template.spec.containers | length' "$f")" \
+    "$("$yq" '[.spec.template.spec.containers[] | select(has("livenessProbe"))]  | length' "$f")" \
+    "$("$yq" '[.spec.template.spec.containers[] | select(has("readinessProbe"))] | length' "$f")"
+}
+
+# ── 1. with the sidecar enabled, the creds-resync container renders ────────
+ENABLED="$WORK/enabled.yaml"
+render --set anthropic.credentialResync.enabled=true > "$ENABLED"
+
+if [ "$("$yq" '[.spec.template.spec.containers[] | select(.name == "creds-resync")] | length' "$ENABLED")" = "1" ]; then
+  ok "the creds-resync sidecar renders when credentialResync.enabled=true"
+else
+  bad "the creds-resync sidecar did NOT render — this test would be asserting on a container the chart does not ship"
+  echo "── rendered containers ──"; "$yq" '.spec.template.spec.containers[].name' "$ENABLED" || true
+  echo; [ "$fail" -eq 0 ] || exit 1
+fi
+
+# ── 2. the sidecar carries BOTH probes ─────────────────────────────────────
+# This is the actual fix: the container the kyverno policy rejected now has
+# each probe. `has()` is handler-agnostic (exec/httpGet/tcpSocket all count).
+cr_live="$("$yq"  '.spec.template.spec.containers[] | select(.name == "creds-resync") | has("livenessProbe")'  "$ENABLED")"
+cr_ready="$("$yq" '.spec.template.spec.containers[] | select(.name == "creds-resync") | has("readinessProbe")' "$ENABLED")"
+[ "$cr_live"  = "true" ] && ok "creds-resync declares a livenessProbe"  || bad "creds-resync has NO livenessProbe — probes-present would DENY the StatefulSet"
+[ "$cr_ready" = "true" ] && ok "creds-resync declares a readinessProbe" || bad "creds-resync has NO readinessProbe — probes-present would DENY the StatefulSet"
+
+# The sidecar is a headless copy-forward loop with NO HTTP port, so an httpGet
+# probe would point at nothing. Assert both probes use the exec handler — a
+# regression to httpGet/tcpSocket here would pass Case 2 (has() is true) while
+# probing a port that does not exist.
+cr_live_exec="$("$yq"  '.spec.template.spec.containers[] | select(.name == "creds-resync") | .livenessProbe  | has("exec")' "$ENABLED")"
+cr_ready_exec="$("$yq" '.spec.template.spec.containers[] | select(.name == "creds-resync") | .readinessProbe | has("exec")' "$ENABLED")"
+[ "$cr_live_exec"  = "true" ] && ok "creds-resync livenessProbe is exec (no HTTP port on this sidecar)"  || bad "creds-resync livenessProbe is NOT exec — this sidecar has no HTTP/TCP port to probe"
+[ "$cr_ready_exec" = "true" ] && ok "creds-resync readinessProbe is exec (no HTTP port on this sidecar)" || bad "creds-resync readinessProbe is NOT exec — this sidecar has no HTTP/TCP port to probe"
+
+# ── 3. the kyverno probes-present invariant holds (EVERY container) ─────────
+# The policy does not single out the sidecar — it requires ALL containers to
+# carry both probes. Assert the count equality directly.
+read -r total live ready <<<"$(counts "$ENABLED")"
+note "containers=$total  with-livenessProbe=$live  with-readinessProbe=$ready"
+if [ "$total" = "$live" ] && [ "$total" = "$ready" ]; then
+  ok "every container carries both probes — kyverno probes-present would ADMIT the StatefulSet"
+else
+  bad "not every container carries both probes ($live/$ready of $total) — kyverno probes-present would DENY the StatefulSet"
+fi
+
+# ── 4. the sidecar-DISABLED path still admits ──────────────────────────────
+# credentialResync.enabled=false drops the sidecar entirely; the sole chepherd
+# container already carries /healthz probes, so the invariant must still hold.
+DISABLED="$WORK/disabled.yaml"
+render --set anthropic.credentialResync.enabled=false > "$DISABLED"
+if [ "$("$yq" '[.spec.template.spec.containers[] | select(.name == "creds-resync")] | length' "$DISABLED")" = "0" ]; then
+  ok "credentialResync.enabled=false drops the creds-resync sidecar (probes render iff the sidecar does)"
+else
+  bad "the creds-resync sidecar rendered even with credentialResync.enabled=false"
+fi
+read -r d_total d_live d_ready <<<"$(counts "$DISABLED")"
+if [ "$d_total" = "$d_live" ] && [ "$d_total" = "$d_ready" ]; then
+  ok "the sidecar-disabled StatefulSet also satisfies probes-present ($d_total/$d_total)"
+else
+  bad "the sidecar-disabled StatefulSet fails probes-present ($d_live/$d_ready of $d_total)"
+fi
+
+# ── 5. VACUITY — the invariant check must be able to FAIL ───────────────────
+# If Case 3 passed only because the counter can never diverge, it proves
+# nothing. Strip the sidecar's probes back out of the enabled render and
+# require the SAME count equality to now report a mismatch.
+STRIPPED="$WORK/stripped.yaml"
+"$yq" '(.spec.template.spec.containers[] | select(.name == "creds-resync")) |= (del(.livenessProbe) | del(.readinessProbe))' "$ENABLED" > "$STRIPPED"
+read -r s_total s_live s_ready <<<"$(counts "$STRIPPED")"
+if [ "$s_total" != "$s_live" ] || [ "$s_total" != "$s_ready" ]; then
+  ok "vacuity: removing the sidecar's probes makes the invariant FAIL ($s_live/$s_ready of $s_total) — the check is real"
+else
+  bad "vacuity: the invariant still passed after the sidecar's probes were removed — the check is decorative"
+fi
+
+echo
+if [ "$fail" -ne 0 ]; then
+  echo "FAIL — the creds-resync sidecar does not satisfy the probes-present invariant."
+  exit 1
+fi
+echo "PASS — creds-resync carries both exec probes; every container satisfies kyverno probes-present."

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-20T08:53:29.738Z",
+  "generatedAt": "2026-08-20T11:00:00.551Z",
   "blueprints": [
     {
       "id": "bp-agenity",
@@ -11,7 +11,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "listed",
-      "version": "0.5.31",
+      "version": "0.5.32",
       "section": "pts-7-org-tenant",
       "depends": [
         "bp-external-secrets"

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -146,7 +146,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "listed",
-    "version": "0.5.31",
+    "version": "0.5.32",
     "section": "pts-7-org-tenant",
     "depends": [
       "bp-external-secrets"

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -4008,7 +4008,13 @@ name: bp-catalyst-platform
 #   sovereign-admin host; the organization-controller registers each Org's
 #   CONCRETE callback https://console.<slug>.<pool-tld>/* at reconcile time.
 #   Umbrella tracks its sub-charts per Inviolable Principle #13.
-version: 1.4.1552
+# 1.4.1553 — #6513: catalog-seed advances bp-agenity 0.5.31 -> 0.5.32. 0.5.31's
+#   creds-resync sidecar shipped with no liveness/readiness probe, so the kyverno
+#   probes-present policy DENIED the per-Org agenity StatefulSet at admission and
+#   the workspace never came up (proven live hw302, blocking the Pillar-4 agentic
+#   walk). 0.5.32 adds both exec probes to the sidecar. Umbrella tracks its
+#   sub-charts per Inviolable Principle #13.
+version: 1.4.1553
 # 1.4.1481 — #6293: catalog-seed advances bp-self-sovereign-cutover
 #   0.1.186 -> 0.1.187, the release that stops step-06 from patching five
 #   HelmRepositories it does not own and then grading itself on whether they

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -6040,7 +6040,11 @@ spec:
   # 0.5.22 (#5617): the oidc-gate companion gains its egress CNP — the per-Org
   # namespace is default-deny and the gate's ingress-only CNP left DNS + the
   # Keycloak token exchange dropped, 500ing every OAuth callback after login.
-  version: "0.5.31"
+  # 0.5.32 (#6513): the creds-resync sidecar gains liveness + readiness probes
+  # so the per-Org agenity StatefulSet passes kyverno probes-present (0.5.31
+  # shipped it probe-less → DENIED at admission, install never came up, hw302).
+  # Lockstep with products/agenity/chart + blueprint.yaml.
+  version: "0.5.32"
   visibility: listed
   card:
     title: "Agenity"
@@ -6070,7 +6074,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-agenity
-    version: 0.5.31
+    version: 0.5.32
   topology:
     supported:
       - singleton


### PR DESCRIPTION
## Problem

The per-Org **Agenity** workspace (`bp-agenity` chart, 0.5.31) fails to install
on a Sovereign. Its StatefulSet is **DENIED at admission** by the kyverno
`probes-present` ClusterPolicy (platform/kyverno-policies K1) because the
**`creds-resync` sidecar** — introduced in 0.5.31 under
`anthropic.credentialResync.enabled` (default **true**, #6317) — declares
**neither a livenessProbe nor a readinessProbe**. The policy requires every
container in a Deployment/StatefulSet/DaemonSet to declare both (a JMESPath
count-equality: `containers[?livenessProbe] | length(@)` must equal
`containers | length(@)`, same for readiness). The main `chepherd` container has
HTTP `/healthz` probes; the new sidecar had none, so the whole StatefulSet was
rejected and the workspace never came up.

Proven live on hw302, blocking the entire Pillar-4 agentic journey (chepherd
install → chat → agent-driven `create_application`). The `bp-openova-mcp` per-Org
install uses the same image but has no such sidecar and installs fine —
isolating the sidecar's missing probes as the sole cause.

## Remediation

`products/agenity/chart/templates/statefulset.yaml` — add an `exec`
livenessProbe + readinessProbe to the `creds-resync` sidecar, rendered under the
**same** `{{ if and .Values.anthropic.credentialsKey (.Values.anthropic.credentialResync).enabled }}`
gate as the container (so the probes exist iff the sidecar does). The sidecar is
a headless copy-forward loop with no HTTP port, so exec is the correct handler,
and each probe is chosen so it can never regress a running workspace:

- **readiness** `test -d /creds` — the Secret mount it watches is visible.
  `/creds` is always present (the `anthropic-creds` volume is an OPTIONAL secret
  that still mounts an empty dir when absent), so this can never false-fail the
  pod NotReady and hide the dashboard the main container must keep serving.
- **liveness** `true` — the container can still exec. The resync is a single
  `sh -c` process, so a dead loop = container exit; container-alive == loop-alive.

It deliberately does **not** probe the freshness of
`/claudehome/.claude/.credentials.json`: a healthy sidecar correctly leaves that
file untouched whenever the Secret carries no newer `expiresAt` (the NEWER-ONLY
predicate), so a freshness probe would kill a working sidecar. The sidecar's
copy-forward function and the `credentialResync` default are unchanged.

## Test

New `products/agenity/chart/tests/creds-resync-probes.sh` renders the chart and
asserts:
1. the sidecar renders when `credentialResync.enabled=true`;
2. it carries both probes, both using the `exec` handler (an httpGet regression
   would probe a nonexistent port);
3. the kyverno count-equality invariant holds across **every** container;
4. the sidecar-disabled path still satisfies the policy (probes render iff the
   sidecar does);
5. **vacuity** — stripping the sidecar's probes back out makes the invariant
   FAIL, proving the check is real.

Runs at PR time via `chart-tests-pr.yaml` under the release-pinned helm + yq; it
renders a single document (`--show-only templates/statefulset.yaml`) so it never
hits the multi-doc yq-version skew (#6235).

## Verified locally

- `helm template` with `credentialResync.enabled=true` → creds-resync now
  carries both exec probes; `containers=2 with-liveness=2 with-readiness=2` →
  kyverno `probes-present` would ADMIT the StatefulSet.
- New test PASS (incl. vacuity control); all existing agenity chart tests PASS
  (credential-resync-6317, credential-verdict, oidc-gate-companion-render).
- `check-chart-version-bumped.sh`: agenity 0.5.31→0.5.32, catalyst 1.4.1552→1.4.1553.
- `check-catalog-seed-lockstep.sh`: PASS (68 checked, 0 fail).
- catalog regen (`build-catalog.mjs`) deterministic, no drift.
- `check-bootstrap-kit-pin-sync.sh`: bp-catalyst-platform chart=1.4.1553 pin=1.4.1553.
- `helm lint`: 0 failed.

## Lockstep (bp-agenity 0.5.31 → 0.5.32)

- `products/agenity/chart/Chart.yaml` (+ statefulset template fix + new test)
- `products/agenity/blueprint.yaml`
- catalog-seed card+source: `products/catalyst/chart/templates/catalog-seed/blueprints.yaml`
- umbrella `products/catalyst/chart/Chart.yaml` 1.4.1552 → 1.4.1553
- bootstrap-kit slot 13 pin `clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml`
- regenerated catalog: `blueprints.json` + `catalog.generated.ts`

bp-agenity is OCI-delivered to Sovereigns, so this reaches hw302 by image/chart
pull once published — not gated by the GitRepository clone issue.

Refs #6513 #3988


<!-- lockstep pin closed via 5a60f9708 -->