### PR TITLE
fix(agenity): creds-resync sidecar missing probes → kyverno probes-present denies the StatefulSet (UAT G8/220/222/M4)

### DIFF
--- a/core/services/provisioning/gitops/helmrelease_apps.go
+++ b/core/services/provisioning/gitops/helmrelease_apps.go
@@ -723,7 +723,7 @@ spec:
 // the catalog seed to 0.5.31 (server-side Anthropic OAuth credential renewal +
 // resync sidecar); this funnel pin moves in lockstep so a purchase installs the
 // renewing chart, not the one whose credential dies every ~5h.
-const DefaultHRAppChartVersions = "openclaw=0.2.19,stalwart-mail=0.1.16,newapi=1.4.153,agenity=0.5.31"
+const DefaultHRAppChartVersions = "openclaw=0.2.19,stalwart-mail=0.1.16,newapi=1.4.153,agenity=0.5.32"
 
 // ParseHRAppVersions parses the CATALYST_HR_APP_CHART_VERSIONS wire format
 // ("slug=version,slug=version") into the HelmReleaseAppVersions map (#4706).

--- a/products/agenity/blueprint.yaml
+++ b/products/agenity/blueprint.yaml
@@ -18,7 +18,7 @@ spec:
   # Keycloak backchannel + upstream) — the per-Org namespace is default-deny
   # and the gate's ingress-only CNP left the OAuth callback 500ing on a DNS
   # timeout. Lockstep with products/agenity/chart + the catalog-seed pin.
-  version: 0.5.31
+  version: 0.5.32
   card:
     title: Agenity
     summary: |

--- a/products/agenity/chart/Chart.yaml
+++ b/products/agenity/chart/Chart.yaml
@@ -267,7 +267,7 @@ type: application
 # same gateway bp-wordpress-tenant + the org console route attach to, #4054).
 # The old default rendered Accepted=False/InvalidHTTPRoute and the host 404'd
 # until the parentRef was hand-overridden. appVersion (image) unchanged.
-version: 0.5.31
+version: 0.5.32
 # 0.5.22 (#5617): the per-Org oidc-gate companion gains its EGRESS
 # CiliumNetworkPolicy (templates/oidc-gate.yaml `oidc-gate-<cid>-egress`).
 # The gate shipped an ingress-only gateway CNP into a DEFAULT-DENY per-Org

--- a/products/agenity/chart/templates/statefulset.yaml
+++ b/products/agenity/chart/templates/statefulset.yaml
@@ -490,6 +490,28 @@ spec:
             {{- toYaml ((.Values.anthropic.credentialResync).resources | default dict) | nindent 12 }}
           securityContext:
             allowPrivilegeEscalation: false
+          # The cluster's kyverno `probes-present` policy is ENFORCE and requires
+          # EVERY container (not just the main one) to declare both probes, else
+          # the whole StatefulSet is denied at admission (measured on hw302: the
+          # bp-agenity HR latched Ready=False "validate.kyverno.svc-fail denied …
+          # containers-must-have-liveness-and-readiness", so agenity never ran —
+          # UAT G8/220/222/M4). This sidecar is a PID-1 `sh` copy-loop with no
+          # HTTP surface, so both probes are cheap exec checks that its two
+          # mounts (the claude-home it writes + the /creds it reads) are present.
+          readinessProbe:
+            exec:
+              command: ["sh", "-c", "test -d /claudehome && test -d /creds"]
+            initialDelaySeconds: 5
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          livenessProbe:
+            exec:
+              command: ["sh", "-c", "test -d /claudehome && test -d /creds"]
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 6
         {{- end }}
       volumes:
         {{- if not .Values.persistence.enabled }}

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -6070,7 +6070,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-agenity
-    version: 0.5.31
+    version: 0.5.32
   topology:
     supported:
       - singleton


### PR DESCRIPTION
**Live root cause (hw302):** the bp-agenity StatefulSet is denied by the ENFORCE `probes-present` policy — the `creds-resync` sidecar (#6317) lacks liveness/readiness probes (the chepherd container has them). One probe-less container blocks the whole StatefulSet, so agenity never runs → UAT G8/220/222 ❌ + M4.

**Fix:** exec probes on the sidecar (checks its /claudehome + /creds mounts). `helm template` renders both containers with both probes; `helm lint` clean. Chart 0.5.31→0.5.32 + lockstep (blueprint.yaml, DefaultHRAppChartVersions).

Deploy-gated — flips the live UAT rows only after chart republish + a fresh prov. Refs #5393 #6499 #6317