### PR TITLE
feat(console): rename Cloud → Resources (Resources/Jobs re-cut, slice 1)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/CloudPage.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/CloudPage.test.tsx
@@ -96,10 +96,10 @@ beforeEach(() => {
 afterEach(() => cleanup())
 
 describe('CloudPage — shell', () => {
-  it('renders the Cloud title', async () => {
+  it('renders the Resources title', async () => {
     renderShell('d-1', 'architecture')
     const title = await screen.findByTestId('cloud-title')
-    expect(title.textContent).toBe('Cloud')
+    expect(title.textContent).toBe('Resources')
   })
 
   it('mounts inside the PortalShell (sidebar present)', async () => {

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/CloudPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/CloudPage.tsx
@@ -7,7 +7,7 @@
  * `view=list&kind=…` query.
  *
  * Layout:
- *   • Header: H1 "Cloud" + tagline + per-Sovereign switcher.
+ *   • Header: H1 "Resources" + tagline + per-Sovereign switcher.
  *   • Toolbar: a segmented View toggle (Graph | List) and a Fullscreen
  *     button on the right.
  *   • Content area: when `view=graph` (default) — renders the
@@ -528,7 +528,7 @@ export function CloudPage({
     <PortalShell
       deploymentId={deploymentId}
       sovereignFQDN={sovereignFQDN}
-      pageTitle="Cloud"
+      pageTitle="Resources"
       headerSlotRight={
         <select
           data-testid="cloud-sovereign-switcher"
@@ -552,7 +552,7 @@ export function CloudPage({
          *  toolbar. A hidden testid anchor preserves the legacy
          *  cloud-title selector used by component tests. */}
         <span data-testid="cloud-title" className="sr-only">
-          Cloud
+          Resources
         </span>
 
         {/* Toolbar: View toggle (left) + chip strip (centre, list view

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/Sidebar.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/Sidebar.tsx
@@ -101,7 +101,7 @@ const FLAT_NAV: FlatNavItem[] = [
   },
   {
     id: 'cloud',
-    label: 'Cloud',
+    label: 'Resources',
     to: '/provision/$deploymentId/cloud',
     icon: CLOUD_ICON,
   },

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/SovereignSidebar.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/SovereignSidebar.tsx
@@ -82,7 +82,7 @@ const FLAT_NAV: FlatNavItem[] = [
   },
   {
     id: 'cloud',
-    label: 'Cloud',
+    label: 'Resources',
     to: '/cloud',
     icon: CLOUD_ICON,
   },


### PR DESCRIPTION
First slice of the **Resources/Jobs re-cut** (founder 2026-08-26).

The assets view is the inventory of nouns that *exist*, so it's named **Resources**, not the vague "Cloud" umbrella. Aligns the top-level nav with the per-app AppDetail **Resources** tab (already uses that word), and sets up the model where reconcilers (HelmRelease / Kustomization / Deployment) live here as assets while `/jobs` holds only bounded processes.

**Label-only:** route id stays `cloud`, path stays `/cloud` — no id-keyed routes/tests/bookmarks break. The infra-graph node type `'Cloud'` is a different concept and is unchanged.

Full UI suite: 2270 pass / 1 expected-fail. Typecheck clean.

Refs #6695

🤖 Generated with [Claude Code](https://claude.com/claude-code)