### PR TITLE
fix(bp-postgres): singleton shared-pg admits region-B keycloak over ClusterMesh — the per-app SSO 500 coin-flip (Refs #6627)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1478,7 +1478,7 @@ spec:
       #   per-Org agenity StatefulSet passes kyverno probes-present (0.5.31
       #   shipped it probe-less → DENIED at admission, install never came up,
       #   hw302; blocked the Pillar-4 agentic walk).
-      version: 1.4.1555
+      version: 1.4.1556
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/clusters/_template/bootstrap-kit/16a-bp-postgres-shared.yaml
+++ b/clusters/_template/bootstrap-kit/16a-bp-postgres-shared.yaml
@@ -190,7 +190,13 @@ spec:
       # CiliumNetworkPolicy denying :5432 to everything but the pair's own Pods and
       # itself, and removes it on every fail-safe path — so the 120s hold no longer
       # accepts consumer writes it is about to discard. Lockstep 16a/16c/16d.
-      version: 0.2.23
+      # 0.2.24 (#6627, Refs #4846 #6106): SINGLETON cross-region shared-consumer
+      #   admission CNP. The singleton operator-probe netpol opened :5432 via a
+      #   k8s-NetworkPolicy namespaceSelector:{} (LOCAL identities only), so a
+      #   region-B keycloak reaching this region-A primary over ClusterMesh was
+      #   DROPPED → JDBC acquisition timeout → ~50% of per-app SSO /auth 500 (hw304).
+      #   Adds the singleton mirror of #4846's identity CNP. Lockstep 16a/16c/16d.
+      version: 0.2.24
       sourceRef:
         kind: HelmRepository
         name: bp-postgres

--- a/clusters/_template/bootstrap-kit/16c-bp-postgres-shared-b.yaml
+++ b/clusters/_template/bootstrap-kit/16c-bp-postgres-shared-b.yaml
@@ -114,7 +114,13 @@ spec:
       # CiliumNetworkPolicy denying :5432 to everything but the pair's own Pods and
       # itself, and removes it on every fail-safe path — so the 120s hold no longer
       # accepts consumer writes it is about to discard. Lockstep 16a/16c/16d.
-      version: 0.2.23
+      # 0.2.24 (#6627, Refs #4846 #6106): SINGLETON cross-region shared-consumer
+      #   admission CNP. The singleton operator-probe netpol opened :5432 via a
+      #   k8s-NetworkPolicy namespaceSelector:{} (LOCAL identities only), so a
+      #   region-B keycloak reaching this region-A primary over ClusterMesh was
+      #   DROPPED → JDBC acquisition timeout → ~50% of per-app SSO /auth 500 (hw304).
+      #   Adds the singleton mirror of #4846's identity CNP. Lockstep 16a/16c/16d.
+      version: 0.2.24
       sourceRef:
         kind: HelmRepository
         name: bp-postgres

--- a/clusters/_template/bootstrap-kit/16d-bp-postgres-shared-c.yaml
+++ b/clusters/_template/bootstrap-kit/16d-bp-postgres-shared-c.yaml
@@ -102,7 +102,13 @@ spec:
       # CiliumNetworkPolicy denying :5432 to everything but the pair's own Pods and
       # itself, and removes it on every fail-safe path — so the 120s hold no longer
       # accepts consumer writes it is about to discard. Lockstep 16a/16c/16d.
-      version: 0.2.23
+      # 0.2.24 (#6627, Refs #4846 #6106): SINGLETON cross-region shared-consumer
+      #   admission CNP. The singleton operator-probe netpol opened :5432 via a
+      #   k8s-NetworkPolicy namespaceSelector:{} (LOCAL identities only), so a
+      #   region-B keycloak reaching this region-A primary over ClusterMesh was
+      #   DROPPED → JDBC acquisition timeout → ~50% of per-app SSO /auth 500 (hw304).
+      #   Adds the singleton mirror of #4846's identity CNP. Lockstep 16a/16c/16d.
+      version: 0.2.24
       sourceRef:
         kind: HelmRepository
         name: bp-postgres

--- a/platform/postgres/blueprint.yaml
+++ b/platform/postgres/blueprint.yaml
@@ -47,7 +47,11 @@ spec:
   # Kustomization-substitute seam and re-clones it onto region B's line, and
   # both DR actors render off ONE side-independent gate so a promoter without a
   # failback is not expressible. New: topology.demoted, topology.failback.*.
-  version: 0.2.23
+  # 0.2.24 — #6627 (Refs #4846 #6106): SINGLETON cross-region shared-consumer
+  #   admission CNP — the region-B keycloak → region-A shared-pg primary cross-mesh
+  #   DROP that 500'd ~50% of per-app SSO /auth on hw304 (the singleton mirror of
+  #   #4846's active-hot-standby carve-out; identity-based, gated on sharedConsumers).
+  version: 0.2.24
   card:
     title: PostgreSQL
     summary: |

--- a/platform/postgres/chart/Chart.yaml
+++ b/platform/postgres/chart/Chart.yaml
@@ -1,5 +1,22 @@
 apiVersion: v2
 name: bp-postgres
+# 0.2.24 — #6627 (Refs #4846 #6106): SINGLETON cross-region shared-consumer
+#   admission. networkpolicy-singleton-operator-probe.yaml (#4442) opened `:5432`
+#   to consumers via a k8s-NetworkPolicy `namespaceSelector:{}`, which a
+#   k8s-NetworkPolicy resolves to LOCAL-cluster identities only. On a 2-region
+#   Sovereign shared-pg is a SINGLETON primary in region A while keycloak (no
+#   SECONDARY_HR_SUSPEND) also runs in region B and shares ONE DB (#4915); the
+#   region-B Pod reaches the region-A primary over ClusterMesh with a
+#   remote-cluster identity the k8s-netpol cannot match → DROP → keycloak-0 JDBC
+#   `Acquisition timeout` → HTTP 500 on every region-B-served /auth → ~50% of
+#   per-app SSO logins fail (measured hw304, dep 438d9077bc2d83e1). Adds the
+#   SINGLETON mirror of #4846's active-hot-standby `-crossregion-dr-primary` CNP:
+#   an identity CiliumNetworkPolicy admitting `:5432` from any-cluster /
+#   any-namespace endpoints (io.cilium.k8s.policy.cluster: Exists — the #6106
+#   idiom, since a singleton is never stamped a peer ClusterMesh name), gated on
+#   sharedConsumers + the cilium.io/v2 capability. Purely additive; the
+#   single-region / per-Org-singleton / active-hot-standby renders are unchanged.
+#   tests/postgres-render.sh Case 5b added.
 # 0.2.23 — #6149 (Refs #5623 #5245 #5331 #5388 #6148): region-A AUTOMATIC DR
 #   FAILBACK, the PAIRING INVARIANT that makes it non-optional, and the #6148
 #   write-guard that fences the hold window.
@@ -415,8 +432,8 @@ name: bp-postgres
 #   honoured — sprig's `default` swallows boolean false). Primary render is
 #   byte-identical. Lockstep slot pins 16a/16c/16d → 0.2.20.
 #   tests/postgres-render.sh Case 21 added.
-version: 0.2.23
-appVersion: 0.2.23
+version: 0.2.24
+appVersion: 0.2.24
 description: |
   Catalyst-authored data-instance Blueprint for a shareable, reusable
   PostgreSQL engine. Each install of bp-postgres = ONE

--- a/platform/postgres/chart/templates/networkpolicy-singleton-operator-probe.yaml
+++ b/platform/postgres/chart/templates/networkpolicy-singleton-operator-probe.yaml
@@ -74,4 +74,67 @@ spec:
         - port: 5432
           protocol: TCP
     {{- end }}
+{{- if and .Values.topology.networkPolicy.sharedConsumers (.Capabilities.APIVersions.Has "cilium.io/v2") }}
+---
+# CROSS-REGION SHARED-PG CONSUMERS (#6627): the k8s-NetworkPolicy `:5432`
+# carve-out above uses `namespaceSelector:{}`, which a k8s-NetworkPolicy resolves
+# to LOCAL-cluster identities ONLY — Cilium implicitly ANDs
+# `io.cilium.k8s.policy.cluster=<local>`. On a 2-region Sovereign a HOST
+# shared-data instance is a SINGLETON primary in region A while its consumers
+# (keycloak first among them — bp-keycloak carries no SECONDARY_HR_SUSPEND, so it
+# renders in BOTH regions and shares ONE keycloak DB, #4915) ALSO run in region B
+# and dial `<instance>-mesh-rw` / `<instance>-rw` over ClusterMesh. A region-B Pod
+# arrives at the region-A primary carrying a REMOTE-CLUSTER identity that neither
+# k8s-netpol rule can match → `Policy denied` DROP at the primary's bpf_lxc → an
+# 8s TCP black-hole → keycloak-0 `GenericJDBCException: Unable to acquire JDBC
+# Connection [Acquisition timeout]` → HTTP 500 `unknown_error` on every
+# region-B-served /auth → ~50% of per-app SSO logins fail (measured live on hw304,
+# dep 438d9077bc2d83e1, 2026-08-23; region-A keycloak with its LOCAL identity
+# passes, so the ELB coin-flip is the ~50%). This is the SINGLETON mirror of the
+# active-hot-standby `-crossregion-dr-primary` carve-out (#4846, networkpolicy.yaml);
+# that fix is gated on active-hot-standby and does NOT render for a singleton
+# shared-pg, so this template re-introduced the local-only trap for the
+# shared-data host instances.
+#
+# The admission MUST be identity-based: an `ipBlock`/`toCIDR` NEVER matches a
+# ClusterMesh remote pod (Cilium assigns a CIDR identity only to IPs that are NOT
+# known endpoints — proven inert on hw228), and a k8s-netpol label selector is
+# implicitly local-scoped. `io.cilium.k8s.policy.cluster: Exists` matches the
+# LOCAL cluster AND every peer, so this ONE rule covers a region-A consumer and
+# the region-B one alike — the cross-cluster mirror of `namespaceSelector:{}`.
+# `k8s:io.kubernetes.pod.namespace: Exists` suppresses the implicit same-namespace
+# AND a namespaced CNP would otherwise apply (#4854), so consumers in EVERY
+# namespace (keycloak, gitea, harbor, grafana, powerdns, newapi …) are admitted —
+# the exact breadth the local rule already grants. Scoped to the single data-tier
+# port 5432. Purely additive: Cilium evaluates the UNION of every policy selecting
+# the endpoint, so the operator-probe default-deny is unchanged. Uses
+# `cluster: Exists` (not the #4846 `In [crossRegionPeerClusters]`) because a
+# singleton shared-pg is never a cnpg-pair and so is never stamped with a peer
+# ClusterMesh name — the #6106 catalyst-api-backchannel idiom. Gated on
+# `sharedConsumers` (host shared-data instances only — a per-Org singleton keeps
+# NO broad rule, its consumers are same-Org) and the cilium.io/v2 capability (so a
+# CRD-less kind CI still installs — #2988/#3102).
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: {{ include "bp-postgres.instanceName" . }}-crossregion-shared-consumers
+  namespace: {{ include "bp-postgres.namespace" . }}
+  labels:
+    {{- include "bp-postgres.labels" . | nindent 4 }}
+spec:
+  endpointSelector:
+    matchLabels:
+      cnpg.io/cluster: {{ include "bp-postgres.instanceName" . }}
+  ingress:
+    - fromEndpoints:
+        - matchExpressions:
+            - key: io.cilium.k8s.policy.cluster
+              operator: Exists
+            - key: k8s:io.kubernetes.pod.namespace
+              operator: Exists
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP
+{{- end }}
 {{- end }}

--- a/platform/postgres/chart/tests/postgres-render.sh
+++ b/platform/postgres/chart/tests/postgres-render.sh
@@ -621,6 +621,80 @@ if grep -q 'key: openova.io/region' "$TMP/shared.yaml"; then
   fail "singleton render leaked region node-affinity (active-hot-standby only)"
 fi
 
+# ── Case 5b: #6627 — sharedConsumers singleton → cross-region consumer CNP ─────
+# The singleton operator-probe netpol opens :5432 to consumers via a k8s-netpol
+# `namespaceSelector:{}`, which a k8s-NetworkPolicy resolves to LOCAL-cluster
+# identities only. On a 2-region Sovereign a region-B keycloak reaches THIS
+# region-A singleton primary over ClusterMesh with a REMOTE-cluster identity the
+# k8s-netpol cannot match → DROP → JDBC acquisition timeout → ~50% of per-app SSO
+# /auth 500 (measured hw304). The fix is the singleton mirror of Case 4e's #4846
+# identity CNP: admit :5432 from ANY cluster + ANY namespace by identity. Gated on
+# sharedConsumers + the cilium.io/v2 capability.
+echo "[render] Case 5b: #6627 sharedConsumers singleton + cilium.io/v2 → identity CNP admitting cross-region :5432 consumers, NO ipBlock"
+cat > "$TMP/sc.values.yaml" <<'YAML'
+instance: { name: shared-pg, namespace: shared-data }
+topology:
+  mode: singleton
+  instances: 1
+  networkPolicy:
+    sharedConsumers: true
+databases:
+  - name: registry
+    owner: harbor
+    reflect: { secretName: harbor-database-secret, namespaces: [harbor] }
+YAML
+helm template shared-pg . -f "$TMP/sc.values.yaml" --namespace shared-data \
+  --api-versions postgresql.cnpg.io/v1 --api-versions cilium.io/v2 > "$TMP/sc.yaml" 2>&1 \
+  || fail "#6627 sharedConsumers singleton render errored"
+# Exactly ONE CiliumNetworkPolicy, named -crossregion-shared-consumers.
+[ "$(grep -cE '^kind: CiliumNetworkPolicy$' "$TMP/sc.yaml")" = "1" ] \
+  || fail "#6627 expected exactly 1 CiliumNetworkPolicy on the sharedConsumers singleton"
+grep -qE '^  name: shared-pg-crossregion-shared-consumers$' "$TMP/sc.yaml" \
+  || fail "#6627 CNP name != shared-pg-crossregion-shared-consumers"
+# It selects the singleton primary Cluster's Pods (endpointSelector).
+grep -qE '^      cnpg.io/cluster: shared-pg$' "$TMP/sc.yaml" \
+  || fail "#6627 CNP endpointSelector must select cnpg.io/cluster: shared-pg"
+# Identity-based admission matching BOTH the local cluster and every peer:
+# io.cilium.k8s.policy.cluster Exists (NOT an In-list — a singleton is never
+# stamped a peer ClusterMesh name), + namespace Exists to reach consumers in every
+# namespace (the cross-cluster mirror of the k8s namespaceSelector:{}).
+grep -q 'key: io.cilium.k8s.policy.cluster' "$TMP/sc.yaml" \
+  || fail "#6627 CNP missing the io.cilium.k8s.policy.cluster identity match"
+grep -q 'operator: Exists' "$TMP/sc.yaml" \
+  || fail "#6627 CNP must use operator: Exists (local + every peer), not an In-list"
+grep -qE '^ +- port: "5432"$' "$TMP/sc.yaml" \
+  || fail "#6627 CNP must admit port 5432 (identity, cross-cluster)"
+# NEVER an ipBlock — inert for ClusterMesh remote endpoints (the reverted #4846
+# first attempt). Match a real `ipBlock:` YAML key, not the prose comment.
+if grep -qE '^[[:space:]]*-?[[:space:]]*ipBlock:' "$TMP/sc.yaml"; then
+  fail "#6627 render leaked an ipBlock rule (inert for ClusterMesh — must be identity CNP)"
+fi
+# The k8s operator-probe netpol AND its broad LOCAL :5432 carve-out remain intact
+# (the CNP is purely additive — it does not replace the local half).
+grep -qE '^  name: shared-pg-allow-cnpg-operator-probe$' "$TMP/sc.yaml" \
+  || fail "#6627 must not drop the CNPG-operator status-probe NetworkPolicy"
+grep -qE '^ +- port: 5432$' "$TMP/sc.yaml" \
+  || fail "#6627 must keep the local k8s namespaceSelector:{} :5432 consumer rule"
+# VACUITY 1 — no cilium.io/v2 capability (kind CI): the CNP MUST NOT render so a
+# CRD-less cluster still installs (#2988/#3102); the k8s netpol still does.
+helm template shared-pg . -f "$TMP/sc.values.yaml" --namespace shared-data \
+  --api-versions postgresql.cnpg.io/v1 > "$TMP/sc-nocilium.yaml" 2>&1 \
+  || fail "#6627 sharedConsumers singleton (no cilium cap) render errored"
+if grep -q 'CiliumNetworkPolicy' "$TMP/sc-nocilium.yaml"; then
+  fail "#6627 CNP rendered without the cilium.io/v2 capability (breaks CRD-less kind CI)"
+fi
+grep -qE '^  name: shared-pg-allow-cnpg-operator-probe$' "$TMP/sc-nocilium.yaml" \
+  || fail "#6627 k8s operator-probe netpol must still render on a CRD-less cluster"
+# VACUITY 2 — sharedConsumers UNSET (per-Org singleton) + cilium.io/v2: NO CNP.
+# The cross-region admission is for the shared-data HOST instances only; a per-Org
+# singleton keeps no broad rule (Case 5 pins the default-render side).
+helm template shared-pg . --set instance.name=shared-pg --set topology.mode=singleton \
+  --namespace shared-data --api-versions postgresql.cnpg.io/v1 --api-versions cilium.io/v2 \
+  > "$TMP/sc-perorg.yaml" 2>&1 || fail "#6627 per-Org singleton render errored"
+if grep -q 'CiliumNetworkPolicy' "$TMP/sc-perorg.yaml"; then
+  fail "#6627 CNP rendered for a per-Org singleton (sharedConsumers=false) — must be host-instance only"
+fi
+
 # ── Case 6: master gate OFF → ZERO resources (#3188 safe-by-default) ──
 # `enabled=false` must render an EMPTY release even with the CNPG CRD
 # present and bindings declared — so the bootstrap-kit slot 16a HR is a

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -4083,7 +4083,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "listed",
-      "version": "0.2.23",
+      "version": "0.2.24",
       "section": "pts-4-1-data-services",
       "depends": [
         "bp-cnpg",

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -4218,7 +4218,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "listed",
-    "version": "0.2.23",
+    "version": "0.2.24",
     "section": "pts-4-1-data-services",
     "depends": [
       "bp-cnpg",

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -4014,7 +4014,7 @@ name: bp-catalyst-platform
 #   the workspace never came up (proven live hw302, blocking the Pillar-4 agentic
 #   walk). 0.5.32 adds both exec probes to the sidecar. Umbrella tracks its
 #   sub-charts per Inviolable Principle #13.
-version: 1.4.1555
+version: 1.4.1556
 # 1.4.1481 — #6293: catalog-seed advances bp-self-sovereign-cutover
 #   0.1.186 -> 0.1.187, the release that stops step-06 from patching five
 #   HelmRepositories it does not own and then grading itself on whether they

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5818,7 +5818,11 @@ spec:
   # + the `-replica-mesh` reverse alias + the topology.demoted rejoin shape, AND the
   # pairing invariant that renders promoter and failback off ONE gate. hw293 shipped
   # 4 promoters against 1 failback and left shared-pg/-b permanently dual-writable.
-  version: "0.2.23"
+  # 0.2.24 (#6627, Refs #4846 #6106): SINGLETON cross-region shared-consumer admission
+  # CNP — region-B keycloak → region-A shared-pg primary was DROPPED cross-mesh (the
+  # singleton netpol's k8s namespaceSelector:{} can't match a remote identity),
+  # 500'ing ~50% of per-app SSO /auth on hw304; adds the singleton mirror of #4846.
+  version: "0.2.24"
   visibility: listed
   # Shareability + Contexts (#3370) — seeded verbatim from
   # platform/postgres/blueprint.yaml (lockstep-guarded). One instance
@@ -5946,7 +5950,10 @@ spec:
     # `-replica-mesh` reverse alias + the topology.demoted rejoin shape) AND the
     # pairing invariant — promoter and failback now ride ONE gate, so a pair that
     # can be promoted can always fail back. hw293 left shared-pg/-b dual-writable.
-    version: "0.2.23"
+    # 0.2.24 (#6627, Refs #4846 #6106): SINGLETON cross-region shared-consumer
+    # admission CNP — region-B keycloak → region-A shared-pg primary DROPPED
+    # cross-mesh, 500'ing ~50% of per-app SSO /auth on hw304 (singleton mirror of #4846).
+    version: "0.2.24"
   # Seeded verbatim from platform/postgres/blueprint.yaml spec.topology.
   # singleton = single-instance Cluster; active-hot-standby = sync
   # replication across regions (ADR-0004 Pillar-3 zero-tx-loss) via the


### PR DESCRIPTION
## Root cause (traced live on hw304, dep `438d9077bc2d83e1`, 2026-08-23)

The per-app SSO landings (gitea/harbor/grafana/openbao — UAT 180/181/182/183/235) are degraded because Keycloak's `/auth` **intermittently 500s** — the same fresh request returns `303` (fast) one call and `500` (`x-envoy-upstream-service-time: 5002`) the next. It is **realm-wide** (`account-console` + `kc_idp_hint=catalyst-pin` also 500s in 5.05s).

The wildcard VIP round-robins `auth.<fqdn>` between the region-A and region-B Keycloak Pods. Region-B `keycloak-0`'s own log:

```
ERROR org.hibernate.exception.GenericJDBCException: Unable to acquire JDBC Connection
      [Acquisition timeout while waiting for new connection]
Caused by: java.util.concurrent.TimeoutException
WARN  io.agroal.pool  Datasource '<default>': The connection attempt failed.
```

`KC_DB_URL = jdbc:postgresql://shared-pg-mesh-rw.shared-data...:5432/keycloak` → the region-A CNPG primary `10.42.3.209`. Region A + B share one keycloak DB, so region-B keycloak MUST reach the region-A primary. Connectivity matrix **from region-B keycloak-0**:

| target (region A) | result |
|---|---|
| `catalyst-api-backchannel...:8080` | **OK 4ms** |
| `10.42.3.141:5432` (org-pg-1, same node, **no NetworkPolicy**) | **OK 3ms** |
| `shared-pg-mesh-rw...:5432` → `10.42.3.209` | **FAIL 8s hang** |
| `10.42.3.209:5432` (primary, direct pod IP) | **FAIL 8s hang** |

ClusterMesh is healthy (`1/1 remote clusters ready`) and the datapath delivers the backend (`1 => 10.42.3.209:5432 active`). The drop is **pod-specific to shared-pg** — the one consumer-hub Cluster carrying an ingress NetworkPolicy:

```yaml
# NetworkPolicy shared-pg-allow-cnpg-operator-probe (podSelector cnpg.io/cluster=shared-pg)
ingress:
- from: [{namespaceSelector: {matchLabels: {kubernetes.io/metadata.name: cnpg-system}}}]  # 8000/9187
- from: [{namespaceSelector: {}}]                                                          # :5432 ← LOCAL ONLY
```

Any k8s NetworkPolicy selecting the pod flips it to **default-deny ingress**. `namespaceSelector: {}` in a **k8s NetworkPolicy** matches **LOCAL-cluster identities only** (Cilium implicitly ANDs `io.cilium.k8s.policy.cluster=<local>`). A region-B keycloak Pod arriving over ClusterMesh carries a **remote-cluster identity** neither rule matches → **DROP → 8s black-hole → Agroal 5s acquisition timeout → HTTP 500** on every region-B-served `/auth`. Region-A keycloak (local identity) → 303. Round-robin ⇒ ~50%. `org-pg` (no NetworkPolicy → default-allow) is the control that proves the mechanism.

## Exact defect

`platform/postgres/chart/templates/networkpolicy-singleton-operator-probe.yaml` (the SINGLETON path, #4442) opens `:5432` only via the local-only k8s-netpol `namespaceSelector: {}` and emits **no cross-region CiliumNetworkPolicy**. The active-hot-standby path already has this carve-out (`networkpolicy.yaml`, #4846 `-crossregion-dr-primary` CNP), but it is gated on active-hot-standby and does not render for a singleton shared-pg.

## Fix

Emit the SINGLETON mirror of #4846 — a `CiliumNetworkPolicy` admitting `:5432` from `fromEndpoints` with `io.cilium.k8s.policy.cluster: Exists` + `k8s:io.kubernetes.pod.namespace: Exists` (the #6106 idiom; a singleton is never stamped a peer ClusterMesh name, so `Exists` not an `In`-list). Gated on `sharedConsumers` (host shared-data instances only) + the `cilium.io/v2` capability (CRD-less kind CI still installs). Purely additive.

- `tests/postgres-render.sh` **Case 5b** — asserts the identity CNP renders (name, endpointSelector, cluster+namespace `Exists`, `:5432`, **no ipBlock**, local k8s carve-out intact) + two vacuity guards (no CNP without the cilium capability; no CNP for a per-Org singleton). Full render suite + `helm lint` green.
- `bp-postgres 0.2.23 → 0.2.24` in lockstep (mirrors the #6149 precedent): Chart.yaml, blueprint.yaml, bootstrap-kit `16a/16c/16d`, catalog-seed card + `source.version`, `catalog.generated.ts`, `blueprints.json`. `check-bootstrap-kit-pin-sync.sh` + `check-catalog-seed-lockstep.sh` green.

## Verification

**Deploy-gated** — verifies on a fresh 2-region fire: region-B keycloak reaches the region-A shared-pg primary → no JDBC acquisition timeout → `/auth` stops 500ing on either region. **Not applied to any live cluster.**

## Scope notes
- **#6314** (agenity per-Org oidc-gate → `auth.<slug>.<pool>`) is a separate, unrelated per-Org root cause — not touched here.
- **#6106/#6172** (catalyst-pin backchannel) are already on main and confirmed working on hw304 (region-B keycloak reaches the catalyst-api backchannel in 4ms).
- **OpenBao 403** on `/v1/sys/internal/ui/mounts` is the separate #5459.

Refs #6627 #4846 #6106

🤖 Generated with [Claude Code](https://claude.com/claude-code)
