### PR TITLE
docs: repair 39 broken cross-references

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,9 @@ The `docs/` tree, in reading order. Every file under `docs/` appears exactly onc
 
 ### Build and operate
 
-- [`docs/RUNBOOKS.md`](docs/RUNBOOKS.md) — provisioning, chart bumps, Blueprint authoring, failover recovery, doc-integrity audit cadence, Sovereign bring-up, UI regression catalog, Catalyst-Zero waterfall
+- [`docs/RUNBOOKS.md`](docs/RUNBOOKS.md) — provisioning, chart bumps, Blueprint authoring, failover recovery, doc-integrity audit cadence, Sovereign bring-up, UI regression catalog, Catalyst-Zero waterfall, OpenovaFlow multi-region rendering verification (folds the former `docs/lessons-learned/`, `docs/runbooks/`, and `docs/proposals/`)
 - [`docs/SRE.md`](docs/SRE.md) — operate a Sovereign in production (SLOs, incident response, GPU ops)
-- [`docs/SECURITY.md`](docs/SECURITY.md) — identity (Cilium WG + Keycloak), secrets (OpenBao + ESO), threat model
-- [`docs/SECRET-ROTATION.md`](docs/SECRET-ROTATION.md) — credential inventory, rotation schedule, rollback path
+- [`docs/SECURITY.md`](docs/SECURITY.md) — identity (Cilium WG + Keycloak), secrets (OpenBao + ESO), threat model, credential rotation + rollback (folds the former `docs/SECRET-ROTATION.md`)
 
 ### Strategy
 
@@ -51,23 +50,6 @@ The `docs/` tree, in reading order. Every file under `docs/` appears exactly onc
 
 - [`docs/ledger/TRACKER.md`](docs/ledger/TRACKER.md) — open-issue + DoD-gate progress board (15-min refresh)
 - [`docs/ledger/TRUST.md`](docs/ledger/TRUST.md) — verification ledger (UNVERIFIED / VERIFIED-PASS / FAIL / PARTIAL)
-
-### Lessons learned ([`docs/lessons-learned/`](docs/lessons-learned/))
-
-- [`docs/lessons-learned/README.md`](docs/lessons-learned/README.md) — index + contribution rules
-- [`docs/lessons-learned/catalyst-bootstrap-api.md`](docs/lessons-learned/catalyst-bootstrap-api.md) — Phase-0 `tofu destroy` + token-hygiene behavior
-- [`docs/lessons-learned/chi-router-quirks.md`](docs/lessons-learned/chi-router-quirks.md) — go-chi percent-encoding + route-match traps
-- [`docs/lessons-learned/helm-controller-logs.md`](docs/lessons-learned/helm-controller-logs.md) — Flux v2.4 nested-JSON log shape for HelmRelease
-- [`docs/lessons-learned/helm-controller-rbac.md`](docs/lessons-learned/helm-controller-rbac.md) — helm-controller SA needs cluster-admin in `flux-system`
-- [`docs/lessons-learned/helm-hooks-and-crd-ordering.md`](docs/lessons-learned/helm-hooks-and-crd-ordering.md) — `before-hook-creation` deadlocks on subchart-registered CRDs
-
-### Operational runbooks ([`docs/runbooks/`](docs/runbooks/))
-
-- [`docs/runbooks/openova-flow-multi-region-verify.md`](docs/runbooks/openova-flow-multi-region-verify.md) — OpenovaFlow multi-region rendering verification
-
-### Proposals ([`docs/proposals/`](docs/proposals/) — in-flight)
-
-- [`docs/proposals/jobs-dependencies-viz.md`](docs/proposals/jobs-dependencies-viz.md) — Jobs Dependencies tab SVG-DAG visualization
 
 ### Session archives ([`docs/sessions/`](docs/sessions/))
 

--- a/core/README.md
+++ b/core/README.md
@@ -2,7 +2,7 @@
 
 The user-facing Catalyst control plane modules. **Status:** Consolidated and deployed on Catalyst-Zero (Contabo k3s) as of Pass 105 (2026-04-28).
 
