### PR TITLE
feat(sovereign-ui): consolidated CronJob schedule timeline + run-history drill-in (P3)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/app/router.tsx
+++ b/products/catalyst/bootstrap/ui/src/app/router.tsx
@@ -69,6 +69,7 @@ import { InstallPage } from '@/pages/sovereign/InstallPage'
 import { JobsPage } from '@/pages/sovereign/JobsPage'
 import { JobDetail } from '@/pages/sovereign/JobDetail'
 import { JobsTimeline } from '@/pages/sovereign/JobsTimeline'
+import { CronScheduleView } from '@/pages/sovereign/jobs-schedule/CronScheduleView'
 import { Dashboard } from '@/pages/sovereign/Dashboard'
 // #3958 — the standalone /reconciliation page is GONE; reconcilers now
 // merge into the unified Cloud graph (/cloud?view=graph).
@@ -928,6 +929,19 @@ const provisionJobsTimelineRoute = createRoute({
   beforeLoad: provisionAuthGuard,
 })
 
+// Consolidated CronJob Schedule view (P3, Refs #6703). Static segment — MUST
+// be registered BEFORE the dynamic `/jobs/$jobId` route below so TanStack
+// resolves `/jobs/schedule` to this surface, not to JobDetail with
+// jobId="schedule". Sibling parity with provisionJobsTimelineRoute. Reached
+// from the /jobs cron chip's "View schedule" affordance; takes no search
+// params (the run-history drawer selection is ephemeral UI state).
+const provisionJobsScheduleRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/provision/$deploymentId/jobs/schedule',
+  component: CronScheduleView,
+  beforeLoad: provisionAuthGuard,
+})
+
 // Per-Job detail page (epic #204).
 const provisionJobDetailRoute = createRoute({
   getParentRoute: () => rootRoute,
@@ -1460,6 +1474,15 @@ const consoleJobsTimelineRoute = createRoute({
   getParentRoute: () => consoleLayoutRoute,
   path: '/jobs/timeline',
   component: JobsTimeline,
+})
+// Consolidated CronJob Schedule view (P3, Refs #6703) — chroot Sovereign
+// Console. Registered BEFORE the dynamic $jobId route so `/jobs/schedule`
+// resolves here, not to JobDetail. Sibling parity with the provision tree's
+// provisionJobsScheduleRoute.
+const consoleJobsScheduleRoute = createRoute({
+  getParentRoute: () => consoleLayoutRoute,
+  path: '/jobs/schedule',
+  component: CronScheduleView,
 })
 const consoleJobDetailRoute = createRoute({
   getParentRoute: () => consoleLayoutRoute,
@@ -2396,6 +2419,7 @@ const routeTree = rootRoute.addChildren([
   provisionInstallBlueprintRoute,
   provisionJobsRoute,
   provisionJobsTimelineRoute,
+  provisionJobsScheduleRoute,
   provisionJobDetailRoute,
   provisionDashboardRoute,
   provisionDecommissionRoute,
@@ -2449,6 +2473,7 @@ const routeTree = rootRoute.addChildren([
     consoleInstallBlueprintRoute,
     consoleJobsRoute,
     consoleJobsTimelineRoute,
+    consoleJobsScheduleRoute,
     consoleJobDetailRoute,
     consoleCloudRoute.addChildren(consoleLegacyCloudRedirectRoutes),
     consoleResourceDetailRoute,

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsPage.cron-schedule-link.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsPage.cron-schedule-link.test.tsx
@@ -1,0 +1,97 @@
+/**
+ * JobsPage.cron-schedule-link.test.tsx — P3 (Refs #6703).
+ *
+ * The consolidated Schedule view is reached from the /jobs CronJob chip via a
+ * contextual "View schedule" link. This locks that the affordance:
+ *   • renders ONLY when the cron chip is active in list view;
+ *   • is absent for another kind, and absent in graph view;
+ *   • points at the `/jobs/schedule` route.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import {
+  RouterProvider,
+  createRouter,
+  createRootRoute,
+  createRoute,
+  createMemoryHistory,
+  Outlet,
+} from '@tanstack/react-router'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { JobsPage } from './JobsPage'
+import { useWizardStore } from '@/entities/deployment/store'
+import { INITIAL_WIZARD_STATE } from '@/entities/deployment/model'
+
+interface JobsSearch {
+  view?: 'graph' | 'list'
+  kind?: string
+}
+
+function renderJobs(initialEntry: string) {
+  const rootRoute = createRootRoute({ component: () => <Outlet /> })
+  const jobsRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/provision/$deploymentId/jobs',
+    component: () => <JobsPage disableStream disableJobsBackfill />,
+    validateSearch: (raw: Record<string, unknown>): JobsSearch => {
+      const out: JobsSearch = {}
+      if (raw.view === 'graph' || raw.view === 'list') out.view = raw.view
+      if (typeof raw.kind === 'string' && raw.kind.length > 0) out.kind = raw.kind
+      return out
+    },
+  })
+  const scheduleRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/provision/$deploymentId/jobs/schedule',
+    component: () => <div data-testid="schedule-target" />,
+  })
+  const homeRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/provision/$deploymentId',
+    component: () => <div data-testid="apps-target" />,
+  })
+  const tree = rootRoute.addChildren([jobsRoute, scheduleRoute, homeRoute])
+  const router = createRouter({
+    routeTree: tree,
+    history: createMemoryHistory({ initialEntries: [initialEntry] }),
+  })
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } })
+  return render(
+    <QueryClientProvider client={qc}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>,
+  )
+}
+
+beforeEach(() => {
+  useWizardStore.setState({ ...INITIAL_WIZARD_STATE })
+  globalThis.fetch = (() =>
+    Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({ events: [], state: undefined, done: false }),
+    } as unknown as Response)) as typeof fetch
+})
+
+afterEach(() => cleanup())
+
+describe('JobsPage — View schedule affordance', () => {
+  it('shows the link when the cron chip is active, pointing at /jobs/schedule', async () => {
+    renderJobs('/provision/d-1/jobs?view=list&kind=cron')
+    const link = await screen.findByTestId('jobs-cron-view-schedule')
+    expect(link).toBeTruthy()
+    expect(link.getAttribute('href')).toContain('/provision/d-1/jobs/schedule')
+  })
+
+  it('hides the link for a non-cron kind', async () => {
+    renderJobs('/provision/d-1/jobs?view=list&kind=lifecycle')
+    await screen.findByTestId('jobs-kind-chips')
+    expect(screen.queryByTestId('jobs-cron-view-schedule')).toBeNull()
+  })
+
+  it('hides the link in graph view', async () => {
+    renderJobs('/provision/d-1/jobs?view=graph&kind=cron')
+    await screen.findByTestId('jobs-graph-view')
+    expect(screen.queryByTestId('jobs-cron-view-schedule')).toBeNull()
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsPage.tsx
@@ -371,6 +371,28 @@ export function JobsPage({
             storageKey="sov-jobs-hidden-kinds"
           />
         )}
+
+        {/* Schedule affordance (P3, Refs #6703). A contextual "View schedule"
+            link — shown ONLY when the CronJob chip is active in list view —
+            routes to the consolidated 24h Schedule timeline. Chosen over a
+            third List/Graph/Schedule toggle value because a time-of-day
+            schedule is meaningful ONLY for CronJobs; a segmented value that is
+            empty for the other 7 kinds would be noise. It mirrors how the
+            "Jobs timeline" retrospective is also a dedicated route, not a
+            view-toggle value. */}
+        {activeView === 'list' && activeKind === 'cron' ? (
+          <Link
+            to={sovereignPathOrDeployments('jobs', { deploymentId, sub: 'schedule' }) as never}
+            className="jobs-view-schedule-link"
+            data-testid="jobs-cron-view-schedule"
+          >
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.6} aria-hidden>
+              <circle cx="12" cy="12" r="9" />
+              <path d="M12 7v5l3 2" strokeLinecap="round" strokeLinejoin="round" />
+            </svg>
+            <span>View schedule →</span>
+          </Link>
+        ) : null}
       </div>
 
       <div id="jobs-page-content" className="mt-4" data-testid="sov-jobs-list" data-view={activeView}>
@@ -423,6 +445,28 @@ const JOBS_PAGE_TOOLBAR_CSS = `
   color: var(--color-accent);
   font-weight: 600;
 }
+.jobs-view-schedule-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  flex-shrink: 0;
+  padding: 0.4rem 0.7rem;
+  font-size: 0.8rem;
+  font-weight: 500;
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  color: var(--color-text-dim);
+  background: var(--color-bg-2);
+  text-decoration: none;
+  white-space: nowrap;
+  transition: color 0.12s ease, border-color 0.12s ease, background 0.12s ease;
+}
+.jobs-view-schedule-link:hover {
+  color: var(--color-accent);
+  border-color: var(--color-accent);
+  background: color-mix(in srgb, var(--color-accent) 12%, var(--color-bg-2));
+}
+.jobs-view-schedule-link svg { width: 15px; height: 15px; }
 `
 
 /**

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/kinds.ts
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/kinds.ts
@@ -30,6 +30,7 @@ import {
   DeploymentsListPage,
   StatefulSetsListPage,
   DaemonSetsListPage,
+  CronJobsListPage,
   ReplicaSetsListPage,
   ConfigMapsListPage,
   SecretsListPage,
@@ -88,6 +89,7 @@ export type CloudListKind =
   | 'deployments'
   | 'statefulsets'
   | 'daemonsets'
+  | 'cronjobs'
   | 'replicasets'
   | 'configmaps'
   | 'secrets'
@@ -132,6 +134,11 @@ export const KIND_TO_REGISTRY: Partial<Record<CloudListKind, string>> = {
   deployments: 'deployment',
   statefulsets: 'statefulset',
   daemonsets: 'daemonset',
+  // Batch (batch/v1). The Schedule surface (Refs #6703) reads the raw
+  // CronJob objects for its 24h timeline; adding the chip here also
+  // auto-subscribes the CloudPage SSE (CLOUD_PAGE_K8S_KINDS is derived from
+  // this map) so the cronjobs chip count + list read live objects.
+  cronjobs: 'cronjob',
   replicasets: 'replicaset',
   services: 'service',
   ingresses: 'ingress',
@@ -282,6 +289,9 @@ const ICON_DEPLOY =
 const ICON_STS = ICON_DEPLOY
 const ICON_DS =
   'M3 6h18M3 12h18M3 18h18M6 6v12M12 6v12M18 6v12'
+// CronJob — a clock (recurring, scheduled work).
+const ICON_CRONJOB =
+  'M12 3a9 9 0 1 0 0 18a9 9 0 0 0 0 -18zM12 8v4l3 2'
 const ICON_RS = ICON_DEPLOY
 const ICON_CFG =
   'M4 7h16M4 12h16M4 17h10M14 17l3 3 3 -5'
@@ -342,6 +352,7 @@ export const KINDS: readonly CloudKindEntry[] = [
   { id: 'deployments', label: 'Deployments', tagline: 'Stateless replicated workloads', hasData: true, Component: DeploymentsListPage, icon: ICON_DEPLOY, category: 'workload', primary: false },
   { id: 'statefulsets', label: 'StatefulSets', tagline: 'Ordered, persistent workloads', hasData: true, Component: StatefulSetsListPage, icon: ICON_STS, category: 'workload', primary: false },
   { id: 'daemonsets', label: 'DaemonSets', tagline: 'One pod per node', hasData: true, Component: DaemonSetsListPage, icon: ICON_DS, category: 'workload', primary: false },
+  { id: 'cronjobs', label: 'CronJobs', tagline: 'Recurring scheduled work — see the Schedule view for the 24h timeline', hasData: true, Component: CronJobsListPage, icon: ICON_CRONJOB, category: 'workload', primary: false },
   { id: 'replicasets', label: 'ReplicaSets', tagline: 'Owned by Deployments', hasData: true, Component: ReplicaSetsListPage, icon: ICON_RS, category: 'workload', primary: false },
 
   // Networking

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/kindsPages.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/kindsPages.tsx
@@ -126,6 +126,49 @@ export function DaemonSetsListPage() {
   )
 }
 
+export function CronJobsListPage() {
+  return (
+    <K8sListPage
+      kind="cronjob"
+      title="CronJobs"
+      tagline="Recurring scheduled work (batch/v1). The Schedule view shows these on a 24h time-of-day timeline."
+      columns={[
+        COL_NAMESPACE,
+        COL_NAME,
+        {
+          header: 'Schedule',
+          extract: (o) => {
+            const s = (o.spec as Record<string, unknown> | undefined)?.['schedule']
+            return typeof s === 'string' && s ? s : '—'
+          },
+        },
+        {
+          header: 'Suspend',
+          extract: (o) =>
+            (o.spec as Record<string, unknown> | undefined)?.['suspend'] === true ? 'yes' : '—',
+          tone: (o): CellTone | undefined =>
+            (o.spec as Record<string, unknown> | undefined)?.['suspend'] === true ? 'warn' : undefined,
+        },
+        {
+          header: 'Last Schedule',
+          extract: (o) => {
+            const t = (o.status as Record<string, unknown> | undefined)?.['lastScheduleTime']
+            return typeof t === 'string' && t ? t : '—'
+          },
+        },
+        {
+          header: 'Active',
+          extract: (o) => {
+            const a = (o.status as Record<string, unknown> | undefined)?.['active']
+            return Array.isArray(a) ? String(a.length) : '0'
+          },
+        },
+        COL_AGE,
+      ]}
+    />
+  )
+}
+
 export function ReplicaSetsListPage() {
   return (
     <K8sListPage

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/jobs-schedule/CronScheduleView.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/jobs-schedule/CronScheduleView.test.tsx
@@ -1,0 +1,175 @@
+/**
+ * CronScheduleView.test.tsx — the consolidated CronJob Schedule surface
+ * (P3-frontend, Refs #6703). Asserts the operator-visible contract:
+ *   • one row per CronJob (SVG + detail table);
+ *   • a fire mark at the correct x for a known schedule (0 12 * * * → 12:00);
+ *   • a collision overlay + summary where ≥2 crons fire on the same minute;
+ *   • the run-history drill-in lists the selected CronJob's child Jobs with
+ *     their statuses.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render, screen, cleanup, fireEvent } from '@testing-library/react'
+import {
+  RouterProvider,
+  createRouter,
+  createRootRoute,
+  createRoute,
+  createMemoryHistory,
+  Outlet,
+} from '@tanstack/react-router'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { CronScheduleView } from './CronScheduleView'
+import type { K8sObject, K8sSnapshot } from '@/widgets/architecture-graph/useK8sCacheStream'
+
+function cronjob(name: string, ns: string, schedule: string): [string, K8sObject] {
+  return [
+    `cronjob:${ns}/${name}`,
+    {
+      apiVersion: 'batch/v1',
+      kind: 'CronJob',
+      metadata: { name, namespace: ns },
+      spec: { schedule },
+      status: {},
+    },
+  ]
+}
+
+function childJob(
+  name: string,
+  ns: string,
+  cronName: string,
+  status: Record<string, unknown>,
+): [string, K8sObject] {
+  return [
+    `job:${ns}/${name}`,
+    {
+      apiVersion: 'batch/v1',
+      kind: 'Job',
+      metadata: {
+        name,
+        namespace: ns,
+        ownerReferences: [{ kind: 'CronJob', name: cronName }],
+      },
+      status,
+    },
+  ]
+}
+
+function makeSnapshot(): K8sSnapshot {
+  return new Map([
+    cronjob('noon-report', 'analytics', '0 12 * * *'),
+    cronjob('backup-a', 'db', '0 0 * * *'),
+    cronjob('backup-b', 'cache', '0 0 * * *'), // collides with backup-a at 00:00
+    childJob('noon-report-1', 'analytics', 'noon-report', {
+      startTime: '2026-08-23T12:00:00Z',
+      completionTime: '2026-08-23T12:00:30Z',
+      succeeded: 1,
+    }),
+    childJob('noon-report-2', 'analytics', 'noon-report', {
+      startTime: '2026-08-24T12:00:00Z',
+      completionTime: '2026-08-24T12:01:00Z',
+      failed: 1,
+    }),
+  ])
+}
+
+const REF = new Date(2026, 7, 24, 6, 0)
+
+function renderSchedule(snapshot: K8sSnapshot) {
+  const rootRoute = createRootRoute({ component: () => <Outlet /> })
+  const scheduleRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/provision/$deploymentId/jobs/schedule',
+    component: () => <CronScheduleView snapshotOverride={snapshot} nowOverride={REF} />,
+  })
+  const jobsRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/provision/$deploymentId/jobs',
+    component: () => <div data-testid="jobs-target" />,
+    validateSearch: (raw: Record<string, unknown>) => raw,
+  })
+  const tree = rootRoute.addChildren([scheduleRoute, jobsRoute])
+  const router = createRouter({
+    routeTree: tree,
+    history: createMemoryHistory({ initialEntries: ['/provision/d-1/jobs/schedule'] }),
+  })
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } })
+  return render(
+    <QueryClientProvider client={qc}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>,
+  )
+}
+
+beforeEach(() => {
+  globalThis.fetch = (() =>
+    Promise.resolve({
+      ok: false,
+      status: 404,
+      json: () => Promise.resolve({}),
+    } as unknown as Response)) as typeof fetch
+})
+
+afterEach(() => cleanup())
+
+describe('CronScheduleView', () => {
+  it('renders one detail-table row per CronJob', async () => {
+    renderSchedule(makeSnapshot())
+    await screen.findByTestId('sov-cron-schedule-timeline')
+    expect(screen.getByTestId('sov-cron-table-row-cronjob-analytics-noon-report')).toBeTruthy()
+    expect(screen.getByTestId('sov-cron-table-row-cronjob-db-backup-a')).toBeTruthy()
+    expect(screen.getByTestId('sov-cron-table-row-cronjob-cache-backup-b')).toBeTruthy()
+    // Human-readable schedule surfaces.
+    expect(screen.getByText('Every day at 12:00')).toBeTruthy()
+  })
+
+  it('places a fire mark at the 12:00 x-position for `0 12 * * *`', async () => {
+    renderSchedule(makeSnapshot())
+    await screen.findByTestId('sov-cron-schedule-timeline')
+    const marks = document.querySelectorAll('[data-testid^="sov-cron-mark-"][data-minute="720"]')
+    expect(marks.length).toBe(1)
+    // x = LABEL_W(220) + PAD_X(20) + (720/1440) * innerW(700) = 590.
+    expect(marks[0].getAttribute('data-x')).toBe('590')
+  })
+
+  it('groups a collision where two CronJobs fire on the same minute', async () => {
+    renderSchedule(makeSnapshot())
+    await screen.findByTestId('sov-cron-schedule-timeline')
+    // backup-a + backup-b both fire at 00:00 → collision at minute 0, count 2.
+    const collision = screen.getByTestId('sov-cron-collision-0')
+    expect(collision.getAttribute('data-count')).toBe('2')
+    // The summary banner reports it.
+    expect(screen.getByTestId('sov-cron-collision-summary')).toBeTruthy()
+    // Noon fires alone — no collision marker there.
+    expect(screen.queryByTestId('sov-cron-collision-720')).toBeNull()
+  })
+
+  it('opens the run-history drawer listing the CronJob child Jobs, newest first', async () => {
+    renderSchedule(makeSnapshot())
+    await screen.findByTestId('sov-cron-schedule-timeline')
+    fireEvent.click(screen.getByTestId('sov-cron-table-row-cronjob-analytics-noon-report'))
+    const drawer = await screen.findByTestId('sov-cron-history-drawer')
+    expect(drawer).toBeTruthy()
+    // Both child runs are listed.
+    expect(screen.getByTestId('sov-cron-run-noon-report-1')).toBeTruthy()
+    expect(screen.getByTestId('sov-cron-run-noon-report-2')).toBeTruthy()
+    // Newest run (noon-report-2, failed) is the first row.
+    const rows = screen.getByTestId('sov-cron-history-table').querySelectorAll('tbody tr')
+    expect(rows[0].getAttribute('data-testid')).toBe('sov-cron-run-noon-report-2')
+    // Closing the drawer removes it.
+    fireEvent.click(screen.getByTestId('sov-cron-history-close'))
+    expect(screen.queryByTestId('sov-cron-history-drawer')).toBeNull()
+  })
+
+  it('renders the empty state when no CronJobs exist', async () => {
+    renderSchedule(new Map())
+    expect(await screen.findByTestId('sov-cron-schedule-empty')).toBeTruthy()
+  })
+
+  it('links back to the jobs cron list', async () => {
+    renderSchedule(makeSnapshot())
+    const back = await screen.findByTestId('sov-cron-schedule-back')
+    expect(back.getAttribute('href')).toContain('/jobs')
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/jobs-schedule/CronScheduleView.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/jobs-schedule/CronScheduleView.tsx
@@ -1,0 +1,618 @@
+/**
+ * CronScheduleView — the consolidated CronJob Schedule surface (P3-frontend,
+ * Refs #6703).
+ *
+ * Answers the founder's two questions directly:
+ *   1. "what is scheduled for 12pm / where do crons collide?" → a read-only
+ *      00:00→24:00 time-of-day timeline (pure SVG, no charting lib per
+ *      INVIOLABLE-PRINCIPLES #2 — same house style as JobsTimeline.tsx) with
+ *      one row per CronJob, a mark at every wall-clock time it fires, hour
+ *      gridlines (noon emphasised), and a collision overlay where ≥2 crons
+ *      fire on the same minute.
+ *   2. "how do I get the complete history of a cron?" → clicking a row opens
+ *      the run-history drawer: that CronJob's child Jobs (ownerRef match),
+ *      newest first, each with a status badge + start + duration.
+ *
+ * Data path (verified — no new fetch layer): the raw batch/v1 CronJob +
+ * child Job objects come from the catalyst-api k8scache SSE stream via
+ * `useK8sCacheStream(deploymentId, { kinds: ['cronjob','job'] })` — the exact
+ * hook + `/api/v1/sovereigns/{id}/k8s/stream` endpoint the Cloud list pages
+ * use. `deriveCronRows` / `childRunsOfCron` (cronScheduleModel.ts) do the
+ * pure shaping; `cronSchedule.ts` parses `.spec.schedule`.
+ *
+ * READ-ONLY: no create/edit ("+ New schedule" is a later phase). Nothing here
+ * mutates cluster state.
+ */
+
+import { useMemo, useState } from 'react'
+import { Link } from '@tanstack/react-router'
+import { useResolvedDeploymentId } from '@/shared/lib/useResolvedDeploymentId'
+import { sovereignPathOrDeployments } from '@/shared/lib/sovereignPaths'
+import { Badge, type BadgeProps } from '@/shared/ui/badge'
+import type { K8sSnapshot } from '@/widgets/architecture-graph/useK8sCacheStream'
+import { useK8sCacheStream } from '@/widgets/architecture-graph/useK8sCacheStream'
+import { PortalShell } from '../PortalShell'
+import {
+  childRunsOfCron,
+  collisionMinutes,
+  deriveCronRows,
+  formatDuration,
+  formatMinuteOfDay,
+  type CronRow,
+  type CronRun,
+  type CronRunStatus,
+} from './cronScheduleModel'
+
+/** The k8scache registry kinds this surface watches (batch/v1). Kept
+ *  module-local (not exported) so this component file stays fast-refresh
+ *  clean — react-refresh/only-export-components. */
+const CRON_SCHEDULE_KINDS = ['cronjob', 'job'] as const
+
+interface CronScheduleViewProps {
+  /** Test seam — a fixed "now" so fire placement + next-fire are deterministic. */
+  nowOverride?: Date
+  /** Test seam — inject a k8scache snapshot instead of opening a live SSE. */
+  snapshotOverride?: K8sSnapshot
+  /** Test seam — preselect a CronJob row's history drawer by its key. */
+  initialSelectedKey?: string
+}
+
+/* ── SVG geometry (derived, not magic — INVIOLABLE-PRINCIPLES #4) ─────── */
+const CHART_W = 960
+const LABEL_W = 220
+const ROW_H = 30
+const PAD_X = 20
+const PAD_Y = 16
+const AXIS_H = 26
+const MINUTES_PER_DAY = 1440
+
+/** Status → Badge variant + label for a run / last-run. */
+const RUN_TONE: Record<CronRunStatus, { variant: BadgeProps['variant']; label: string }> = {
+  succeeded: { variant: 'success', label: 'Succeeded' },
+  failed: { variant: 'error', label: 'Failed' },
+  running: { variant: 'info', label: 'Running' },
+  unknown: { variant: 'default', label: 'Unknown' },
+}
+
+/** Sanitise a snapshot key (`cronjob:ns/name@cluster`) into a testid-safe id. */
+function safeId(key: string): string {
+  return key.replace(/[^a-zA-Z0-9_-]+/g, '-')
+}
+
+function RunStatusBadge({ status }: { status: CronRunStatus }) {
+  const tone = RUN_TONE[status]
+  return <Badge variant={tone.variant}>{tone.label}</Badge>
+}
+
+export function CronScheduleView({
+  nowOverride,
+  snapshotOverride,
+  initialSelectedKey,
+}: CronScheduleViewProps = {}) {
+  const { deploymentId: resolvedId } = useResolvedDeploymentId()
+  const deploymentId = resolvedId ?? ''
+
+  // Live k8scache stream — same hook + endpoint as the Cloud list pages.
+  // Disabled entirely when a test injects a snapshot.
+  const live = useK8sCacheStream(deploymentId, {
+    kinds: CRON_SCHEDULE_KINDS,
+    enabled: !snapshotOverride,
+  })
+  const snapshot = snapshotOverride ?? live.snapshot
+  const status = snapshotOverride ? 'open' : live.status
+
+  const now = useMemo(() => nowOverride ?? new Date(), [nowOverride])
+  const rows = useMemo(
+    () => deriveCronRows(snapshot, now),
+    // live.revision bumps on every applied SSE delta (the snapshot Map ref is
+    // stable in-place, so it alone would never retrigger — mirror K8sListPage).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [snapshot, live.revision, now],
+  )
+  const collisions = useMemo(() => collisionMinutes(rows), [rows])
+
+  const [selectedKey, setSelectedKey] = useState<string | null>(
+    initialSelectedKey ?? null,
+  )
+  const selectedRow = rows.find((r) => r.key === selectedKey) ?? null
+  const selectedRuns = useMemo(
+    () => (selectedRow ? childRunsOfCron(snapshot, selectedRow) : []),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [selectedRow, snapshot, live.revision],
+  )
+
+  return (
+    <PortalShell
+      deploymentId={deploymentId}
+      sovereignFQDN={null}
+      pageTitle="CronJob schedule"
+      headerSlotLeft={
+        <Link
+          to={sovereignPathOrDeployments('jobs', { deploymentId }) as never}
+          search={{ view: 'list', kind: 'cron' } as never}
+          className="text-[11px] text-[var(--color-text-dim)] hover:text-[var(--color-text)] no-underline"
+          data-testid="sov-cron-schedule-back"
+        >
+          ← Back to jobs
+        </Link>
+      }
+    >
+      <style>{CRON_SCHEDULE_CSS}</style>
+      <div data-testid="sov-cron-schedule">
+        <p className="mt-4 text-sm text-[var(--color-text-dim)]">
+          Every CronJob on the Sovereign, placed on a 24-hour clock by its
+          schedule — read down a time to see what fires then, and where runs
+          collide. Times are the CronJob&rsquo;s own wall-clock schedule.
+        </p>
+
+        {rows.length === 0 ? (
+          <div
+            className="mt-6 rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-2)] p-6 text-sm text-[var(--color-text-dim)]"
+            data-testid="sov-cron-schedule-empty"
+          >
+            {status === 'connecting'
+              ? 'Connecting to the live cluster stream…'
+              : 'No CronJobs scheduled on this Sovereign.'}
+          </div>
+        ) : (
+          <>
+            {collisions.size > 0 ? (
+              <CollisionSummary collisions={collisions} />
+            ) : null}
+            <ScheduleTimeline
+              rows={rows}
+              collisions={collisions}
+              onSelect={setSelectedKey}
+              selectedKey={selectedKey}
+            />
+            <ScheduleTable
+              rows={rows}
+              onSelect={setSelectedKey}
+              selectedKey={selectedKey}
+            />
+          </>
+        )}
+      </div>
+
+      {selectedRow ? (
+        <RunHistoryDrawer
+          row={selectedRow}
+          runs={selectedRuns}
+          onClose={() => setSelectedKey(null)}
+        />
+      ) : null}
+    </PortalShell>
+  )
+}
+
+/* ── Collision summary banner ─────────────────────────────────────────── */
+
+function CollisionSummary({ collisions }: { collisions: Map<number, number> }) {
+  const entries = [...collisions.entries()].sort((a, b) => a[0] - b[0])
+  const preview = entries
+    .slice(0, 6)
+    .map(([minute, count]) => `${formatMinuteOfDay(minute)} (${count})`)
+    .join(', ')
+  return (
+    <div
+      className="mt-5 rounded-lg border border-[var(--color-warning)]/35 bg-[var(--color-warning)]/10 p-3 text-xs text-[var(--color-text)]"
+      data-testid="sov-cron-collision-summary"
+    >
+      <span className="font-semibold text-[var(--color-warning)]">
+        {entries.length} collision {entries.length === 1 ? 'time' : 'times'}
+      </span>{' '}
+      — {entries.length === 1 ? 'a minute where' : 'minutes where'} 2+ CronJobs
+      fire together: {preview}
+      {entries.length > 6 ? ', …' : ''}
+    </div>
+  )
+}
+
+/* ── The 24h SVG time-of-day timeline ─────────────────────────────────── */
+
+interface ScheduleTimelineProps {
+  rows: CronRow[]
+  collisions: Map<number, number>
+  selectedKey: string | null
+  onSelect: (key: string) => void
+}
+
+function ScheduleTimeline({ rows, collisions, selectedKey, onSelect }: ScheduleTimelineProps) {
+  const innerW = CHART_W - LABEL_W - PAD_X * 2
+  const rowsTop = PAD_Y + AXIS_H
+  const totalH = rows.length * ROW_H + AXIS_H + PAD_Y * 2
+
+  const xForMinute = (minuteOfDay: number): number =>
+    LABEL_W + PAD_X + (minuteOfDay / MINUTES_PER_DAY) * innerW
+
+  // Hour gridlines every 2 hours (00,02,…,24).
+  const hourTicks: number[] = []
+  for (let h = 0; h <= 24; h += 2) hourTicks.push(h)
+
+  return (
+    <div
+      className="mt-4 overflow-auto rounded-xl border border-[var(--color-border)] bg-[var(--color-surface)] p-2"
+      data-testid="sov-cron-schedule-timeline-wrap"
+    >
+      <svg
+        width={CHART_W}
+        height={totalH}
+        viewBox={`0 0 ${CHART_W} ${totalH}`}
+        data-testid="sov-cron-schedule-timeline"
+        role="img"
+        aria-label="CronJob schedule — 24 hour time-of-day timeline"
+      >
+        {/* Hour gridlines + labels */}
+        <g data-testid="sov-cron-schedule-axis">
+          {hourTicks.map((h) => {
+            const x = xForMinute(h * 60)
+            const noon = h === 12
+            return (
+              <g key={h}>
+                <line
+                  x1={x}
+                  x2={x}
+                  y1={rowsTop}
+                  y2={totalH - PAD_Y}
+                  stroke={noon ? 'var(--color-accent)' : 'var(--color-border)'}
+                  strokeWidth={noon ? 1 : 0.5}
+                  strokeDasharray={noon ? '4 3' : undefined}
+                  data-testid={`sov-cron-gridline-${h}`}
+                />
+                <text
+                  x={x}
+                  y={PAD_Y + AXIS_H - 9}
+                  fill={noon ? 'var(--color-accent)' : 'var(--color-text-dim)'}
+                  fontSize={10}
+                  fontWeight={noon ? 600 : 400}
+                  textAnchor="middle"
+                >
+                  {String(h).padStart(2, '0')}:00
+                </text>
+              </g>
+            )
+          })}
+        </g>
+
+        {/* Collision overlay — a full-height accent line at each colliding
+            minute so "3 crons at midnight" is visible at a glance. */}
+        <g data-testid="sov-cron-schedule-collisions">
+          {[...collisions.entries()].map(([minute, count]) => (
+            <line
+              key={minute}
+              x1={xForMinute(minute)}
+              x2={xForMinute(minute)}
+              y1={rowsTop}
+              y2={totalH - PAD_Y}
+              stroke="var(--color-warning)"
+              strokeWidth={1.5}
+              opacity={0.5}
+              data-testid={`sov-cron-collision-${minute}`}
+              data-count={count}
+            >
+              <title>{`${count} CronJobs fire at ${formatMinuteOfDay(minute)}`}</title>
+            </line>
+          ))}
+        </g>
+
+        {/* Rows */}
+        <g data-testid="sov-cron-schedule-rows">
+          {rows.map((row, i) => {
+            const y = rowsTop + i * ROW_H
+            const cy = y + ROW_H / 2
+            const sid = safeId(row.key)
+            const selected = row.key === selectedKey
+            return (
+              <g
+                key={row.key}
+                data-testid={`sov-cron-row-${sid}`}
+                data-suspended={row.suspended ? 'true' : 'false'}
+              >
+                {/* Clickable row background (opens the run-history drawer). */}
+                <rect
+                  x={PAD_X}
+                  y={y}
+                  width={CHART_W - PAD_X * 2}
+                  height={ROW_H}
+                  fill={selected ? 'var(--color-accent)' : 'transparent'}
+                  opacity={selected ? 0.08 : 0}
+                  className="sov-cron-rowbg"
+                  data-testid={`sov-cron-rowbg-${sid}`}
+                  onClick={() => onSelect(row.key)}
+                >
+                  <title>{`${row.namespace}/${row.name} — ${row.description}`}</title>
+                </rect>
+                {/* Label */}
+                <text
+                  x={PAD_X + 4}
+                  y={cy + 4}
+                  fill="var(--color-text-strong)"
+                  fontSize={12}
+                  fontWeight={500}
+                  className="sov-cron-rowlabel"
+                  onClick={() => onSelect(row.key)}
+                >
+                  {truncate(row.name, 30)}
+                </text>
+                {/* Fire marks */}
+                {row.fireMinutes.map((minute) => (
+                  <circle
+                    key={minute}
+                    cx={xForMinute(minute)}
+                    cy={cy}
+                    r={2.6}
+                    fill={row.suspended ? 'var(--color-text-dim)' : 'var(--color-accent)'}
+                    opacity={row.suspended ? 0.4 : 0.9}
+                    data-testid={`sov-cron-mark-${sid}-${minute}`}
+                    data-minute={minute}
+                    data-x={xForMinute(minute)}
+                  >
+                    <title>{`${row.name} fires at ${formatMinuteOfDay(minute)}`}</title>
+                  </circle>
+                ))}
+                {/* Suspended rows fire nothing — show a hint pill. */}
+                {row.suspended ? (
+                  <text
+                    x={LABEL_W + PAD_X + 6}
+                    y={cy + 4}
+                    fill="var(--color-text-dim)"
+                    fontSize={10}
+                    fontStyle="italic"
+                  >
+                    suspended
+                  </text>
+                ) : null}
+              </g>
+            )
+          })}
+        </g>
+      </svg>
+    </div>
+  )
+}
+
+/* ── Per-cron detail table (the interactive list) ─────────────────────── */
+
+interface ScheduleTableProps {
+  rows: CronRow[]
+  selectedKey: string | null
+  onSelect: (key: string) => void
+}
+
+function ScheduleTable({ rows, selectedKey, onSelect }: ScheduleTableProps) {
+  return (
+    <div className="mt-4 overflow-x-auto rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-2)]">
+      <table
+        className="w-full border-collapse text-sm"
+        data-testid="sov-cron-schedule-table"
+      >
+        <thead className="text-xs uppercase tracking-wide text-[var(--color-text-dim)]">
+          <tr className="border-b border-[var(--color-border)]">
+            <th className="px-3 py-2 text-left font-medium">Namespace</th>
+            <th className="px-3 py-2 text-left font-medium">CronJob</th>
+            <th className="px-3 py-2 text-left font-medium">Schedule</th>
+            <th className="px-3 py-2 text-left font-medium">Next fire</th>
+            <th className="px-3 py-2 text-left font-medium">Last run</th>
+            <th className="px-3 py-2 text-left font-medium">Runs</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row) => {
+            const sid = safeId(row.key)
+            const selected = row.key === selectedKey
+            return (
+              <tr
+                key={row.key}
+                data-testid={`sov-cron-table-row-${sid}`}
+                className={
+                  'cursor-pointer border-b border-[var(--color-border)] last:border-0 hover:bg-[var(--color-bg-3)] ' +
+                  (selected ? 'bg-[var(--color-bg-3)]' : '')
+                }
+                onClick={() => onSelect(row.key)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault()
+                    onSelect(row.key)
+                  }
+                }}
+                role="button"
+                tabIndex={0}
+                aria-label={`Run history for ${row.name}`}
+              >
+                <td className="px-3 py-2 text-[var(--color-text-dim)]">{row.namespace || '—'}</td>
+                <td className="px-3 py-2 font-medium text-[var(--color-text-strong)]">
+                  {row.name}
+                  {row.suspended ? (
+                    <span className="ml-2 rounded bg-[var(--color-bg-3)] px-1.5 py-0.5 text-[10px] uppercase text-[var(--color-text-dim)]">
+                      suspended
+                    </span>
+                  ) : null}
+                </td>
+                <td className="px-3 py-2">
+                  <span className="font-mono text-xs text-[var(--color-text-dim)]">{row.schedule || '—'}</span>
+                  <span className="ml-2 text-[var(--color-text)]">{row.description}</span>
+                </td>
+                <td className="px-3 py-2 text-[var(--color-text)]">
+                  {row.nextFire ? formatDateTime(row.nextFire) : '—'}
+                </td>
+                <td className="px-3 py-2">
+                  {row.latestRun ? (
+                    <span className="inline-flex items-center gap-2">
+                      <RunStatusBadge status={row.latestRun.status} />
+                      <span className="text-xs text-[var(--color-text-dim)]">
+                        {row.latestRun.startTime ? formatDateTime(new Date(row.latestRun.startTime)) : ''}
+                      </span>
+                    </span>
+                  ) : row.lastScheduleTime ? (
+                    <span className="text-xs text-[var(--color-text-dim)]">
+                      last scheduled {formatDateTime(new Date(row.lastScheduleTime))}
+                    </span>
+                  ) : (
+                    <span className="text-[var(--color-text-dim)]">—</span>
+                  )}
+                </td>
+                <td className="px-3 py-2 text-[var(--color-text-dim)] tabular-nums">
+                  {row.runCount}
+                </td>
+              </tr>
+            )
+          })}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+/* ── Run-history drawer ───────────────────────────────────────────────── */
+
+interface RunHistoryDrawerProps {
+  row: CronRow
+  runs: CronRun[]
+  onClose: () => void
+}
+
+function RunHistoryDrawer({ row, runs, onClose }: RunHistoryDrawerProps) {
+  return (
+    <div className="sov-cron-drawer-scrim" data-testid="sov-cron-history-scrim" onClick={onClose}>
+      <aside
+        className="sov-cron-drawer"
+        data-testid="sov-cron-history-drawer"
+        role="dialog"
+        aria-label={`Run history for ${row.name}`}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="sov-cron-drawer-head">
+          <div>
+            <div className="text-sm font-semibold text-[var(--color-text-strong)]">{row.name}</div>
+            <div className="text-xs text-[var(--color-text-dim)]">
+              {row.namespace} · <span className="font-mono">{row.schedule}</span> · {row.description}
+            </div>
+          </div>
+          <button
+            type="button"
+            className="sov-cron-drawer-close"
+            data-testid="sov-cron-history-close"
+            aria-label="Close run history"
+            onClick={onClose}
+          >
+            ✕
+          </button>
+        </div>
+
+        <div className="sov-cron-drawer-body">
+          {runs.length === 0 ? (
+            <div
+              className="rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-2)] p-4 text-sm text-[var(--color-text-dim)]"
+              data-testid="sov-cron-history-empty"
+            >
+              No runs recorded yet for this CronJob.
+              {row.lastScheduleTime
+                ? ` Last scheduled ${formatDateTime(new Date(row.lastScheduleTime))}.`
+                : ''}
+            </div>
+          ) : (
+            <table className="w-full border-collapse text-sm" data-testid="sov-cron-history-table">
+              <thead className="text-xs uppercase tracking-wide text-[var(--color-text-dim)]">
+                <tr className="border-b border-[var(--color-border)]">
+                  <th className="px-2 py-2 text-left font-medium">Run</th>
+                  <th className="px-2 py-2 text-left font-medium">Status</th>
+                  <th className="px-2 py-2 text-left font-medium">Started</th>
+                  <th className="px-2 py-2 text-left font-medium">Duration</th>
+                </tr>
+              </thead>
+              <tbody>
+                {runs.map((run) => (
+                  <tr
+                    key={run.name}
+                    data-testid={`sov-cron-run-${safeId(run.name)}`}
+                    className="border-b border-[var(--color-border)] last:border-0"
+                  >
+                    <td className="px-2 py-2 font-mono text-xs text-[var(--color-text)]">{run.name}</td>
+                    <td className="px-2 py-2">
+                      <RunStatusBadge status={run.status} />
+                    </td>
+                    <td className="px-2 py-2 text-xs text-[var(--color-text-dim)]">
+                      {run.startTime ? formatDateTime(new Date(run.startTime)) : '—'}
+                    </td>
+                    <td className="px-2 py-2 text-xs text-[var(--color-text-dim)] tabular-nums">
+                      {run.status === 'running' && run.startTime && !run.completionTime
+                        ? 'in progress'
+                        : formatDuration(run.durationMs)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+      </aside>
+    </div>
+  )
+}
+
+/* ── Small formatters ─────────────────────────────────────────────────── */
+
+function truncate(s: string, max: number): string {
+  if (s.length <= max) return s
+  return s.slice(0, Math.max(0, max - 1)) + '…'
+}
+
+/** `MMM D, HH:MM` in the viewer's locale — compact, unambiguous. */
+function formatDateTime(d: Date): string {
+  if (Number.isNaN(d.getTime())) return '—'
+  return d.toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+const CRON_SCHEDULE_CSS = `
+.sov-cron-rowbg { cursor: pointer; }
+.sov-cron-rowlabel { cursor: pointer; }
+.sov-cron-schedule-rows g:hover .sov-cron-rowbg { opacity: 0.06; fill: var(--color-accent); }
+
+.sov-cron-drawer-scrim {
+  position: fixed;
+  inset: 0;
+  z-index: 3000;
+  background: rgba(0, 0, 0, 0.35);
+  display: flex;
+  justify-content: flex-end;
+}
+.sov-cron-drawer {
+  width: min(560px, 92vw);
+  height: 100%;
+  background: var(--color-surface);
+  border-left: 1px solid var(--color-border);
+  box-shadow: -12px 0 32px rgba(0, 0, 0, 0.35);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+.sov-cron-drawer-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 1rem 1.1rem;
+  border-bottom: 1px solid var(--color-border);
+}
+.sov-cron-drawer-close {
+  border: 1px solid var(--color-border);
+  background: var(--color-bg-2);
+  color: var(--color-text-dim);
+  border-radius: 6px;
+  width: 28px;
+  height: 28px;
+  cursor: pointer;
+  line-height: 1;
+  flex-shrink: 0;
+}
+.sov-cron-drawer-close:hover { color: var(--color-text); }
+.sov-cron-drawer-body {
+  padding: 0.9rem 1.1rem;
+  overflow-y: auto;
+}
+`

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/jobs-schedule/cronScheduleModel.test.ts
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/jobs-schedule/cronScheduleModel.test.ts
@@ -1,0 +1,199 @@
+/**
+ * cronScheduleModel.test.ts — pins the pure derivation behind the Schedule
+ * surface (P3-frontend, Refs #6703): CronJob rows + fire placement, child-Job
+ * run-history matching, and the collision set — all read off a k8scache
+ * snapshot exactly as the live SSE stream delivers it.
+ */
+
+import { describe, expect, it } from 'vitest'
+import type { K8sObject, K8sSnapshot } from '@/widgets/architecture-graph/useK8sCacheStream'
+import {
+  childRunsOfCron,
+  collisionMinutes,
+  deriveCronRows,
+  formatDuration,
+  jobRunStatus,
+} from './cronScheduleModel'
+
+function cronjob(
+  name: string,
+  ns: string,
+  schedule: string,
+  extra: Partial<{ suspend: boolean; lastScheduleTime: string; cluster: string }> = {},
+): [string, K8sObject] {
+  const cluster = extra.cluster ?? ''
+  const key = `cronjob:${ns}/${name}${cluster ? `@${cluster}` : ''}`
+  const obj: K8sObject = {
+    apiVersion: 'batch/v1',
+    kind: 'CronJob',
+    metadata: { name, namespace: ns },
+    spec: { schedule, ...(extra.suspend ? { suspend: true } : {}) },
+    status: extra.lastScheduleTime ? { lastScheduleTime: extra.lastScheduleTime } : {},
+    ...(cluster ? { clusterId: cluster } : {}),
+  }
+  return [key, obj]
+}
+
+function childJob(
+  name: string,
+  ns: string,
+  cronName: string,
+  status: Record<string, unknown>,
+  cluster = '',
+): [string, K8sObject] {
+  const key = `job:${ns}/${name}${cluster ? `@${cluster}` : ''}`
+  const obj: K8sObject = {
+    apiVersion: 'batch/v1',
+    kind: 'Job',
+    metadata: {
+      name,
+      namespace: ns,
+      ownerReferences: [{ apiVersion: 'batch/v1', kind: 'CronJob', name: cronName }],
+    },
+    status,
+    ...(cluster ? { clusterId: cluster } : {}),
+  }
+  return [key, obj]
+}
+
+const REF = new Date(2026, 7, 24, 6, 0) // Mon 2026-08-24 06:00 local
+
+describe('jobRunStatus', () => {
+  it('reads Complete/Failed conditions first', () => {
+    expect(jobRunStatus({ status: { conditions: [{ type: 'Complete', status: 'True' }] } })).toBe('succeeded')
+    expect(jobRunStatus({ status: { conditions: [{ type: 'Failed', status: 'True' }] } })).toBe('failed')
+  })
+  it('falls back to count fields', () => {
+    expect(jobRunStatus({ status: { succeeded: 1 } })).toBe('succeeded')
+    expect(jobRunStatus({ status: { failed: 2 } })).toBe('failed')
+    expect(jobRunStatus({ status: { active: 1 } })).toBe('running')
+    expect(jobRunStatus({ status: {} })).toBe('unknown')
+  })
+})
+
+describe('deriveCronRows', () => {
+  it('shapes each CronJob with schedule, description, fires + next fire', () => {
+    const snap: K8sSnapshot = new Map([
+      cronjob('nightly-backup', 'db', '0 0 * * *'),
+      cronjob('noon-report', 'analytics', '0 12 * * *'),
+    ])
+    const rows = deriveCronRows(snap, REF)
+    expect(rows).toHaveLength(2)
+    // Sorted by namespace: analytics before db.
+    expect(rows[0].name).toBe('noon-report')
+    expect(rows[0].description).toBe('Every day at 12:00')
+    expect(rows[0].fireMinutes).toEqual([720])
+    // Next fire today at 12:00 (REF is 06:00).
+    expect(rows[0].nextFire).toEqual(new Date(2026, 7, 24, 12, 0))
+
+    expect(rows[1].name).toBe('nightly-backup')
+    expect(rows[1].fireMinutes).toEqual([0])
+    // Midnight already passed on REF day → next fire tomorrow 00:00.
+    expect(rows[1].nextFire).toEqual(new Date(2026, 7, 25, 0, 0))
+  })
+
+  it('draws no marks for a suspended CronJob', () => {
+    const snap: K8sSnapshot = new Map([
+      cronjob('paused', 'db', '0 12 * * *', { suspend: true }),
+    ])
+    const rows = deriveCronRows(snap, REF)
+    expect(rows[0].suspended).toBe(true)
+    expect(rows[0].fireMinutes).toEqual([])
+    expect(rows[0].nextFire).toBeNull()
+  })
+
+  it('attaches the latest child run + run count', () => {
+    const snap: K8sSnapshot = new Map([
+      cronjob('scan', 'sec', '0 * * * *'),
+      childJob('scan-1', 'sec', 'scan', {
+        startTime: '2026-08-24T04:00:00Z',
+        completionTime: '2026-08-24T04:00:30Z',
+        succeeded: 1,
+      }),
+      childJob('scan-2', 'sec', 'scan', {
+        startTime: '2026-08-24T05:00:00Z',
+        completionTime: '2026-08-24T05:00:20Z',
+        succeeded: 1,
+      }),
+    ])
+    const rows = deriveCronRows(snap, REF)
+    expect(rows[0].runCount).toBe(2)
+    // Newest first → scan-2 is the latest run.
+    expect(rows[0].latestRun?.name).toBe('scan-2')
+    expect(rows[0].latestRun?.status).toBe('succeeded')
+  })
+
+  it('leaves an unparseable schedule as a null parse with a raw description', () => {
+    const snap: K8sSnapshot = new Map([cronjob('broken', 'x', 'not-a-cron')])
+    const rows = deriveCronRows(snap, REF)
+    expect(rows[0].parsed).toBeNull()
+    expect(rows[0].fireMinutes).toEqual([])
+  })
+})
+
+describe('childRunsOfCron', () => {
+  it('matches by ownerReference + namespace, newest first', () => {
+    const snap: K8sSnapshot = new Map([
+      cronjob('scan', 'sec', '0 * * * *'),
+      childJob('scan-old', 'sec', 'scan', { startTime: '2026-08-24T01:00:00Z', succeeded: 1 }),
+      childJob('scan-new', 'sec', 'scan', { startTime: '2026-08-24T03:00:00Z', failed: 1 }),
+      // Different owner — must NOT be listed.
+      childJob('other-1', 'sec', 'other-cron', { startTime: '2026-08-24T02:00:00Z', succeeded: 1 }),
+      // Same name, different namespace — must NOT be listed.
+      childJob('scan-x', 'db', 'scan', { startTime: '2026-08-24T02:30:00Z', succeeded: 1 }),
+    ])
+    const row = deriveCronRows(snap, REF).find((r) => r.name === 'scan')!
+    const runs = childRunsOfCron(snap, row)
+    expect(runs.map((r) => r.name)).toEqual(['scan-new', 'scan-old'])
+    expect(runs[0].status).toBe('failed')
+  })
+
+  it('region-scopes child jobs when both carry a cluster id (#5571)', () => {
+    const snap: K8sSnapshot = new Map([
+      cronjob('scan', 'sec', '0 * * * *', { cluster: 'region-a' }),
+      childJob('scan-a', 'sec', 'scan', { startTime: '2026-08-24T01:00:00Z', succeeded: 1 }, 'region-a'),
+      childJob('scan-b', 'sec', 'scan', { startTime: '2026-08-24T01:00:00Z', succeeded: 1 }, 'region-b'),
+    ])
+    const row = deriveCronRows(snap, REF).find((r) => r.cluster === 'region-a')!
+    const runs = childRunsOfCron(snap, row)
+    expect(runs.map((r) => r.name)).toEqual(['scan-a'])
+  })
+
+  it('computes run duration from start + completion', () => {
+    const snap: K8sSnapshot = new Map([
+      cronjob('scan', 'sec', '0 * * * *'),
+      childJob('scan-1', 'sec', 'scan', {
+        startTime: '2026-08-24T04:00:00Z',
+        completionTime: '2026-08-24T04:02:05Z',
+        succeeded: 1,
+      }),
+    ])
+    const row = deriveCronRows(snap, REF)[0]
+    const runs = childRunsOfCron(snap, row)
+    expect(runs[0].durationMs).toBe(125_000)
+  })
+})
+
+describe('collisionMinutes', () => {
+  it('flags a minute where two distinct CronJobs fire together', () => {
+    const snap: K8sSnapshot = new Map([
+      cronjob('backup-a', 'db', '0 0 * * *'), // midnight
+      cronjob('backup-b', 'cache', '0 0 * * *'), // midnight — collides
+      cronjob('noon', 'x', '0 12 * * *'), // 12:00 — alone
+    ])
+    const rows = deriveCronRows(snap, REF)
+    const collisions = collisionMinutes(rows)
+    expect(collisions.get(0)).toBe(2) // 2 crons at 00:00
+    expect(collisions.has(720)).toBe(false) // noon is alone
+  })
+})
+
+describe('formatDuration', () => {
+  it('formats ms / s / m / h buckets', () => {
+    expect(formatDuration(820)).toBe('820ms')
+    expect(formatDuration(3200)).toBe('3.2s')
+    expect(formatDuration(125_000)).toBe('2m 05s')
+    expect(formatDuration(3_720_000)).toBe('1h 02m')
+    expect(formatDuration(undefined)).toBe('—')
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/jobs-schedule/cronScheduleModel.ts
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/jobs-schedule/cronScheduleModel.ts
@@ -1,0 +1,249 @@
+/**
+ * cronScheduleModel.ts — pure derivation of the consolidated CronJob
+ * Schedule view's data from the live k8scache SSE snapshot (P3-frontend,
+ * Refs #6703).
+ *
+ * The /jobs job-store rows carry a CronJob's LATEST-run status but not the
+ * raw `.spec.schedule` nor the full child-Job run history the founder asked
+ * for ("what fires at 12:00 + collisions" and "the complete history of a
+ * cron"). Those live only on the raw batch/v1 CronJob + Job objects, which
+ * the catalyst-api k8scache now watches (kinds `cronjob` + `job`). This
+ * module reads them straight off the same `K8sSnapshot` the Cloud list
+ * pages consume — no new fetch layer — and shapes them for the SVG timeline
+ * + the run-history drawer.
+ *
+ * Everything here is a pure function of (snapshot, referenceDate) so the
+ * correctness-critical fire-placement + child-Job matching is unit-tested
+ * without a DOM or a live EventSource.
+ */
+
+import type { K8sObject, K8sSnapshot } from '@/widgets/architecture-graph/useK8sCacheStream'
+import {
+  describeCron,
+  fireMinutesOnDate,
+  nextFireTime,
+  tryParseCron,
+  type ParsedCron,
+} from '@/shared/lib/cronSchedule'
+
+/** k8s Job terminal/active state, mapped to a small closed vocabulary. */
+export type CronRunStatus = 'succeeded' | 'failed' | 'running' | 'unknown'
+
+/** One historical run (child Job) of a CronJob. */
+export interface CronRun {
+  /** Child Job name. */
+  name: string
+  namespace: string
+  status: CronRunStatus
+  /** ISO start time (`.status.startTime`), when present. */
+  startTime?: string
+  /** ISO completion time (`.status.completionTime`), when present. */
+  completionTime?: string
+  /** Wall-clock run duration in ms, when both start + completion are known. */
+  durationMs?: number
+}
+
+/** One CronJob row on the Schedule surface. */
+export interface CronRow {
+  /** Stable id — `namespace/name@cluster` (region-safe, #5571). */
+  key: string
+  name: string
+  namespace: string
+  /** k8scache region id, when the stream attributes one. */
+  cluster?: string
+  /** Raw 5-field schedule (`.spec.schedule`). */
+  schedule: string
+  /** Parsed schedule, or null when unparseable / @reboot. */
+  parsed: ParsedCron | null
+  /** Human-readable schedule (`describeCron`). */
+  description: string
+  /** `.spec.suspend === true` — a suspended CronJob does not fire. */
+  suspended: boolean
+  /** `.status.lastScheduleTime` — when the controller last scheduled a run. */
+  lastScheduleTime?: string
+  /** Minutes-of-day (0..1439) the cron fires on the reference date. */
+  fireMinutes: number[]
+  /** Next wall-clock fire at/after the reference date (local calendar). */
+  nextFire: Date | null
+  /** The most-recent child-Job run, when any exists in the snapshot. */
+  latestRun: CronRun | null
+  /** How many child-Job runs are visible in the snapshot. */
+  runCount: number
+}
+
+/** Read a nested string from an unstructured object without `any`. */
+function str(obj: Record<string, unknown> | undefined, key: string): string | undefined {
+  const v = obj?.[key]
+  return typeof v === 'string' ? v : undefined
+}
+function num(obj: Record<string, unknown> | undefined, key: string): number | undefined {
+  const v = obj?.[key]
+  return typeof v === 'number' ? v : undefined
+}
+
+/**
+ * Classify a k8s Job object's run status. Prefers the explicit
+ * `.status.conditions` (Complete / Failed), falling back to the count
+ * fields (`succeeded` / `failed` / `active`).
+ */
+export function jobRunStatus(job: K8sObject): CronRunStatus {
+  const status = (job.status as Record<string, unknown> | undefined) ?? {}
+  const conds = status['conditions'] as Array<Record<string, unknown>> | undefined
+  if (Array.isArray(conds)) {
+    for (const c of conds) {
+      if (c?.['status'] !== 'True') continue
+      if (c?.['type'] === 'Complete') return 'succeeded'
+      if (c?.['type'] === 'Failed') return 'failed'
+    }
+  }
+  if ((num(status, 'succeeded') ?? 0) > 0) return 'succeeded'
+  if ((num(status, 'failed') ?? 0) > 0) return 'failed'
+  if ((num(status, 'active') ?? 0) > 0) return 'running'
+  return 'unknown'
+}
+
+/** True when `job` is a child run of the CronJob `cronName`/`ns` (ownerRef). */
+function isChildOf(job: K8sObject, cronName: string, ns: string): boolean {
+  if ((job.metadata?.namespace ?? '') !== ns) return false
+  const refs = job.metadata?.ownerReferences ?? []
+  return refs.some((r) => r?.kind === 'CronJob' && r?.name === cronName)
+}
+
+function toRun(job: K8sObject): CronRun {
+  const status = (job.status as Record<string, unknown> | undefined) ?? {}
+  const startTime = str(status, 'startTime')
+  const completionTime = str(status, 'completionTime')
+  let durationMs: number | undefined
+  if (startTime && completionTime) {
+    const d = new Date(completionTime).getTime() - new Date(startTime).getTime()
+    if (Number.isFinite(d) && d >= 0) durationMs = d
+  }
+  return {
+    name: job.metadata?.name ?? '',
+    namespace: job.metadata?.namespace ?? '',
+    status: jobRunStatus(job),
+    startTime,
+    completionTime,
+    durationMs,
+  }
+}
+
+/** Sort key for a run — startTime (newest first), then creationTimestamp. */
+function runSortValue(job: K8sObject): number {
+  const status = (job.status as Record<string, unknown> | undefined) ?? {}
+  const start = str(status, 'startTime') ?? job.metadata?.creationTimestamp
+  const t = start ? new Date(start).getTime() : 0
+  return Number.isFinite(t) ? t : 0
+}
+
+/**
+ * All child-Job runs of a CronJob row, newest first. Reads raw `job:` keys
+ * from the snapshot and matches by ownerReference (kind=CronJob) + namespace,
+ * and (when both carry it) region — a 2-region Sovereign runs the same
+ * CronJob in both regions, so an unqualified name match would cross-list.
+ */
+export function childRunsOfCron(snapshot: K8sSnapshot, row: CronRow): CronRun[] {
+  const jobs: K8sObject[] = []
+  for (const [key, obj] of snapshot.entries()) {
+    if (!key.startsWith('job:')) continue
+    if (!isChildOf(obj, row.name, row.namespace)) continue
+    // Region-scope when both sides carry a cluster id (#5571).
+    if (row.cluster && obj.clusterId && obj.clusterId !== row.cluster) continue
+    jobs.push(obj)
+  }
+  jobs.sort((a, b) => runSortValue(b) - runSortValue(a))
+  return jobs.map(toRun)
+}
+
+/**
+ * Derive the CronJob rows from the snapshot for a reference date. The date
+ * gates `fireMinutes` (day-of-month / month / day-of-week) and seeds
+ * next-fire; the timeline x-axis itself is the cron's wall-clock minute.
+ */
+export function deriveCronRows(snapshot: K8sSnapshot, referenceDate: Date): CronRow[] {
+  const rows: CronRow[] = []
+  for (const [key, obj] of snapshot.entries()) {
+    if (!key.startsWith('cronjob:')) continue
+    const name = obj.metadata?.name ?? ''
+    const namespace = obj.metadata?.namespace ?? ''
+    const cluster = obj.clusterId
+    const spec = (obj.spec as Record<string, unknown> | undefined) ?? {}
+    const status = (obj.status as Record<string, unknown> | undefined) ?? {}
+    const schedule = str(spec, 'schedule') ?? ''
+    const parsed = schedule ? tryParseCron(schedule) : null
+    const suspended = spec['suspend'] === true
+
+    const runs = childRunsOfCron(
+      snapshot,
+      { key, name, namespace, cluster } as CronRow,
+    )
+
+    rows.push({
+      key,
+      name,
+      namespace,
+      cluster,
+      schedule,
+      parsed,
+      description: schedule ? describeCron(parsed ?? schedule) : '—',
+      suspended,
+      lastScheduleTime: str(status, 'lastScheduleTime'),
+      // A suspended CronJob is drawn with no marks — it is not firing.
+      fireMinutes: parsed && !suspended ? fireMinutesOnDate(parsed, referenceDate) : [],
+      nextFire: parsed && !suspended ? nextFireTime(parsed, referenceDate) : null,
+      latestRun: runs[0] ?? null,
+      runCount: runs.length,
+    })
+  }
+  rows.sort((a, b) => {
+    if (a.namespace !== b.namespace) return a.namespace.localeCompare(b.namespace)
+    if (a.name !== b.name) return a.name.localeCompare(b.name)
+    return (a.cluster ?? '').localeCompare(b.cluster ?? '')
+  })
+  return rows
+}
+
+/**
+ * Minutes-of-day where ≥2 DISTINCT CronJobs fire simultaneously — the
+ * "collision" set the operator wants to spot (e.g. three backups all at
+ * midnight). Returns minute → count of distinct crons (only entries ≥2).
+ */
+export function collisionMinutes(rows: readonly CronRow[]): Map<number, number> {
+  const perMinute = new Map<number, Set<string>>()
+  for (const row of rows) {
+    for (const minute of new Set(row.fireMinutes)) {
+      let set = perMinute.get(minute)
+      if (!set) {
+        set = new Set<string>()
+        perMinute.set(minute, set)
+      }
+      set.add(row.key)
+    }
+  }
+  const out = new Map<number, number>()
+  for (const [minute, set] of perMinute.entries()) {
+    if (set.size >= 2) out.set(minute, set.size)
+  }
+  return out
+}
+
+/** Format a minute-of-day (0..1439) as `HH:MM`. */
+export function formatMinuteOfDay(minuteOfDay: number): string {
+  const h = Math.floor(minuteOfDay / 60)
+  const m = minuteOfDay % 60
+  return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`
+}
+
+/** Compact human duration (`820ms` / `3.2s` / `4m 05s` / `1h 02m`). */
+export function formatDuration(ms: number | undefined): string {
+  if (ms == null || !Number.isFinite(ms) || ms < 0) return '—'
+  if (ms < 1000) return `${ms}ms`
+  const totalSec = Math.round(ms / 1000)
+  if (totalSec < 60) return `${(ms / 1000).toFixed(1)}s`
+  const min = Math.floor(totalSec / 60)
+  const sec = totalSec % 60
+  if (min < 60) return `${min}m ${String(sec).padStart(2, '0')}s`
+  const hr = Math.floor(min / 60)
+  const remMin = min % 60
+  return `${hr}h ${String(remMin).padStart(2, '0')}m`
+}

--- a/products/catalyst/bootstrap/ui/src/shared/lib/cronSchedule.test.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/lib/cronSchedule.test.ts
@@ -1,0 +1,217 @@
+/**
+ * cronSchedule.test.ts — correctness lock for the dependency-free cron
+ * parser behind the /jobs Schedule timeline (P3-frontend, Refs #6703).
+ *
+ * An operator trusts "what fires at 12:00", so every field form (star, step,
+ * range, list, numeric), the Vixie DOM/DOW AND-vs-OR rule, macros, fire-time
+ * enumeration, next-fire, and describe() are pinned here.
+ */
+
+import { describe, expect, it } from 'vitest'
+import {
+  CronParseError,
+  describeCron,
+  fireMinutesOnDate,
+  matchesDate,
+  nextFireTime,
+  parseCron,
+  tryParseCron,
+} from './cronSchedule'
+
+/** A local date at (y, m0, d, hh, mm). Local time is what the parser reads. */
+function at(y: number, m0: number, d: number, hh = 0, mm = 0): Date {
+  return new Date(y, m0, d, hh, mm, 0, 0)
+}
+
+describe('parseCron — field expansion', () => {
+  it('expands `*` to the full domain', () => {
+    const p = parseCron('* * * * *')!
+    expect(p.minute.values.size).toBe(60)
+    expect(p.hour.values.size).toBe(24)
+    expect(p.dom.values.size).toBe(31)
+    expect(p.month.values.size).toBe(12)
+    // dow: 0..7 with 7→0 ⇒ 0..6 = 7 distinct days.
+    expect([...p.dow.values].sort((a, b) => a - b)).toEqual([0, 1, 2, 3, 4, 5, 6])
+    expect(p.minute.star).toBe(true)
+    expect(p.dom.star).toBe(true)
+    expect(p.dow.star).toBe(true)
+  })
+
+  it('expands a step field `*/15`', () => {
+    const p = parseCron('*/15 * * * *')!
+    expect([...p.minute.values].sort((a, b) => a - b)).toEqual([0, 15, 30, 45])
+    expect(p.minute.star).toBe(true)
+  })
+
+  it('expands a range `9-17`', () => {
+    const p = parseCron('0 9-17 * * *')!
+    expect([...p.hour.values].sort((a, b) => a - b)).toEqual([9, 10, 11, 12, 13, 14, 15, 16, 17])
+    expect(p.hour.star).toBe(false)
+  })
+
+  it('expands a list `0,15,30,45`', () => {
+    const p = parseCron('0,15,30,45 * * * *')!
+    expect([...p.minute.values].sort((a, b) => a - b)).toEqual([0, 15, 30, 45])
+  })
+
+  it('expands a range+step `10-40/10`', () => {
+    const p = parseCron('10-40/10 * * * *')!
+    expect([...p.minute.values].sort((a, b) => a - b)).toEqual([10, 20, 30, 40])
+  })
+
+  it('expands a bare `n/step` from n to max', () => {
+    const p = parseCron('5/15 * * * *')!
+    expect([...p.minute.values].sort((a, b) => a - b)).toEqual([5, 20, 35, 50])
+  })
+
+  it('maps day-of-week 7 to 0 (Sunday)', () => {
+    const p = parseCron('0 0 * * 7')!
+    expect([...p.dow.values]).toEqual([0])
+    expect(p.dow.star).toBe(false)
+  })
+
+  it('composes fields: weekday business hours', () => {
+    const p = parseCron('0,30 9-17 * * 1-5')!
+    expect([...p.minute.values].sort((a, b) => a - b)).toEqual([0, 30])
+    expect(p.hour.values.has(9)).toBe(true)
+    expect(p.hour.values.has(18)).toBe(false)
+    expect([...p.dow.values].sort((a, b) => a - b)).toEqual([1, 2, 3, 4, 5])
+  })
+})
+
+describe('parseCron — errors + macros', () => {
+  it('rejects the wrong field count', () => {
+    expect(() => parseCron('* * * *')).toThrow(CronParseError)
+    expect(() => parseCron('* * * * * *')).toThrow(CronParseError)
+  })
+  it('rejects an out-of-range value', () => {
+    expect(() => parseCron('60 * * * *')).toThrow(CronParseError)
+    expect(() => parseCron('0 24 * * *')).toThrow(CronParseError)
+    expect(() => parseCron('0 0 32 * *')).toThrow(CronParseError)
+    expect(() => parseCron('0 0 * 13 *')).toThrow(CronParseError)
+  })
+  it('rejects non-numeric + inverted ranges + zero step', () => {
+    expect(() => parseCron('x * * * *')).toThrow(CronParseError)
+    expect(() => parseCron('30-10 * * * *')).toThrow(CronParseError)
+    expect(() => parseCron('*/0 * * * *')).toThrow(CronParseError)
+  })
+  it('expands @daily / @hourly / @weekly macros', () => {
+    expect(fireMinutesOnDate(parseCron('@daily')!, at(2026, 7, 24))).toEqual([0])
+    expect(fireMinutesOnDate(parseCron('@hourly')!, at(2026, 7, 24)).length).toBe(24)
+    // @weekly = Sunday 00:00; 2026-08-23 is a Sunday.
+    expect(fireMinutesOnDate(parseCron('@weekly')!, at(2026, 7, 23))).toEqual([0])
+    expect(fireMinutesOnDate(parseCron('@weekly')!, at(2026, 7, 24))).toEqual([])
+  })
+  it('treats @reboot as unschedulable (null)', () => {
+    expect(parseCron('@reboot')).toBeNull()
+    expect(tryParseCron('@reboot')).toBeNull()
+  })
+  it('tryParseCron swallows errors', () => {
+    expect(tryParseCron('nonsense')).toBeNull()
+    expect(tryParseCron('61 * * * *')).toBeNull()
+  })
+})
+
+describe('fireMinutesOnDate', () => {
+  it('0 12 * * * fires once at 12:00 (720)', () => {
+    expect(fireMinutesOnDate(parseCron('0 12 * * *')!, at(2026, 7, 24))).toEqual([720])
+  })
+  it('*/15 * * * * fires 96 times, first at 0 and last at 1425', () => {
+    const fires = fireMinutesOnDate(parseCron('*/15 * * * *')!, at(2026, 7, 24))
+    expect(fires.length).toBe(96)
+    expect(fires[0]).toBe(0)
+    expect(fires[fires.length - 1]).toBe(23 * 60 + 45)
+  })
+  it('0 0 * * 0 fires only on Sundays', () => {
+    const p = parseCron('0 0 * * 0')!
+    // 2026-08-23 is a Sunday, 2026-08-24 a Monday.
+    expect(fireMinutesOnDate(p, at(2026, 7, 23))).toEqual([0])
+    expect(fireMinutesOnDate(p, at(2026, 7, 24))).toEqual([])
+  })
+  it('produces the wall-clock minute = hour*60 + minute', () => {
+    // 30 8,20 * * * ⇒ 08:30 (510) and 20:30 (1230).
+    expect(fireMinutesOnDate(parseCron('30 8,20 * * *')!, at(2026, 7, 24))).toEqual([510, 1230])
+  })
+})
+
+describe('matchesDate — Vixie DOM/DOW rule', () => {
+  it('ORs DOM and DOW when both are restricted', () => {
+    // "1st of the month OR any Sunday". 2026-08-01 is a Saturday (dom match),
+    // 2026-08-23 is a Sunday (dow match), 2026-08-10 is neither.
+    const p = parseCron('0 0 1 * 0')!
+    expect(matchesDate(p, at(2026, 7, 1))).toBe(true) // 1st
+    expect(matchesDate(p, at(2026, 7, 23))).toBe(true) // Sunday
+    expect(matchesDate(p, at(2026, 7, 10))).toBe(false) // neither
+  })
+  it('ANDs when DOM is a star', () => {
+    // "* * * * 1" (Mondays only). 2026-08-24 is a Monday.
+    const p = parseCron('0 0 * * 1')!
+    expect(matchesDate(p, at(2026, 7, 24))).toBe(true)
+    expect(matchesDate(p, at(2026, 7, 25))).toBe(false)
+  })
+  it('respects the month gate', () => {
+    const p = parseCron('0 0 * 12 *')!
+    expect(matchesDate(p, at(2026, 11, 5))).toBe(true) // December
+    expect(matchesDate(p, at(2026, 7, 5))).toBe(false) // August
+  })
+})
+
+describe('nextFireTime', () => {
+  it('finds the next daily fire later the same day', () => {
+    const next = nextFireTime(parseCron('0 12 * * *')!, at(2026, 7, 24, 9, 0))
+    expect(next).toEqual(at(2026, 7, 24, 12, 0))
+  })
+  it('rolls to the next day when today has passed', () => {
+    const next = nextFireTime(parseCron('0 12 * * *')!, at(2026, 7, 24, 13, 0))
+    expect(next).toEqual(at(2026, 7, 25, 12, 0))
+  })
+  it('advances to the next matching weekday', () => {
+    // Sundays only; from Monday 2026-08-24 the next Sunday is 2026-08-30.
+    const next = nextFireTime(parseCron('0 0 * * 0')!, at(2026, 7, 24, 0, 0))
+    expect(next).toEqual(at(2026, 7, 30, 0, 0))
+  })
+  it('picks the immediate next step within the hour', () => {
+    const next = nextFireTime(parseCron('*/15 * * * *')!, at(2026, 7, 24, 10, 7))
+    expect(next).toEqual(at(2026, 7, 24, 10, 15))
+  })
+  it('returns null for an impossible date (Feb 30)', () => {
+    expect(nextFireTime(parseCron('0 0 30 2 *')!, at(2026, 0, 1))).toBeNull()
+  })
+})
+
+describe('describeCron', () => {
+  it('0 12 * * * → Every day at 12:00', () => {
+    expect(describeCron('0 12 * * *')).toBe('Every day at 12:00')
+  })
+  it('0 0 * * 0 → Every Sunday at 00:00', () => {
+    expect(describeCron('0 0 * * 0')).toBe('Every Sunday at 00:00')
+  })
+  it('*/15 * * * * → Every 15 minutes', () => {
+    expect(describeCron('*/15 * * * *')).toBe('Every 15 minutes')
+  })
+  it('* * * * * → Every minute', () => {
+    expect(describeCron('* * * * *')).toBe('Every minute')
+  })
+  it('0 */2 * * * → Every 2 hours', () => {
+    expect(describeCron('0 */2 * * *')).toBe('Every 2 hours')
+  })
+  it('0 0 * * 1-5 → Monday–Friday at 00:00', () => {
+    expect(describeCron('0 0 * * 1-5')).toBe('Monday–Friday at 00:00')
+  })
+  it('15 * * * * → Every hour at :15', () => {
+    expect(describeCron('15 * * * *')).toBe('Every hour at :15')
+  })
+  it('0 3 1 * * → On day 1 of the month at 03:00', () => {
+    expect(describeCron('0 3 1 * *')).toBe('On day 1 of the month at 03:00')
+  })
+  it('@daily → Every day at 00:00', () => {
+    expect(describeCron('@daily')).toBe('Every day at 00:00')
+  })
+  it('@reboot → At startup', () => {
+    expect(describeCron('@reboot')).toBe('At startup')
+  })
+  it('falls back to the raw expression for exotic shapes', () => {
+    // Two hours + two minutes with a weekday gate — no canned phrase.
+    expect(describeCron('0,30 8,20 * * 1-5')).toBe('0,30 8,20 * * 1-5')
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/shared/lib/cronSchedule.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/lib/cronSchedule.ts
@@ -1,0 +1,372 @@
+/**
+ * cronSchedule.ts — a minimal, dependency-free standard-cron parser for the
+ * sovereign-admin /jobs consolidated Schedule view (P3-frontend, Refs #6703).
+ *
+ * There is intentionally NO npm dependency (cron-parser / cronstrue): the
+ * "what fires at 12:00" timeline an operator trusts must be small, auditable,
+ * and unit-tested in this repo. This module supports the standard 5-field
+ * Kubernetes CronJob syntax:
+ *
+ *   ┌───────────── minute        (0-59)
+ *   │ ┌─────────── hour          (0-23)
+ *   │ │ ┌───────── day-of-month  (1-31)
+ *   │ │ │ ┌─────── month         (1-12)
+ *   │ │ │ │ ┌───── day-of-week   (0-7, both 0 and 7 = Sunday)
+ *   * * * * *
+ *
+ * Per field, each comma item may be `*`, a step (a star or range followed by
+ * a slash-N), a range `a-b`, a list `a,b,c`, or a plain numeric value — all
+ * composable (`0,30 9-17 * * 1-5`).
+ * The predefined macros `@yearly`/`@annually`/`@monthly`/`@weekly`/`@daily`/
+ * `@midnight`/`@hourly` normalise to their 5-field equivalents; `@reboot`
+ * has no wall-clock schedule and parses as unschedulable (null).
+ *
+ * Day-of-month vs day-of-week uses the canonical Vixie-cron rule: if BOTH
+ * fields are restricted (neither is a star), a fire happens when EITHER
+ * matches; if either field is a star, they are ANDed. This is the behaviour
+ * `man 5 crontab` documents and the kube-controller-manager's robfig/cron
+ * implements — getting it wrong would mis-place marks on the timeline.
+ *
+ * The x-axis of the Schedule timeline is the cron's OWN wall-clock time
+ * (hour/minute fields placed directly on a 00:00→24:00 axis) — it is NOT
+ * converted to the viewer's timezone, so "fires at 12:00" is literally
+ * `hour == 12`. Only the day-of-month/month/day-of-week gate needs a
+ * reference calendar date to decide whether the cron fires that day at all;
+ * that reference (and next-fire) is evaluated against the supplied Date.
+ */
+
+/** One parsed cron field: the expanded set of allowed values + the Vixie
+ *  "star" flag (set when the raw field is a star — `*` or a star-step). */
+export interface CronField {
+  /** The raw field text, trimmed. */
+  raw: string
+  /** Every allowed value in the field's domain. */
+  values: ReadonlySet<number>
+  /** True when the field is a star (`*` or a star-step) — the Vixie
+   *  DOM_STAR/DOW_STAR flag that decides AND-vs-OR between day-of-month and
+   *  day-of-week. */
+  star: boolean
+}
+
+/** A fully parsed 5-field cron expression. */
+export interface ParsedCron {
+  minute: CronField
+  hour: CronField
+  dom: CronField
+  month: CronField
+  dow: CronField
+}
+
+/** Thrown by {@link parseCron} on a syntactically invalid expression. */
+export class CronParseError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'CronParseError'
+  }
+}
+
+interface FieldSpec {
+  min: number
+  max: number
+  /** day-of-week only: map 7 → 0 (both are Sunday). */
+  wrap7to0?: boolean
+}
+
+const MINUTE: FieldSpec = { min: 0, max: 59 }
+const HOUR: FieldSpec = { min: 0, max: 23 }
+const DOM: FieldSpec = { min: 1, max: 31 }
+const MONTH: FieldSpec = { min: 1, max: 12 }
+const DOW: FieldSpec = { min: 0, max: 7, wrap7to0: true }
+
+/** Predefined macros → their canonical 5-field expansions. */
+const MACROS: Readonly<Record<string, string>> = Object.freeze({
+  '@yearly': '0 0 1 1 *',
+  '@annually': '0 0 1 1 *',
+  '@monthly': '0 0 1 * *',
+  '@weekly': '0 0 * * 0',
+  '@daily': '0 0 * * *',
+  '@midnight': '0 0 * * *',
+  '@hourly': '0 * * * *',
+})
+
+/**
+ * Expand a single cron field (which may itself be a comma list) into the
+ * set of allowed values in [spec.min, spec.max]. Throws CronParseError on
+ * anything malformed so a bad chart schedule surfaces as an honest error
+ * rather than a silently-empty timeline.
+ */
+function expandField(raw: string, spec: FieldSpec): CronField {
+  const text = raw.trim()
+  if (text === '') throw new CronParseError('empty field')
+  const star = text === '*' || text.startsWith('*/')
+  const values = new Set<number>()
+
+  const norm = (n: number): number => (spec.wrap7to0 && n === 7 ? 0 : n)
+  const inRange = (n: number): boolean => n >= spec.min && n <= spec.max
+  const int = (s: string): number => {
+    if (!/^\d+$/.test(s)) throw new CronParseError(`not a number: "${s}"`)
+    return Number(s)
+  }
+
+  for (const item of text.split(',')) {
+    const part = item.trim()
+    if (part === '') throw new CronParseError(`empty list item in "${raw}"`)
+
+    // Split optional /step.
+    let rangePart = part
+    let step = 1
+    const slash = part.indexOf('/')
+    if (slash !== -1) {
+      rangePart = part.slice(0, slash)
+      const stepStr = part.slice(slash + 1)
+      step = int(stepStr)
+      if (step <= 0) throw new CronParseError(`step must be positive in "${part}"`)
+    }
+
+    let lo: number
+    let hi: number
+    if (rangePart === '*') {
+      lo = spec.min
+      hi = spec.max
+    } else if (rangePart.includes('-')) {
+      const [aStr, bStr] = rangePart.split('-')
+      if (bStr === undefined || aStr === '' || bStr === '') {
+        throw new CronParseError(`malformed range "${rangePart}"`)
+      }
+      lo = int(aStr)
+      hi = int(bStr)
+    } else {
+      lo = int(rangePart)
+      // A bare `n/step` counts from n up to the field max (cron semantics).
+      hi = slash !== -1 ? spec.max : lo
+    }
+
+    if (!inRange(lo) || !inRange(hi)) {
+      throw new CronParseError(
+        `value out of range [${spec.min}-${spec.max}] in "${part}"`,
+      )
+    }
+    if (lo > hi) throw new CronParseError(`inverted range "${rangePart}"`)
+
+    for (let v = lo; v <= hi; v += step) values.add(norm(v))
+  }
+
+  return { raw: text, values, star }
+}
+
+/**
+ * Parse a 5-field cron expression (or a supported macro). Throws
+ * CronParseError on invalid syntax; returns null for `@reboot` (no
+ * wall-clock schedule to place on a timeline).
+ */
+export function parseCron(expr: string): ParsedCron | null {
+  const trimmed = (expr ?? '').trim()
+  if (trimmed === '') throw new CronParseError('empty expression')
+
+  if (trimmed.startsWith('@')) {
+    const lower = trimmed.toLowerCase()
+    if (lower === '@reboot') return null
+    const expanded = MACROS[lower]
+    if (!expanded) throw new CronParseError(`unknown macro "${trimmed}"`)
+    return parseCron(expanded)
+  }
+
+  const fields = trimmed.split(/\s+/)
+  if (fields.length !== 5) {
+    throw new CronParseError(
+      `expected 5 fields, got ${fields.length} in "${expr}"`,
+    )
+  }
+  return {
+    minute: expandField(fields[0], MINUTE),
+    hour: expandField(fields[1], HOUR),
+    dom: expandField(fields[2], DOM),
+    month: expandField(fields[3], MONTH),
+    dow: expandField(fields[4], DOW),
+  }
+}
+
+/**
+ * Non-throwing variant — returns null on ANY parse failure (including
+ * @reboot). Used by the UI where a malformed schedule must degrade to
+ * "unparseable" rather than crash the render.
+ */
+export function tryParseCron(expr: string): ParsedCron | null {
+  try {
+    return parseCron(expr)
+  } catch {
+    return null
+  }
+}
+
+/**
+ * True when the cron's day-gate (day-of-month / month / day-of-week) matches
+ * the given calendar date. Implements the Vixie AND-vs-OR rule between DOM
+ * and DOW. Evaluated against the Date's LOCAL calendar fields.
+ */
+export function matchesDate(parsed: ParsedCron, date: Date): boolean {
+  const month = date.getMonth() + 1
+  if (!parsed.month.values.has(month)) return false
+
+  const dom = date.getDate()
+  const dow = date.getDay() // 0 = Sunday
+  const domMatch = parsed.dom.values.has(dom)
+  const dowMatch = parsed.dow.values.has(dow)
+
+  // Vixie rule: if either day field is a star, AND them; if both are
+  // restricted, OR them (the "runs on the 1st AND every Sunday" behaviour).
+  if (parsed.dom.star || parsed.dow.star) return domMatch && dowMatch
+  return domMatch || dowMatch
+}
+
+/**
+ * All minutes-of-day (0..1439) at which the cron fires on `date`'s calendar
+ * day, ascending. Empty when the day-gate does not match that date. The
+ * values are wall-clock (hour*60 + minute) — position them directly on a
+ * 00:00→24:00 axis.
+ */
+export function fireMinutesOnDate(parsed: ParsedCron, date: Date): number[] {
+  if (!matchesDate(parsed, date)) return []
+  const hours = [...parsed.hour.values].sort((a, b) => a - b)
+  const minutes = [...parsed.minute.values].sort((a, b) => a - b)
+  const out: number[] = []
+  for (const h of hours) {
+    for (const m of minutes) out.push(h * 60 + m)
+  }
+  return out
+}
+
+/**
+ * The next wall-clock fire at or after `from` (strictly after `from`'s
+ * minute), evaluated against the local calendar. Returns null if no fire is
+ * found within a ~4-year horizon (e.g. an impossible date like Feb 30) or
+ * for an unschedulable expression.
+ *
+ * Iterates day-by-day (not minute-by-minute) so a yearly cron resolves in a
+ * few hundred cheap iterations, not half a million.
+ */
+export function nextFireTime(parsed: ParsedCron, from: Date): Date | null {
+  // Start of the minute strictly after `from`.
+  const cursor = new Date(from)
+  cursor.setSeconds(0, 0)
+  cursor.setMinutes(cursor.getMinutes() + 1)
+
+  const fromDayStart = new Date(
+    cursor.getFullYear(),
+    cursor.getMonth(),
+    cursor.getDate(),
+  )
+  const startMinuteOfDay = cursor.getHours() * 60 + cursor.getMinutes()
+
+  const MAX_DAYS = 366 * 4
+  for (let i = 0; i < MAX_DAYS; i++) {
+    const day = new Date(fromDayStart)
+    day.setDate(day.getDate() + i)
+    if (!matchesDate(parsed, day)) continue
+    const lower = i === 0 ? startMinuteOfDay : 0
+    for (const minuteOfDay of fireMinutesOnDate(parsed, day)) {
+      if (minuteOfDay >= lower) {
+        const fire = new Date(day)
+        fire.setHours(Math.floor(minuteOfDay / 60), minuteOfDay % 60, 0, 0)
+        return fire
+      }
+    }
+  }
+  return null
+}
+
+/* ── Human-readable describe() ────────────────────────────────────────── */
+
+const DOW_NAMES = [
+  'Sunday',
+  'Monday',
+  'Tuesday',
+  'Wednesday',
+  'Thursday',
+  'Friday',
+  'Saturday',
+]
+
+const pad2 = (n: number): string => String(n).padStart(2, '0')
+
+/** The step `n` of a star-step field (`*` slash `n`), or null. */
+function starStep(field: CronField): number | null {
+  const m = /^\*\/(\d+)$/.exec(field.raw)
+  return m ? Number(m[1]) : null
+}
+
+/** The single value of a field, or null when it holds 0 or >1 values. */
+function soleValue(field: CronField): number | null {
+  if (field.values.size !== 1) return null
+  return [...field.values][0]
+}
+
+const isEvery = (field: CronField): boolean => field.raw === '*'
+
+/** Render the day-of-week set as "Sunday" / "Monday–Friday" / "Mon, Wed". */
+function describeDow(field: CronField): string {
+  const vals = [...field.values].sort((a, b) => a - b)
+  if (vals.length === 1) return `Every ${DOW_NAMES[vals[0]]}`
+  // Contiguous run → "A–B" (only when it doesn't wrap through Sunday).
+  const contiguous = vals.every((v, i) => i === 0 || v === vals[i - 1] + 1)
+  if (contiguous) return `${DOW_NAMES[vals[0]]}–${DOW_NAMES[vals[vals.length - 1]]}`
+  return vals.map((v) => DOW_NAMES[v]).join(', ')
+}
+
+/**
+ * A best-effort human sentence for a cron expression. Deliberately covers
+ * the common shapes robustly and falls back to the raw expression for
+ * anything exotic rather than over-reaching on natural language.
+ */
+export function describeCron(input: ParsedCron | string): string {
+  const parsed = typeof input === 'string' ? tryParseCron(input) : input
+  if (!parsed) {
+    if (typeof input === 'string') {
+      return input.trim().toLowerCase() === '@reboot' ? 'At startup' : input
+    }
+    return ''
+  }
+  const { minute, hour, dom, month, dow } = parsed
+  const dayFieldsBare = isEvery(dom) && isEvery(month) && isEvery(dow)
+
+  // Every minute.
+  if (isEvery(minute) && isEvery(hour) && dayFieldsBare) return 'Every minute'
+
+  // Every N minutes.
+  const minStep = starStep(minute)
+  if (minStep && isEvery(hour) && dayFieldsBare) {
+    return minStep === 1 ? 'Every minute' : `Every ${minStep} minutes`
+  }
+
+  const m = soleValue(minute)
+
+  // Every N hours (at minute 0).
+  const hourStep = starStep(hour)
+  if (m === 0 && hourStep && dayFieldsBare) {
+    return hourStep === 1 ? 'Every hour' : `Every ${hourStep} hours`
+  }
+
+  // Hourly at a fixed minute.
+  if (m !== null && isEvery(hour) && dayFieldsBare) {
+    return `Every hour at :${pad2(m)}`
+  }
+
+  const h = soleValue(hour)
+  if (m !== null && h !== null) {
+    const time = `${pad2(h)}:${pad2(m)}`
+    if (dayFieldsBare) return `Every day at ${time}`
+    // Weekly / weekday cadence.
+    if (isEvery(dom) && isEvery(month) && !dow.star) {
+      return `${describeDow(dow)} at ${time}`
+    }
+    // Monthly day(s).
+    if (!dom.star && dow.star && isEvery(month)) {
+      const days = [...dom.values].sort((a, b) => a - b).join(', ')
+      return `On day ${days} of the month at ${time}`
+    }
+    return `At ${time}`
+  }
+
+  // Anything else — return the normalised raw expression (safe, honest).
+  return `${minute.raw} ${hour.raw} ${dom.raw} ${month.raw} ${dow.raw}`
+}


### PR DESCRIPTION
## What

The consolidated **CronJob Schedule** surface (Refs #6703) — the founder's "what fires at 12pm" view — plus the **cron run-history drill-in**.

- Reached via a contextual **"View schedule →"** link shown when the CronJob chip is active in `/jobs` list view (route `/jobs/schedule`).
- A read-only 24h time-of-day timeline (pure SVG, JobsTimeline house style) showing every CronJob at its fire times, with collision detection; each cron shows schedule (human-readable), next fire, last-run status.
- Run-history drawer: a CronJob's child Jobs (ownerRef match) newest-first, each with status + start + duration.

## Reuse (not ad-hoc)

Reuses the established `Badge` (`@/shared/ui/badge`), `useK8sCacheStream` (same hook as the cloud list — reads the now-watched `batch/v1` cronjob+job kinds), `PortalShell`, and `sovereignPathOrDeployments`. The only genuinely-new pieces are the dependency-free cron parser (no existing one) and the schedule surface itself (no existing schedule view). Also first-classes `cronjobs` as a browsable Cloud resource kind (mirrors daemonsets).

## Verification

Rebased onto the merged graph+chips rework (#6708). `tsc -b` clean; **full ui vitest 264 files / 2364 pass + 1 pre-existing expected-fail** (incl. 37 cron-parser tests, model + view + affordance tests); no new eslint errors.

## Rollout

Frontend catalyst-ui + the already-merged catalyst-api cronjob/job watch (#6705). Rolling roll to hw305 after merge; validated live.

Refs #6703