### PR TITLE
docs(system-design): fix mermaid parse error in §10 Blueprint-delivery diagram

### DIFF
--- a/docs/SYSTEM-DESIGN.md
+++ b/docs/SYSTEM-DESIGN.md
@@ -365,8 +365,8 @@ the generated UI.
 ```mermaid
 graph LR
   SRC["platform/&lt;x&gt; or products/&lt;x&gt;<br/>chart/ + blueprint.yaml"] -->|CI on tag| OCI["ghcr.io/openova-io/bp-x:semver (signed)"]
-  OCI -->|deploy-bot bumps pin LINES (never blanket)| SEED["catalog-seed blueprints.yaml"]
-  SEED -->|mirror to Sovereign Gitea (daily; Harbor after cutover)| GIT["Sovereign Git + registry"]
+  OCI -->|"deploy-bot bumps pin LINES (never blanket)"| SEED["catalog-seed blueprints.yaml"]
+  SEED -->|"mirror to Sovereign Gitea (daily; Harbor after cutover)"| GIT["Sovereign Git + registry"]
   GIT -->|Flux GitRepository/HelmRepository| HR["HelmRelease per Application"]
   HR --> RUN["running workload"]
   RUN -->|fresh-prov walk + screenshot| PROVE["'delivered' (merged ≠ delivered)"]


### PR DESCRIPTION
GitHub failed to render the §10 Blueprint-delivery diagram — the two edge labels held unquoted parentheses (`(never blanket)`) and a semicolon, which mermaid reads as a node-shape start (`got 'PS'`). Quoting both pipe-delimited edge labels fixes it. Audited all 9 canonical docs / 86 diagrams: this was the only diagram with the defect; other scanner hits are the supported line-break token in node labels, which renders. Docs-only.