### PR TITLE
feat(k8scache): watch batch/v1 CronJob + Job (P3 schedule-timeline data)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/k8scache/kinds.go
+++ b/products/catalyst/bootstrap/api/internal/k8scache/kinds.go
@@ -127,6 +127,13 @@ var DefaultKinds = []Kind{
 	// The graph adapter chases this hop to attribute Pods to their Deployment.
 	{Name: "replicaset", GVR: schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "replicasets"}, Namespaced: true},
 
+	// Batch (batch/v1). CronJob carries `.spec.schedule` + `.status.lastScheduleTime`
+	// (the consolidated Schedule-timeline surface + "latest run" glyph); Job is the
+	// CronJob's per-fire child (ownerRef CronJob -> the run-history drill-in). Both
+	// GVRs are GA since k8s 1.21 and served on every cluster, so NOT Optional.
+	{Name: "cronjob", GVR: schema.GroupVersionResource{Group: "batch", Version: "v1", Resource: "cronjobs"}, Namespaced: true},
+	{Name: "job", GVR: schema.GroupVersionResource{Group: "batch", Version: "v1", Resource: "jobs"}, Namespaced: true},
+
 	// Networking (networking.k8s.io/v1).
 	{Name: "ingress", GVR: schema.GroupVersionResource{Group: "networking.k8s.io", Version: "v1", Resource: "ingresses"}, Namespaced: true},
 	// EndpointSlice — exact Service→Pod membership without recomputing


### PR DESCRIPTION
## What

Registers `batch/v1` **CronJob** and **Job** in the catalyst-api k8scache `DefaultKinds`, so the raw objects flow through the resource SSE stream that already powers the sovereign-admin cloud-list and dashboard treemap.

This is the **data prerequisite for P3** of the Jobs/Resources re-cut (epic #6703): the consolidated **CronJob Schedule timeline** ("what fires at 12pm", collision view) and the **run-history drill-in** the founder asked for ("if I need to access to the complete history of cron jobs, how?").

## Why this is complete + safe backend

- **CronJob** carries `.spec.schedule`, `.status.lastScheduleTime`, `.status.active` — everything the timeline + "latest run" glyph need.
- **Job** is the CronJob's per-fire child (`ownerRef` CronJob -> Job) — the run-history list.
- Both GVRs are GA since k8s 1.21 and served on every cluster, so **NOT `Optional`** (the #5352 discovery-probe gate is only for provider-specific GVRs).
- **RBAC already complete** — `batch/jobs` and `batch/cronjobs` both have `get/list/watch` on `catalyst-api-cutover-driver` ClusterRole (added by the #3646 cron-visibility fix). No RBAC change.
- **No redaction risk** — `redactObject` is a no-op for non-`Sensitive` kinds, so `.spec.schedule` survives the snapshot/SSE path unchanged. No projection/transform code needed.

## Test

- `go build ./internal/k8scache/...` clean.
- `go test ./internal/k8scache/...` green, including the two registry-invariant tests (`optional_gvr_gate_5352_test.go` `TestDefaultKinds_OptionalFlags`, `k8scache_test.go`) — the new kinds correctly fall outside both the `wantOptional` and `wantNonOptional` pin lists without breaking them.

## Rollout

Backend-only; merges independently of the P1/P2 catalyst-ui rolls. The live hw305 catalyst-api roll (Recreate strategy) will be **batched** with the rest of P3/P4 backend, or applied via the `CATALYST_K8SCACHE_KINDS_CONFIGMAP` operator override to avoid a pod restart — decided at rollout time.

Refs #6703