### PR TITLE
docs: fix mermaid sequenceDiagram parse errors (semicolons split messages)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -999,11 +999,11 @@ sequenceDiagram
   participant GW as Cilium HTTPRoute
   participant PDM as PowerDNS via PDM /v1/commit
   C->>L: validate lease holder is current primary
-  C->>PG: cordon old primary; demote → promote standby
+  C->>PG: cordon old primary, demote then promote standby
   C->>GW: drain traffic (weight → 0 over 10s)
   C->>PDM: flip lua-record probe target (TTL ~30s)
-  C->>L: release old lease; acquire on new primary
-  C->>PG: uncordon new primary; resume traffic
+  C->>L: release old lease, acquire on new primary
+  C->>PG: uncordon new primary, resume traffic
   C->>C: audit event on NATS catalyst.audit
 ```
 

--- a/docs/DOD.md
+++ b/docs/DOD.md
@@ -235,13 +235,13 @@ sequenceDiagram
   Cust->>MP: redeem code → PIN magic-link
   Cust->>MP: pick Postgres-backed bundle + 2-region topology
   MP->>Cat: provision Org + 2 independent CNPG clusters
-  Cat-->>Cust: console.&lt;orgslug&gt;.omani.homes
+  Cat-->>Cust: console.[orgslug].omani.homes
 
   Note over Cust,MCP: Phase 2 — Agenity agent adds an app via MCP
   Cust->>Ag: open Agenity, prompt "add a Postgres-backed app"
   Ag->>MCP: create_application (per-Org bearer)
   MCP->>Cat: POST .../applications install seam
-  Cat-->>Cust: &lt;newapp&gt;.&lt;orgslug&gt;.omani.homes reachable
+  Cat-->>Cust: [newapp].[orgslug].omani.homes reachable
 ```
 
 ### Phase 0 — Operator issues voucher via BSS
@@ -707,7 +707,7 @@ sequenceDiagram
   U->>Ag: "install a Postgres-backed notes app"
   Ag->>MCP: create_application (per-Org bearer)
   MCP->>Cat: forward bearer → install seam
-  Cat-->>U: notes.&lt;orgslug&gt;.omani.homes (trusted TLS)
+  Cat-->>U: notes.[orgslug].omani.homes (trusted TLS)
 ```
 
 The tenant **never** typed a kubeconfig, never opened Git, never copied a DB

--- a/docs/SYSTEM-DESIGN.md
+++ b/docs/SYSTEM-DESIGN.md
@@ -443,8 +443,8 @@ sequenceDiagram
   participant Sov as Sovereign /auth/handover
   participant KC as Keycloak (sovereign realm)
   participant GATE as oidc-gate + app
-  MS->>Sov: GET /auth/handover?token=&lt;RS256 handover JWT&gt;
-  Note right of Sov: verify iss, aud=console.&lt;fqdn&gt;, role=sovereign-admin,<br/>email_verified, one-time jti
+  MS->>Sov: GET /auth/handover?token=[RS256 handover JWT]
+  Note right of Sov: verify iss, aud=console.[fqdn], role=sovereign-admin,<br/>email_verified, one-time jti
   Sov->>KC: EnsureUser + ImpersonateToken
   Sov-->>U: 302 /dashboard + catalyst_session (tier=owner)
   U->>GATE: open grafana/gitea/…


### PR DESCRIPTION
A `;` in a mermaid **sequenceDiagram** message/Note is a statement separator — it splits the message and the leftover becomes a malformed statement (`Parse error ... got NEWLINE`). Fixed 4 broken diagram blocks (ARCHITECTURE §8.2, SYSTEM-DESIGN §13, DOD §5.5/§5.6).

**Verified with mermaid 11's own parser** (`mermaid.parse` via jsdom) across all 9 canonical docs: **86/86 diagrams parse, 0 failures.** stateDiagram `;` does not break, so SECURITY was correctly left untouched. Docs-only.