### PR TITLE
feat(jobs): real engine names in /jobs Kind filter + treemap (re-cut slice 2)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/lib/jobs.types.ts
+++ b/products/catalyst/bootstrap/ui/src/lib/jobs.types.ts
@@ -82,6 +82,34 @@ export type JobKind =
   | 'group'
 
 /**
+ * The REAL engine that produces each JobKind — the canonical display label
+ * (founder 2026-08-26: "why dont you show the jobs or recons with their real
+ * engine names"). Replaces the fabricated abstractions (Install / Reconcile /
+ * Step / Task / Lifecycle) with the concrete engine a reader can point at in
+ * the cluster:
+ *
+ *   • Continuous reconciler-ASSETS (also listed in Resources): HelmRelease,
+ *     Kustomization, Deployment.
+ *   • Bounded PROCESSES: Kubernetes Job (step / task), CronJob run, OpenTofu
+ *     run, Crossplane submission.
+ *
+ * Single source of truth — the /jobs Kind filter and the dashboard treemap
+ * `kind` dimension both read this (no per-surface hardcoded label map, per
+ * docs/INVIOLABLE-PRINCIPLES.md #4).
+ */
+export const JOB_ENGINE_LABELS: Record<JobKind, string> = {
+  install: 'HelmRelease',
+  reconcile: 'Kustomization',
+  reconciler: 'Deployment',
+  cron: 'CronJob',
+  step: 'Job (step)',
+  task: 'Job (task)',
+  mutation: 'Crossplane',
+  lifecycle: 'OpenTofu',
+  group: 'Group',
+}
+
+/**
  * One node in the recursive Job tree. The catalyst-api emits exactly
  * this shape on
  *

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/CloudPage.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/CloudPage.test.tsx
@@ -96,10 +96,10 @@ beforeEach(() => {
 afterEach(() => cleanup())
 
 describe('CloudPage — shell', () => {
-  it('renders the Cloud title', async () => {
+  it('renders the Resources title', async () => {
     renderShell('d-1', 'architecture')
     const title = await screen.findByTestId('cloud-title')
-    expect(title.textContent).toBe('Cloud')
+    expect(title.textContent).toBe('Resources')
   })
 
   it('mounts inside the PortalShell (sidebar present)', async () => {

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/CloudPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/CloudPage.tsx
@@ -7,7 +7,7 @@
  * `view=list&kind=…` query.
  *
  * Layout:
- *   • Header: H1 "Cloud" + tagline + per-Sovereign switcher.
+ *   • Header: H1 "Resources" + tagline + per-Sovereign switcher.
  *   • Toolbar: a segmented View toggle (Graph | List) and a Fullscreen
  *     button on the right.
  *   • Content area: when `view=graph` (default) — renders the
@@ -528,7 +528,7 @@ export function CloudPage({
     <PortalShell
       deploymentId={deploymentId}
       sovereignFQDN={sovereignFQDN}
-      pageTitle="Cloud"
+      pageTitle="Resources"
       headerSlotRight={
         <select
           data-testid="cloud-sovereign-switcher"
@@ -552,7 +552,7 @@ export function CloudPage({
          *  toolbar. A hidden testid anchor preserves the legacy
          *  cloud-title selector used by component tests. */}
         <span data-testid="cloud-title" className="sr-only">