-> **Read first:** [`docs/PROVISIONING-PLAN.md`](../docs/PROVISIONING-PLAN.md), [`docs/GLOSSARY.md`](../docs/GLOSSARY.md), [`docs/ARCHITECTURE.md`](../docs/ARCHITECTURE.md), [`docs/STATUS.md`](../docs/STATUS.md).
+> **Read first:** [`docs/RUNBOOKS.md`](../docs/RUNBOOKS.md), [`docs/GLOSSARY.md`](../docs/GLOSSARY.md), [`docs/ARCHITECTURE.md`](../docs/ARCHITECTURE.md), [`docs/STATUS.md`](../docs/STATUS.md).
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1871,17 +1871,17 @@ Each major Blueprint folder ships a `DESIGN.md` capturing the architectural deci
 | Chart | DESIGN.md |
 |---|---|
 | bp-cnpg-pair | [`platform/cnpg-pair/DESIGN.md`](../platform/cnpg-pair/DESIGN.md) — synchronous `remote_apply` ReplicaCluster, ClusterMesh wiring, pre-merge guards (PRs #2087/#2093) |
-| bp-continuum | [`platform/continuum/DESIGN.md`](../platform/continuum/DESIGN.md) — lease + witness, switchover sequence, PDM integration |
-| bp-self-sovereign-cutover | [`platform/self-sovereign-cutover/DESIGN.md`](../platform/self-sovereign-cutover/DESIGN.md) — 8-tether pivot, 11-step chain, egress-block DoD test |
+| bp-continuum | [`products/continuum/DESIGN.md`](../products/continuum/DESIGN.md) — lease + witness, switchover sequence, PDM integration |
+| bp-self-sovereign-cutover | [`platform/self-sovereign-cutover/chart/README.md`](../platform/self-sovereign-cutover/chart/README.md) — 8-tether pivot, 11-step chain, egress-block DoD test |
 | bp-agenity | [`products/agenity/README.md`](../products/agenity/README.md) — per-Org **Agenity** workspace (Pillar 4); auto-attaches `bp-openova-mcp` with full org knowledge |
 | bp-openova-mcp | [`products/openova-mcp/README.md`](../products/openova-mcp/README.md) — RBAC-scoped OpenOva MCP server with mutating tools (e.g. `create_application`) |
-| bp-kyverno | [`platform/kyverno/DESIGN.md`](../platform/kyverno/DESIGN.md) — label-vocab mutate + validate ClusterPolicies, audit ↔ enforce toggle |
-| bp-catalyst-platform | [`products/catalyst/DESIGN.md`](../products/catalyst/DESIGN.md) — umbrella composition; component-by-component bring-up order |
-| bp-cortex | [`products/cortex/DESIGN.md`](../products/cortex/DESIGN.md) — Knative → KServe → vLLM/bge pipeline; OpenMeter metering |
-| bp-axon | [`products/axon/DESIGN.md`](../products/axon/DESIGN.md) — standalone gateway profile + Claude Code subscription proxy |
-| bp-fingate | [`products/fingate/DESIGN.md`](../products/fingate/DESIGN.md) — FAPI-mode Keycloak + ext_authz + 6 banking services |
-| bp-fabric | [`products/fabric/DESIGN.md`](../products/fabric/DESIGN.md) — Strimzi + Flink + Temporal + Debezium + Iceberg + ClickHouse |
-| bp-relay | [`products/relay/DESIGN.md`](../products/relay/DESIGN.md) — Stalwart + LiveKit + Stunner + Matrix + Guacamole |
+| bp-kyverno | [`platform/kyverno/README.md`](../platform/kyverno/README.md) — label-vocab mutate + validate ClusterPolicies, audit ↔ enforce toggle |
+| bp-catalyst-platform | [`products/catalyst/README.md`](../products/catalyst/README.md) — umbrella composition; component-by-component bring-up order |
+| bp-cortex | [`products/cortex/README.md`](../products/cortex/README.md) — Knative → KServe → vLLM/bge pipeline; OpenMeter metering |
+| bp-axon | [`products/axon/README.md`](../products/axon/README.md) — standalone gateway profile + Claude Code subscription proxy |
+| bp-fingate | [`products/fingate/README.md`](../products/fingate/README.md) — FAPI-mode Keycloak + ext_authz + 6 banking services |
+| bp-fabric | [`products/fabric/README.md`](../products/fabric/README.md) — Strimzi + Flink + Temporal + Debezium + Iceberg + ClickHouse |
+| bp-relay | [`products/relay/README.md`](../products/relay/README.md) — Stalwart + LiveKit + Stunner + Matrix + Guacamole |
 
 Where a chart does not yet ship a DESIGN.md, the canonical authoring rule is in [`docs/RUNBOOKS.md`](RUNBOOKS.md). When a chart's DESIGN.md contradicts this document, this document wins; raise a PR to reconcile.
 

--- a/docs/RUNBOOKS.md
+++ b/docs/RUNBOOKS.md
@@ -2407,7 +2407,7 @@ Each phase produces one or more commits to `openova/`. Each commit is real worki
 
 #### 11.5.7 Phase 7 — Franchise model docs + voucher propagation
 
-**What:** Read existing voucher implementation in admin app. Write [`FRANCHISE-MODEL.md`](FRANCHISE-MODEL.md) documenting it as canonical. Ensure the new Sovereign at `omantel.omani.works` has its own admin surface (the same admin app, deployed inside the Sovereign) where omantel-admin can issue vouchers to omantel's tenants. Update [`GLOSSARY.md`](GLOSSARY.md) with `Voucher` and `Franchisee` definitions if not already present.
+**What:** Read existing voucher implementation in admin app. Write [`BUSINESS-STRATEGY.md` §10.8](BUSINESS-STRATEGY.md#108-franchise-model--end-to-end-mechanics) documenting it as canonical. Ensure the new Sovereign at `omantel.omani.works` has its own admin surface (the same admin app, deployed inside the Sovereign) where omantel-admin can issue vouchers to omantel's tenants. Update [`GLOSSARY.md`](GLOSSARY.md) with `Voucher` and `Franchisee` definitions if not already present.
 
 **Outputs:**
 

--- a/docs/adr/0002-post-handover-sovereignty-cutover.md
+++ b/docs/adr/0002-post-handover-sovereignty-cutover.md
@@ -205,4 +205,4 @@ Every cutover step publishes a CloudEvents-shaped envelope on NATS JetStream (`c
 
 ---
 
-*Part of [OpenOva](https://openova.io). Read in conjunction with [ADR-0001](0001-catalyst-control-plane-architecture.md), [`ARCHITECTURE.md`](../ARCHITECTURE.md) §11, and [`INVIOLABLE-PRINCIPLES.md`](../INVIOLABLE-PRINCIPLES.md) Principle #11.*
+*Part of [OpenOva](https://openova.io). Read in conjunction with [ADR-0001](0001-catalyst-control-plane-architecture.md), [`ARCHITECTURE.md`](../ARCHITECTURE.md) §11, and [`INVIOLABLE-PRINCIPLES.md`](../PRINCIPLES.md) Principle #11.*

--- a/docs/adr/0003-rbac-newapi-user-create-hook.md
+++ b/docs/adr/0003-rbac-newapi-user-create-hook.md
@@ -34,9 +34,9 @@ A Sovereign Marketplace (SME) admin signs into the unified RBAC console (deliver
 
 | # | System | Where | Why it must exist |
 |---|---|---|---|
-| 1 | SME-vcluster Keycloak | Inside the SME tenant's vCluster (per [Inviolable Principle 7](../INVIOLABLE-PRINCIPLES.md), tenancy is K8s-native) | Identity. The user logs into OpenClaw / WordPress / unified RBAC console via OIDC against this realm. |
+| 1 | SME-vcluster Keycloak | Inside the SME tenant's vCluster (per [Inviolable Principle 7](../PRINCIPLES.md), tenancy is K8s-native) | Identity. The user logs into OpenClaw / WordPress / unified RBAC console via OIDC against this realm. |
 | 2 | NewAPI admin API | OTECH control plane, in-cluster only (`http://newapi.newapi.svc`) | Per-user LLM gateway record + per-user API key. NewAPI meters usage by API key; the key's lineage to the SME user is what makes billing reconcile. |
-| 3 | K8s `Secret` in the SME tenant namespace | Tenant ns of the OTECH cluster, name `newapi-key-{sme-user-uuid}` | Credential delivery. The OpenClaw per-user pod ([#803](https://github.com/openova-io/openova/issues/803)) mounts this Secret as `NEWAPI_KEY` env. Per [Inviolable Principle 7](../INVIOLABLE-PRINCIPLES.md), Secret-as-truth is the K8s-native delivery mechanism. |
+| 3 | K8s `Secret` in the SME tenant namespace | Tenant ns of the OTECH cluster, name `newapi-key-{sme-user-uuid}` | Credential delivery. The OpenClaw per-user pod ([#803](https://github.com/openova-io/openova/issues/803)) mounts this Secret as `NEWAPI_KEY` env. Per [Inviolable Principle 7](../PRINCIPLES.md), Secret-as-truth is the K8s-native delivery mechanism. |
 
 ### 2.2 Locked decisions inherited from [#795](https://github.com/openova-io/openova/issues/795)
 
@@ -128,7 +128,7 @@ Idempotent retry path: on `409 Conflict` (`external_id` already exists), follow 
 | | |
 |---|---|
 | **Method** | server-side apply (`Apply` verb, field manager `unified-rbac`) |
-| **API client** | `k8s.io/client-go` against the OTECH cluster's api-server using unified-rbac's pod ServiceAccount token. **Never `exec.Command("kubectl", ...)` — see [Inviolable Principle 3](../INVIOLABLE-PRINCIPLES.md).** |
+| **API client** | `k8s.io/client-go` against the OTECH cluster's api-server using unified-rbac's pod ServiceAccount token. **Never `exec.Command("kubectl", ...)` — see [Inviolable Principle 3](../PRINCIPLES.md).** |
 | **RBAC** | A namespaced `Role` bound to the unified-rbac ServiceAccount in **each** SME tenant namespace, scoped to `secrets:get,list,watch,create,update,patch` on names matching `newapi-key-*`. Provisioned at SME tenant onboarding, not at user-create time. |
 
 Resource:
@@ -192,7 +192,7 @@ pending ──▶ kc_created ──▶ newapi_created ──▶ secret_applied �
 
 A goroutine inside the unified-rbac controller publishes a heartbeat envelope on NATS subject `unified-rbac.reconcile-pending` every 30 s; a consumer in the same service (durable consumer, max-deliver=1, ack-wait=20 s) handles the heartbeat by querying `user_provision_state` for rows in any state other than `done` or `failed` whose `updated_at` is older than the per-state retry interval, and re-runs each.
 
-This is a NATS heartbeat — **not** a Kubernetes `CronJob`, which would violate the architecture's event-driven posture (per [Inviolable Principle 1](../INVIOLABLE-PRINCIPLES.md) and [ADR-0001 §6](0001-catalyst-control-plane-architecture.md)). The advantage of self-publishing on NATS: cross-replica consistency is automatic (whichever unified-rbac replica the consumer message lands on processes the batch), and the heartbeat itself is observable in NATS metrics for ops.
+This is a NATS heartbeat — **not** a Kubernetes `CronJob`, which would violate the architecture's event-driven posture (per [Inviolable Principle 1](../PRINCIPLES.md) and [ADR-0001 §6](0001-catalyst-control-plane-architecture.md)). The advantage of self-publishing on NATS: cross-replica consistency is automatic (whichever unified-rbac replica the consumer message lands on processes the batch), and the heartbeat itself is observable in NATS metrics for ops.
 
 ### 3.6 NATS event emission
 
@@ -292,11 +292,11 @@ A failed state must always carry a structured `last_error` field that:
 
 ### 5.4 Direct `kubectl` shell-out for the Secret apply
 
-**Rejected per [Inviolable Principle 3](../INVIOLABLE-PRINCIPLES.md).** `exec.Command("kubectl", ...)` from a Go service is forbidden — it opaque-wraps the K8s api-server, hides errors, prevents structured handling, and creates dependency on a `kubectl` binary in the container image. `client-go` server-side apply is the canonical path.
+**Rejected per [Inviolable Principle 3](../PRINCIPLES.md).** `exec.Command("kubectl", ...)` from a Go service is forbidden — it opaque-wraps the K8s api-server, hides errors, prevents structured handling, and creates dependency on a `kubectl` binary in the container image. `client-go` server-side apply is the canonical path.
 
 ### 5.5 Kubernetes `CronJob` reconciler
 
-**Rejected per [Inviolable Principle 1](../INVIOLABLE-PRINCIPLES.md) and [ADR-0001 §6](0001-catalyst-control-plane-architecture.md).** A CronJob is a polling pattern; it's also operationally noisy (one Job pod per tick, per replica). The NATS-heartbeat-to-self pattern is event-driven, observable in standard NATS metrics, and naturally cross-replica-consistent.
+**Rejected per [Inviolable Principle 1](../PRINCIPLES.md) and [ADR-0001 §6](0001-catalyst-control-plane-architecture.md).** A CronJob is a polling pattern; it's also operationally noisy (one Job pod per tick, per replica). The NATS-heartbeat-to-self pattern is event-driven, observable in standard NATS metrics, and naturally cross-replica-consistent.
 
 ### 5.6 Synchronous "wait for everything before returning to the admin"
 
@@ -321,4 +321,4 @@ A failed state must always carry a structured `last_error` field that:
 
 ---
 
-*Part of [OpenOva](https://openova.io). Read in conjunction with [ADR-0001](0001-catalyst-control-plane-architecture.md), [ADR-0002](0002-post-handover-sovereignty-cutover.md), and [`INVIOLABLE-PRINCIPLES.md`](../INVIOLABLE-PRINCIPLES.md).*
+*Part of [OpenOva](https://openova.io). Read in conjunction with [ADR-0001](0001-catalyst-control-plane-architecture.md), [ADR-0002](0002-post-handover-sovereignty-cutover.md), and [`INVIOLABLE-PRINCIPLES.md`](../PRINCIPLES.md).*

--- a/docs/ledger/TRUST.md
+++ b/docs/ledger/TRUST.md
@@ -618,7 +618,7 @@ Wave 5.153 + 5.154 + 5.155 + 5.156 + 5.157 — canonical Sovereign wipe cascade 
 
 Reviewer verdict: sub-agent `a0f1a7ecf9826a9ea` 🟢 VERIFIED-PASS on Wave 5.155 with file:line cites — [comment 4554307903](https://github.com/openova-io/openova/issues/2521#issuecomment-4554307903).
 
-Memory: [`feedback_hcs_kom4dc_wipe_cascade_quirks.md`](../../../.claude/projects/-home-openova-repos-openova/memory/feedback_hcs_kom4dc_wipe_cascade_quirks.md) — 5-quirk Kom4DC reference for future sessions.
+Memory: `feedback_hcs_kom4dc_wipe_cascade_quirks.md` — 5-quirk Kom4DC reference for future sessions.
 
 Issues closed: #2520 + #2521 + #2522 + #2523 (all with status/completed).
 

--- a/infra/providers/hetzner/README.md
+++ b/infra/providers/hetzner/README.md
@@ -2,7 +2,7 @@
 
 Canonical Phase 0 OpenTofu module that provisions a single-region OR multi-region Catalyst Sovereign on Hetzner Cloud and bootstraps it onto Flux-driven GitOps. After `tofu apply` finishes, every subsequent change to the Sovereign goes through Crossplane (cloud resources) and Flux (Kubernetes resources). OpenTofu state is archived and never touched again.
 
-This module is the implementation of [`docs/SOVEREIGN-PROVISIONING.md`](../../docs/SOVEREIGN-PROVISIONING.md) §3 (Phase 0 — Bootstrap) and follows [`docs/PRINCIPLES.md`](../../docs/PRINCIPLES.md) — every value the wizard or operator picks is a variable; nothing is hardcoded.
+This module is the implementation of [`docs/RUNBOOKS.md`](../../../docs/RUNBOOKS.md) §3 (Phase 0 — Bootstrap) and follows [`docs/PRINCIPLES.md`](../../../docs/PRINCIPLES.md) — every value the wizard or operator picks is a variable; nothing is hardcoded.
 
 ---
 
@@ -27,7 +27,7 @@ After Phase 0, the cluster's Flux pulls `clusters/<sovereign_fqdn>/` from the pu
 
 ## Network
 
-**Per [`docs/DOD.md`](../../docs/DOD.md) A2 (founder ruling 2026-05-15): every region has its OWN `hcloud_network`. Provider private networks NEVER span regions — inter-region traffic flows exclusively over Cilium WireGuard (UDP 51871) on each region's public IP through the DMZ vCluster.**
+**Per [`docs/DOD.md`](../../../docs/DOD.md) A2 (founder ruling 2026-05-15): every region has its OWN `hcloud_network`. Provider private networks NEVER span regions — inter-region traffic flows exclusively over Cilium WireGuard (UDP 51871) on each region's public IP through the DMZ vCluster.**
 
 This is the same rule whether the secondary region is Hetzner, AWS, or Huawei (DoD A6). The Hetzner module is provider-mix-friendly: a sister-provider module owns its own regions, and the inter-region link sits ABOVE the provider layer.
 
@@ -104,7 +104,7 @@ The module accepts a `var.regions[]` list-of-objects payload that captures the w
 
 ### EPIC-6 (#1101) example: 3-region Continuum DR shape
 
-Per [`docs/ARCHITECTURE.md`](../../docs/ARCHITECTURE.md) §3.8 + §11, the EPIC-6 demo brings up one mgmt cluster + two data-plane clusters with Cilium ClusterMesh between them. Slice G1 provisions the cloud substrate; slice G3 wires ClusterMesh.
+Per [`docs/ARCHITECTURE.md`](../../../docs/ARCHITECTURE.md) §3.8 + §11, the EPIC-6 demo brings up one mgmt cluster + two data-plane clusters with Cilium ClusterMesh between them. Slice G1 provisions the cloud substrate; slice G3 wires ClusterMesh.
 
 ```jsonc
 {
@@ -156,7 +156,7 @@ The catalyst-api joins `secondary_region_keys` with `Request.Regions[1+]` to pro
 ### Out of scope for slice G1
 
 - **Cilium ClusterMesh wiring** — slice G3 (joins separate clusters into a single mesh).
-- **Per-cluster GitOps differentiation** — every secondary CP today renders an identical Flux Kustomization pointed at `clusters/<sovereign_fqdn>/`. Per-cluster paths (`clusters/hz-fsn-rtz-prod/`, etc., per [`docs/ARCHITECTURE.md`](../../docs/ARCHITECTURE.md) §4.1) ship in slice G3 alongside ClusterMesh.
+- **Per-cluster GitOps differentiation** — every secondary CP today renders an identical Flux Kustomization pointed at `clusters/<sovereign_fqdn>/`. Per-cluster paths (`clusters/hz-fsn-rtz-prod/`, etc., per [`docs/ARCHITECTURE.md`](../../../docs/ARCHITECTURE.md) §4.1) ship in slice G3 alongside ClusterMesh.
 - **Non-Hetzner regions** — `var.regions[]` may carry `oci` / `aws` / `huawei` / `azure` entries; the Hetzner overlay filters them out (`if r.provider == "hetzner"`). Sister-provider modules (slice G2 / G4 / …) own their own iteration.
 
 ### Resource address contract
@@ -384,7 +384,7 @@ See [`variables.tf`](variables.tf) for the authoritative source. Highlights:
 | `gitops_repo_url` | public OpenOva monorepo | string |
 | `gitops_branch` | `main` | string |
 
-Every default is the **common case** for a solo Sovereign. The waterfall doctrine ([`docs/PRINCIPLES.md`](../../docs/PRINCIPLES.md) §1) means the defaults must produce a working production-shape Sovereign, not a "demo it first" scaffold.
+Every default is the **common case** for a solo Sovereign. The waterfall doctrine ([`docs/PRINCIPLES.md`](../../../docs/PRINCIPLES.md) §1) means the defaults must produce a working production-shape Sovereign, not a "demo it first" scaffold.
 
 ---
 
@@ -456,7 +456,7 @@ Out of scope by design — these are Crossplane / Flux territory:
 - DNS records beyond the Phase-0 wildcard (handled by External-DNS in the Sovereign once the bootstrap kit comes up).
 - Day-2 cluster ops (node addition/removal — Crossplane Composition).
 
-If you find yourself adding any of these to `main.tf`, you're violating [`docs/PRINCIPLES.md`](../../docs/PRINCIPLES.md) §3 — stop and route the work to Crossplane / Flux instead.
+If you find yourself adding any of these to `main.tf`, you're violating [`docs/PRINCIPLES.md`](../../../docs/PRINCIPLES.md) §3 — stop and route the work to Crossplane / Flux instead.
 
 ---
 
@@ -500,4 +500,4 @@ History: PR #1311 (Fix #73) shipped exactly this bug, broke `tofu plan` immediat
 
 ---
 
-*Part of the public OpenOva Catalyst monorepo. See [`docs/SOVEREIGN-PROVISIONING.md`](../../docs/SOVEREIGN-PROVISIONING.md) for the end-to-end provisioning narrative and [`docs/ARCHITECTURE.md`](../../docs/ARCHITECTURE.md) for the resource budget that drives the sizing defaults.*
+*Part of the public OpenOva Catalyst monorepo. See [`docs/RUNBOOKS.md`](../../../docs/RUNBOOKS.md) for the end-to-end provisioning narrative and [`docs/ARCHITECTURE.md`](../../../docs/ARCHITECTURE.md) for the resource budget that drives the sizing defaults.*

--- a/tools/qa-loop/README.md
+++ b/tools/qa-loop/README.md
@@ -17,7 +17,7 @@ Drives a single headless Chromium against every `executor_method ==
 "playwright"` row in a matrix JSON file. Memory-conscious (one
 browser, one context, one page reused across all rows — under
 ~2 GiB RSS so the Coordinator can hold parallel Fix Authors per
-[`feedback_machine_saturation_3rd_violation.md`](../../../.claude/projects/-home-openova-repos-openova-private/memory/feedback_machine_saturation_3rd_violation.md)).
+`feedback_machine_saturation_3rd_violation.md`).
 
 **The key feature is nav-interrupted recovery** (qa-loop iter-11
 Cluster-B fix). The SPA's React route guard often pushes the


### PR DESCRIPTION
Repairs all broken relative .md links found repo-wide: INVIOLABLE-PRINCIPLES→PRINCIPLES (ADRs), stale root-README doc index, missing DESIGN.md links in ARCHITECTURE, hetzner README relative-path depth, SOVEREIGN-PROVISIONING→RUNBOOKS, and removes two links into .claude memory from tracked docs. No new dangling links.