### PR TITLE
feat(sovereign-ui): /jobs per-kind chips + List⇄Graph toggle (P1b, mirror /cloud)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/app/router.tsx
+++ b/products/catalyst/bootstrap/ui/src/app/router.tsx
@@ -887,13 +887,34 @@ const provisionCatalogDetailRoute = createRoute({
   beforeLoad: provisionAuthGuard,
 })
 
+// P1b (Refs #6703) — search-param contract for the /jobs List⇄Graph
+// toggle + per-kind chip filter. Mirrors CloudSearch. `kind` is passed
+// through as a free string (JobsPage's isValidJobKind is the closed-set
+// guard at read time), matching how CloudSearch threads its `kind`.
+interface JobsSearch {
+  view?: 'graph' | 'list'
+  kind?: string
+}
+
 // Global jobs list — table view (issue #204 founder spec). Each row is
 // a clickable link that navigates to the per-job detail page.
+//
+// P1b (Refs #6703) — the /jobs page mirrors /cloud's UX: a List⇄Graph
+// `view` toggle + a per-kind `kind` chip filter. This validateSearch is
+// CRITICAL: without it TanStack Router drops the unknown `?view=`/`?kind=`
+// params on navigation and the view/kind never persist across a toggle.
+// Mirrors provisionCloudRoute.validateSearch (CloudSearch) above.
 const provisionJobsRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/provision/$deploymentId/jobs',
   component: JobsPage,
   beforeLoad: provisionAuthGuard,
+  validateSearch: (raw: Record<string, unknown>): JobsSearch => {
+    const out: JobsSearch = {}
+    if (raw.view === 'graph' || raw.view === 'list') out.view = raw.view
+    if (typeof raw.kind === 'string' && raw.kind.length > 0) out.kind = raw.kind
+    return out
+  },
 })
 
 // Jobs timeline (Gantt-style retrospective). Static segment, MUST be
