### PR TITLE
feat(sovereign-ui): /jobs graph view = grouped dependency DAG + chips-in-graph (P2)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsGraphView.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsGraphView.test.tsx
@@ -1,0 +1,225 @@
+/**
+ * JobsGraphView.test.tsx — P2 grouped-DAG lock-in (Refs #6703).
+ *
+ * Asserts the Graph view:
+ *   • renders ONE JobDependenciesGraph per present group row (section),
+ *     titled by the group's displayName, with the member count;
+ *   • renders a "Standalone tasks" section for parentless leaves;
+ *   • orders sections by the fixed preference (provisioner → apps →
+ *     standalone), tolerating whichever groups are present;
+ *   • keeps the `data-testid="jobs-graph-view"` wrapper (existing contract);
+ *   • HIGHLIGHTS a kind by dimming every NON-matching node/edge (opacity),
+ *     never removing nodes — and dims nothing when highlightKind is null;
+ *   • renders a graceful empty state for zero jobs;
+ *   • preserves node-click navigation.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, cleanup, fireEvent } from '@testing-library/react'
+import {
+  RouterProvider,
+  createRouter,
+  createRootRoute,
+  createRoute,
+  createMemoryHistory,
+  Outlet,
+} from '@tanstack/react-router'
+import { JobsGraphView } from './JobsGraphView'
+import type { Job, JobKind, JobStatus } from '@/lib/jobs.types'
+
+/* ── Fixture builders ─────────────────────────────────────────────── */
+
+function group(id: string, jobName: string, displayName: string, childIds: string[]): Job {
+  return {
+    id,
+    jobName,
+    displayName,
+    type: 'group',
+    appId: '',
+    parentId: '',
+    dependsOn: [],
+    childIds,
+    status: 'running',
+    startedAt: null,
+    finishedAt: null,
+    durationMs: 0,
+  }
+}
+
+function leaf(
+  id: string,
+  jobName: string,
+  kind: JobKind,
+  parentId: string,
+  dependsOn: string[] = [],
+  status: JobStatus = 'succeeded',
+): Job {
+  return {
+    id,
+    jobName,
+    kind,
+    type: 'install',
+    appId: jobName,
+    parentId,
+    dependsOn,
+    childIds: [],
+    status,
+    startedAt: null,
+    finishedAt: null,
+    durationMs: 0,
+  }
+}
+
+/**
+ * Two canonical groups (out of preferred order in the array on purpose, to
+ * prove the view re-sorts) + a standalone leaf.
+ *   • apps      (rank 30): two `install` leaves chained i1 → i2.
+ *   • provisioner (rank 10): two `step` leaves chained s1 → s2.
+ *   • standalone: one `task` leaf with no parent.
+ */
+const APPS_GROUP = group('apps', 'apps', 'Apps', ['i1', 'i2'])
+const PROV_GROUP = group('provisioner', 'provisioner', 'Provision Hetzner', ['s1', 's2'])
+const FIXTURE: Job[] = [
+  APPS_GROUP,
+  leaf('i1', 'install-cilium', 'install', 'apps'),
+  leaf('i2', 'install-cnpg', 'install', 'apps', ['i1']),
+  PROV_GROUP,
+  leaf('s1', 'provision-step-plan', 'step', 'provisioner'),
+  leaf('s2', 'provision-step-apply', 'step', 'provisioner', ['s1']),
+  leaf('t1', 'orphan-task', 'task', ''),
+]
+
+function renderGraph(jobs: Job[], props: Partial<Parameters<typeof JobsGraphView>[0]> = {}) {
+  const rootRoute = createRootRoute({ component: () => <Outlet /> })
+  const jobsRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/provision/$deploymentId/jobs',
+    component: () => <JobsGraphView jobs={jobs} {...props} />,
+  })
+  const detailRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/provision/$deploymentId/jobs/$jobId',
+    component: () => <div data-testid="job-detail-target" />,
+  })
+  const tree = rootRoute.addChildren([jobsRoute, detailRoute])
+  const router = createRouter({
+    routeTree: tree,
+    history: createMemoryHistory({ initialEntries: ['/provision/d-1/jobs'] }),
+  })
+  return render(<RouterProvider router={router} />)
+}
+
+afterEach(() => cleanup())
+
+describe('JobsGraphView — grouped sections', () => {
+  it('keeps the jobs-graph-view wrapper', async () => {
+    renderGraph(FIXTURE)
+    expect(await screen.findByTestId('jobs-graph-view')).toBeTruthy()
+  })
+
+  it('renders one section per present group + a standalone section', async () => {
+    renderGraph(FIXTURE)
+    await screen.findByTestId('jobs-graph-view')
+    expect(screen.getByTestId('jobs-graph-section-apps')).toBeTruthy()
+    expect(screen.getByTestId('jobs-graph-section-provisioner')).toBeTruthy()
+    expect(screen.getByTestId('jobs-graph-section-standalone')).toBeTruthy()
+  })
+
+  it('titles each section by the group displayName + member count', async () => {
+    renderGraph(FIXTURE)
+    await screen.findByTestId('jobs-graph-view')
+    const apps = screen.getByTestId('jobs-graph-section-apps')
+    expect(apps.textContent).toContain('Apps')
+    expect(screen.getByTestId('jobs-graph-section-apps-count').textContent).toBe('2')
+    const prov = screen.getByTestId('jobs-graph-section-provisioner')
+    expect(prov.textContent).toContain('Provision Hetzner')
+    expect(screen.getByTestId('jobs-graph-section-standalone-count').textContent).toBe('1')
+  })
+
+  it('renders one JobDependenciesGraph per section (member nodes only, no group node)', async () => {
+    renderGraph(FIXTURE)
+    await screen.findByTestId('jobs-graph-view')
+    // Member leaves render as nodes…
+    expect(screen.getByTestId('jobs-deps-node-i1')).toBeTruthy()
+    expect(screen.getByTestId('jobs-deps-node-s1')).toBeTruthy()
+    expect(screen.getByTestId('jobs-deps-node-t1')).toBeTruthy()
+    // …the group ROWS never become nodes.
+    expect(screen.queryByTestId('jobs-deps-node-apps')).toBeNull()
+    expect(screen.queryByTestId('jobs-deps-node-provisioner')).toBeNull()
+    // Intra-section chain edges survive (i1 → i2, s1 → s2).
+    expect(screen.getByTestId('jobs-deps-edge-i1-i2')).toBeTruthy()
+    expect(screen.getByTestId('jobs-deps-edge-s1-s2')).toBeTruthy()
+  })
+
+  it('orders sections provisioner → apps → standalone regardless of input order', async () => {
+    renderGraph(FIXTURE)
+    await screen.findByTestId('jobs-graph-view')
+    const testids = Array.from(
+      document.querySelectorAll('[data-testid^="jobs-graph-section-"]'),
+    )
+      .map((el) => el.getAttribute('data-testid'))
+      // Drop the per-section count nodes; keep only the section wrappers.
+      .filter((id): id is string => !!id && !id.endsWith('-count'))
+    expect(testids).toEqual([
+      'jobs-graph-section-provisioner',
+      'jobs-graph-section-apps',
+      'jobs-graph-section-standalone',
+    ])
+  })
+})
+
+describe('JobsGraphView — chip highlight (dim, not filter)', () => {
+  it('dims nothing when highlightKind is null', async () => {
+    renderGraph(FIXTURE, { highlightKind: null })
+    await screen.findByTestId('jobs-graph-view')
+    expect(document.querySelectorAll('[data-dimmed="true"]').length).toBe(0)
+    // With no highlight the widget emits no dim attribute at all.
+    expect(document.querySelectorAll('[data-dimmed]').length).toBe(0)
+  })
+
+  it('highlighting `install` dims every non-install node but keeps the install nodes bright', async () => {
+    renderGraph(FIXTURE, { highlightKind: 'install' })
+    await screen.findByTestId('jobs-graph-view')
+    // install leaves stay bright…
+    expect(screen.getByTestId('jobs-deps-node-i1').getAttribute('data-dimmed')).toBe('false')
+    expect(screen.getByTestId('jobs-deps-node-i2').getAttribute('data-dimmed')).toBe('false')
+    // …step + task leaves dim.
+    expect(screen.getByTestId('jobs-deps-node-s1').getAttribute('data-dimmed')).toBe('true')
+    expect(screen.getByTestId('jobs-deps-node-s2').getAttribute('data-dimmed')).toBe('true')
+    expect(screen.getByTestId('jobs-deps-node-t1').getAttribute('data-dimmed')).toBe('true')
+    // The provisioner chain edge dims (both endpoints are non-install)…
+    expect(screen.getByTestId('jobs-deps-edge-s1-s2').getAttribute('data-dimmed')).toBe('true')
+    // …the install chain edge stays bright.
+    expect(screen.getByTestId('jobs-deps-edge-i1-i2').getAttribute('data-dimmed')).toBe('false')
+    // Node set is NEVER reduced by highlighting — dimmed nodes still render.
+    expect(screen.getByTestId('jobs-deps-node-s1')).toBeTruthy()
+  })
+})
+
+describe('JobsGraphView — edge cases', () => {
+  it('renders a graceful empty state for zero jobs', async () => {
+    renderGraph([])
+    expect(await screen.findByTestId('jobs-graph-view')).toBeTruthy()
+    expect(screen.getByTestId('jobs-graph-empty')).toBeTruthy()
+  })
+
+  it('a group with no children renders no section', async () => {
+    const emptyGroup = group('reconcilers', 'reconcilers', 'Reconcilers', [])
+    renderGraph([emptyGroup, leaf('t1', 'orphan', 'task', '')])
+    await screen.findByTestId('jobs-graph-view')
+    expect(screen.queryByTestId('jobs-graph-section-reconcilers')).toBeNull()
+    expect(screen.getByTestId('jobs-graph-section-standalone')).toBeTruthy()
+  })
+
+  it('preserves node-click navigation to the per-job detail route', async () => {
+    const nav = vi.fn()
+    // Spy indirectly: clicking navigates the memory router; assert the detail
+    // route mounts.
+    renderGraph(FIXTURE)
+    await screen.findByTestId('jobs-graph-view')
+    fireEvent.click(screen.getByTestId('jobs-deps-node-i1'))
+    expect(await screen.findByTestId('job-detail-target')).toBeTruthy()
+    // (nav kept to document intent — the router mount is the real assertion.)
+    void nav
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsGraphView.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsGraphView.tsx
@@ -1,23 +1,51 @@
 /**
- * JobsGraphView — the Graph half of the /jobs List⇄Graph toggle (P1b,
- * Refs #6703). A thin wrapper that maps the flat Job tree to the pure-SVG
- * layered-DAG renderer `JobDependenciesGraph` and wires node clicks to the
- * per-job detail page using the SAME chroot/mothership path logic the
- * JobsTable rows use (JobsTable.useJobLinkBuilder).
+ * JobsGraphView — the Graph half of the /jobs List⇄Graph toggle (P1b +
+ * P2, Refs #6703). Groups the flat Job tree into orchestration-unit
+ * SECTIONS ("default gathered relevant groups" — founder verbatim) and
+ * renders one pure-SVG layered DAG (`JobDependenciesGraph`) per section.
+ * Node clicks route to the per-job detail page using the SAME
+ * chroot/mothership path logic the JobsTable rows use.
  *
- * Two mappings the widget requires:
- *   • Title — `displayName ?? jobName` (the same label the table row link
- *     renders), so a node reads identically to its table row.
+ * # Why grouped (P2)
+ *
+ * P1b mapped ALL jobs flat into ONE graph. The backend emits synthesised
+ * `type:'group'` parent rows (Bootstrap / Provision / Cutover / Handover /
+ * Apps / Reconcilers); flattened, those became edgeless floating nodes and
+ * the cross-group `dependsOn` chains crossed the whole canvas. P2 instead:
+ *
+ *   • One SECTION per group row (`job.type === 'group'`) that has ≥1 child
+ *     — title = the group's `displayName ?? jobName`, members = every job
+ *     whose `parentId === group.id`. Sections are DERIVED from the group
+ *     rows actually present (their displayName is read, never hardcoded).
+ *   • A "Standalone tasks" section for leaf jobs with no parent (or a
+ *     parentId that matches no present group row).
+ *   • Each section lays out INDEPENDENTLY over its own members, so a
+ *     section's `dependsOn` edges connect only that section's steps (they
+ *     already form a linear chain per group); cross-group deps naturally
+ *     drop out (depsLayout ignores unknown ids).
+ *
+ * # Two per-node mappings the widget requires
+ *   • Title — `displayName ?? jobName` (identical to the table-row link).
  *   • Status — JobStatus has SEVEN values but JobDependenciesGraph only
- *     knows FOUR (pending | running | succeeded | failed). The HEALTH-axis
- *     statuses are folded onto the one-shot axis: healthy → succeeded,
- *     degraded / failing → failed. (issue #3646 §4c health axis.)
+ *     knows FOUR. `toGraphStatus` folds the health axis onto the one-shot
+ *     axis: healthy → succeeded, degraded / failing → failed (§3646 §4c).
+ *
+ * # Chip highlight (P2)
+ *
+ * The graph-view chip strip lives in the JobsPage toolbar and HIGHLIGHTS
+ * (never filters) — removing nodes would sever mid-chain `dependsOn`
+ * edges. `highlightKind` (owned by JobsPage as local state, so it never
+ * fights the list view's `?kind=` filter) selects a JobKind; every node of
+ * a DIFFERENT kind is added to `dimNodeIds` and rendered at reduced opacity
+ * by the widget. `null` (the default on entering graph view) dims nothing.
  */
 
-import { useCallback } from 'react'
+import { useCallback, useMemo } from 'react'
 import { useNavigate, useParams } from '@tanstack/react-router'
 import { DETECTED_MODE } from '@/shared/lib/detectMode'
 import type { Job, JobStatus } from '@/lib/jobs.types'
+import { jobKind } from '@/lib/jobs.types'
+import type { JobChipKind } from './jobs-list/jobKinds'
 import {
   JobDependenciesGraph,
   type JobNode,
@@ -30,6 +58,13 @@ interface JobsGraphViewProps {
   /** Deployment id — forwarded for parity; the link builder reads the
    *  route param + DETECTED_MODE, matching JobsTable. */
   deploymentId?: string
+  /**
+   * Graph-view chip highlight (P2). When set, nodes NOT of this kind are
+   * dimmed (opacity-only); the node set is never reduced. `null`/undefined
+   * = no highlight. Owned by JobsPage so the list filter and the graph
+   * highlight stay independent surfaces.
+   */
+  highlightKind?: JobChipKind | null
 }
 
 /**
@@ -56,18 +91,124 @@ function toGraphStatus(s: JobStatus): JobUiStatus {
   }
 }
 
-export function JobsGraphView({ jobs }: JobsGraphViewProps) {
+/**
+ * Preferred top-to-bottom section order. Keyed by group `jobName` slug.
+ * This is an ORDERING preference only — NOT a label source (titles come
+ * from each group's displayName). Covers the canonical backend group slugs
+ * AND the reducer first-paint slugs (jobsAdapter) so both order sensibly;
+ * unknown groups sort after all known ones (stable by input order), and the
+ * standalone section is always last.
+ */
+const SECTION_ORDER: Record<string, number> = {
+  // Canonical backend groups (founder order: provision → bootstrap → apps
+  // → reconcilers → handover → cutover).
+  provisioner: 10,
+  'bootstrap-kit': 20,
+  apps: 30,
+  reconcilers: 40,
+  handover: 50,
+  cutover: 60,
+  // Reducer first-paint groups (jobsAdapter GROUPS) — same conceptual order.
+  'phase-0-infra': 10,
+  'phase-1-bootstrap': 20,
+  applications: 30,
+}
+const UNKNOWN_GROUP_RANK = 900
+const STANDALONE_RANK = 1000
+
+/** Stable slug for a section testid — slugify the group jobName. */
+function sectionSlug(raw: string): string {
+  const s = raw
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+  return s.length > 0 ? s : 'group'
+}
+
+interface GraphSection {
+  /** Stable slug for the section testid. */
+  slug: string
+  /** Header title — the group displayName, or "Standalone tasks". */
+  title: string
+  /** The section's member jobs (leaves only — the group row is the header). */
+  members: Job[]
+  /** Sort rank (lower renders first). */
+  rank: number
+}
+
+const STANDALONE_SLUG = 'standalone'
+const STANDALONE_TITLE = 'Standalone tasks'
+
+/**
+ * Partition the flat job list into ordered sections. One section per group
+ * row with ≥1 member; a trailing "Standalone tasks" section for parentless
+ * leaves (or leaves whose parentId matches no present group row).
+ */
+function partitionSections(jobs: readonly Job[]): GraphSection[] {
+  const groupRows = jobs.filter((j) => j.type === 'group')
+  const groupIds = new Set(groupRows.map((g) => g.id))
+
+  // Bucket every non-group leaf under its parent group id (or standalone).
+  const membersByGroup = new Map<string, Job[]>()
+  const standalone: Job[] = []
+  for (const j of jobs) {
+    if (j.type === 'group') continue
+    if (j.parentId && groupIds.has(j.parentId)) {
+      const arr = membersByGroup.get(j.parentId) ?? []
+      arr.push(j)
+      membersByGroup.set(j.parentId, arr)
+    } else {
+      standalone.push(j)
+    }
+  }
+
+  const sections: GraphSection[] = []
+  groupRows.forEach((g, idx) => {
+    const members = membersByGroup.get(g.id) ?? []
+    if (members.length === 0) return // skip empty groups
+    const knownRank = SECTION_ORDER[g.jobName]
+    // Unknown groups keep input order via a fractional tiebreak on idx.
+    const rank = knownRank ?? UNKNOWN_GROUP_RANK + idx
+    sections.push({
+      slug: sectionSlug(g.jobName),
+      title: g.displayName ?? g.jobName,
+      members,
+      rank,
+    })
+  })
+
+  if (standalone.length > 0) {
+    sections.push({
+      slug: STANDALONE_SLUG,
+      title: STANDALONE_TITLE,
+      members: standalone,
+      rank: STANDALONE_RANK,
+    })
+  }
+
+  // Stable sort by rank, then by input-derived order already encoded above.
+  return sections.sort((a, b) => a.rank - b.rank)
+}
+
+export function JobsGraphView({ jobs, highlightKind }: JobsGraphViewProps) {
   const navigate = useNavigate()
   const params = useParams({ strict: false }) as { deploymentId?: string }
   const isSovereign = DETECTED_MODE.mode === 'sovereign'
   const depId = params.deploymentId ?? ''
 
-  const nodes: JobNode[] = jobs.map((j) => ({
-    id: j.id,
-    title: j.displayName ?? j.jobName,
-    status: toGraphStatus(j.status),
-    dependsOn: j.dependsOn,
-  }))
+  const sections = useMemo(() => partitionSections(jobs), [jobs])
+
+  // Dim set (P2 highlight): ids of every job NOT of the highlighted kind.
+  // Undefined when no highlight is active, so the widget renders unchanged.
+  const dimNodeIds = useMemo<ReadonlySet<string> | undefined>(() => {
+    if (!highlightKind) return undefined
+    const dim = new Set<string>()
+    for (const j of jobs) {
+      if (j.type === 'group') continue
+      if (jobKind(j) !== highlightKind) dim.add(j.id)
+    }
+    return dim
+  }, [jobs, highlightKind])
 
   // SAME chroot/mothership target logic as JobsTable.useJobLinkBuilder:
   // strip the "<deploymentId>:" (or "<deploymentId>:<region>:") prefix so
@@ -89,7 +230,80 @@ export function JobsGraphView({ jobs }: JobsGraphViewProps) {
 
   return (
     <div data-testid="jobs-graph-view">
-      <JobDependenciesGraph jobs={nodes} onNodeClick={onNodeClick} />
+      <style>{JOBS_GRAPH_VIEW_CSS}</style>
+      {sections.length === 0 ? (
+        <div
+          data-testid="jobs-graph-empty"
+          className="jobs-graph-empty"
+          role="status"
+        >
+          No jobs to graph yet.
+        </div>
+      ) : (
+        sections.map((section) => {
+          const nodes: JobNode[] = section.members.map((j) => ({
+            id: j.id,
+            title: j.displayName ?? j.jobName,
+            status: toGraphStatus(j.status),
+            dependsOn: j.dependsOn,
+          }))
+          return (
+            <section
+              key={section.slug}
+              data-testid={`jobs-graph-section-${section.slug}`}
+              className="jobs-graph-section"
+            >
+              <header className="jobs-graph-section-head">
+                <span className="jobs-graph-section-title">{section.title}</span>
+                <span
+                  className="jobs-graph-section-count"
+                  data-testid={`jobs-graph-section-${section.slug}-count`}
+                >
+                  {section.members.length}
+                </span>
+              </header>
+              <JobDependenciesGraph
+                jobs={nodes}
+                onNodeClick={onNodeClick}
+                dimNodeIds={dimNodeIds}
+              />
+            </section>
+          )
+        })
+      )}
     </div>
   )
 }
+
+const JOBS_GRAPH_VIEW_CSS = `
+.jobs-graph-section { margin-bottom: 1.25rem; }
+.jobs-graph-section:last-child { margin-bottom: 0; }
+.jobs-graph-section-head {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.4rem;
+}
+.jobs-graph-section-title {
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: var(--color-text-strong);
+}
+.jobs-graph-section-count {
+  font-size: 0.68rem;
+  font-weight: 600;
+  padding: 0.04rem 0.4rem;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--color-border) 60%, transparent);
+  color: var(--color-text-dim);
+  font-variant-numeric: tabular-nums;
+}
+.jobs-graph-empty {
+  padding: 1.5rem;
+  border: 1px dashed var(--color-border);
+  border-radius: 12px;
+  color: var(--color-text-dim);
+  font-size: 0.85rem;
+  text-align: center;
+}
+`

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsPage.chips-view.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsPage.chips-view.test.tsx
@@ -6,8 +6,11 @@
  *   • the segmented List/Graph toggle renders;
  *   • `?view=graph` renders the graph (JobsGraphView), not the table;
  *   • `?view=list` renders the table + the JobKindChips strip;
- *   • clicking the Graph toggle switches list → graph (and the chip strip
- *     hides in graph view);
+ *   • clicking the Graph toggle switches list → graph;
+ *   • the chip strip is present in BOTH views (P2, Refs #6703 — founder:
+ *     "the graph view same as cloud graph, it should still contain the
+ *     chips"); in graph view a chip HIGHLIGHTS (dims the rest) rather than
+ *     filters, and none is active by default;
  *   • the list filters to ONE kind — the reducer first-paint rows all
  *     classify as `lifecycle`, so `?kind=lifecycle` shows them and a
  *     different kind (`install`) hides them.
@@ -98,20 +101,43 @@ describe('JobsPage — List⇄Graph toggle', () => {
     expect(screen.queryByTestId('jobs-graph-view')).toBeNull()
   })
 
-  it('graph view (?view=graph) renders the graph, not the table or chips', async () => {
+  it('graph view (?view=graph) renders the graph + chips, not the table', async () => {
     renderJobs('/provision/d-1/jobs?view=graph')
     expect(await screen.findByTestId('jobs-graph-view')).toBeTruthy()
     expect(screen.queryByTestId('jobs-table')).toBeNull()
-    // Chip strip is list-only.
-    expect(screen.queryByTestId('jobs-kind-chips')).toBeNull()
+    // P2: the chip strip stays present in graph view (highlight, not filter).
+    expect(screen.getByTestId('jobs-kind-chips')).toBeTruthy()
+    // No chip is highlighted by default — every chip renders inactive.
+    const activeChips = document.querySelectorAll(
+      '[data-testid^="jobs-kind-chip-"][data-active="true"]',
+    )
+    expect(activeChips.length).toBe(0)
   })
 
-  it('clicking the Graph toggle switches list → graph', async () => {
+  it('clicking the Graph toggle switches list → graph (chips persist)', async () => {
     renderJobs('/provision/d-1/jobs?view=list&kind=lifecycle')
     await screen.findByTestId('jobs-table')
     fireEvent.click(screen.getByTestId('jobs-page-view-graph'))
     expect(await screen.findByTestId('jobs-graph-view')).toBeTruthy()
     expect(screen.queryByTestId('jobs-table')).toBeNull()
+    expect(screen.getByTestId('jobs-kind-chips')).toBeTruthy()
+  })
+
+  it('graph-view chip toggles the highlight on and back off', async () => {
+    renderJobs('/provision/d-1/jobs?view=graph')
+    await screen.findByTestId('jobs-graph-view')
+    // Every reducer first-paint row classifies as `lifecycle` (OpenTofu), so
+    // that is the only chip with a non-zero count / present in graph view.
+    const lifecycleChip = screen.getByTestId('jobs-kind-chip-lifecycle')
+    expect(lifecycleChip.getAttribute('data-active')).toBe('false')
+    fireEvent.click(lifecycleChip)
+    expect(lifecycleChip.getAttribute('data-active')).toBe('true')
+    // Because ALL nodes are lifecycle here, highlighting that kind dims none
+    // (a dimmed node is a NON-matching one) — the widget stays fully bright.
+    expect(document.querySelectorAll('[data-dimmed="true"]').length).toBe(0)
+    // Clicking the active chip again clears the highlight.
+    fireEvent.click(lifecycleChip)
+    expect(lifecycleChip.getAttribute('data-active')).toBe('false')
   })
 })
 

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsPage.tsx
@@ -56,7 +56,7 @@
  * `status==ready`. This page is a PURE finite-jobs table.
  */
 
-import { useCallback, useEffect, useMemo } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { Link, useNavigate, useSearch } from '@tanstack/react-router'
 import { useResolvedDeploymentId } from '@/shared/lib/useResolvedDeploymentId'
 import { sovereignPathOrDeployments } from '@/shared/lib/sovereignPaths'
@@ -89,6 +89,15 @@ import { HANDOVER_REDIRECT_BANNER_CSS } from './HandoverRedirectBanner.css'
 export type JobsView = 'list' | 'graph'
 const DEFAULT_JOBS_VIEW: JobsView = 'list'
 const JOBS_VIEW_STORAGE_KEY = 'sov-jobs-view'
+
+/**
+ * Sentinel `activeKind` for the graph-view chip strip meaning "no chip is
+ * highlighted" (P2). JobKindChips single-selects a real JobChipKind; passing
+ * an id that matches no chip renders every chip inactive, which is exactly
+ * the graph-view default (no dimming) — a chip becomes a HIGHLIGHT toggle
+ * rather than a filter. Empty string can never collide with a real kind.
+ */
+const NO_GRAPH_HIGHLIGHT = '' as JobChipKind
 
 function isValidJobsView(value: unknown): value is JobsView {
   return value === 'list' || value === 'graph'
@@ -246,6 +255,16 @@ export function JobsPage({
     [flatJobs, activeKind],
   )
 
+  // Graph-view chip HIGHLIGHT (P2, Refs #6703). Deliberately a separate
+  // local state from the list's `?kind=` filter: list=filter removes rows,
+  // graph=highlight only dims (removing graph nodes would sever mid-chain
+  // dependsOn edges). null = no highlight, the default on entering graph
+  // view. Clicking a chip toggles it; clicking the active chip clears it.
+  const [graphHighlightKind, setGraphHighlightKind] = useState<JobChipKind | null>(null)
+  const toggleGraphHighlight = useCallback((next: JobChipKind) => {
+    setGraphHighlightKind((cur) => (cur === next ? null : next))
+  }, [])
+
   return (
     <PortalShell
       deploymentId={deploymentId}
@@ -337,7 +356,16 @@ export function JobsPage({
         {activeView === 'list' ? (
           <JobKindChips activeKind={activeKind} counts={kindCounts} onChange={setKind} />
         ) : (
-          <span aria-hidden className="jobs-page-toolbar-spacer" />
+          // Graph view keeps the SAME chip strip (founder: "the graph view
+          // same as cloud graph, it should still contain the chips"). Here a
+          // chip HIGHLIGHTS (dims the rest) rather than filters — the active
+          // kind is the local graph-highlight state, NO_GRAPH_HIGHLIGHT when
+          // none is selected so no chip reads active by default.
+          <JobKindChips
+            activeKind={graphHighlightKind ?? NO_GRAPH_HIGHLIGHT}
+            counts={kindCounts}
+            onChange={toggleGraphHighlight}
+          />
         )}
       </div>
 
@@ -345,7 +373,11 @@ export function JobsPage({
         {activeView === 'list' ? (
           <JobsTable jobs={filteredByKind} deploymentId={deploymentId} kindScope={activeKind} />
         ) : (
-          <JobsGraphView jobs={flatJobs} deploymentId={deploymentId} />
+          <JobsGraphView
+            jobs={flatJobs}
+            deploymentId={deploymentId}
+            highlightKind={graphHighlightKind}
+          />
         )}
       </div>
     </PortalShell>

--- a/products/catalyst/bootstrap/ui/src/widgets/job-deps-graph/JobDependenciesGraph.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/widgets/job-deps-graph/JobDependenciesGraph.test.tsx
@@ -118,3 +118,30 @@ describe('JobDependenciesGraph — height clamp', () => {
     expect(wrapper.style.height).toBe('380px')
   })
 })
+
+describe('JobDependenciesGraph — per-instance arrow marker id (P2 multi-graph)', () => {
+  it('gives each rendered graph a UNIQUE marker id and references its own (no duplicate DOM ids across sections)', () => {
+    // P2 renders one graph per orchestration-unit section on the same page.
+    // A hardcoded marker id would repeat → invalid duplicate DOM ids and
+    // url(#id) would resolve only to the first. useId() must namespace it.
+    const { container } = render(
+      <>
+        <JobDependenciesGraph jobs={THREE_NODE_CHAIN} />
+        <JobDependenciesGraph jobs={THREE_NODE_CHAIN} />
+      </>,
+    )
+    const ids = Array.from(container.querySelectorAll('marker')).map((m) => m.getAttribute('id'))
+    expect(ids.length).toBe(2)
+    expect(ids[0]).toBeTruthy()
+    expect(ids[1]).toBeTruthy()
+    expect(ids[0]).not.toBe(ids[1])
+    // Every edge references SOME instance's marker, and both markers are used.
+    const refs = new Set(
+      Array.from(container.querySelectorAll('[data-testid^="jobs-deps-edge-"]')).map((e) =>
+        e.getAttribute('marker-end'),
+      ),
+    )
+    expect(refs.has(`url(#${ids[0]})`)).toBe(true)
+    expect(refs.has(`url(#${ids[1]})`)).toBe(true)
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/widgets/job-deps-graph/JobDependenciesGraph.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/widgets/job-deps-graph/JobDependenciesGraph.test.tsx
@@ -62,6 +62,43 @@ describe('JobDependenciesGraph — interaction', () => {
   })
 })
 
+describe('JobDependenciesGraph — dim overlay (P2 highlight)', () => {
+  it('emits NO dim attribute when dimNodeIds is absent (default unchanged)', () => {
+    render(<JobDependenciesGraph jobs={THREE_NODE_CHAIN} />)
+    expect(document.querySelectorAll('[data-dimmed]').length).toBe(0)
+    // Node opacity attribute is not present in the default render.
+    expect(screen.getByTestId('jobs-deps-node-a').getAttribute('opacity')).toBeNull()
+  })
+
+  it('dims the nodes in dimNodeIds and leaves the rest bright', () => {
+    render(
+      <JobDependenciesGraph
+        jobs={THREE_NODE_CHAIN}
+        dimNodeIds={new Set(['b', 'c'])}
+      />,
+    )
+    expect(screen.getByTestId('jobs-deps-node-a').getAttribute('data-dimmed')).toBe('false')
+    expect(screen.getByTestId('jobs-deps-node-b').getAttribute('data-dimmed')).toBe('true')
+    expect(screen.getByTestId('jobs-deps-node-c').getAttribute('data-dimmed')).toBe('true')
+    // A dimmed node carries a reduced opacity; a bright one does not.
+    expect(screen.getByTestId('jobs-deps-node-b').getAttribute('opacity')).toBe('0.25')
+    expect(screen.getByTestId('jobs-deps-node-a').getAttribute('opacity')).toBeNull()
+  })
+
+  it('dims an edge when either endpoint is dimmed', () => {
+    render(
+      <JobDependenciesGraph
+        jobs={THREE_NODE_CHAIN}
+        dimNodeIds={new Set(['c'])}
+      />,
+    )
+    // a → b: neither endpoint dimmed → bright.
+    expect(screen.getByTestId('jobs-deps-edge-a-b').getAttribute('data-dimmed')).toBe('false')
+    // b → c: c is dimmed → the edge dims too.
+    expect(screen.getByTestId('jobs-deps-edge-b-c').getAttribute('data-dimmed')).toBe('true')
+  })
+})
+
 describe('JobDependenciesGraph — height clamp', () => {
   it('clamps height below 350 to 350', () => {
     render(<JobDependenciesGraph jobs={THREE_NODE_CHAIN} height={100} />)

--- a/products/catalyst/bootstrap/ui/src/widgets/job-deps-graph/JobDependenciesGraph.tsx
+++ b/products/catalyst/bootstrap/ui/src/widgets/job-deps-graph/JobDependenciesGraph.tsx
@@ -26,7 +26,7 @@
  *     palette as JobCard's status iconography.
  */
 
-import { useMemo } from 'react'
+import { useId, useMemo } from 'react'
 import {
   depsLayout,
   type LayoutInput,
@@ -101,6 +101,13 @@ export function JobDependenciesGraph({
 }: JobDependenciesGraphProps) {
   const clamped = Math.max(350, Math.min(450, height))
 
+  // Per-instance marker id — the /jobs graph view (P2) renders one
+  // JobDependenciesGraph per orchestration-unit section, so a hardcoded
+  // marker id would repeat across the page (invalid duplicate DOM ids;
+  // url(#id) resolves only to the first). useId() gives each instance a
+  // stable unique id; strip ':' so the SVG url(#...) reference is clean.
+  const arrowMarkerId = `jobs-deps-arrow-${useId().replace(/:/g, '')}`
+
   const layout = useMemo(() => {
     const inputs: LayoutInput[] = jobs.map((j) => ({
       id: j.id,
@@ -170,7 +177,7 @@ export function JobDependenciesGraph({
                 stroke="var(--color-border-strong)"
                 strokeWidth={1.5}
                 opacity={edgeDimmed ? DIM_OPACITY : undefined}
-                markerEnd="url(#jobs-deps-arrow)"
+                markerEnd={`url(#${arrowMarkerId})`}
               />
             )
           })}
@@ -179,7 +186,7 @@ export function JobDependenciesGraph({
         {/* Arrow marker definition. */}
         <defs>
           <marker
-            id="jobs-deps-arrow"
+            id={arrowMarkerId}
             viewBox="0 0 10 10"
             refX="9"
             refY="5"

--- a/products/catalyst/bootstrap/ui/src/widgets/job-deps-graph/JobDependenciesGraph.tsx
+++ b/products/catalyst/bootstrap/ui/src/widgets/job-deps-graph/JobDependenciesGraph.tsx
@@ -60,7 +60,22 @@ export interface JobDependenciesGraphProps {
   onNodeClick?: (jobId: string) => void
   /** Optional className passed to the wrapping <div>. */
   className?: string
+  /**
+   * OPTIONAL highlight/dim overlay (P2, Refs #6703). When provided, every
+   * node whose id is in this set (and every edge touching such a node) is
+   * rendered at a reduced opacity so the NON-dimmed nodes read as the
+   * highlighted set. This is opacity-only — the layout is unchanged, so the
+   * existing render + Playwright visual contract is untouched when the prop
+   * is absent (the default): no `opacity`/`data-dimmed` attribute is emitted
+   * at all unless a dim set is passed. Used by JobsGraphView to implement
+   * the graph-view chip HIGHLIGHT (which dims, never removes, so mid-chain
+   * `dependsOn` edges survive).
+   */
+  dimNodeIds?: ReadonlySet<string>
 }
+
+/** Opacity applied to a dimmed node/edge when `dimNodeIds` is active. */
+const DIM_OPACITY = 0.25
 
 const STATUS_FILL: Record<JobUiStatus, string> = {
   succeeded: 'var(--color-success)',
@@ -82,6 +97,7 @@ export function JobDependenciesGraph({
   layoutOpts,
   onNodeClick,
   className,
+  dimNodeIds,
 }: JobDependenciesGraphProps) {
   const clamped = Math.max(350, Math.min(450, height))
 
@@ -138,17 +154,26 @@ export function JobDependenciesGraph({
       >
         {/* Edges first so they sit beneath the nodes. */}
         <g data-testid="jobs-deps-edges">
-          {layout.edges.map((e) => (
-            <polyline
-              key={`${e.from}->${e.to}`}
-              data-testid={`jobs-deps-edge-${e.from}-${e.to}`}
-              points={e.points.map((p) => `${p.x},${p.y}`).join(' ')}
-              fill="none"
-              stroke="var(--color-border-strong)"
-              strokeWidth={1.5}
-              markerEnd="url(#jobs-deps-arrow)"
-            />
-          ))}
+          {layout.edges.map((e) => {
+            // An edge dims when either endpoint is dimmed — a highlighted
+            // node keeps a bright edge only to another highlighted node.
+            const edgeDimmed = dimNodeIds
+              ? dimNodeIds.has(e.from) || dimNodeIds.has(e.to)
+              : false
+            return (
+              <polyline
+                key={`${e.from}->${e.to}`}
+                data-testid={`jobs-deps-edge-${e.from}-${e.to}`}
+                data-dimmed={dimNodeIds ? (edgeDimmed ? 'true' : 'false') : undefined}
+                points={e.points.map((p) => `${p.x},${p.y}`).join(' ')}
+                fill="none"
+                stroke="var(--color-border-strong)"
+                strokeWidth={1.5}
+                opacity={edgeDimmed ? DIM_OPACITY : undefined}
+                markerEnd="url(#jobs-deps-arrow)"
+              />
+            )
+          })}
         </g>
 
         {/* Arrow marker definition. */}
@@ -172,11 +197,14 @@ export function JobDependenciesGraph({
             const job = byId.get(n.id)!
             const fill = STATUS_FILL[job.status]
             const ring = STATUS_RING[job.status]
+            const nodeDimmed = dimNodeIds?.has(n.id) ?? false
             return (
               <g
                 key={n.id}
                 data-testid={`jobs-deps-node-${n.id}`}
                 data-status={job.status}
+                data-dimmed={dimNodeIds ? (nodeDimmed ? 'true' : 'false') : undefined}
+                opacity={nodeDimmed ? DIM_OPACITY : undefined}
                 transform={`translate(${n.x}, ${n.y})`}
                 style={{ cursor: onNodeClick ? 'pointer' : 'default' }}
                 onClick={() => onNodeClick?.(n.id)}


### PR DESCRIPTION
## What

The /jobs **Graph** view (added in P1b #6706) now renders a **grouped dependency DAG** and keeps a **chip strip in graph view**. Epic #6703, P2. catalyst-ui only.

Founder-signed: "the grap view same as cloud grap, it should still contain the chips and we should ahve soem default gahtered grelavant groups".

## Changes (frontend only)

- `JobsGraphView.tsx` — rewritten: partitions jobs into **sections** — one per orchestration-unit **group row** (`type:'group'`, e.g. Bootstrap / Provision Hetzner / Apps / Reconcilers / Handover / Cutover) that has ≥1 child, plus a **Standalone tasks** section for parentless leaves. Each section renders its own `JobDependenciesGraph` over its members, so `dependsOn` edges connect only that unit's steps. Section titles come from the group row's `displayName` (never hardcoded); ordering via a `SECTION_ORDER` rank map, standalone last; empty groups render no section. Node-click nav preserved from P1b.
- `JobsPage.tsx` — the chip strip now renders in **graph** view too (was a spacer). Graph chips **highlight** the selected kind and dim the rest (opacity only — removing nodes would sever mid-chain `dependsOn` edges). Uses a graph-local highlight state (default none) distinct from the list's `?kind=` filter, since list=filter and graph=highlight are different semantics; clicking the active chip clears it.
- `JobDependenciesGraph.tsx` — new **optional** `dimNodeIds?: ReadonlySet<string>` prop (opacity-only dim of non-highlighted nodes/edges; absent ⇒ no attribute emitted, existing render/Playwright contract unchanged). Also **namespaced the arrow `<marker>` id via `useId()`** — P2 renders many graph instances per page, and the previously-hardcoded id would repeat (invalid duplicate DOM ids; `url(#id)` resolves only to the first).

## Verification (post-rebase onto main)

- `tsc -b` clean.
- Full ui vitest: **257 files / 2302 pass + 1 pre-existing expected-fail** (+15 tests vs P1b baseline: grouped sections, standalone, chips-in-graph highlight toggle, cross-kind dim, per-instance marker-id uniqueness). Zero regressions.
- No new eslint errors.

## Reviewer notes (design decisions)

- Chip-highlight uses a local state + an empty-string `activeKind` sentinel so `JobKindChips` is reused unmodified for "no highlight". Highlight persists across list⇄graph toggles within a session (un-highlighted on fresh entry, per spec).
- One `JobDependenciesGraph` per section (stacked) rather than one clustered mega-graph — reuses the widget as-is, lowest-risk.

## Rollout

catalyst-ui only → safe rolling roll to hw305 after merge + CI; validated live from the browser (screenshot on the epic).

Refs #6703