### PR TITLE
docs(uat): confirm hw305 as live env in H1 header (greens drift guard on main)

### DIFF
--- a/docs/ledger/UAT.md
+++ b/docs/ledger/UAT.md
@@ -1,4 +1,4 @@
-# UAT — Sovereign acceptance walk (RESET 2026-08-23 — pending hw305)
+# UAT — Sovereign acceptance walk on `hw305.omantel.biz` (walked from 2026-08-23)
 
 **Tally (286 rows):** ✅ 244 · ❌ 9 · ⚠️ 2 · ⏳ 31
 


### PR DESCRIPTION
The no-`--env` UAT drift guard has been RED on main since the 2026-08-23 reset: `reset-uat.py` writes `(RESET … — pending hw305)`, and `header_env()` treats any `pending` header as *no concrete env* → the guard then requires the ledger to be evidence-free, but main carries 244 ✅ hw305/hw302 rows.

hw305 is live and 244 rows are walked on it, so this flips the header to the concrete `on \`hw305.omantel.biz\`` token — the confirm step that closes the reset→walk flow (the flip `reset-uat.py`'s own comment references but doesn't perform).

**Verified locally (worktree off origin/main):**
- drift guard NO `--env` (CI mode) → rc=0, resolves current env=hw305
- drift guard `--env hw305` → rc=0
- drift guard `--self-test` → rc=0
- clause-identity, partition --check, walk-respects-scheduler, fix-sha → all rc=0

Header only — no row glyph/evidence changed.