### PR TITLE
feat(dashboard): converged Sovereign treemap defaults to real resource/health map (#6695)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/lib/treemap.types.test.ts
+++ b/products/catalyst/bootstrap/ui/src/lib/treemap.types.test.ts
@@ -23,8 +23,26 @@ import {
   statusColor,
   aggregateStatusKinds,
   isJobSourcedStack,
+  RESOURCE_DEFAULT_LAYERS,
   type TreemapItem,
 } from './treemap.types'
+
+describe('RESOURCE_DEFAULT_LAYERS (#6695 — converged-Sovereign default)', () => {
+  it('is the real resource/health stack [namespace, application]', () => {
+    // The converged (ready) Dashboard defaults to this stack coloured by
+    // health so DOWN components surface as red tiles instead of hiding in a
+    // green "Done" block. namespace outer / application inner keeps every
+    // namespace visible (unlike the pre-#4731 organization grouping that
+    // collapsed most tiles into "Platform overhead").
+    expect(RESOURCE_DEFAULT_LAYERS).toEqual(['namespace', 'application'])
+  })
+
+  it('is a real-resource stack (NOT job-sourced) so it uses the live backend', () => {
+    // A job-sourced stack builds from the synthetic job tree; the converged
+    // default must instead call getDashboardTreemap against live pods.
+    expect(isJobSourcedStack(RESOURCE_DEFAULT_LAYERS)).toBe(false)
+  })
+})
 
 describe('utilizationColor', () => {
   it('maps 0% → blue', () => {

--- a/products/catalyst/bootstrap/ui/src/lib/treemap.types.ts
+++ b/products/catalyst/bootstrap/ui/src/lib/treemap.types.ts
@@ -76,6 +76,28 @@ export function isJobSourcedStack(layers: readonly TreemapDimension[]): boolean 
 }
 
 /**
+ * Default layer stack for a CONVERGED (ready) Sovereign: the real
+ * resource/health map — `namespace` outer, `application` inner. Grounded
+ * entirely in live Kubernetes objects via {@link getDashboardTreemap}
+ * (never the synthetic job tree), so it pairs with `colorBy='health'` +
+ * `sizeBy='cpu_request'` to make DOWN components surface as red tiles
+ * instead of hiding inside a green "Done" block. `cpu_request` (a
+ * constant request, present regardless of pod health) is deliberate: a
+ * fully-down app keeps a visible red tile, whereas sizing by ready-pod
+ * count would collapse it to zero area and vanish it.
+ *
+ * The provisioning-time default stays the job-sourced
+ * `PROVISIONING_DEFAULT_LAYERS` (progress → kind) so a converging env
+ * still shows what is installing; Dashboard.tsx picks between the two on
+ * `status === 'ready'`. Neither stack is hardcoded in the page — both are
+ * exported constants (INVIOLABLE-PRINCIPLES #4).
+ */
+export const RESOURCE_DEFAULT_LAYERS: readonly TreemapDimension[] = [
+  'namespace',
+  'application',
+]
+
+/**
  * What the gradient maps to. The backend stamps every cell with a
  * `percentage` field whose semantics depend on this selector.
  *

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/ConvergenceWizard.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/ConvergenceWizard.test.tsx
@@ -258,58 +258,65 @@ describe('Dashboard state-aware view', () => {
     expect(size.value).toBe('uniform')
   })
 
-  // #4731 amend (founder escalation 2026-07-05): the ready default NO LONGER
-  // flips to the resource stack — the founder rejected that ("why is the
-  // second layer not kind by default"). [progress, kind] is the default
-  // UNCONDITIONALLY, converging AND converged.
-  it('KEEPS the [progress, kind] default when status is ready (no morph)', async () => {
+  // #6695 (founder 2026-08-26): the ready default FLIPS to the real
+  // resource/health map. The #4731 amendment had kept [progress, kind]
+  // unconditionally, but on a converged Sovereign that job stack was
+  // meaningless ("install, install, install… nothing distinguishable"), so
+  // ready now shows [namespace, application] coloured by health.
+  it('#6695 — flips to the resource/health map when status is ready', async () => {
     stubEventsFetch({ status: 'ready' } as DeploymentSnapshot)
     renderDashboard()
     await screen.findByTestId('dashboard-treemap-frame')
-    // Even on a converged (ready) Sovereign the default stack stays
-    // [progress, kind] coloured by status — never the old
-    // [family/organization, application] + utilisation flip.
+    // Converged ⇒ the default stack is [namespace, application] (real k8s
+    // objects), coloured by HEALTH so down components pop red, sized by
+    // cpu_request so a fully down app keeps a visible tile.
     await waitFor(() => {
       expect(
         (screen.getByTestId('treemap-layer-0-select') as HTMLSelectElement).value,
-      ).toBe('progress')
+      ).toBe('namespace')
     })
     const layer1 = screen.getByTestId('treemap-layer-1-select') as HTMLSelectElement
     const colour = screen.getByTestId('treemap-color-select') as HTMLSelectElement
     const size = screen.getByTestId('treemap-size-select') as HTMLSelectElement
-    expect(layer1.value).toBe('kind')
-    expect(colour.value).toBe('status')
-    expect(size.value).toBe('uniform')
+    expect(layer1.value).toBe('application')
+    expect(colour.value).toBe('health')
+    expect(size.value).toBe('cpu_request')
     expect(screen.queryByTestId('dashboard-view-toggle')).toBeNull()
   })
 
-  it('the resource stack (family/application + utilisation) stays selectable on ready', async () => {
-    // MUST-PRESERVE: org / application / utilization are never removed —
-    // they are just no longer the default. The operator re-stacks to the
-    // pods/utilisation view by picking non-job dimensions for BOTH layers.
+  it('the job stack AND utilisation colour both stay selectable on ready', async () => {
+    // MUST-PRESERVE: neither vocabulary is removed — the operator can pivot
+    // back to the job-sourced [progress, kind] view, and utilisation colour
+    // is still pickable on a resource stack (it is just no longer the ready
+    // default, which is now health).
     stubEventsFetch({ status: 'ready' } as DeploymentSnapshot)
     renderDashboard()
+    // Ready default is the resource stack.
     await waitFor(() => {
       expect(
         (screen.getByTestId('treemap-layer-0-select') as HTMLSelectElement).value,
-      ).toBe('progress')
+      ).toBe('namespace')
     })
-    fireEvent.change(screen.getByTestId('treemap-layer-0-select'), {
-      target: { value: 'family' },
-    })
-    fireEvent.change(screen.getByTestId('treemap-layer-1-select'), {
-      target: { value: 'application' },
+    // utilisation colour is still selectable on the resource stack.
+    fireEvent.change(screen.getByTestId('treemap-color-select'), {
+      target: { value: 'utilization' },
     })
     await waitFor(() => {
       expect(
-        (screen.getByTestId('treemap-layer-1-select') as HTMLSelectElement).value,
-      ).toBe('application')
+        (screen.getByTestId('treemap-color-select') as HTMLSelectElement).value,
+      ).toBe('utilization')
     })
-    // A fully non-job stack sources from pods/utilisation again: colour/size
-    // re-derive to the resource vocabulary.
-    const colour = screen.getByTestId('treemap-color-select') as HTMLSelectElement
-    const size = screen.getByTestId('treemap-size-select') as HTMLSelectElement
-    expect(colour.value).toBe('utilization')
-    expect(size.value).toBe('cpu_request')
+    // The job-sourced [progress, kind] view is still reachable — picking
+    // progress for layer 0 flips the whole stack back to the job vocabulary
+    // (colour re-derives to status, size to uniform).
+    fireEvent.change(screen.getByTestId('treemap-layer-0-select'), {
+      target: { value: 'progress' },
+    })
+    await waitFor(() => {
+      expect(
+        (screen.getByTestId('treemap-color-select') as HTMLSelectElement).value,
+      ).toBe('status')
+    })
+    expect((screen.getByTestId('treemap-size-select') as HTMLSelectElement).value).toBe('uniform')
   })
 })

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/Dashboard.progress-layers.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/Dashboard.progress-layers.test.tsx
@@ -10,9 +10,13 @@
  *      including the HelmRelease installs the finite /jobs view dropped
  *      (the treemap now reads ?inventory=full). See
  *      `renders the full platform inventory as leaves`.
- *   2. "second layer is not kind by default" — the default stack is
- *      [progress, kind] UNCONDITIONALLY, incl. a converged (ready) env.
- *      See `defaults to [progress, kind] even when status=ready`.
+ *   2. "second layer is not kind by default" — the CONVERGING default is
+ *      [progress, kind]. (#6695, founder 2026-08-26: this now applies only
+ *      while status != ready; a CONVERGED env flips to the real
+ *      resource/health map [namespace, application] + health, because the
+ *      "install, install, install…" job stack was meaningless on a
+ *      converged Sovereign. See `converging … defaults to [progress, kind]`
+ *      and `#6695 — converged (status=ready) flips … resource/health map`.)
  *   3. "cutover kinds still showing as pending" — the dormant cutover
  *      steps collapse into ONE `cutover (dormant)` leaf in a Dormant
  *      bucket, coloured dormant-grey, never pending. See
@@ -366,6 +370,16 @@ function stubFetch(jobs: Job[], status: string) {
         json: () => Promise.resolve({ events: [], state: { status }, done: true }),
       } as unknown as Response)
     }
+    // #6695 — a CONVERGED (ready) env defaults to the real resource/health
+    // stack, which fetches this endpoint instead of the job tree. Answer it
+    // with an empty-but-valid TreemapData so the ready-flip render path does
+    // not error (the ready test asserts the CONTROLS, not cell data).
+    if (u.includes('/dashboard/treemap')) {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ items: [], total_count: 0 }),
+      } as unknown as Response)
+    }
     return Promise.resolve({
       ok: true,
       json: () => Promise.resolve({}),
@@ -408,9 +422,10 @@ function renderDashboard() {
 describe('Dashboard — job-sourced Progress treemap render', () => {
   beforeEach(() => {
     useWizardStore.setState({ ...INITIAL_WIZARD_STATE })
-    // status=ready: the CONVERGED moment — the map must STILL default to
-    // [progress, kind] (complaint #2) and render the full inventory.
-    stubFetch(fullInventoryJobs(), 'ready')
+    // #6695 — the CONVERGING moment: while status != ready the map defaults
+    // to the job-sourced [progress, kind] stack (what is installing). The
+    // ready-flip to the real resource/health stack has its own test below.
+    stubFetch(fullInventoryJobs(), 'provisioning')
     Object.defineProperty(HTMLDivElement.prototype, 'clientWidth', {
       configurable: true,
       get() {
@@ -432,11 +447,10 @@ describe('Dashboard — job-sourced Progress treemap render', () => {
       SyncResizeObserver
   })
 
-  it('complaint #2 — defaults to [progress, kind] even when status=ready', async () => {
+  it('converging (status != ready) defaults to the job-sourced [progress, kind] stack', async () => {
+    // beforeEach stubs status='provisioning' → the converging moment.
     renderDashboard()
     await screen.findByTestId('dashboard-treemap-frame')
-    // The two default layer selects are Progress + Kind — NOT the old
-    // ready-flip to Organization / Application.
     const layer0 = (await screen.findByTestId('treemap-layer-0-select')) as HTMLSelectElement
     const layer1 = (await screen.findByTestId('treemap-layer-1-select')) as HTMLSelectElement
     expect(layer0.value).toBe('progress')
@@ -444,6 +458,26 @@ describe('Dashboard — job-sourced Progress treemap render', () => {
     // Job-sourced ⇒ Color=Status, Size=Uniform (auto-locked to the job vocab).
     expect((screen.getByTestId('treemap-color-select') as HTMLSelectElement).value).toBe('status')
     expect((screen.getByTestId('treemap-size-select') as HTMLSelectElement).value).toBe('uniform')
+  })
+
+  it('#6695 — converged (status=ready) flips the default to the real resource/health map', async () => {
+    // The founder reversed the #4731 always-[progress,kind] default: on a
+    // CONVERGED Sovereign the "install, install, install…" job stack was
+    // meaningless. It now flips to the real resource/health map so down
+    // components surface as red tiles.
+    stubFetch(fullInventoryJobs(), 'ready')
+    renderDashboard()
+    await screen.findByTestId('dashboard-treemap-frame')
+    const layer0 = (await screen.findByTestId('treemap-layer-0-select')) as HTMLSelectElement
+    const layer1 = (await screen.findByTestId('treemap-layer-1-select')) as HTMLSelectElement
+    // RESOURCE_DEFAULT_LAYERS = [namespace, application] — real k8s objects,
+    // NOT the synthetic [progress, kind] job tree.
+    expect(layer0.value).toBe('namespace')
+    expect(layer1.value).toBe('application')
+    // Resource-sourced on ready ⇒ Color=Health (down components pop red),
+    // Size=cpu_request (a down app keeps a visible tile, never area 0).
+    expect((screen.getByTestId('treemap-color-select') as HTMLSelectElement).value).toBe('health')
+    expect((screen.getByTestId('treemap-size-select') as HTMLSelectElement).value).toBe('cpu_request')
   })
 
   it('renders the /jobs inventory as status-coloured cells + dormant + legend', async () => {

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/Dashboard.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/Dashboard.tsx
@@ -56,11 +56,15 @@
  * GET /api/v1/deployments/{id}/jobs (buildJobsTreemapData in the
  * sibling ./dashboardJobsTreemap.ts pure module); every other stack
  * calls getDashboardTreemap exactly as before.
- * While `status != ready` the DEFAULTS are layers=['progress','kind'],
- * colorBy='status', sizeBy='uniform'; on ready they flip to the
- * resource defaults — same pane, same component, a defaults change,
- * not a component swap. Job-leaf clicks deep-link to JobDetail logs
- * via the same convention as JobsTable's useJobLinkBuilder.
+ * The DEFAULT stack is convergence-gated (#6695): while `status != ready`
+ * it is layers=['progress','kind'], colorBy='status', sizeBy='uniform'
+ * (the job-sourced view of what is installing); on ready it flips to the
+ * REAL resource/health map — layers=['namespace','application'],
+ * colorBy='health', sizeBy='cpu_request' (RESOURCE_DEFAULT_LAYERS) — so a
+ * converged Sovereign shows down components as red tiles, not a wall of
+ * "install…". Same pane, same component: a defaults change, not a
+ * component swap. Job-leaf clicks deep-link to JobDetail logs via the
+ * same convention as JobsTable's useJobLinkBuilder.
  *
  * Per docs/INVIOLABLE-PRINCIPLES.md #4 (never hardcode), the metric
  * options + dimension list live in the controller / types module, not
@@ -98,6 +102,7 @@ import {
   colorFunctionFor,
   getDashboardTreemap,
   isJobSourcedStack,
+  RESOURCE_DEFAULT_LAYERS,
   statusColor,
   walkDrillPath,
   type TreemapColorBy,
@@ -202,22 +207,30 @@ export function Dashboard({
 
   const isReady = (snapshot?.status ?? '').trim().toLowerCase() === 'ready'
 
-  // #4731 amend (founder escalation 2026-07-05): the default layer stack is
-  // [progress, kind] UNCONDITIONALLY — on a provisioning env AND on a
-  // converged (ready) env. The prior code flipped the ready default to
-  // [organization, application] + utilization; the founder rejected that
-  // ("why the second layer is not kind by default"). The one treemap now
-  // reads the FULL platform inventory in BOTH moments: converging fills
-  // Running/Pending, converged is a big green Done block sub-divided by
-  // kind, with the parked cutover tether in Dormant. organization /
-  // application / utilization stay AVAILABLE — one click away in the layer
-  // controller — they are just no longer the default.
+  // #6695 (founder 2026-08-26): the default layer stack is CONVERGENCE-GATED.
+  //   • converging (status != ready) → PROVISIONING_DEFAULT_LAYERS
+  //     ([progress, kind]) — the job-sourced view of what is installing.
+  //   • converged (status == ready)  → RESOURCE_DEFAULT_LAYERS
+  //     ([namespace, application]) coloured by HEALTH, sized by cpu_request
+  //     — the real resource/health map grounded in live pods/HelmReleases,
+  //     so DOWN components surface as red tiles instead of hiding in a
+  //     green "Done" block.
   //
-  // Implementation (same pattern as the old userView): the `user*` states
-  // stay null until the operator touches a control; the effective value is
-  // the user's choice if set, else the [progress, kind] default. No
-  // status-gated flip, no setState-in-effect storm; the user keeps control
-  // once they touch the toolbar.
+  // This restores the ready-flip the #4731 amendment removed, but to a
+  // BETTER real-resource stack than the pre-#4731 one: the founder rejected
+  // [progress, kind]-always as meaningless on a converged env ("install,
+  // install, install… nothing distinguishable"), and the pre-#4731 default
+  // ([organization, application] + utilization) both collapsed most tiles
+  // into a single "Platform overhead" bucket AND coloured by utilisation
+  // (orthogonal to "is it up?"). Namespace grouping keeps every namespace
+  // visible and HEALTH colour makes grafana/powerdns-admin/etc. pop red.
+  // The job-sourced [progress, kind] view stays one click away in the layer
+  // controller.
+  //
+  // Implementation (unchanged pattern): the `user*` states stay null until
+  // the operator touches a control; the effective value is the user's
+  // choice if set, else the convergence-gated default. No setState-in-effect
+  // storm; the user keeps control once they touch the toolbar.
   const [userLayers, setUserLayers] = useState<readonly TreemapDimension[] | null>(
     initialLayers ?? null,
   )
@@ -227,15 +240,20 @@ export function Dashboard({
   const [userSizeBy, setUserSizeBy] = useState<TreemapSizeBy | null>(
     initialSizeBy ?? null,
   )
-  const layers: readonly TreemapDimension[] = userLayers ?? PROVISIONING_DEFAULT_LAYERS
+  const defaultLayers: readonly TreemapDimension[] = isReady
+    ? RESOURCE_DEFAULT_LAYERS
+    : PROVISIONING_DEFAULT_LAYERS
+  const layers: readonly TreemapDimension[] = userLayers ?? defaultLayers
   // The data-source rule (#4731, the only conditional): progress/kind
   // in the stack → Job tree; anything else → getDashboardTreemap.
   const jobSourced = isJobSourcedStack(layers)
-  // Colour/size defaults follow the STACK's nature, not readiness — a
-  // post-ready operator re-adding the Progress layer gets status/uniform
-  // back, and a converging operator pivoting to a resource stack gets
-  // utilisation/cpu_request.
-  const colorBy: TreemapColorBy = userColorBy ?? (jobSourced ? 'status' : 'utilization')
+  // Colour/size defaults follow the STACK's nature: a job-sourced stack →
+  // status/uniform; a resource stack on a CONVERGED env → health/cpu_request
+  // (health so the eye goes to the down components; cpu_request so a fully
+  // down app keeps a visible red tile). A converging operator who manually
+  // pivots to a resource stack keeps the historic utilisation default.
+  const colorBy: TreemapColorBy =
+    userColorBy ?? (jobSourced ? 'status' : isReady ? 'health' : 'utilization')
   const sizeBy: TreemapSizeBy = userSizeBy ?? (jobSourced ? 'uniform' : 'cpu_request')
   const setColorBy = (next: TreemapColorBy) => setUserColorBy(next)
   const setSizeBy = (next: TreemapSizeBy) => setUserSizeBy(next)


### PR DESCRIPTION
## What
On a converged (ready) Sovereign the Dashboard treemap defaulted to the **job-sourced** `[progress, kind]` stack — synthetic job records, uniform tile area (footprint invisible), tiles named literally `install-<app>`, and a **fabricated** name-prefix `kind` taxonomy. On a converged env that renders as a wall of tiles all reading "install…" — zero observability, the exact surface the founder flagged.

This flips the **converged** default to the **real resource/health map** that already exists (`getDashboardTreemap`, grounded in live pods/HelmReleases):

| moment | layers | color | size |
|---|---|---|---|
| converging (`status != ready`) | `[progress, kind]` *(unchanged)* | status | uniform |
| **converged (`status == ready`)** | **`[namespace, application]`** | **health** | **cpu_request** |

`cpu_request` (not `replica_count`) is deliberate: a fully-down app keeps its request, so it stays a **visible red tile** instead of collapsing to area 0. `PROVISIONING_DEFAULT_LAYERS` is unchanged; the job view stays one click away.

This restores the ready-flip the #4731 amendment removed, but to a better stack than the pre-#4731 `[organization, application] + utilization` (which collapsed most tiles into one "Platform overhead" bucket and colored by utilisation, orthogonal to "is it up?").

## Verified live (hw305, 2026-08-26)
`group_by=namespace,application&color_by=health&size_by=cpu_request` returns 45 namespace tiles subdivided by app; down components surface as red: **grafana 0%**, **powerdns-admin 0%**, **chepherd-rtz-a 0%** (size 1005 — big red), catalyst 85.7% / agwalk305 88.9% amber. All hidden by the old `[progress,kind]` default.

## Tests
- `treemap.types.test.ts`: `RESOURCE_DEFAULT_LAYERS` unit assertions (is `[namespace, application]`, is not job-sourced).
- Rewrote the three ready-default render tests in `Dashboard.progress-layers.test.tsx` and `ConvergenceWizard.test.tsx` that encoded the now-reversed #4731 always-`[progress,kind]` premise: converging → job view; ready → resource/health map; both vocabularies stay selectable.
- Full UI suite: 2270 passed / 1 expected-fail. Typecheck + production build clean.

## Delivery
Console-only change → rebuilds `catalyst-ui` → rolled onto live hw305 via `kubectl set image` (rolling update, no wipe, no re-prov, catalyst-api untouched).

Refs #6695 #4731

🤖 Generated with [Claude Code](https://claude.com/claude-code)