@@ -1395,6 +1416,16 @@ const consoleJobsRoute = createRoute({
   getParentRoute: () => consoleLayoutRoute,
   path: '/jobs',
   component: JobsPage,
+  // P1b (Refs #6703) — mirrors provisionJobsRoute.validateSearch so the
+  // chroot Sovereign Console's /jobs also persists `?view=`/`?kind=`
+  // across the List⇄Graph toggle + chip filter. Without it TanStack
+  // Router drops the params and the view silently resets.
+  validateSearch: (raw: Record<string, unknown>): JobsSearch => {
+    const out: JobsSearch = {}
+    if (raw.view === 'graph' || raw.view === 'list') out.view = raw.view
+    if (typeof raw.kind === 'string' && raw.kind.length > 0) out.kind = raw.kind
+    return out
+  },
 })
 // #3601 (EPIC #3597) — Catalog as its OWN left-nav page (chroot Sovereign
 // Console). `/catalog` renders the catalog grid that used to be the

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsGraphView.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsGraphView.tsx
@@ -1,0 +1,95 @@
+/**
+ * JobsGraphView — the Graph half of the /jobs List⇄Graph toggle (P1b,
+ * Refs #6703). A thin wrapper that maps the flat Job tree to the pure-SVG
+ * layered-DAG renderer `JobDependenciesGraph` and wires node clicks to the
+ * per-job detail page using the SAME chroot/mothership path logic the
+ * JobsTable rows use (JobsTable.useJobLinkBuilder).
+ *
+ * Two mappings the widget requires:
+ *   • Title — `displayName ?? jobName` (the same label the table row link
+ *     renders), so a node reads identically to its table row.
+ *   • Status — JobStatus has SEVEN values but JobDependenciesGraph only
+ *     knows FOUR (pending | running | succeeded | failed). The HEALTH-axis
+ *     statuses are folded onto the one-shot axis: healthy → succeeded,
+ *     degraded / failing → failed. (issue #3646 §4c health axis.)
+ */
+
+import { useCallback } from 'react'
+import { useNavigate, useParams } from '@tanstack/react-router'
+import { DETECTED_MODE } from '@/shared/lib/detectMode'
+import type { Job, JobStatus } from '@/lib/jobs.types'
+import {
+  JobDependenciesGraph,
+  type JobNode,
+  type JobUiStatus,
+} from '@/widgets/job-deps-graph/JobDependenciesGraph'
+
+interface JobsGraphViewProps {
+  /** The flat Job tree to draw (groups + leaves). */
+  jobs: readonly Job[]
+  /** Deployment id — forwarded for parity; the link builder reads the
+   *  route param + DETECTED_MODE, matching JobsTable. */
+  deploymentId?: string
+}
+
+/**
+ * Fold the 7-value JobStatus onto the 4-value graph vocabulary. The
+ * health axis (issue #3646 §4c) collapses to the one-shot axis:
+ *   healthy  → succeeded   (running-forever and that's correct)
+ *   degraded → failed      (running-forever and that's a hang)
+ *   failing  → failed
+ */
+function toGraphStatus(s: JobStatus): JobUiStatus {
+  switch (s) {
+    case 'running':
+      return 'running'
+    case 'succeeded':
+    case 'healthy':
+      return 'succeeded'
+    case 'failed':
+    case 'degraded':
+    case 'failing':
+      return 'failed'
+    case 'pending':
+    default:
+      return 'pending'
+  }
+}
+
+export function JobsGraphView({ jobs }: JobsGraphViewProps) {
+  const navigate = useNavigate()
+  const params = useParams({ strict: false }) as { deploymentId?: string }
+  const isSovereign = DETECTED_MODE.mode === 'sovereign'
+  const depId = params.deploymentId ?? ''
+
+  const nodes: JobNode[] = jobs.map((j) => ({
+    id: j.id,
+    title: j.displayName ?? j.jobName,
+    status: toGraphStatus(j.status),
+    dependsOn: j.dependsOn,
+  }))
+
+  // SAME chroot/mothership target logic as JobsTable.useJobLinkBuilder:
+  // strip the "<deploymentId>:" (or "<deploymentId>:<region>:") prefix so
+  // the id matches jobs.Store's bare jobName key, encode the segment (the
+  // `/` inside a multi-region bare name must stay path-safe), and stay
+  // scoped under /provision/<id>/jobs on the mothership monitor surface.
+  const onNodeClick = useCallback(
+    (jobId: string) => {
+      const bare = jobId.includes(':') ? jobId.slice(jobId.indexOf(':') + 1) : jobId
+      const encoded = encodeURIComponent(bare)
+      const to =
+        isSovereign || !depId
+          ? `/jobs/${encoded}`
+          : `/provision/${depId}/jobs/${encoded}`
+      navigate({ to: to as never })
+    },
+    [navigate, isSovereign, depId],
+  )
+
+  return (
+    <div data-testid="jobs-graph-view">
+      <JobDependenciesGraph jobs={nodes} onNodeClick={onNodeClick} />
+    </div>
+  )
+}

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsPage.chips-view.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsPage.chips-view.test.tsx
@@ -1,0 +1,136 @@
+/**
+ * JobsPage.chips-view.test.tsx — P1b (Refs #6703).
+ *
+ * Lock-in for the /jobs List⇄Graph toggle + per-kind chip strip that
+ * mirrors the /cloud (Resources) UX. Asserts:
+ *   • the segmented List/Graph toggle renders;
+ *   • `?view=graph` renders the graph (JobsGraphView), not the table;
+ *   • `?view=list` renders the table + the JobKindChips strip;
+ *   • clicking the Graph toggle switches list → graph (and the chip strip
+ *     hides in graph view);
+ *   • the list filters to ONE kind — the reducer first-paint rows all
+ *     classify as `lifecycle`, so `?kind=lifecycle` shows them and a
+ *     different kind (`install`) hides them.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render, screen, cleanup, fireEvent } from '@testing-library/react'
+import {
+  RouterProvider,
+  createRouter,
+  createRootRoute,
+  createRoute,
+  createMemoryHistory,
+  Outlet,
+} from '@tanstack/react-router'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { JobsPage } from './JobsPage'
+import { useWizardStore } from '@/entities/deployment/store'
+import { INITIAL_WIZARD_STATE } from '@/entities/deployment/model'
+
+interface JobsSearch {
+  view?: 'graph' | 'list'
+  kind?: string
+}
+
+function renderJobs(initialEntry: string) {
+  const rootRoute = createRootRoute({ component: () => <Outlet /> })
+  const jobsRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/provision/$deploymentId/jobs',
+    component: () => <JobsPage disableStream disableJobsBackfill />,
+    // Mirror the production route so navigate() round-trips ?view=/?kind=.
+    validateSearch: (raw: Record<string, unknown>): JobsSearch => {
+      const out: JobsSearch = {}
+      if (raw.view === 'graph' || raw.view === 'list') out.view = raw.view
+      if (typeof raw.kind === 'string' && raw.kind.length > 0) out.kind = raw.kind
+      return out
+    },
+  })
+  const homeRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/provision/$deploymentId',
+    component: () => <div data-testid="apps-target" />,
+  })
+  const jobDetailRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/provision/$deploymentId/jobs/$jobId',
+    component: () => <div data-testid="job-detail-target" />,
+  })
+  const tree = rootRoute.addChildren([jobsRoute, homeRoute, jobDetailRoute])
+  const router = createRouter({
+    routeTree: tree,
+    history: createMemoryHistory({ initialEntries: [initialEntry] }),
+  })
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  })
+  return render(
+    <QueryClientProvider client={qc}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>,
+  )
+}
+
+beforeEach(() => {
+  useWizardStore.setState({ ...INITIAL_WIZARD_STATE })
+  globalThis.fetch = (() =>
+    Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({ events: [], state: undefined, done: false }),
+    } as unknown as Response)) as typeof fetch
+})
+
+afterEach(() => cleanup())
+
+describe('JobsPage — List⇄Graph toggle', () => {
+  it('renders the segmented view toggle', async () => {
+    renderJobs('/provision/d-1/jobs?view=list&kind=lifecycle')
+    expect(await screen.findByTestId('jobs-page-view-toggle')).toBeTruthy()
+    expect(screen.getByTestId('jobs-page-view-list')).toBeTruthy()
+    expect(screen.getByTestId('jobs-page-view-graph')).toBeTruthy()
+  })
+
+  it('list view (default) renders the table + the JobKindChips strip', async () => {
+    renderJobs('/provision/d-1/jobs?view=list&kind=lifecycle')
+    expect(await screen.findByTestId('jobs-table')).toBeTruthy()
+    expect(screen.getByTestId('jobs-kind-chips')).toBeTruthy()
+    expect(screen.queryByTestId('jobs-graph-view')).toBeNull()
+  })
+
+  it('graph view (?view=graph) renders the graph, not the table or chips', async () => {
+    renderJobs('/provision/d-1/jobs?view=graph')
+    expect(await screen.findByTestId('jobs-graph-view')).toBeTruthy()
+    expect(screen.queryByTestId('jobs-table')).toBeNull()
+    // Chip strip is list-only.
+    expect(screen.queryByTestId('jobs-kind-chips')).toBeNull()
+  })
+
+  it('clicking the Graph toggle switches list → graph', async () => {
+    renderJobs('/provision/d-1/jobs?view=list&kind=lifecycle')
+    await screen.findByTestId('jobs-table')
+    fireEvent.click(screen.getByTestId('jobs-page-view-graph'))
+    expect(await screen.findByTestId('jobs-graph-view')).toBeTruthy()
+    expect(screen.queryByTestId('jobs-table')).toBeNull()
+  })
+})
+
+describe('JobsPage — list view filters to one kind (mirrors /cloud)', () => {
+  it('?kind=lifecycle shows the reducer first-paint rows', async () => {
+    renderJobs('/provision/d-1/jobs?view=list&kind=lifecycle')
+    await screen.findByTestId('jobs-table')
+    // cluster-bootstrap + bp-cilium are lifecycle-classified reducer rows.
+    expect(screen.queryByTestId('jobs-table-row-cluster-bootstrap')).toBeTruthy()
+    expect(screen.queryByTestId('jobs-table-row-bp-cilium')).toBeTruthy()
+  })
+
+  it('?kind=install hides the lifecycle-classified reducer rows', async () => {
+    renderJobs('/provision/d-1/jobs?view=list&kind=install')
+    await screen.findByTestId('jobs-table')
+    // Under the install lens the lifecycle first-paint rows are filtered out.
+    expect(screen.queryByTestId('jobs-table-row-cluster-bootstrap')).toBeNull()
+    expect(screen.queryByTestId('jobs-table-row-bp-cilium')).toBeNull()
+    // The empty-state row is what the operator sees instead.
+    expect(screen.getByTestId('jobs-table-empty')).toBeTruthy()
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsPage.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsPage.test.tsx
@@ -64,7 +64,15 @@ function renderJobs(deploymentId: string) {
   ])
   const router = createRouter({
     routeTree: tree,
-    history: createMemoryHistory({ initialEntries: [`/provision/${deploymentId}/jobs`] }),
+    // P1b (Refs #6703): /jobs now mirrors /cloud — list view shows ONE
+    // JobKind at a time (default `install`). The reducer first-paint rows
+    // this harness exercises all classify as `lifecycle` (their titles —
+    // "Install Cilium", "Provision infrastructure — …" — don't match the
+    // `install-` prefix, and groups are `group`), so the row-level
+    // assertions below select the `lifecycle` chip to see them all.
+    history: createMemoryHistory({
+      initialEntries: [`/provision/${deploymentId}/jobs?view=list&kind=lifecycle`],
+    }),
   })
   // Each render gets its own QueryClient so the live-jobs-backfill
   // query cache never bleeds between tests. Even with backfill

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsPage.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsPage.test.tsx
@@ -124,17 +124,28 @@ describe('JobsPage — table view (NOT accordion)', () => {
     expect(table.tagName.toLowerCase()).toBe('table')
   })
 
-  it('renders the canonical columns including Kind (issue #3646)', async () => {
+  it('drops the redundant per-row Kind column when the chip strip scopes the kind (#3646 intent preserved via chips)', async () => {
     renderJobs('d-1')
     const table = await screen.findByTestId('jobs-table')
     const headers = within(table).getAllByRole('columnheader').map((h) => (h.textContent ?? '').toLowerCase().trim())
-    // Kind inserted after Name (#3646); Runs after Status (#3925 run-history
-    // depth); Parent (not the legacy "batch") is the canonical column;
-    // Actions trails when a deploymentId is threaded (JobsPage threads it).
-    // Assert the stable left columns.
-    expect(headers.slice(0, 9)).toEqual([
-      'name', 'kind', 'app', 'deps', 'parent', 'status', 'runs', 'started', 'duration',
+    // The /jobs page mirrors /cloud: the chip strip single-selects the
+    // JobKind, so every visible row IS that kind — a per-row Kind column
+    // (and a second Kind filter dropdown) would be redundant. JobsPage
+    // passes kindScope, so JobsTable hides both. The kind is NOT lost:
+    // it is surfaced by the active chip (this preserves the #3646 intent
+    // that the typed kind stays visible — the unscoped JobsTable still
+    // renders the Kind column, covered in JobsTable.test.tsx).
+    expect(headers).not.toContain('kind')
+    // Runs after Status (#3925 run-history depth); Parent (not legacy
+    // "batch") is canonical; Actions trails when a deploymentId is threaded.
+    expect(headers.slice(0, 8)).toEqual([
+      'name', 'app', 'deps', 'parent', 'status', 'runs', 'started', 'duration',
     ])
+    // And the redundant Kind filter dropdown is gone from the table toolbar.
+    expect(screen.queryByTestId('jobs-filter-kind')).toBeNull()
+    // The kind IS surfaced — via the chip strip (active kind = lifecycle →
+    // the real engine label "OpenTofu", per JOB_ENGINE_LABELS.lifecycle).
+    expect(screen.getByTestId('jobs-kind-chips')).toBeTruthy()
   })
 
   it('does NOT render any legacy accordion testids', async () => {

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsPage.tsx
@@ -56,13 +56,23 @@
  * `status==ready`. This page is a PURE finite-jobs table.
  */
 
-import { useMemo } from 'react'
-import { Link } from '@tanstack/react-router'
+import { useCallback, useEffect, useMemo } from 'react'
+import { Link, useNavigate, useSearch } from '@tanstack/react-router'
 import { useResolvedDeploymentId } from '@/shared/lib/useResolvedDeploymentId'
 import { sovereignPathOrDeployments } from '@/shared/lib/sovereignPaths'
 import { useWizardStore } from '@/entities/deployment/store'
 import { PortalShell } from './PortalShell'
 import { JobsTable } from './JobsTable'
+import { JobsGraphView } from './JobsGraphView'
+import { JobKindChips } from './jobs-list/JobKindChips'
+import {
+  DEFAULT_JOB_KIND,
+  isValidJobKind,
+  readPersistedJobKind,
+  writePersistedJobKind,
+  type JobChipKind,
+} from './jobs-list/jobKinds'
+import { deriveJobKindCounts } from './jobs-list/jobKindCounts'
 import { resolveApplications } from './applicationCatalog'
 import { useDeploymentEvents } from './useDeploymentEvents'
 import { deriveJobs } from './jobs'