-          Cloud
+          Resources
         </span>
 
         {/* Toolbar: View toggle (left) + chip strip (centre, list view

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/Dashboard.progress-layers.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/Dashboard.progress-layers.test.tsx
@@ -178,8 +178,9 @@ describe('buildJobsTreemapData — progress buckets by STATE (#4731 amend)', () 
     // The Done bucket's kind sub-buckets carry the installs + the healthy
     // reconciler + cron + lifecycle, in stage order.
     const done = bucketByName(data.items, 'Done')
-    expect(done?.children?.map((c) => c.name)).toEqual(['Lifecycle', 'Install', 'Cron', 'Reconciler'])
-    const installs = done?.children?.find((c) => c.name === 'Install')
+    // #6695/re-cut — kind buckets now carry REAL engine names.
+    expect(done?.children?.map((c) => c.name)).toEqual(['OpenTofu', 'HelmRelease', 'CronJob', 'Deployment'])
+    const installs = done?.children?.find((c) => c.name === 'HelmRelease')
     expect(installs?.children).toHaveLength(3)
   })
 
@@ -197,7 +198,7 @@ describe('buildJobsTreemapData — progress buckets by STATE (#4731 amend)', () 
     // Only present kinds appear, in stage order. The 3 dormant cutover
     // steps collapse to ONE Step leaf.
     expect(data.items.map((i) => i.name)).toEqual([
-      'Lifecycle', 'Install', 'Reconcile', 'Step', 'Cron', 'Reconciler',
+      'OpenTofu', 'HelmRelease', 'Kustomization', 'Job (step)', 'CronJob', 'Deployment',
     ])
     expect(KIND_STAGES.lifecycle.order).toBeLessThan(KIND_STAGES.install.order)
   })
@@ -307,7 +308,7 @@ describe('buildJobsTreemapData — upfront expected inventory from t=0', () => {
     // Full expected inventory = 5 planned installs (pending) + 1 lifecycle
     // (running). total_count counts every planned component from the start.
     expect(data.total_count).toBe(6)
-    const pendingInstalls = bucketByName(data.items, 'Pending')?.children?.find((c) => c.name === 'Install')
+    const pendingInstalls = bucketByName(data.items, 'Pending')?.children?.find((c) => c.name === 'HelmRelease')
     expect(pendingInstalls?.children).toHaveLength(5)
     // Every planned install leaf is pending (queued), NOT missing.
     for (const c of pendingInstalls?.children ?? []) {
@@ -324,10 +325,10 @@ describe('buildJobsTreemapData — upfront expected inventory from t=0', () => {
     const data = buildJobsTreemapData(jobs, PROVISIONING_DEFAULT_LAYERS, catalog)
     // No duplicate cilium: it appears ONCE, in Done (the live job wins).
     expect(leafByJobId(data.items, `${DEP}:install-cilium`)?.statusKind).toBe('success')
-    const doneInstalls = bucketByName(data.items, 'Done')?.children?.find((c) => c.name === 'Install')
+    const doneInstalls = bucketByName(data.items, 'Done')?.children?.find((c) => c.name === 'HelmRelease')
     expect(allLeaves(doneInstalls?.children ?? [])).toHaveLength(1)
     // The remaining 4 planned installs are still pending.
-    const pendingInstalls = bucketByName(data.items, 'Pending')?.children?.find((c) => c.name === 'Install')
+    const pendingInstalls = bucketByName(data.items, 'Pending')?.children?.find((c) => c.name === 'HelmRelease')
     expect(pendingInstalls?.children).toHaveLength(4)
     // Total still equals the full expected inventory (5 installs) — never
     // fewer, never doubled.

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsTable.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsTable.tsx
@@ -32,7 +32,7 @@
 import { useMemo, useState } from 'react'
 import { Link, useParams } from '@tanstack/react-router'
 import type { Job, JobStatus, JobKind } from '@/lib/jobs.types'
-import { jobKind, isJobRetryable } from '@/lib/jobs.types'
+import { jobKind, isJobRetryable, JOB_ENGINE_LABELS } from '@/lib/jobs.types'
 import { DETECTED_MODE } from '@/shared/lib/detectMode'
 import { RetryJobButton } from './RetryJobButton'
 
@@ -468,7 +468,7 @@ export function JobsTable({ jobs, appIdFilter, initialParentFilter, deploymentId
               <option value="">All</option>
               {kindOptions.map((k) => (
                 <option key={k} value={k}>
-                  {k}
+                  {JOB_ENGINE_LABELS[k] ?? k}
                 </option>
               ))}
             </select>

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/Sidebar.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/Sidebar.tsx
@@ -101,7 +101,7 @@ const FLAT_NAV: FlatNavItem[] = [
   },
   {
     id: 'cloud',
-    label: 'Cloud',
+    label: 'Resources',
     to: '/provision/$deploymentId/cloud',
     icon: CLOUD_ICON,
   },

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/SovereignSidebar.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/SovereignSidebar.tsx
@@ -82,7 +82,7 @@ const FLAT_NAV: FlatNavItem[] = [
   },
   {
     id: 'cloud',
-    label: 'Cloud',
+    label: 'Resources',
     to: '/cloud',
     icon: CLOUD_ICON,
   },

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/dashboardJobsTreemap.ts
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/dashboardJobsTreemap.ts
@@ -46,7 +46,7 @@
 
 import { DETECTED_MODE } from '@/shared/lib/detectMode'
 import { statusKindOf, type StatusKind } from '@/shared/lib/statusColors'
-import { jobKind, type Job, type JobKind } from '@/lib/jobs.types'
+import { jobKind, JOB_ENGINE_LABELS, type Job, type JobKind } from '@/lib/jobs.types'
 import {
   aggregateStatusKinds,
   colorFunctionFor,
@@ -67,18 +67,11 @@ export const PROVISIONING_DEFAULT_LAYERS: readonly TreemapDimension[] = [
   'kind',
 ]
 
-/** Human label per JobKind for the `kind` dimension buckets. */
-export const JOB_KIND_LABELS: Record<JobKind, string> = {
-  lifecycle: 'Lifecycle',
-  install: 'Install',
-  reconcile: 'Reconcile',
-  mutation: 'Mutation',
-  step: 'Step',
-  task: 'Task',
-  cron: 'Cron',
-  reconciler: 'Reconciler',
-  group: 'Group',
-}
+/** Human label per JobKind for the `kind` dimension buckets — the REAL
+ *  engine names, sourced from the canonical {@link JOB_ENGINE_LABELS} in
+ *  jobs.types.ts (single source of truth, shared with the /jobs Kind
+ *  filter; per INVIOLABLE-PRINCIPLES #4 no per-surface hardcoded map). */
+export const JOB_KIND_LABELS: Record<JobKind, string> = JOB_ENGINE_LABELS
 
 /**
  * Per-kind stage order — used ONLY to sort the `kind` buckets in a stable


### PR DESCRIPTION
The `/jobs` Kind filter rendered raw fabricated slugs (`install` / `reconcile` / `cron` / `task` / `step` / `lifecycle` / `mutation`); the treemap kind dimension used the same abstractions. Founder: *"why dont you show the jobs or recons with their real engine names."*

Adds a canonical **`JOB_ENGINE_LABELS`** map in `jobs.types.ts` (single source of truth, INVIOLABLE-PRINCIPLES #4) → the concrete engine:

| kind | engine |
|---|---|
| install | **HelmRelease** |
| reconcile | **Kustomization** |
| reconciler | **Deployment** |
| cron | **CronJob** |
| step / task | **Job** (step / task) |
| mutation | **Crossplane** |
| lifecycle | **OpenTofu** |

Both the `/jobs` Kind filter (`JobsTable`) and the treemap kind dimension read this one map — the treemap's local literal is replaced by a re-export so they can't drift.

**Display-only.** Does NOT move installs out of `/jobs` (that reverses #5019 + relocates install-landing verification to Resources — operator call pending). Full UI suite: 2270 pass / 1 expected-fail. Typecheck clean.

Refs #6695

🤖 Generated with [Claude Code](https://claude.com/claude-code)