### PR TITLE
fix(console): serve index.html with Cache-Control no-cache (#6697)

### DIFF
--- a/products/catalyst/bootstrap/ui/nginx.conf
+++ b/products/catalyst/bootstrap/ui/nginx.conf
@@ -81,8 +81,29 @@ server {
     # passes through to / directly. Both paths resolve to /assets/* here.
     # React routes (/dashboard, /wizard, etc.) fall through to /index.html
     # and are handled client-side (issue #596).
+    #
+    # index.html MUST be revalidated on every load. The hashed /assets/* bundles
+    # are cached `immutable` (above), but index.html is the manifest that names
+    # the current bundle hash — if the BROWSER caches index.html heuristically
+    # (no cache-control ⇒ nginx sends only etag/last-modified), a freshly rolled
+    # deploy stays INVISIBLE on a normal reload: the browser reuses the stale
+    # index.html, which still points at the OLD bundle hash, so the whole app is
+    # the previous version until a hard-reload. `no-cache` forces a conditional
+    # request every load (etag ⇒ 304 when unchanged, fresh HTML the instant the
+    # bundle hash changes), so a rolled image shows up on an ordinary refresh.
     location / {
         try_files $uri /index.html;
+        add_header Cache-Control "no-cache" always;
+
+        # Re-emit security headers — nginx add_header is inherited only when the
+        # current level defines NO add_header at all; the Cache-Control above
+        # shadows the server-level set, so restate them here (see /api/ comment).
+        add_header Strict-Transport-Security "max-age=15552000; includeSubDomains; preload" always;
+        add_header X-Frame-Options "DENY" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: blob: https:; connect-src 'self' wss: https:; font-src 'self' data: https://fonts.gstatic.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self' https:" always;
+        add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
     }
 
     # Health check (used by K8s probes)


### PR DESCRIPTION
## Problem
`catalyst-ui` serves hashed `/assets/*` bundles `immutable` (correct) but `index.html` with **no `Cache-Control`** — so browsers heuristically cache it and a freshly rolled deploy stays invisible on a normal reload (the stale index.html points at the old bundle hash). Observed live on hw305 after a verified image roll: the operator's tab kept showing the old dashboard until a hard-reload.

## Fix
`Cache-Control: no-cache` on the SPA-fallback `location /` (security headers re-emitted per nginx's add_header inheritance rule). Forces revalidation every load; hashed assets stay immutable. A rolled image now shows on an ordinary refresh — no hard-reload needed.

Refs #6697 #6695

🤖 Generated with [Claude Code](https://claude.com/claude-code)