@@ -70,8 +80,28 @@ import { adaptDerivedJobsToFlat } from './jobsAdapter'
 import { useLiveJobsBackfill } from './useLiveJobsBackfill'
 import { DETECTED_MODE } from '@/shared/lib/detectMode'
 import type { Job } from '@/lib/jobs.types'
+import { jobKind } from '@/lib/jobs.types'
 import { HandoverRedirectBanner } from './HandoverRedirectBanner'
 import { HANDOVER_REDIRECT_BANNER_CSS } from './HandoverRedirectBanner.css'
+
+/* ── View mode (List ⇄ Graph toggle, P1b Refs #6703) ─────────────── */
+
+export type JobsView = 'list' | 'graph'
+const DEFAULT_JOBS_VIEW: JobsView = 'list'
+const JOBS_VIEW_STORAGE_KEY = 'sov-jobs-view'
+
+function isValidJobsView(value: unknown): value is JobsView {
+  return value === 'list' || value === 'graph'
+}
+
+function writePersistedJobsView(view: JobsView): void {
+  if (typeof window === 'undefined') return
+  try {
+    window.localStorage.setItem(JOBS_VIEW_STORAGE_KEY, view)
+  } catch {
+    /* noop */
+  }
+}
 
 interface JobsPageProps {
   /** Test seam — disables the live SSE EventSource attach. */
@@ -85,16 +115,22 @@ interface JobsPageProps {
    * or window.location. Production call sites never set this.
    */
   disableHandoverAutoRedirect?: boolean
+  /** Test seam — force the view irrespective of URL/storage (highest
+   *  precedence, mirroring CloudPage.viewOverride). */
+  viewOverride?: JobsView
 }
 
 export function JobsPage({
   disableStream = false,
   disableJobsBackfill = false,
   disableHandoverAutoRedirect = false,
+  viewOverride,
 }: JobsPageProps = {}) {
   const { deploymentId: resolvedId } = useResolvedDeploymentId()
   const deploymentId = resolvedId ?? ''
   const store = useWizardStore()
+  const navigate = useNavigate()
+  const search = useSearch({ strict: false }) as { view?: string; kind?: string }
 
   const applications = useMemo(
     () => resolveApplications(store.selectedComponents),
@@ -145,6 +181,71 @@ export function JobsPage({
   const handoverActive =
     handoverReady !== null && handoverURL !== '' && !isSovereignMode
 
+  /* ── View + kind resolution (P1b — mirror /cloud UX) ───────────── */
+  // Chroot-aware nav target: on the mothership monitor surface every link
+  // MUST stay scoped under /provision/<id>/jobs; on the Sovereign's adult
+  // hostname (DETECTED_MODE === 'sovereign') the id is implicit → /jobs.
+  const jobsPath = (id: string) =>
+    DETECTED_MODE.mode === 'sovereign' || !id ? '/jobs' : `/provision/${id}/jobs`
+
+  // Precedence: viewOverride → URL ?view= → default 'list'. The persisted
+  // value is WRITTEN on change but (like CloudPage) NOT consulted for the
+  // default, so a fresh /jobs load lands on List, never silently on Graph.
+  const activeView: JobsView = useMemo(() => {
+    if (viewOverride) return viewOverride
+    if (isValidJobsView(search.view)) return search.view
+    return DEFAULT_JOBS_VIEW
+  }, [viewOverride, search.view])
+
+  useEffect(() => {
+    writePersistedJobsView(activeView)
+  }, [activeView])
+
+  // Active kind: URL ?kind= → persisted → DEFAULT_JOB_KIND (mirror cloud).
+  const activeKind: JobChipKind = useMemo(() => {
+    if (isValidJobKind(search.kind)) return search.kind
+    return readPersistedJobKind() ?? DEFAULT_JOB_KIND
+  }, [search.kind])
+
+  useEffect(() => {
+    writePersistedJobKind(activeKind)
+  }, [activeKind])
+
+  function setView(next: JobsView) {
+    if (next === activeView) return
+    const target: { view: JobsView; kind?: string } = { view: next }
+    if (next === 'list' && typeof search.kind === 'string') target.kind = search.kind
+    navigate({
+      to: jobsPath(deploymentId) as never,
+      params: { deploymentId } as never,
+      search: target as never,
+      replace: false,
+    })
+  }
+
+  const setKind = useCallback(
+    (next: JobChipKind) => {
+      navigate({
+        to: jobsPath(deploymentId) as never,
+        params: { deploymentId } as never,
+        search: { view: 'list', kind: next } as never,
+        replace: false,
+      })
+    },
+    [navigate, deploymentId],
+  )
+
+  // Per-kind count map behind the chip badges — derived from the SAME
+  // flat list the table/graph render (production path, not a literal).
+  const kindCounts = useMemo(() => deriveJobKindCounts(flatJobs), [flatJobs])
+
+  // List view shows exactly one kind at a time (the /cloud contract).
+  // `jobKind()` reads the backend-stamped kind, never a name prefix.
+  const filteredByKind = useMemo(
+    () => flatJobs.filter((j) => jobKind(j) === activeKind),
+    [flatJobs, activeKind],
+  )
+
   return (
     <PortalShell
       deploymentId={deploymentId}
@@ -165,6 +266,7 @@ export function JobsPage({
       }
     >
       <style>{HANDOVER_REDIRECT_BANNER_CSS}</style>
+      <style>{JOBS_PAGE_TOOLBAR_CSS}</style>
 
       <HandoverRedirectBanner
         handoverURL={handoverURL}
@@ -184,12 +286,112 @@ export function JobsPage({
         </div>
       ) : null}
 
-      <div className="mt-6" data-testid="sov-jobs-list">
-        <JobsTable jobs={flatJobs} deploymentId={deploymentId} />
+      {/* Toolbar — segmented List/Graph toggle + (list view) the job-kind
+          chip strip. Mirrors CloudPage's toolbar (issue #366 / #3978). */}
+      <div className="jobs-page-toolbar mt-6" data-testid="jobs-page-toolbar">
+        <div
+          role="tablist"
+          aria-label="Jobs view"
+          className="jobs-page-view-toggle"
+          data-testid="jobs-page-view-toggle"
+        >
+          <button
+            type="button"
+            role="tab"
+            data-testid="jobs-page-view-list"
+            data-active={activeView === 'list' ? 'true' : 'false'}
+            aria-selected={activeView === 'list'}
+            aria-controls="jobs-page-content"
+            onClick={() => setView('list')}
+            className={`jobs-page-view-tab ${activeView === 'list' ? 'jobs-page-view-tab-active' : ''}`}
+          >
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.6} aria-hidden>
+              <line x1="4" y1="6" x2="20" y2="6" strokeLinecap="round" />
+              <line x1="4" y1="12" x2="20" y2="12" strokeLinecap="round" />
+              <line x1="4" y1="18" x2="20" y2="18" strokeLinecap="round" />
+            </svg>
+            <span>List</span>
+          </button>
+          <button
+            type="button"
+            role="tab"
+            data-testid="jobs-page-view-graph"
+            data-active={activeView === 'graph' ? 'true' : 'false'}
+            aria-selected={activeView === 'graph'}
+            aria-controls="jobs-page-content"
+            onClick={() => setView('graph')}
+            className={`jobs-page-view-tab ${activeView === 'graph' ? 'jobs-page-view-tab-active' : ''}`}
+          >
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.6} aria-hidden>
+              <circle cx="6" cy="6" r="2" />
+              <circle cx="18" cy="6" r="2" />
+              <circle cx="12" cy="18" r="2" />
+              <line x1="7.5" y1="7" x2="11" y2="16.5" strokeLinecap="round" />
+              <line x1="16.5" y1="7" x2="13" y2="16.5" strokeLinecap="round" />
+              <line x1="8" y1="6" x2="16" y2="6" strokeLinecap="round" />
+            </svg>
+            <span>Graph</span>
+          </button>
+        </div>
+
+        {activeView === 'list' ? (
+          <JobKindChips activeKind={activeKind} counts={kindCounts} onChange={setKind} />
+        ) : (
+          <span aria-hidden className="jobs-page-toolbar-spacer" />
+        )}
+      </div>
+
+      <div id="jobs-page-content" className="mt-4" data-testid="sov-jobs-list" data-view={activeView}>
+        {activeView === 'list' ? (
+          <JobsTable jobs={filteredByKind} deploymentId={deploymentId} />
+        ) : (
+          <JobsGraphView jobs={flatJobs} deploymentId={deploymentId} />
+        )}
       </div>
     </PortalShell>
   )
 }
+
+const JOBS_PAGE_TOOLBAR_CSS = `
+.jobs-page-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+.jobs-page-toolbar-spacer { flex: 1; }
+.jobs-page-toolbar > [data-testid="jobs-kind-chips"] {
+  flex: 1;
+  overflow-x: auto;
+}
+.jobs-page-view-toggle {
+  display: inline-flex;
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  overflow: hidden;
+  background: var(--color-bg-2);
+  flex-shrink: 0;
+}
+.jobs-page-view-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.4rem 0.85rem;
+  font-size: 0.82rem;
+  color: var(--color-text-dim);
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+  transition: background 0.12s ease, color 0.12s ease;
+}
+.jobs-page-view-tab:hover { color: var(--color-text); background: var(--color-surface-hover); }
+.jobs-page-view-tab svg { width: 16px; height: 16px; }
+.jobs-page-view-tab + .jobs-page-view-tab { border-left: 1px solid var(--color-border); }
+.jobs-page-view-tab-active {
+  background: color-mix(in srgb, var(--color-accent) 16%, transparent);
+  color: var(--color-accent);
+  font-weight: 600;
+}
+`
 
 /**
  * markProvisional flags reducer-derived rows whose status is still

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsPage.tsx
@@ -343,7 +343,7 @@ export function JobsPage({
 
       <div id="jobs-page-content" className="mt-4" data-testid="sov-jobs-list" data-view={activeView}>
         {activeView === 'list' ? (
-          <JobsTable jobs={filteredByKind} deploymentId={deploymentId} />
+          <JobsTable jobs={filteredByKind} deploymentId={deploymentId} kindScope={activeKind} />
         ) : (
           <JobsGraphView jobs={flatJobs} deploymentId={deploymentId} />
         )}

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsTable.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsTable.tsx
@@ -288,13 +288,26 @@ interface JobsTableProps {
    * control is hidden (e.g. a preview surface with no live cluster).
    */
   deploymentId?: string
+  /**
+   * When the PARENT already scopes the list to a single JobKind (the
+   * /jobs page's chip strip, P1b), the table's own Kind filter dropdown
+   * and Kind column are redundant — every visible row is that one kind.
+   * Setting kindScope hides both, exactly as `appIdFilter` hides the App
+   * dropdown, so /jobs mirrors the /cloud single-kind list contract with
+   * no double kind selector. Rows are assumed pre-filtered by the caller;
+   * the internal kindFilter stays neutral.
+   */
+  kindScope?: JobKind
 }
 
 const STATUS_VALUES: readonly JobStatus[] = [
   'running', 'pending', 'succeeded', 'failed', 'healthy', 'degraded', 'failing',
 ]
 
-export function JobsTable({ jobs, appIdFilter, initialParentFilter, deploymentId }: JobsTableProps) {
+export function JobsTable({ jobs, appIdFilter, initialParentFilter, deploymentId, kindScope }: JobsTableProps) {
+  // When the parent scopes to one kind (the /jobs chip strip) the Kind
+  // filter + Kind column are redundant; hide both.
+  const showKind = !kindScope
   const [search, setSearch] = useState<string>('')
   const [statusFilter, setStatusFilter] = useState<'' | JobStatus>('')
   const [kindFilter, setKindFilter] = useState<'' | JobKind>('')
@@ -455,24 +468,27 @@ export function JobsTable({ jobs, appIdFilter, initialParentFilter, deploymentId
 
           {/* Kind filter (issue #3646) — scope the canvas to a single
               activity kind (cron / reconcile / install / task / …). Only
-              the kinds actually present render as options. */}
-          <label className="jobs-filter-label">
-            <span className="jobs-filter-caption">Kind</span>
-            <select
-              value={kindFilter}
-              onChange={(e) => setKindFilter(e.target.value as '' | JobKind)}
-              className="jobs-filter-select"
-              data-testid="jobs-filter-kind"
-              aria-label="Filter by kind"
-            >
-              <option value="">All</option>
-              {kindOptions.map((k) => (
-                <option key={k} value={k}>
-                  {JOB_ENGINE_LABELS[k] ?? k}
-                </option>
-              ))}
-            </select>
-          </label>
+              the kinds actually present render as options. Hidden when the
+              parent already scopes to one kind via the chip strip (P1b). */}
+          {showKind ? (
+            <label className="jobs-filter-label">
+              <span className="jobs-filter-caption">Kind</span>
+              <select
+                value={kindFilter}
+                onChange={(e) => setKindFilter(e.target.value as '' | JobKind)}
+                className="jobs-filter-select"
+                data-testid="jobs-filter-kind"
+                aria-label="Filter by kind"
+              >
+                <option value="">All</option>
+                {kindOptions.map((k) => (
+                  <option key={k} value={k}>
+                    {JOB_ENGINE_LABELS[k] ?? k}
+                  </option>
+                ))}
+              </select>
+            </label>
+          ) : null}
 
           {appIdFilter ? null : (
             <label className="jobs-filter-label">
@@ -558,8 +574,9 @@ export function JobsTable({ jobs, appIdFilter, initialParentFilter, deploymentId
             <tr>
               <th data-col="name">Name</th>
               {/* Kind column (issue #3646) — the typed activity kind, read
-                  from job.kind (never a JobName-prefix string-match). */}
-              <th data-col="kind">Kind</th>
+                  from job.kind (never a JobName-prefix string-match).
+                  Hidden when kindScope is set (every row is that kind). */}
+              {showKind ? <th data-col="kind">Kind</th> : null}
               <th data-col="app">App</th>
               {/* Region column — shown only on a multi-region Sovereign
                   (2+ distinct regions in the job set), matching the
@@ -585,10 +602,10 @@ export function JobsTable({ jobs, appIdFilter, initialParentFilter, deploymentId
             {visibleJobs.length === 0 ? (
               <tr>
                 {/* base 8 cols (name,app,deps,parent,status,runs,started,
-                    duration) + Kind (+1) + Region (showRegion) + Actions
-                    (deploymentId). */}
+                    duration) + Kind (showKind) + Region (showRegion) +
+                    Actions (deploymentId). */}
                 <td
-                  colSpan={9 + (showRegion ? 1 : 0) + (deploymentId ? 1 : 0)}
+                  colSpan={8 + (showKind ? 1 : 0) + (showRegion ? 1 : 0) + (deploymentId ? 1 : 0)}
                   className="jobs-empty"
                   data-testid="jobs-table-empty"
                 >
@@ -602,6 +619,7 @@ export function JobsTable({ jobs, appIdFilter, initialParentFilter, deploymentId
                   job={j}
                   parentLabel={parentLabelById.get(j.parentId) ?? j.parentId}
                   showRegion={showRegion}
+                  showKind={showKind}
                   regionUnionByGroupId={regionUnionByGroupId}
                   deploymentId={deploymentId}
                 />
@@ -620,6 +638,9 @@ interface JobRowProps {
   /** Render the Region cell — true only on a multi-region Sovereign so
       a single-region table keeps its original column set. */
   showRegion: boolean
+  /** Render the Kind cell — false when the parent scopes to one kind
+      (the /jobs chip strip), so the constant column is dropped. */
+  showKind: boolean
   /** Distinct region keys per group id (regionUnionOfGroup output) —
       drives the group-row Region cell union and the Parent chip's
       hover title on a multi-region Sovereign. */
@@ -677,7 +698,7 @@ function useJobLinkBuilder(): (jobId: string) => string {
   }
 }
 
-function JobRow({ job, parentLabel, showRegion, regionUnionByGroupId, deploymentId }: JobRowProps) {
+function JobRow({ job, parentLabel, showRegion, showKind, regionUnionByGroupId, deploymentId }: JobRowProps) {
   const started = formatRelative(job.startedAt)
   const jobLink = useJobLinkBuilder()
   const region = regionFromJob(job)
@@ -708,17 +729,19 @@ function JobRow({ job, parentLabel, showRegion, regionUnionByGroupId, deployment
           {job.displayName ?? job.jobName}
         </Link>
       </td>
-      <td className="jobs-cell jobs-cell-kind">
-        {/* Kind chip — read from job.kind (issue #3646), never inferred
-            from a JobName prefix. */}
-        <span
-          className={`jobs-kind-chip jobs-kind-${kind}`}
-          data-testid={`jobs-cell-kind-${job.id}`}
-          data-kind={kind}
-        >
-          {JOB_ENGINE_LABELS[kind] ?? kind}
-        </span>
-      </td>
+      {showKind ? (
+        <td className="jobs-cell jobs-cell-kind">
+          {/* Kind chip — read from job.kind (issue #3646), never inferred
+              from a JobName prefix. */}
+          <span
+            className={`jobs-kind-chip jobs-kind-${kind}`}
+            data-testid={`jobs-cell-kind-${job.id}`}
+            data-kind={kind}
+          >
+            {JOB_ENGINE_LABELS[kind] ?? kind}
+          </span>
+        </td>
+      ) : null}
       <td className="jobs-cell jobs-cell-app">
         {job.appId ? (
           <Chip text={job.appId} testid={`jobs-cell-app-${job.id}`} kind="app" />

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/jobs-list/JobKindChips.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/jobs-list/JobKindChips.test.tsx
@@ -1,0 +1,108 @@
+/**
+ * JobKindChips.test.tsx — P1b (Refs #6703).
+ *
+ * The /jobs chip strip is a pure renderer over the JOB_KINDS catalogue.
+ * These guards pin the operator-visible contract:
+ *   • chips render the REAL engine labels (HelmRelease / CronJob / …),
+ *     never a fabricated abstraction;
+ *   • a non-active chip whose count is exactly 0 is HIDDEN (founder rule —
+ *     don't show an engine with no rows), while the ACTIVE chip stays
+ *     visible even at 0 so context survives navigating to an empty kind;
+ *   • clicking a chip fires onChange with that kind id;
+ *   • the overflow engines live in the `+ More` popover with their labels.
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { cleanup, render, screen, fireEvent } from '@testing-library/react'
+import type { JobKind } from '@/lib/jobs.types'
+import { JobKindChips } from './JobKindChips'
+import { JOB_ENGINE_LABELS } from '@/lib/jobs.types'
+
+afterEach(cleanup)
+
+function counts(overrides: Partial<Record<JobKind, number | null>>): Record<JobKind, number | null> {
+  const base = {
+    install: 0, reconcile: 0, step: 0, mutation: 0,
+    cron: 0, task: 0, reconciler: 0, lifecycle: 0, group: 0,
+  } as Record<JobKind, number | null>
+  return { ...base, ...overrides }
+}
+
+describe('JobKindChips', () => {
+  it('renders primary chips with their REAL engine labels', () => {
+    render(
+      <JobKindChips
+        activeKind="install"
+        counts={counts({ install: 5, cron: 3, mutation: 2, lifecycle: 1 })}
+        onChange={() => {}}
+      />,
+    )
+    // Labels come from JOB_ENGINE_LABELS — assert the actual engine names.
+    expect(screen.getByTestId('jobs-kind-chip-install').textContent).toContain(JOB_ENGINE_LABELS.install) // HelmRelease
+    expect(screen.getByTestId('jobs-kind-chip-cron').textContent).toContain(JOB_ENGINE_LABELS.cron) // CronJob
+    expect(screen.getByTestId('jobs-kind-chip-mutation').textContent).toContain(JOB_ENGINE_LABELS.mutation) // Crossplane
+    expect(screen.getByTestId('jobs-kind-chip-lifecycle').textContent).toContain(JOB_ENGINE_LABELS.lifecycle) // OpenTofu
+    // The active chip's count badge shows the number.
+    expect(screen.getByTestId('jobs-kind-chip-install-count').textContent).toBe('5')
+  })
+
+  it('HIDES a non-active chip whose count is exactly 0', () => {
+    render(
+      <JobKindChips
+        activeKind="install"
+        counts={counts({ install: 5, step: 0, task: 0 })}
+        onChange={() => {}}
+      />,
+    )
+    // step + task are primary but 0 and non-active → not rendered.
+    expect(screen.queryByTestId('jobs-kind-chip-step')).toBeNull()
+    expect(screen.queryByTestId('jobs-kind-chip-task')).toBeNull()
+    // install stays (active).
+    expect(screen.queryByTestId('jobs-kind-chip-install')).toBeTruthy()
+  })
+
+  it('keeps the ACTIVE chip visible even when its count is 0', () => {
+    render(
+      <JobKindChips
+        activeKind="step"
+        counts={counts({ step: 0, install: 4 })}
+        onChange={() => {}}
+      />,
+    )
+    const active = screen.getByTestId('jobs-kind-chip-step')
+    expect(active).toBeTruthy()
+    expect(active.getAttribute('data-active')).toBe('true')
+    expect(screen.getByTestId('jobs-kind-chip-step-count').textContent).toBe('0')
+  })
+
+  it('fires onChange with the clicked kind id', () => {
+    const onChange = vi.fn()
+    render(
+      <JobKindChips
+        activeKind="install"
+        counts={counts({ install: 5, cron: 3 })}
+        onChange={onChange}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('jobs-kind-chip-cron'))
+    expect(onChange).toHaveBeenCalledWith('cron')
+  })
+
+  it('exposes the overflow engines (Kustomization / Deployment) in the + More popover', () => {
+    const onChange = vi.fn()
+    render(
+      <JobKindChips
+        activeKind="install"
+        counts={counts({ install: 5, reconcile: 2, reconciler: 1 })}
+        onChange={onChange}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('jobs-kind-chip-more'))
+    const reconcileItem = screen.getByTestId('jobs-kind-chip-more-item-reconcile')
+    const reconcilerItem = screen.getByTestId('jobs-kind-chip-more-item-reconciler')
+    expect(reconcileItem.textContent).toContain(JOB_ENGINE_LABELS.reconcile) // Kustomization
+    expect(reconcilerItem.textContent).toContain(JOB_ENGINE_LABELS.reconciler) // Deployment
+    fireEvent.click(reconcilerItem)
+    expect(onChange).toHaveBeenCalledWith('reconciler')
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/jobs-list/JobKindChips.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/jobs-list/JobKindChips.tsx
@@ -1,0 +1,377 @@
+/**
+ * JobKindChips — compact horizontal chip strip rendered in the JobsPage
+ * toolbar in list view (P1b, Refs #6703). A pixel-for-pixel clone of
+ * CloudKindChips: the /jobs surface mirrors the /cloud (Resources) UX.
+ *
+ * Layout contract:
+ *   • Primary chips (JOB_KINDS `primary: true`) render inline; a trailing
+ *     `+ More` button opens a portaled popover with the overflow chips.
+ *   • Each chip ≈ 28px tall: small icon + REAL engine label + count badge.
+ *     Active chip uses the accent colour + stroke.
+ *   • Click → fires `onChange(kind)`; single-select, exactly like Cloud.
+ *   • A non-active chip whose count is exactly 0 is hidden (the founder
+ *     rule: don't show a chip the operator can't meaningfully click). The
+ *     active chip stays visible even at 0 so context isn't lost.
+ *
+ * Per docs/INVIOLABLE-PRINCIPLES.md #4 (never hardcode) every label/icon
+ * flows through the JOB_KINDS catalogue in jobKinds.ts; this is a pure
+ * renderer. Labels are the engine names (HelmRelease / Kustomization / …).
+ */
+
+import { useEffect, useLayoutEffect, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
+import type { JobKind } from '@/lib/jobs.types'
+import {
+  JOB_KINDS,
+  type JobKindEntry,
+  type JobChipKind,
+} from './jobKinds'
+
+interface JobKindChipsProps {
+  /** Currently active kind. */
+  activeKind: JobChipKind
+  /** Per-kind count map. `null` renders "—" (jobs counts are never null). */
+  counts: Record<JobKind, number | null>
+  /** Switch to a different kind. */
+  onChange: (next: JobChipKind) => void
+}
+
+export function JobKindChips({ activeKind, counts, onChange }: JobKindChipsProps) {
+  const primary = JOB_KINDS.filter((k) => k.primary)
+  const overflow = JOB_KINDS.filter((k) => !k.primary)
+  const activeInOverflow = overflow.some((k) => k.id === activeKind)
+
+  return (
+    <div
+      className="jobs-kind-chips"
+      data-testid="jobs-kind-chips"
+      role="tablist"
+      aria-label="Job kind"
+    >
+      <style>{JOB_KIND_CHIPS_CSS}</style>
+      {primary.map((k) => (
+        <KindChip
+          key={k.id}
+          kind={k}
+          active={k.id === activeKind}
+          count={counts[k.id]}
+          onClick={() => onChange(k.id)}
+        />
+      ))}
+      <MoreChipPopover
+        items={overflow}
+        counts={counts}
+        activeKind={activeKind}
+        activeInGroup={activeInOverflow}
+        onChange={onChange}
+      />
+    </div>
+  )
+}
+
+/* ── Single chip ────────────────────────────────────────────────── */
+
+interface KindChipProps {
+  kind: JobKindEntry
+  active: boolean
+  count: number | null
+  onClick: () => void
+}
+
+function KindChip({ kind, active, count, onClick }: KindChipProps) {
+  const showCount = count !== null
+  // Hide a non-active chip whose count is exactly 0 — the operator can't
+  // meaningfully click an engine with no rows. The active chip stays
+  // visible even at 0 so context survives navigating to an empty kind.
+  if (!active && showCount && count === 0) {
+    return null
+  }
+  return (
+    <button
+      type="button"
+      role="tab"
+      aria-selected={active}
+      aria-pressed={active}
+      data-testid={`jobs-kind-chip-${kind.id}`}
+      data-kind={kind.id}
+      data-active={active ? 'true' : 'false'}
+      data-category={kind.category}
+      className={`jobs-kind-chip${active ? ' jobs-kind-chip-active' : ''}`}
+      onClick={onClick}
+    >
+      <span className="jobs-kind-chip-icon" aria-hidden>
+        <svg
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={1.6}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <path d={kind.icon} />
+        </svg>
+      </span>
+      <span className="jobs-kind-chip-label">{kind.label}</span>
+      <span
+        className="jobs-kind-chip-count"
+        data-testid={`jobs-kind-chip-${kind.id}-count`}
+      >
+        {showCount ? count : '—'}
+      </span>
+    </button>
+  )
+}
+
+/* ── More-chip overflow popover ─────────────────────────────────── */
+
+interface MoreChipPopoverProps {
+  items: JobKindEntry[]
+  counts: Record<JobKind, number | null>
+  activeKind: JobChipKind
+  activeInGroup: boolean
+  onChange: (next: JobChipKind) => void
+}
+
+function MoreChipPopover({
+  items,
+  counts,
+  activeKind,
+  activeInGroup,
+  onChange,
+}: MoreChipPopoverProps) {
+  const [open, setOpen] = useState(false)
+  const wrapRef = useRef<HTMLDivElement | null>(null)
+  const popoverRef = useRef<HTMLDivElement | null>(null)
+  const [coords, setCoords] = useState<{ left: number; top: number } | null>(null)
+
+  // Click-outside dismissal — match against BOTH the +More button AND the
+  // portaled popover (different DOM trees).
+  useEffect(() => {
+    if (!open) return
+    function onDoc(ev: MouseEvent) {
+      const t = ev.target as Node | null
+      if (!wrapRef.current?.contains(t) && !popoverRef.current?.contains(t)) {
+        setOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', onDoc)
+    return () => document.removeEventListener('mousedown', onDoc)
+  }, [open])
+
+  // Position the portaled popover under the +More button; recompute on
+  // open + on viewport scroll/resize so the anchor stays correct.
+  useLayoutEffect(() => {
+    // When closed the popover render is gated on `open`, so stale coords
+    // are harmless — no need to setState here (avoids a cascading render).
+    if (!open) return
+    function reposition() {
+      const btn = wrapRef.current?.querySelector(
+        '[data-testid="jobs-kind-chip-more"]',
+      ) as HTMLElement | null
+      if (!btn) return
+      const r = btn.getBoundingClientRect()
+      setCoords({ left: r.right, top: r.bottom + 6 })
+    }
+    reposition()
+    window.addEventListener('resize', reposition)
+    window.addEventListener('scroll', reposition, true)
+    return () => {
+      window.removeEventListener('resize', reposition)
+      window.removeEventListener('scroll', reposition, true)
+    }
+  }, [open])
+
+  const popover = open && coords && typeof document !== 'undefined' ? (
+    createPortal(
+      <div
+        ref={popoverRef}
+        data-testid="jobs-kind-chip-more-popover"
+        role="menu"
+        className="jobs-kind-chip-more-pop"
+        style={{
+          position: 'fixed',
+          left: coords.left,
+          top: coords.top,
+          transform: 'translateX(-100%)',
+        }}
+      >
+        {items.map((k) => {
+          const c = counts[k.id]
+          const showCount = c !== null
+          const active = k.id === activeKind
+          return (
+            <button
+              key={k.id}
+              type="button"
+              role="menuitemradio"
+              aria-checked={active}
+              data-testid={`jobs-kind-chip-more-item-${k.id}`}
+              onClick={() => {
+                onChange(k.id)
+                setOpen(false)
+              }}
+              className={`jobs-kind-chip-more-item${
+                active ? ' jobs-kind-chip-more-item-active' : ''
+              }`}
+            >
+              <span className="jobs-kind-chip-icon" aria-hidden>
+                <svg
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth={1.6}
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <path d={k.icon} />
+                </svg>
+              </span>
+              <span className="jobs-kind-chip-more-item-label">{k.label}</span>
+              <span className="jobs-kind-chip-count">{showCount ? c : '—'}</span>
+            </button>
+          )
+        })}
+      </div>,
+      document.body,
+    )
+  ) : null
+
+  return (
+    <div className="jobs-kind-chip-more-wrap" ref={wrapRef}>
+      <button
+        type="button"
+        data-testid="jobs-kind-chip-more"
+        data-active={activeInGroup ? 'true' : 'false'}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        onClick={() => setOpen((v) => !v)}
+        className={`jobs-kind-chip jobs-kind-chip-more${
+          activeInGroup ? ' jobs-kind-chip-active' : ''
+        }`}
+      >
+        <span aria-hidden>+</span>
+        <span className="jobs-kind-chip-label">More</span>
+      </button>
+      {popover}
+    </div>
+  )
+}
+
+/* ── Local CSS ──────────────────────────────────────────────────── */
+
+const JOB_KIND_CHIPS_CSS = `
+.jobs-kind-chips {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  flex-wrap: wrap;
+}
+.jobs-kind-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  height: 28px;
+  padding: 0 0.6rem;
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  background: var(--color-bg-2);
+  color: var(--color-text-dim);
+  font-size: 0.78rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.12s ease, color 0.12s ease, border-color 0.12s ease;
+  white-space: nowrap;
+}
+.jobs-kind-chip:hover {
+  color: var(--color-text);
+  border-color: color-mix(in srgb, var(--color-accent) 50%, var(--color-border));
+}
+.jobs-kind-chip:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+.jobs-kind-chip-active {
+  background: color-mix(in srgb, var(--color-accent) 14%, var(--color-bg-2));
+  border-color: var(--color-accent);
+  color: var(--color-accent);
+  font-weight: 600;
+}
+.jobs-kind-chip-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+}
+.jobs-kind-chip-icon svg {
+  width: 16px;
+  height: 16px;
+}
+/* Reconciler engines (HelmRelease / Kustomization / Deployment) — violet,
+   matching the Cloud reconciler family so the cross-surface family reads. */
+.jobs-kind-chip[data-category="reconciler"] .jobs-kind-chip-icon { color: #a78bfa; }
+/* Bounded processes (Job step / Job task / CronJob) — blue. */
+.jobs-kind-chip[data-category="process"] .jobs-kind-chip-icon { color: #60a5fa; }
+/* Crossplane mutations — amber. */
+.jobs-kind-chip[data-category="mutation"] .jobs-kind-chip-icon { color: #f59e0b; }
+/* OpenTofu lifecycle — green. */
+.jobs-kind-chip[data-category="lifecycle"] .jobs-kind-chip-icon { color: #34d399; }
+.jobs-kind-chip-active .jobs-kind-chip-icon {
+  color: var(--color-accent);
+}
+.jobs-kind-chip-label { line-height: 1; }
+.jobs-kind-chip-count {
+  font-size: 0.68rem;
+  font-weight: 600;
+  padding: 0.04rem 0.4rem;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--color-border) 60%, transparent);
+  color: var(--color-text-dim);
+  font-variant-numeric: tabular-nums;
+}
+.jobs-kind-chip-active .jobs-kind-chip-count {
+  background: color-mix(in srgb, var(--color-accent) 22%, transparent);
+  color: var(--color-accent);
+}
+
+.jobs-kind-chip-more-wrap { position: relative; z-index: 50; }
+.jobs-kind-chip-more { color: var(--color-text); }
+.jobs-kind-chip-more-pop {
+  position: absolute;
+  right: 0;
+  top: calc(100% + 6px);
+  z-index: 2000;
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  min-width: 13rem;
+  padding: 0.35rem;
+  border-radius: 10px;
+  border: 1px solid var(--color-border);
+  background: var(--color-bg-2);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
+}
+.jobs-kind-chip-more-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  padding: 0.4rem 0.55rem;
+  border: 0;
+  background: transparent;
+  border-radius: 6px;
+  color: var(--color-text);
+  font-size: 0.82rem;
+  cursor: pointer;
+  text-align: left;
+  width: 100%;
+}
+.jobs-kind-chip-more-item:hover {
+  background: var(--color-surface-hover);
+}
+.jobs-kind-chip-more-item-active {
+  background: color-mix(in srgb, var(--color-accent) 12%, transparent);
+  color: var(--color-accent);
+  font-weight: 600;
+}
+.jobs-kind-chip-more-item-label { flex: 1; }
+`

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/jobs-list/jobKindCounts.test.ts
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/jobs-list/jobKindCounts.test.ts
@@ -1,0 +1,88 @@
+/**
+ * jobKindCounts.test.ts — P1b (Refs #6703).
+ *
+ * `deriveJobKindCounts` is the production derivation behind the /jobs
+ * chip badges. These guards pin:
+ *   • the tally is per `jobKind(j)` — the backend-stamped kind wins, and a
+ *     legacy row with no `kind` derives from its jobName prefix;
+ *   • `group` rows are EXCLUDED (a synthesised parent is not an engine);
+ *   • a kind with no rows reports 0 (not undefined) so the chip can apply
+ *     its "hide 0-count non-active" rule on a real number.
+ */
+
+import { describe, it, expect } from 'vitest'
+import type { Job, JobKind, JobType } from '@/lib/jobs.types'
+import { deriveJobKindCounts } from './jobKindCounts'
+
+function job(id: string, opts: Partial<Job> = {}): Job {
+  return {
+    id,
+    jobName: opts.jobName ?? id,
+    type: (opts.type ?? 'install') as JobType,
+    appId: '',
+    parentId: '',
+    dependsOn: [],
+    childIds: [],
+    status: 'succeeded',
+    startedAt: null,
+    finishedAt: null,
+    durationMs: 0,
+    ...opts,
+  }
+}
+
+describe('deriveJobKindCounts', () => {
+  it('tallies each job under its backend-stamped kind', () => {
+    const counts = deriveJobKindCounts([
+      job('a', { kind: 'install' }),
+      job('b', { kind: 'install' }),
+      job('c', { kind: 'cron' }),
+      job('d', { kind: 'mutation' }),
+      job('e', { kind: 'step' }),
+    ])
+    expect(counts.install).toBe(2)
+    expect(counts.cron).toBe(1)
+    expect(counts.mutation).toBe(1)
+    expect(counts.step).toBe(1)
+  })
+
+  it('reports 0 (not undefined) for a kind with no rows', () => {
+    const counts = deriveJobKindCounts([job('a', { kind: 'install' })])
+    expect(counts.reconciler).toBe(0)
+    expect(counts.task).toBe(0)
+    expect(counts.lifecycle).toBe(0)
+  })
+
+  it('EXCLUDES group rows — a synthesised parent is not a filterable engine', () => {
+    const counts = deriveJobKindCounts([
+      job('grp', { type: 'group', kind: 'group', childIds: ['a'] }),
+      job('a', { kind: 'install', parentId: 'grp' }),
+    ])
+    // The group must NOT be counted anywhere; only the install leaf is.
+    expect(counts.group).toBe(0)
+    expect(counts.install).toBe(1)
+    const total = (Object.keys(counts) as JobKind[]).reduce((s, k) => s + counts[k], 0)
+    expect(total).toBe(1)
+  })
+
+  it('derives a legacy row with no kind from its jobName prefix (jobKind, not the raw name)', () => {
+    const counts = deriveJobKindCounts([
+      job('x', { jobName: 'install-openbao' }), // no kind → jobKind → install
+      job('y', { jobName: 'cron-trivy-scan' }), // no kind → jobKind → cron
+      job('z', { jobName: 'anything-else' }), // no prefix match → lifecycle
+    ])
+    expect(counts.install).toBe(1)
+    expect(counts.cron).toBe(1)
+    expect(counts.lifecycle).toBe(1)
+  })
+
+  it('empty input yields an all-zero map with every JobKind key present', () => {
+    const counts = deriveJobKindCounts([])
+    for (const k of [
+      'install', 'reconcile', 'step', 'mutation',
+      'cron', 'task', 'reconciler', 'lifecycle', 'group',
+    ] as JobKind[]) {
+      expect(counts[k]).toBe(0)
+    }
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/jobs-list/jobKindCounts.ts
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/jobs-list/jobKindCounts.ts
@@ -1,0 +1,43 @@
+/**
+ * jobs-list/jobKindCounts.ts — the per-kind count map behind the /jobs
+ * chip badges (P1b, Refs #6703).
+ *
+ * The jobs analogue of cloud-list/kindCounts.ts. Extracted as PRODUCTION
+ * code (not a hand-built literal in a test) so a guard can assert on the
+ * VALUE the page actually renders — handing JobKindChips a synthetic
+ * `counts` prop would prove nothing about what the operator sees.
+ *
+ * Semantics:
+ *   • Every JobKind key is present and starts at 0.
+ *   • Each job is tallied under `jobKind(j)` — the canonical "read the
+ *     kind, not the name-prefix" accessor (issue #3646). `group` rows are
+ *     EXCLUDED (a synthesised parent is not an engine you filter by), so
+ *     the `group` bucket stays 0.
+ */
+
+import type { Job, JobKind } from '@/lib/jobs.types'
+import { jobKind } from '@/lib/jobs.types'
+
+const ALL_JOB_KINDS: readonly JobKind[] = [
+  'install',
+  'reconcile',
+  'step',
+  'mutation',
+  'cron',
+  'task',
+  'reconciler',
+  'lifecycle',
+  'group',
+]
+
+export function deriveJobKindCounts(jobs: readonly Job[]): Record<JobKind, number> {
+  const counts = {} as Record<JobKind, number>
+  for (const k of ALL_JOB_KINDS) counts[k] = 0
+  for (const j of jobs) {
+    const k = jobKind(j)
+    // Groups are synthesised parents — never a filterable engine.
+    if (k === 'group') continue
+    counts[k] = (counts[k] ?? 0) + 1
+  }
+  return counts
+}

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/jobs-list/jobKinds.ts
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/jobs-list/jobKinds.ts
@@ -1,0 +1,118 @@
+/**
+ * jobs-list/jobKinds.ts — single source of truth for the /jobs parent
+ * surface's job-kind chip catalogue (P1b, Refs #6703).
+ *
+ * The jobs analogue of cloud-list/kinds.ts: the /jobs page mirrors the
+ * /cloud (Resources) page's UX — a per-kind chip strip that single-selects
+ * the JobKind the list view filters to, plus a List⇄Graph toggle. This
+ * catalogue drives the chip strip exactly as `KINDS` drives CloudKindChips.
+ *
+ * Two hard rules (docs/INVIOLABLE-PRINCIPLES.md #4 — never hardcode):
+ *   1. The chip catalogue covers every `JobKind` value EXCEPT `group`
+ *      (a synthesised parent row is not an engine an operator filters by).
+ *   2. Each chip's LABEL is the REAL engine name, taken verbatim from
+ *      `JOB_ENGINE_LABELS` in lib/jobs.types.ts (founder 2026-08-26 — "show
+ *      the jobs with their real engine names"). There is no second label
+ *      map to drift out of sync: JOB_KIND_LABEL below reads that constant.
+ */
+
+import type { JobKind } from '@/lib/jobs.types'
+import { JOB_ENGINE_LABELS } from '@/lib/jobs.types'
+
+/**
+ * The JobKind ids that get a chip — every `JobKind` EXCEPT `group`.
+ * Declared as a typed tuple so the catalogue below can never drift from
+ * the canonical `JobKind` union without a compile error.
+ */
+export type JobChipKind = Exclude<JobKind, 'group'>
+
+export interface JobKindEntry {
+  id: JobChipKind
+  /** REAL engine label — always sourced from JOB_ENGINE_LABELS. */
+  label: string
+  /** Free-form one-line tagline (subtitles / hover context). */
+  tagline: string
+  /** SVG path data on the canonical 24x24 viewBox — Tabler-style. */
+  icon: string
+  /** Conceptual category (drives the chip-tint colour in JobKindChips). */
+  category: 'reconciler' | 'process' | 'mutation' | 'lifecycle'
+  /** True → renders inline in the chip strip; false → `+ More` popover. */
+  primary: boolean
+}
+
+/* Tabler / lucide-style outlines on the 24x24 viewBox. */
+const ICON_HELMRELEASE =
+  'M12 3a9 9 0 1 0 9 9M12 3v9l6.5 6.5M12 3a9 9 0 0 1 9 9h-9'
+const ICON_KUSTOMIZATION =
+  'M12 3l8 4 -8 4 -8 -4zM4 11l8 4 8 -4M4 15l8 4 8 -4'
+const ICON_DEPLOYMENT =
+  'M5 4h6v6H5zM13 4h6v6h-6zM5 14h6v6H5zM13 14h6v6h-6z'
+const ICON_CRONJOB =
+  'M12 3a9 9 0 1 0 0 18a9 9 0 0 0 0 -18zM12 8v4l3 2'
+const ICON_JOB_STEP =
+  'M4 5h16v14H4zM9 9l5 3 -5 3z'
+const ICON_JOB_TASK =
+  'M4 7h9M4 12h9M4 17h6M15 8l2 2 4 -4'
+const ICON_CROSSPLANE =
+  'M12 3l8 4v10l-8 4 -8 -4V7zM4 7l8 4 8 -4M12 11v10'
+const ICON_OPENTOFU =
+  'M4 12a8 8 0 0 1 13.7 -5.6L20 8M20 4v4h-4M20 12a8 8 0 0 1 -13.7 5.6L4 16M4 20v-4h4'
+
+/**
+ * Canonical job-kind catalogue. Order matters — `primary: true` entries
+ * render inline in the chip strip; everything else lives in the `+ More`
+ * popover. Labels are pulled from JOB_ENGINE_LABELS so the chip text and
+ * the JobsTable Kind column always read the same engine name.
+ */
+export const JOB_KINDS: readonly JobKindEntry[] = [
+  // Primary chips — the most-used finite-work engines stay inline.
+  { id: 'install', label: JOB_ENGINE_LABELS.install, tagline: 'Flux HelmRelease install leaves — one per Blueprint.', icon: ICON_HELMRELEASE, category: 'reconciler', primary: true },
+  { id: 'step', label: JOB_ENGINE_LABELS.step, tagline: 'One step of a projected activity (provision / cutover).', icon: ICON_JOB_STEP, category: 'process', primary: true },
+  { id: 'task', label: JOB_ENGINE_LABELS.task, tagline: 'Standalone / owned batch Kubernetes Jobs.', icon: ICON_JOB_TASK, category: 'process', primary: true },
+  { id: 'cron', label: JOB_ENGINE_LABELS.cron, tagline: 'Recurring CronJob runs — each run is an Execution.', icon: ICON_CRONJOB, category: 'process', primary: true },
+  { id: 'mutation', label: JOB_ENGINE_LABELS.mutation, tagline: 'Day-2 Crossplane XRC submissions.', icon: ICON_CROSSPLANE, category: 'mutation', primary: true },
+  { id: 'lifecycle', label: JOB_ENGINE_LABELS.lifecycle, tagline: 'Phase-0 / lifecycle OpenTofu runs.', icon: ICON_OPENTOFU, category: 'lifecycle', primary: true },
+
+  /* ── Overflow — accessible via the `+ More` popover ───────────── */
+  // The open-ended reconcilers are excluded from /jobs by the backend
+  // (jobs.FilterFiniteJobs); they surface primarily on the Cloud
+  // Reconciliation lens. Kept here so a row that IS present is filterable.
+  { id: 'reconcile', label: JOB_ENGINE_LABELS.reconcile, tagline: 'Flux Kustomization reconcile leaves.', icon: ICON_KUSTOMIZATION, category: 'reconciler', primary: false },
+  { id: 'reconciler', label: JOB_ENGINE_LABELS.reconciler, tagline: 'Long-running reconciler Deployments (health axis).', icon: ICON_DEPLOYMENT, category: 'reconciler', primary: false },
+] as const
+
+export const JOB_KIND_IDS: readonly JobChipKind[] = JOB_KINDS.map((k) => k.id)
+
+/** Default active chip — HelmRelease installs are the bulk of /jobs
+ *  (the ~65 install-* leaves, the documented "install lens"). */
+export const DEFAULT_JOB_KIND: JobChipKind = 'install'
+
+/** localStorage key — distinct from the Cloud list's `sov-cloud-list-kind`. */
+export const JOB_KIND_STORAGE_KEY = 'sov-jobs-list-kind'
+
+export function isValidJobKind(value: unknown): value is JobChipKind {
+  return typeof value === 'string' && (JOB_KIND_IDS as readonly string[]).includes(value)
+}
+
+export function readPersistedJobKind(): JobChipKind | null {
+  if (typeof window === 'undefined') return null
+  try {
+    const raw = window.localStorage.getItem(JOB_KIND_STORAGE_KEY)
+    return isValidJobKind(raw) ? raw : null
+  } catch {
+    return null
+  }
+}
+
+export function writePersistedJobKind(kind: JobChipKind): void {
+  if (typeof window === 'undefined') return
+  try {
+    window.localStorage.setItem(JOB_KIND_STORAGE_KEY, kind)
+  } catch {
+    /* noop */
+  }
+}
+
+export function findJobKind(id: JobChipKind): JobKindEntry {
+  return JOB_KINDS.find((k) => k.id === id) ?? JOB_KINDS[0]
+}


### PR DESCRIPTION
## What

The sovereign-admin **/jobs** page now mirrors **/cloud**'s UX: a per-kind **chip strip** + a segmented **List⇄Graph** toggle. Part of the Jobs/Resources re-cut (epic #6703), P1b.

Founder-signed design: Resources = assets (nouns), Jobs = processes (verbs); chips carry the **real engine names** (HelmRelease / Kustomization / Deployment / CronJob / Job (step) / Job (task) / Crossplane / OpenTofu), single-selected exactly like /cloud's kind chips.

## Changes

**New (`products/catalyst/bootstrap/ui/src/`):**
- `pages/sovereign/jobs-list/jobKinds.ts` — `JOB_KINDS` catalogue over `JobKind` minus `group`; labels sourced verbatim from `JOB_ENGINE_LABELS` (no second label map to drift). `DEFAULT_JOB_KIND='install'` (the ~65-HelmRelease bulk), storage key `sov-jobs-list-kind`.
- `pages/sovereign/jobs-list/JobKindChips.tsx` — chip strip (primary inline + `+ More` popover; hides a 0-count non-active chip; keeps the active chip at 0). Clone of `CloudKindChips`.
- `pages/sovereign/jobs-list/jobKindCounts.ts` — `deriveJobKindCounts(jobs)` (production code, so the count guard asserts on what the page renders).
- `pages/sovereign/JobsGraphView.tsx` — `Job[]`→`JobNode[]`, folds the 7-value `JobStatus` onto the graph's 4, renders `JobDependenciesGraph`, node-click nav replicating `JobsTable`'s chroot/mothership link logic. (The grouped-DAG default groupings are P2.)
- 3 vitest files: `jobKindCounts.test.ts`, `JobKindChips.test.tsx`, `JobsPage.chips-view.test.tsx`.

**Edited:**
- `pages/sovereign/JobsPage.tsx` — `activeView` (viewOverride→`?view=`→`'list'`) + `activeKind` (`?kind=`→persisted→default); toolbar (toggle + chips in list view); list→`JobsTable jobs={filteredByKind} kindScope={activeKind}`, graph→`JobsGraphView`. Handover + backfill banners kept.
- `app/router.tsx` — `validateSearch` on **both** `provisionJobsRoute` and `consoleJobsRoute` (the param-persistence fix — TanStack drops unknown search params without it).
- `pages/sovereign/JobsTable.tsx` — new `kindScope` prop: when the parent scopes to one kind, hide the redundant **Kind filter dropdown** + **Kind column** (two kind selectors and a constant "HelmRelease/HelmRelease/…" column are the "install install install, none distinguishable" repetition the founder rejected, relocated). Same pattern as `appIdFilter` hiding the App dropdown. Unscoped JobsTable (AppDetail Jobs tab) still renders the Kind column.
- `pages/sovereign/JobsPage.test.tsx` — updated for the scoped-view behaviour (Kind surfaced via chips, not a per-row column).

## #3646 (typed-kind visibility) preserved

The "invisible failing class" intent of #3646 is intact: the active kind is surfaced by the chip strip, and the **unscoped** JobsTable still renders the Kind column (`JobsTable.test.tsx:287`). Hiding is scoped strictly to the /jobs chip-driven view.

## Faithful /cloud mirror (design-parity notes)

- Single-kind list, no "all" state — matches /cloud (`DEFAULT_KIND='clusters'`, no all-view).
- Chips are **count-only** — matches CloudKindChips (also count-only). Surfacing per-kind *failure* state on chips would be a **platform-wide** enhancement (applies equally to /cloud) — tracked as follow-up, not a P1b regression.

## Verification

- `npx tsc -b` clean.
- Full ui vitest: **256 files, 2287 pass + 1 pre-existing expected-fail**.
- No new eslint errors (react-refresh baseline 8 == 8 on JobsTable; pre-existing, also present in router.tsx).

## Rollout

catalyst-ui only → safe rolling `kubectl set image` on live hw305 after merge + CI. Validated live from the browser post-roll (screenshot to follow on the epic).

Refs #6703