### PR TITLE
fix(cutover): secondary gitea-mirror mints a region-local PAT for the git push, unwedging step-01 on a 2-region Sovereign (#6645)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -1094,7 +1094,13 @@ spec:
       #   throttled IPv4-only egress runs ~19 min, and the 20-min ceiling plus the
       #   DNS/PAT readiness waits reaped the Job as DeadlineExceeded before the mirror
       #   landed (hw302), wedging the cutover at step-01 (G11 / UAT row 166).
-      version: 0.1.198
+      # 0.1.199 (#6645, Refs #6490): the SECONDARY-region gitea-mirror leg mints a
+      #   region-local Gitea PAT and git-auths the push/ls-remote WITH IT (mirroring
+      #   the PRIMARY step-01). hw305 region-B: the curl API accepted the admin
+      #   password but Gitea's git-over-HTTP refuses a password under an external
+      #   login source, so the header-authed PASSWORD push FATALed "Could not read
+      #   from remote repository" and wedged the cutover at step-01.
+      version: 0.1.199
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1483,7 +1483,12 @@ spec:
       #   ~470 MB monorepo bare-clone + force-push over a throttled egress finishes
       #   inside budget; the old 20-min ceiling reaped the Job as DeadlineExceeded
       #   and wedged the cutover at step-01 on hw302).
-      version: 1.4.1559
+      # 1.4.1560 — lockstep for bp-self-sovereign-cutover 0.1.199 (#6645, Refs #6490:
+      #   the SECONDARY-region gitea-mirror leg mints a region-local Gitea PAT and
+      #   git-auths the push WITH IT — Gitea git-over-HTTP refuses the admin password
+      #   under an external login source, wedging the cutover at step-01 on hw305
+      #   region-B). Umbrella tracks its sub-charts per Inviolable Principle #13.
+      version: 1.4.1560
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.198
+  version: 0.1.199
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -4191,7 +4191,18 @@ name: bp-self-sovereign-cutover
 #   step-01 (G11 / UAT row 166). 45 min gives comfortable headroom; the clone stays
 #   --bare (it needs all refs+blobs to push). Chart-test Case 97 pins the raised
 #   deadline. Catalog + bootstrap-kit slot 06a move to 0.1.198 in lockstep.
-version: 0.1.198
+# 0.1.199 (#6645, Refs #6490 #5262) — the SECONDARY-region gitea-mirror leg
+#   (secondary-mirror.sh) now MINTS a region-local Gitea PAT and git-auths the
+#   push/ls-remote WITH IT, mirroring the PRIMARY step-01 push-auth. Root cause
+#   (hw305 region-B, dep b2b00ce4c833badf): Gitea's git-over-HTTP BasicAuth
+#   REFUSES an account password when an external login source (openova-sso
+#   OAuth2) is configured — the curl API accepts the same password, but the
+#   header-authed PASSWORD push FATALed "Could not read from remote repository",
+#   wedging the cutover at step-01. The #6490 http.extraHeader move only fixed a
+#   URL-special-char parse; a password is still refused for git-HTTP. Fix mints a
+#   PAT via the admin BasicAuth API (proven working) and uses it for the push,
+#   plus a mirror=false guard. Catalog + bootstrap-kit slot 06a move to 0.1.199.
+version: 0.1.199
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/secondary-mirror-script-configmap.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/secondary-mirror-script-configmap.yaml
@@ -21,12 +21,18 @@ closing `git ls-remote` self-verify — the #6490 ordering gate: this region's
 Gitea must serve a COMPLETE ref advertisement before step-05 pivots its Flux
 GitRepository at it.
 
-Auth is BasicAuth with the secondary's OWN gitea-admin-secret (username +
-password env, from a secretKeyRef the stamping Job wires). A secondary does NOT
-run bp-catalyst-platform (SECONDARY_HR_SUSPEND), so the `catalyst-gitea-token`
-PAT step-01 uses on the primary does not exist there; admin BasicAuth is the
-credential available in-region. curl calls carry --max-time so a converging
-login source cannot hang the step.
+Auth (#6645): the /api/v1 calls (org/repo create, PAT mint, repo-meta readback)
+use BasicAuth with the secondary's OWN gitea-admin-secret (username + password
+env, from a secretKeyRef the stamping Job wires) — the proven-working API path.
+But the git-over-HTTP push/ls-remote authenticate with a freshly MINTED PAT, not
+that password: Gitea's git-HTTP BasicAuth refuses an account password when an
+external login source (bp-gitea's openova-sso OAuth2) is configured, even though
+the API accepts it — the exact region-B discriminator (API OK, push "Could not
+read from remote repository"). A secondary runs no bp-catalyst-platform, so the
+`catalyst-gitea-token` PAT step-01 uses on the primary does not exist here; we
+mint one in-region via the admin BasicAuth API and use it for the push, mirroring
+the primary's PAT-authed push. curl calls carry --max-time so a converging login
+source cannot hang the step.
 
 RENDER-GATED: emitted only when secondaryRegions.mirrorToSecondaryGitea is true,
 so a single-region Sovereign renders byte-identical (this whole object absent).
@@ -99,7 +105,57 @@ data:
       fi
     fi
 
-    # 3. bare-clone upstream and force-push explicit refspecs (never mirror mode
+    # 2b. #6645 — mirror=false guard. A Gitea PULL-MIRROR repo is READ-ONLY: the
+    #     force-push below is rejected and git surfaces only the opaque
+    #     "Could not read from remote repository". Gitea 1.22 cannot convert a
+    #     pull-mirror to a standalone repo via API (same constraint step-01/PR
+    #     #1029 designed around on the primary), so we FATAL naming the exact
+    #     cause instead of failing opaquely inside the push. The create path
+    #     above makes a REGULAR repo (auto_init:false, never /repos/migrate), so
+    #     this only fires if something else seeded a pull-mirror in this region.
+    repo_meta=$(curl -fsS --max-time 60 \
+        -H "Authorization: Basic ${basic_auth}" -H "Accept: application/json" \
+        "${api_url}/repos/${GITEA_ORG}/${GITEA_REPO}" 2>/dev/null || echo "{}")
+    if printf '%s' "${repo_meta}" | grep -q '"mirror":true'; then
+      echo "[secondary-mirror] FATAL: ${GITEA_ORG}/${GITEA_REPO} is a Gitea PULL-MIRROR (read-only) in this region — the region-local force-push cannot land (#6645). A pull-mirror cannot be converted to standalone via the Gitea API; recreate it as a regular (non-mirror) repo before re-triggering." >&2
+      exit 1
+    fi
+
+    # 3. #6645 — mint a fresh region-local PAT and authenticate the git-over-HTTP
+    #    push/ls-remote WITH IT, exactly as the PRIMARY (region-A) mirror does
+    #    (01-gitea-mirror-job.yaml uses the bootstrap-minted catalyst-gitea-token
+    #    PAT). WHY NOT the admin password: Gitea's git-over-HTTP BasicAuth REFUSES
+    #    an account password when an external login source (bp-gitea's openova-sso
+    #    OAuth2) is configured — it demands a token — EVEN THOUGH the /api/v1 calls
+    #    above accept that same password. That is the exact region-B discriminator
+    #    (#6645, hw305 dep b2b00ce4c833badf): the curl API BasicAuth succeeds
+    #    ("repo already present") while the header-authed push FATALs with
+    #    "Could not read from remote repository". The earlier http.extraHeader
+    #    BasicAuth-password variant (#6490) only dodged a URL-special-char parse
+    #    bug — it still presents a PASSWORD, so it does not clear this rejection.
+    #    A secondary runs no bp-catalyst-platform, so the primary's
+    #    catalyst-gitea-token PAT does not exist here; we MINT one via the admin
+    #    BasicAuth API (the proven-working path) and use it — a PAT is accepted as
+    #    the git-HTTP password under any username. Delete-then-create keeps it
+    #    idempotent: a token's sha1 is only returned at creation.
+    pat_name="cutover-secondary-mirror"
+    curl -fsS -o /dev/null --max-time 60 -X DELETE \
+      -H "Authorization: Basic ${basic_auth}" \
+      "${api_url}/users/${GITEA_USERNAME}/tokens/${pat_name}" 2>/dev/null || true
+    mint_resp=$(curl -fsS --max-time 60 -X POST \
+      -H "Authorization: Basic ${basic_auth}" -H "Content-Type: application/json" \
+      -d "{\"name\":\"${pat_name}\",\"scopes\":[\"write:repository\",\"read:repository\"]}" \
+      "${api_url}/users/${GITEA_USERNAME}/tokens" 2>/dev/null || echo "")
+    GITEA_PAT=$(printf '%s' "${mint_resp}" | sed -n 's/.*"sha1":"\([0-9a-fA-F]*\)".*/\1/p')
+    if [ -z "${GITEA_PAT}" ]; then
+      echo "[secondary-mirror] FATAL: could not mint a region-local Gitea PAT (POST ${api_url}/users/${GITEA_USERNAME}/tokens returned no sha1) — git-over-HTTP will not accept the admin password when an external login source is configured (#6645)" >&2
+      exit 1
+    fi
+    # token BasicAuth header (user:PAT) — THIS is what git-over-HTTP accepts. The
+    # push URL still carries NO credentials (the #6490 URL-special-char safety).
+    token_auth=$(printf '%s' "${GITEA_USERNAME}:${GITEA_PAT}" | base64 -w0 2>/dev/null || printf '%s' "${GITEA_USERNAME}:${GITEA_PAT}" | base64 | tr -d '\n')
+
+    # 4. bare-clone upstream and force-push explicit refspecs (never mirror mode
     #    #5011) with the #6488 large-clone robustness.
     git config --global user.name "self-sovereign-cutover-secondary"
     git config --global user.email "cutover@${gitea_host}"
@@ -108,13 +164,6 @@ data:
     git config --global http.lowSpeedLimit 1000
     git config --global http.lowSpeedTime 600
 
-    # Authenticate the git push/ls-remote over HTTP with the SAME BasicAuth
-    # header the curl API calls above use — NOT URL-injected credentials. A
-    # region-local Gitea admin password containing a URL-special char
-    # (/ @ : & % …) breaks either the sed replacement or git's URL parse, so
-    # the API calls succeed (header-authenticated) while the push FATALs with
-    # "Could not read from remote repository" (#6490, live-confirmed hw301
-    # region-B). The push URL carries NO credentials.
     push_url="${GITEA_INTERNAL_URL}/${GITEA_ORG}/${GITEA_REPO}.git"
     workdir=$(mktemp -d)
     cd "${workdir}"
@@ -135,19 +184,19 @@ data:
     fi
     cd upstream.git
     echo "[secondary-mirror] pushing upstream branches + tags to the region-local Gitea"
-    push_err=$(git -c http.extraHeader="Authorization: Basic ${basic_auth}" push --force "${push_url}" 'refs/heads/*:refs/heads/*' 'refs/tags/*:refs/tags/*' 2>&1) || {
+    push_err=$(git -c http.extraHeader="Authorization: Basic ${token_auth}" push --force "${push_url}" 'refs/heads/*:refs/heads/*' 'refs/tags/*:refs/tags/*' 2>&1) || {
       echo "[secondary-mirror] FATAL: git push to the region-local Gitea failed" >&2
-      printf '%s\n' "${push_err}" | sed -E "s,${GITEA_PASSWORD}+,REDACTED,g" >&2
+      printf '%s\n' "${push_err}" | sed -E "s,${GITEA_PAT}+,REDACTED,g;s,${GITEA_PASSWORD}+,REDACTED,g" >&2
       exit 1
     }
     echo "[secondary-mirror] pushed all upstream branches + tags"
 
-    # 4. ls-remote self-verify — the #6490 ordering gate. The region's Gitea must
+    # 5. ls-remote self-verify — the #6490 ordering gate. The region's Gitea must
     #    serve a COMPLETE ref advertisement (the class that truncated at pkt-line
     #    3 cross-region); prove it locally before step-05 pivots Flux at it.
-    if ! git -c http.extraHeader="Authorization: Basic ${basic_auth}" ls-remote --heads "${push_url}" >/tmp/.lsr 2>/tmp/.lsr.err; then
+    if ! git -c http.extraHeader="Authorization: Basic ${token_auth}" ls-remote --heads "${push_url}" >/tmp/.lsr 2>/tmp/.lsr.err; then
       echo "[secondary-mirror] FATAL: git ls-remote of the pushed repo failed — its ref advertisement is not servable (the pkt-line 3 EOF class, #6490)" >&2
-      sed -E "s,${GITEA_PASSWORD}+,REDACTED,g" /tmp/.lsr.err >&2 || true
+      sed -E "s,${GITEA_PAT}+,REDACTED,g;s,${GITEA_PASSWORD}+,REDACTED,g" /tmp/.lsr.err >&2 || true
       exit 1
     fi
     if ! grep -q "refs/heads/${UPSTREAM_BRANCH}" /tmp/.lsr; then

--- a/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
+++ b/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
@@ -5484,33 +5484,44 @@ fi
 grep -q 'names a HEALTHY HelmRelease' "$TMP/c95/out.txt" || { echo "FAIL: CONTROL — the platform stale-override rejection lost its class name (#5391/#6273)" >&2; exit 1; }
 echo "  PASS (#6273: BOTH Phase A0 passes partition by ownership — the HelmRelease pass and the override-free wl_pending pass each WARN-and-proceed on Organization namespaces with every offender named, its TERMINAL tag intact and the re-install cost stated; platform offenders stay FATAL, named and classified, are counted alone in the headline, and the VACUITY CONTROL proves that FATAL flips to a warning when the one discriminating input flips; leak controls: identical workloads in harbor still fatal, unlabelled namespaces still fatal, stale override on a platform release still rejected)"
 
-echo "[cutover-contract] Case 96: the region-local gitea-mirror git push/ls-remote authenticate with an Authorization header, NEVER URL-injected credentials — a Gitea admin password holding a URL-special char breaks URL-injection but not the header (#6490, Refs #3379, UAT row 166)"
+echo "[cutover-contract] Case 96: the region-local gitea-mirror git push/ls-remote authenticate with an Authorization header, NEVER URL-injected credentials; and the SECONDARY-region push presents a freshly MINTED PAT (not the admin password), which Gitea git-over-HTTP requires under an external login source (#6645, Refs #6490 #3379, UAT row 166)"
 # Live hw301 region-B (me-east-215-b-1): the secondary-mirror's curl API calls
 # (base64 Authorization: Basic header) SUCCEEDED — "org already present", "repo
 # already present" — while `git push` FATALed "Could not read from remote
-# repository", because the push path is different: it injected
-# ${GITEA_USERNAME}:${GITEA_PASSWORD}@ into the URL, and the region-local Gitea
-# admin password held a URL-special char (/ @ : & % …) that broke either the sed
-# replacement or git's URL parse. The durable fix: git push + git ls-remote
-# carry the SAME `http.extraHeader="Authorization: Basic ${basic_auth}"` the curl
-# API calls use, and the remote URL carries NO credentials. This guards the two
-# admin-BasicAuth mirror sites; the PAT-authed primary step-01 (01-gitea-mirror)
-# is a separate contract (#5262 — a hex PAT is immune to URL-special chars).
+# repository". The #6490 pass moved the push OFF URL-injection onto the SAME
+# admin-password http.extraHeader the API uses. But hw305 region-B (dep
+# b2b00ce4c833badf) then showed that is still insufficient: Gitea's git-over-HTTP
+# BasicAuth REFUSES an account password when an external login source (bp-gitea's
+# openova-sso OAuth2) is configured, even though /api/v1 accepts that same
+# password — so the header-authed PASSWORD push still FATALed the same way. The
+# durable #6645 fix mirrors the PRIMARY step-01 push-auth: mint a region-local
+# PAT via the admin BasicAuth API (the proven-working path) and git-auth the
+# push/ls-remote WITH THE PAT (token_auth header) against a credential-free
+# remote URL. The PRIMARY resync push (part b) keeps the admin-BasicAuth header —
+# region-A works and the resync is a separate, post-cutover, default-severed site.
 c96_fail=0
 # (a) the SECONDARY-region mirror ConfigMap (render-gated on mirrorToSecondaryGitea).
 helm template smoke-secmirror . --set secondaryRegions.mirrorToSecondaryGitea=true \
   --show-only templates/secondary-mirror-script-configmap.yaml > "$TMP/r_6490_secondary.yaml"
 F="$TMP/r_6490_secondary.yaml"
-if ! grep -qF 'git -c http.extraHeader="Authorization: Basic ${basic_auth}" push --force "${push_url}"' "$F"; then
-  echo "FAIL: secondary-mirror push does not carry the Authorization: Basic http.extraHeader (#6490)" >&2; c96_fail=1
+if ! grep -qF 'git -c http.extraHeader="Authorization: Basic ${token_auth}" push --force "${push_url}"' "$F"; then
+  echo "FAIL: secondary-mirror push does not carry the MINTED-PAT Authorization: Basic http.extraHeader (#6645)" >&2; c96_fail=1
 fi
-if ! grep -qF 'git -c http.extraHeader="Authorization: Basic ${basic_auth}" ls-remote --heads "${push_url}"' "$F"; then
-  echo "FAIL: secondary-mirror ls-remote does not carry the Authorization: Basic http.extraHeader (#6490)" >&2; c96_fail=1
+if ! grep -qF 'git -c http.extraHeader="Authorization: Basic ${token_auth}" ls-remote --heads "${push_url}"' "$F"; then
+  echo "FAIL: secondary-mirror ls-remote does not carry the MINTED-PAT Authorization: Basic http.extraHeader (#6645)" >&2; c96_fail=1
+fi
+if ! grep -qF 'users/${GITEA_USERNAME}/tokens' "$F"; then
+  echo "FAIL: secondary-mirror does not mint a region-local PAT via /api/v1/users/.../tokens for the push (#6645)" >&2; c96_fail=1
 fi
 if ! grep -qF 'push_url="${GITEA_INTERNAL_URL}/${GITEA_ORG}/${GITEA_REPO}.git"' "$F"; then
   echo "FAIL: secondary-mirror push_url is not the credential-free remote URL (#6490)" >&2; c96_fail=1
 fi
-# anti-regression (non-vacuous — TRUE on the old URL-injection script, FALSE now):
+# anti-regression (non-vacuous — TRUE on the pre-#6645 basic_auth-password push):
+# the push/ls-remote must NOT git-auth with the admin-password header.
+if grep -qE 'http\.extraHeader="Authorization: Basic \$\{basic_auth\}" (push|ls-remote)' "$F"; then
+  echo "FAIL: secondary-mirror still git-auths with the admin password (basic_auth) — Gitea git-HTTP refuses a password under an external login source (#6645 regression)" >&2; c96_fail=1
+fi
+# anti-regression (non-vacuous — TRUE on the pre-#6490 URL-injection script, FALSE now):
 # no credential-in-URL injection may survive anywhere in the script.
 if grep -qF '${GITEA_USERNAME}:${GITEA_PASSWORD}@' "$F"; then
   echo "FAIL: secondary-mirror still URL-injects the admin password — breaks on a URL-special-char password (#6490 regression)" >&2; c96_fail=1
@@ -5526,7 +5537,7 @@ if grep -qF '${GITEA_USERNAME}:${GITEA_PASSWORD}@' "$G"; then
   echo "FAIL: mirror-resync still URL-injects the admin password — breaks on a URL-special-char password (#6490 regression)" >&2; c96_fail=1
 fi
 if [ "$c96_fail" -ne 0 ]; then exit 1; fi
-echo "  PASS (#6490: the secondary-mirror + primary resync git push/ls-remote authenticate via an http.extraHeader Authorization: Basic — the same header the curl API calls use — against a credential-free remote URL; zero admin-password URL-injection survives, so a URL-special-char Gitea admin password no longer FATALs the push)"
+echo "  PASS (#6645: the SECONDARY-region mirror mints a region-local PAT and git-auths the push/ls-remote WITH IT — Gitea git-over-HTTP requires a token, not the admin password, under an external login source — against a credential-free remote URL; the PRIMARY resync keeps its admin-BasicAuth header [region-A works]; zero admin-password URL-injection survives on either site)"
 
 echo "[cutover-contract] Case 97: Step-01 gitea-mirror activeDeadlineSeconds must cover the ~470MB monorepo clone+push over a throttled link (#6511, Refs #6508 #3379, UAT row 166)"
 # hw302 live (2026-08-20): step-01 bare-clones the openova monorepo — now ~470 MB

--- a/platform/self-sovereign-cutover/chart/tests/step6490-secondary-gitea-mirror.sh
+++ b/platform/self-sovereign-cutover/chart/tests/step6490-secondary-gitea-mirror.sh
@@ -172,19 +172,48 @@ if grep -qF 'app.kubernetes.io/managed-by: flux' "${TMP}/secjob.yaml"; then
 else
   fail "secondary mirror Job lacks app.kubernetes.io/managed-by: flux — ns gitea's kyverno flux-managed ClusterPolicy DENIES step-01's set -e apply and the cutover halts (#6493)"
 fi
-# #6490 header-auth: the push + ls-remote authenticate with the SAME
-# Authorization: Basic http.extraHeader the curl API calls use — NOT a
-# URL-injected admin password, which FATALs ("Could not read from remote
-# repository") when the region-local Gitea password holds a URL-special char.
-if grep -qF 'http.extraHeader="Authorization: Basic ${basic_auth}" push --force' "${TMP}/secmirror.sh"; then
-  pass "secondary-mirror.sh force-pushes via the Authorization: Basic http.extraHeader (#6490)"
+# #6645 push-auth parity with the PRIMARY: the git push + ls-remote authenticate
+# with a freshly MINTED region-local PAT (token_auth header), NOT the admin
+# password (basic_auth). Gitea's git-over-HTTP BasicAuth refuses an account
+# password when an external login source (openova-sso OAuth2) is configured, so
+# the pre-#6645 basic_auth-password push FATALed ("Could not read from remote
+# repository") on the secondary even though the curl API accepted the same
+# password. The push URL still carries NO credentials (#6490 safety preserved).
+if grep -qF 'users/${GITEA_USERNAME}/tokens' "${TMP}/secmirror.sh" \
+   && grep -qF 'GITEA_PAT=$(printf' "${TMP}/secmirror.sh" \
+   && grep -qF '"sha1":' "${TMP}/secmirror.sh"; then
+  pass "secondary-mirror.sh mints a region-local PAT via the admin BasicAuth API and captures its sha1 (#6645)"
 else
-  fail "secondary-mirror.sh does not header-authenticate the force-push (#6490)"
+  fail "secondary-mirror.sh does not mint a region-local PAT for the push (#6645)"
 fi
-if grep -qF 'http.extraHeader="Authorization: Basic ${basic_auth}" ls-remote --heads' "${TMP}/secmirror.sh"; then
-  pass "secondary-mirror.sh ls-remote self-verifies via the header (the #6490 ordering gate)"
+if grep -qF 'token_auth=$(printf' "${TMP}/secmirror.sh" \
+   && grep -qF '${GITEA_USERNAME}:${GITEA_PAT}' "${TMP}/secmirror.sh"; then
+  pass "secondary-mirror.sh builds the token_auth header from user:PAT (#6645)"
 else
-  fail "secondary-mirror.sh lacks the header-authed git ls-remote success gate (#6490)"
+  fail "secondary-mirror.sh does not build a user:PAT BasicAuth header (#6645)"
+fi
+if grep -qF 'http.extraHeader="Authorization: Basic ${token_auth}" push --force' "${TMP}/secmirror.sh"; then
+  pass "secondary-mirror.sh force-pushes via the MINTED-PAT http.extraHeader (#6645 push-auth parity)"
+else
+  fail "secondary-mirror.sh does not PAT-authenticate the force-push (#6645)"
+fi
+if grep -qF 'http.extraHeader="Authorization: Basic ${token_auth}" ls-remote --heads' "${TMP}/secmirror.sh"; then
+  pass "secondary-mirror.sh ls-remote self-verifies via the minted-PAT header (the #6490 ordering gate, #6645 auth)"
+else
+  fail "secondary-mirror.sh lacks the PAT-authed git ls-remote success gate (#6645)"
+fi
+# anti-regression (non-vacuous — TRUE on the pre-#6645 basic_auth-password push):
+# the git push/ls-remote must NOT authenticate with the admin-password header.
+if grep -qE 'http\.extraHeader="Authorization: Basic \$\{basic_auth\}" (push|ls-remote)' "${TMP}/secmirror.sh"; then
+  fail "secondary-mirror.sh still git-auths with the admin password (basic_auth) — Gitea git-HTTP refuses a password under an external login source (#6645 regression)"
+else
+  pass "secondary-mirror.sh git-auths with the minted PAT, never the admin password (#6645)"
+fi
+# #6645 mirror=false guard — a pull-mirror repo is read-only; the push cannot land.
+if grep -qF '"mirror":true' "${TMP}/secmirror.sh"; then
+  pass "secondary-mirror.sh guards against a read-only pull-mirror repo before pushing (#6645)"
+else
+  fail "secondary-mirror.sh lacks the mirror=false guard (#6645)"
 fi
 # anti-regression (non-vacuous — TRUE on the pre-#6490 URL-injection script):
 # zero URL-injected credentials may survive in the region-local push.

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -4640,7 +4640,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "0.1.198",
+      "version": "0.1.199",
       "section": "pts-2-3-per-sovereign-supporting-services",
       "depends": [
         "bp-gitea",

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -4775,7 +4775,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "0.1.198",
+    "version": "0.1.199",
     "section": "pts-2-3-per-sovereign-supporting-services",
     "depends": [
       "bp-gitea",

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -4020,7 +4020,13 @@ name: bp-catalyst-platform
 #   budget; the old 20-min ceiling reaped the Job as DeadlineExceeded and wedged
 #   the cutover at step-01 on hw302). Umbrella tracks its sub-charts per Inviolable
 #   Principle #13.
-version: 1.4.1559
+# 1.4.1560 — lockstep for bp-self-sovereign-cutover 0.1.199 (#6645, Refs #6490:
+#   the SECONDARY-region gitea-mirror leg mints a region-local Gitea PAT and
+#   git-auths the push WITH IT — Gitea git-over-HTTP refuses the admin password
+#   under an external login source, so the header-authed PASSWORD push FATALed and
+#   wedged the cutover at step-01 on hw305 region-B). Umbrella tracks its
+#   sub-charts per Inviolable Principle #13.
+version: 1.4.1560
 # 1.4.1481 — #6293: catalog-seed advances bp-self-sovereign-cutover
 #   0.1.186 -> 0.1.187, the release that stops step-06 from patching five
 #   HelmRepositories it does not own and then grading itself on whether they
@@ -4207,7 +4213,7 @@ version: 1.4.1559
 # scripts/check-chart-version-forward.sh (#5743) fails unless the two match —
 # main was carrying a pre-existing 1.4.1330/1.4.1329 split, so this bump heals
 # it in the same commit, exactly as the documented self-heal contract does.
-appVersion: 1.4.1559
+appVersion: 1.4.1560
 # 1.4.239 — Wave 3 / Issue #2140 (2026-05-23): Huawei provider
 # implementation lands behind the Wave 2 CloudProvider interface.
 # Adds the OpenTofu module at infra/providers/huawei/ (VPC + Subnet +

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5120,7 +5120,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.1.198"
+  version: "0.1.199"
   visibility: unlisted
   card:
     title: "Self-Sovereignty Cutover"
@@ -5137,7 +5137,7 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-self-sovereign-cutover
-    version: "0.1.198"
+    version: "0.1.199"
   topology:
     supported:
       - singleton


### PR DESCRIPTION
## Problem

The sovereignty cutover wedges at **step-01** on a 2-region Sovereign (live-diagnosed on hw305, dep `b2b00ce4c833badf`). Step-01's PRIMARY (region-A) mirror succeeds, then blocks up to 2100s on the SECONDARY Job `cutover-gitea-mirror-secondary-*-b-1` (region-B, ns `gitea`), which repeatedly fails:

```
[secondary-mirror] pushing upstream branches + tags to the region-local Gitea
[secondary-mirror] FATAL: git push to the region-local Gitea failed
fatal: Could not read from remote repository.
```

## Root cause

`secondary-mirror.sh` authenticated the git-over-HTTP push with the **admin `gitea-admin-secret` PASSWORD** via `http.extraHeader="Authorization: Basic ${basic_auth}"`.

The discriminator: the curl `/api/v1` calls with that **same credential SUCCEED** ("repo already present"), so the password is valid against Gitea's API — yet the git push with the same header FATALs auth. Gitea's **git-over-HTTP BasicAuth REFUSES an account password when an external login source** (bp-gitea's `openova-sso` OAuth2) is configured; it demands a token. The API accepts the password; git-HTTP does not.

The earlier #6490 pass had only moved the push OFF URL-injected creds (which broke on a URL-special-char password) onto the header — but it still presents a **PASSWORD**, so the rejection persisted. The PRIMARY step-01 avoids this entirely by pushing with a **PAT** (the bootstrap-minted `catalyst-gitea-token`), a direct local sha1 lookup never routed to the external source.

## Fix

Mirror the PRIMARY's proven push-auth path into the secondary. A secondary runs no bp-catalyst-platform, so the `catalyst-gitea-token` PAT does not exist in-region — so the script now:

1. **Mints a fresh region-local PAT** via the admin BasicAuth API (`POST /api/v1/users/${GITEA_USERNAME}/tokens`, the proven-working path; delete-then-create for idempotency), and **git-auths the push + ls-remote WITH IT** (`token_auth = base64(user:PAT)`, which git-over-HTTP accepts under any username). The push URL still carries **no credentials**, so the #6490 URL-special-char safety is preserved.
2. Adds a **`mirror=false` guard**: if the region-local repo is a Gitea pull-mirror (read-only, un-pushable, not API-convertible), the script FATALs naming the exact cause instead of failing opaquely inside the push.

The shared `cutover-secondary-mirror-script` ConfigMap is reused by both step-01 and the step-11 resync secondary leg, so **both secondary legs are fixed by this one change**. The PRIMARY resync push is untouched (region-A works).

**Exact fix:** `platform/self-sovereign-cutover/chart/templates/secondary-mirror-script-configmap.yaml` — the PAT-mint block + `token_auth` header on the `git push`/`git ls-remote` (was `${basic_auth}`), plus the pull-mirror guard.

## Tests

- `chart/tests/cutover-contract.sh` **Case 96** rewritten to assert the PAT-mint push-auth (`token_auth`), the `/users/.../tokens` mint, and a non-vacuous anti-regression that FAILS on the pre-#6645 `basic_auth`-password push. Full suite: **All gates green**.
- `chart/tests/step6490-secondary-gitea-mirror.sh` extended with the PAT-mint / `mirror=false` assertions. All pass, and the single-region render stays **byte-identical to origin/main**.
- Lockstep/version guards green: `check-cutover-version-floor.py` (7 pins / 5 sites at 0.1.199), `check-umbrella-republish-gate.py` (umbrella 1.4.1560), `check-catalog-seed-source-coverage.py`.

## Versioning

Lockstep bump `bp-self-sovereign-cutover` **0.1.198 → 0.1.199** across all five sites (Chart.yaml, blueprint.yaml, catalog-seed card + source, generated catalog, bootstrap-kit slot 06a); the seed touch forces the umbrella `bp-catalyst-platform` **1.4.1559 → 1.4.1560** (Chart.yaml version + appVersion, bootstrap-kit slot-13). Verified unclaimed by any open PR.

## Scope / caveats

Code fix only — the live cutover was **not** re-triggered. Region-B was not re-probed; the two most-likely causes are fixed together — push-auth parity via a minted PAT (matching the live-diagnosed discriminator) and the `mirror=false` guard.

Refs #6645 #6490 #5262 #3379

🤖 Generated with [Claude Code](https://claude.com/claude-code)
