### PR TITLE
docs(uat): fix ledger table overflow — table-layout:fixed + wrap long tokens

### DIFF
--- a/docs/ledger/UAT.md
+++ b/docs/ledger/UAT.md
@@ -4,6 +4,16 @@
 
 > **One acceptance case per row, walked on the env in the title.** Result: `✅` pass · `❌` fail · `⚠️` partial · `☐` open · `⏳` carried/due · `⛔` blocked. Test-case + Evidence show the gist (full walk history in git); `#NNNN` = issue; 📷 opens the screenshot (also collected in the gallery below the table).
 
+<style>
+/* Keep the ledger table inside the viewport: fixed columns so the width% hints
+   are honoured, and wrap long unbreakable tokens (FQDNs, paths, hashes, URLs)
+   inside their cell instead of forcing the column wide + overflowing off-screen. */
+table { table-layout: fixed; width: 100%; }
+th, td { overflow-wrap: anywhere; word-break: break-word; vertical-align: top; }
+td code, td a { word-break: break-all; overflow-wrap: anywhere; }
+td img { max-width: 100%; height: auto; }
+</style>
+
 <table width="100%">
 <thead><tr><th width="6%">#</th><th width="16%">📷</th><th width="9%">Result</th><th width="35%">Test case</th><th width="34%">Evidence</th></tr></thead>
 <tbody>


### PR DESCRIPTION
The UAT ledger table was overflowing off-screen (Evidence column cut off). Root cause: **no wrap/layout CSS** — with the default `table-layout: auto`, long unbreakable tokens in `<code>` spans (FQDNs like `shared-pg-b-mesh-rw.shared-data.svc.cluster.local`, node names, paths, issue URLs) forced columns wider than their `width%` hints, pushing the rightmost column past the viewport.

Fix — a scoped `<style>` block before the table:
- `table-layout: fixed` so the 6/16/9/35/34 column widths are honoured
- `overflow-wrap: anywhere` + `word-break: break-word` on cells
- `word-break: break-all` on `code`/links so long tokens wrap inside the column
- `max-width: 100%` on `img` so screenshots don't overflow

All 6 UAT guards still green (the `<tr id>`/`<td>` parsing is unaffected by the style block).