### PR TITLE
fix(jobs): Kind column badge shows real engine name (re-cut)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsTable.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsTable.tsx
@@ -716,7 +716,7 @@ function JobRow({ job, parentLabel, showRegion, regionUnionByGroupId, deployment
           data-testid={`jobs-cell-kind-${job.id}`}
           data-kind={kind}
         >
-          {kind}
+          {JOB_ENGINE_LABELS[kind] ?? kind}
         </span>
       </td>
       <td className="jobs-cell jobs-cell-app">


### PR DESCRIPTION
Slice 2 relabelled the /jobs Kind filter + treemap, but the always-visible Kind **column** badge still showed the raw slug (`{kind}` → TASK/STEP). Now renders `JOB_ENGINE_LABELS[kind]` (Job (task) / HelmRelease / CronJob…). `data-kind` attr + className unchanged so CSS/tests pass. Full suite 2270 pass. Refs #6695